### PR TITLE
Replace bin/wisp symlink with autobuild wrapper script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Wisp is a Go CLI tool. The project uses standard Go tooling with no external bui
 
 - `cmd/wisp/main.go` - Main entry point for the CLI
 - `dist/` - Build output directory (gitignored)
-- `bin/wisp` - Symlink to the compiled binary
+- `bin/wisp` - Wrapper script that auto-builds and runs dist/wisp
 
 ## Development Notes
 

--- a/bin/wisp
+++ b/bin/wisp
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ ! -f "$REPO_ROOT/dist/wisp" ]; then
+  echo "Building wisp..." >&2
+  (cd "$REPO_ROOT" && go build -o dist/wisp ./cmd/wisp)
+fi
+
+exec "$REPO_ROOT/dist/wisp" "$@"


### PR DESCRIPTION
bin/wisp now auto-builds dist/wisp if it doesn't exist before running it, removing the need to manually build first.