### PR TITLE
Implement wisp v0 mount, unmount, and materialize commands

### DIFF
--- a/cmd/wisp/main.go
+++ b/cmd/wisp/main.go
@@ -3,13 +3,19 @@ package main
 import (
 	"fmt"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
-func main() {
-	if len(os.Args) < 2 {
-		fmt.Println("wisp - a command-line tool")
-		os.Exit(0)
-	}
+var rootCmd = &cobra.Command{
+	Use:   "wisp",
+	Short: "Wisp - filesystem mounting and script execution",
+	Long:  `Wisp provides filesystem mounting and script execution with output materialization.`,
+}
 
-	fmt.Printf("Hello, %s!\n", os.Args[1])
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/cmd/wisp/v0.go
+++ b/cmd/wisp/v0.go
@@ -63,8 +63,29 @@ var unmountCmd = &cobra.Command{
 	Short: "Unmount a previously mounted target",
 	Long:  `Unmount a previously mounted target and clean up any associated resources.`,
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("unmount: target=%s (not yet implemented)\n", args[0])
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := args[0]
+
+		// Convert to absolute path
+		absTarget, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("failed to resolve target path: %w", err)
+		}
+
+		// Create state manager
+		st, err := state.NewStateInHomeDir()
+		if err != nil {
+			return err
+		}
+
+		// Perform unmount
+		if err := mount.Unmount(absTarget, st); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			return err
+		}
+
+		fmt.Printf("Unmounted %s\n", absTarget)
+		return nil
 	},
 }
 

--- a/cmd/wisp/v0.go
+++ b/cmd/wisp/v0.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var v0Cmd = &cobra.Command{
+	Use:   "v0",
+	Short: "v0 commands for filesystem mounting and materialization",
+	Long:  `v0 provides filesystem mounting and script execution with output materialization. Targets macOS using bindfs and macFUSE.`,
+}
+
+var mountCmd = &cobra.Command{
+	Use:   "mount <src> <target>",
+	Short: "Mount a source directory to a target path",
+	Long: `Mount a source directory to a target path with specified access mode.
+
+Modes:
+  ro      - Read-only access to source files
+  rw      - Read-write access; writes go directly to source
+  overlay - Read-write access; writes do not affect source`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		mode, _ := cmd.Flags().GetString("mode")
+		fmt.Printf("mount: src=%s target=%s mode=%s (not yet implemented)\n", args[0], args[1], mode)
+	},
+}
+
+var unmountCmd = &cobra.Command{
+	Use:   "unmount <target>",
+	Short: "Unmount a previously mounted target",
+	Long:  `Unmount a previously mounted target and clean up any associated resources.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("unmount: target=%s (not yet implemented)\n", args[0])
+	},
+}
+
+var materializeCmd = &cobra.Command{
+	Use:   "materialize",
+	Short: "Run a script and copy output files to a destination",
+	Long: `Run a script and copy output files to a destination directory.
+
+This simulates a sandboxed execution model where the script runs in isolation
+and its outputs are "materialized" to the host.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		script, _ := cmd.Flags().GetString("script")
+		workdir, _ := cmd.Flags().GetString("workdir")
+		outdir, _ := cmd.Flags().GetString("outdir")
+		destdir, _ := cmd.Flags().GetString("destdir")
+		fmt.Printf("materialize: script=%s workdir=%s outdir=%s destdir=%s (not yet implemented)\n",
+			script, workdir, outdir, destdir)
+	},
+}
+
+func init() {
+	// Add v0 command to root
+	rootCmd.AddCommand(v0Cmd)
+
+	// Add subcommands to v0
+	v0Cmd.AddCommand(mountCmd)
+	v0Cmd.AddCommand(unmountCmd)
+	v0Cmd.AddCommand(materializeCmd)
+
+	// Mount command flags
+	mountCmd.Flags().StringP("mode", "m", "", "Access mode: ro, rw, or overlay (required)")
+	mountCmd.MarkFlagRequired("mode")
+
+	// Materialize command flags
+	materializeCmd.Flags().String("script", "", "Path to the script to execute (required)")
+	materializeCmd.Flags().String("workdir", "", "Working directory for script execution (required)")
+	materializeCmd.Flags().String("outdir", "", "Directory where the script writes output files (required)")
+	materializeCmd.Flags().String("destdir", "", "Host directory where output files are copied (required)")
+	materializeCmd.MarkFlagRequired("script")
+	materializeCmd.MarkFlagRequired("workdir")
+	materializeCmd.MarkFlagRequired("outdir")
+	materializeCmd.MarkFlagRequired("destdir")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/gofixpoint/wisp
 
 go 1.25.3
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/deps/check.go
+++ b/internal/deps/check.go
@@ -1,0 +1,61 @@
+package deps
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// DependencyError represents a missing dependency with installation instructions.
+type DependencyError struct {
+	Name         string
+	Instructions string
+}
+
+func (e *DependencyError) Error() string {
+	return fmt.Sprintf("%s is not installed.\n\n%s", e.Name, e.Instructions)
+}
+
+// CheckBindfs verifies that bindfs is installed and available in PATH.
+func CheckBindfs() error {
+	_, err := exec.LookPath("bindfs")
+	if err != nil {
+		return &DependencyError{
+			Name:         "bindfs",
+			Instructions: "Install bindfs using Homebrew:\n  brew install bindfs",
+		}
+	}
+	return nil
+}
+
+// CheckMacFUSE verifies that macFUSE is installed.
+func CheckMacFUSE() error {
+	// Check for macFUSE filesystem bundle
+	paths := []string{
+		"/Library/Filesystems/macfuse.fs",
+		"/Library/Filesystems/osxfuse.fs", // Older name
+	}
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+	}
+
+	return &DependencyError{
+		Name:         "macFUSE",
+		Instructions: "Install macFUSE from: https://osxfuse.github.io/\n\nOr install via Homebrew:\n  brew install --cask macfuse",
+	}
+}
+
+// CheckAll verifies all required dependencies are installed.
+// Returns an error describing the first missing dependency found.
+func CheckAll() error {
+	if err := CheckMacFUSE(); err != nil {
+		return err
+	}
+	if err := CheckBindfs(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/deps/check_test.go
+++ b/internal/deps/check_test.go
@@ -1,0 +1,68 @@
+package deps
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDependencyError(t *testing.T) {
+	err := &DependencyError{
+		Name:         "test-dep",
+		Instructions: "Install with: test install",
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "test-dep") {
+		t.Errorf("error message should contain dependency name, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Install with: test install") {
+		t.Errorf("error message should contain instructions, got: %s", msg)
+	}
+}
+
+func TestCheckBindfs(t *testing.T) {
+	// This test checks the actual system state.
+	// If bindfs is installed, it should pass; if not, it should return an error.
+	err := CheckBindfs()
+	if err != nil {
+		depErr, ok := err.(*DependencyError)
+		if !ok {
+			t.Errorf("expected DependencyError, got: %T", err)
+		}
+		if depErr.Name != "bindfs" {
+			t.Errorf("expected name 'bindfs', got: %s", depErr.Name)
+		}
+		if !strings.Contains(depErr.Instructions, "brew install bindfs") {
+			t.Errorf("instructions should mention brew install, got: %s", depErr.Instructions)
+		}
+	}
+}
+
+func TestCheckMacFUSE(t *testing.T) {
+	// This test checks the actual system state.
+	err := CheckMacFUSE()
+	if err != nil {
+		depErr, ok := err.(*DependencyError)
+		if !ok {
+			t.Errorf("expected DependencyError, got: %T", err)
+		}
+		if depErr.Name != "macFUSE" {
+			t.Errorf("expected name 'macFUSE', got: %s", depErr.Name)
+		}
+		if !strings.Contains(depErr.Instructions, "osxfuse.github.io") {
+			t.Errorf("instructions should mention osxfuse.github.io, got: %s", depErr.Instructions)
+		}
+	}
+}
+
+func TestCheckAll(t *testing.T) {
+	// CheckAll should return nil only if both dependencies are installed
+	err := CheckAll()
+	if err != nil {
+		// Verify it's a DependencyError
+		_, ok := err.(*DependencyError)
+		if !ok {
+			t.Errorf("expected DependencyError, got: %T", err)
+		}
+	}
+}

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -1,0 +1,65 @@
+package materialize
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// Options contains the options for the materialize command.
+type Options struct {
+	Script  string // Path to the script to execute
+	Workdir string // Working directory for script execution
+	Outdir  string // Directory where the script writes output files
+	Destdir string // Host directory where output files are copied
+}
+
+// Run executes a script and copies its output to the destination directory.
+func Run(opts Options) error {
+	// Validate script exists and is executable
+	scriptInfo, err := os.Stat(opts.Script)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("script does not exist: %s", opts.Script)
+		}
+		return fmt.Errorf("failed to stat script: %w", err)
+	}
+	if scriptInfo.IsDir() {
+		return fmt.Errorf("script is a directory: %s", opts.Script)
+	}
+
+	// Create workdir if it doesn't exist
+	if err := os.MkdirAll(opts.Workdir, 0755); err != nil {
+		return fmt.Errorf("failed to create workdir: %w", err)
+	}
+
+	// Create outdir if it doesn't exist
+	if err := os.MkdirAll(opts.Outdir, 0755); err != nil {
+		return fmt.Errorf("failed to create outdir: %w", err)
+	}
+
+	// Create destdir if it doesn't exist
+	if err := os.MkdirAll(opts.Destdir, 0755); err != nil {
+		return fmt.Errorf("failed to create destdir: %w", err)
+	}
+
+	// Execute the script
+	cmd := exec.Command(opts.Script)
+	cmd.Dir = opts.Workdir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("script execution failed: %w", err)
+	}
+
+	// Copy outdir contents to destdir using rsync
+	rsyncCmd := exec.Command("rsync", "-a", opts.Outdir+"/", opts.Destdir+"/")
+	rsyncCmd.Stdout = os.Stdout
+	rsyncCmd.Stderr = os.Stderr
+	if err := rsyncCmd.Run(); err != nil {
+		return fmt.Errorf("failed to copy output files: %w", err)
+	}
+
+	return nil
+}

--- a/internal/mount/mount.go
+++ b/internal/mount/mount.go
@@ -1,0 +1,156 @@
+package mount
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/gofixpoint/wisp/internal/deps"
+	"github.com/gofixpoint/wisp/internal/state"
+)
+
+// Mode represents the mount access mode.
+type Mode string
+
+const (
+	ModeReadOnly Mode = "ro"
+	ModeReadWrite Mode = "rw"
+	ModeOverlay  Mode = "overlay"
+)
+
+// ValidateMode checks if a mode string is valid.
+func ValidateMode(mode string) error {
+	switch Mode(mode) {
+	case ModeReadOnly, ModeReadWrite, ModeOverlay:
+		return nil
+	default:
+		return fmt.Errorf("invalid mode %q: must be ro, rw, or overlay", mode)
+	}
+}
+
+// Mount mounts a source directory to a target path with the specified mode.
+func Mount(src, target, mode string, st state.State) error {
+	// Check dependencies
+	if err := deps.CheckAll(); err != nil {
+		return err
+	}
+
+	// Validate mode
+	if err := ValidateMode(mode); err != nil {
+		return err
+	}
+
+	// Validate source exists and is a directory
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("source directory does not exist: %s", src)
+		}
+		return fmt.Errorf("failed to stat source: %w", err)
+	}
+	if !srcInfo.IsDir() {
+		return fmt.Errorf("source is not a directory: %s", src)
+	}
+
+	// Check if target is already mounted
+	if st.MountExists(target) {
+		return fmt.Errorf("target is already mounted: %s", target)
+	}
+
+	// Create target directory if it doesn't exist
+	if err := os.MkdirAll(target, 0755); err != nil {
+		return fmt.Errorf("failed to create target directory: %w", err)
+	}
+
+	var mountInfo state.MountInfo
+	mountInfo.Source = src
+	mountInfo.Target = target
+	mountInfo.Mode = mode
+
+	switch Mode(mode) {
+	case ModeReadOnly:
+		if err := mountReadOnly(src, target); err != nil {
+			return err
+		}
+	case ModeReadWrite:
+		if err := mountReadWrite(src, target); err != nil {
+			return err
+		}
+	case ModeOverlay:
+		tempDir, err := mountOverlay(src, target)
+		if err != nil {
+			return err
+		}
+		mountInfo.TempDir = tempDir
+	}
+
+	// Save mount info to state
+	if err := st.SaveMount(mountInfo); err != nil {
+		// Try to unmount and clean up if we fail to save state
+		unmountBindfs(target)
+		if mountInfo.TempDir != "" {
+			os.RemoveAll(mountInfo.TempDir)
+		}
+		return fmt.Errorf("failed to save mount state: %w", err)
+	}
+
+	return nil
+}
+
+// mountReadOnly mounts source to target in read-only mode.
+func mountReadOnly(src, target string) error {
+	cmd := exec.Command("bindfs", "-o", "ro", src, target)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("bindfs read-only mount failed: %w", err)
+	}
+	return nil
+}
+
+// mountReadWrite mounts source to target in read-write mode.
+func mountReadWrite(src, target string) error {
+	cmd := exec.Command("bindfs", src, target)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("bindfs read-write mount failed: %w", err)
+	}
+	return nil
+}
+
+// mountOverlay creates a copy of source in a temp directory and mounts it.
+func mountOverlay(src, target string) (string, error) {
+	// Create temp directory
+	tempDir, err := os.MkdirTemp("", "wisp-overlay-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
+
+	// Copy source to temp using rsync
+	// The trailing slash on src ensures we copy contents, not the directory itself
+	rsyncCmd := exec.Command("rsync", "-a", src+"/", tempDir+"/")
+	rsyncCmd.Stdout = os.Stdout
+	rsyncCmd.Stderr = os.Stderr
+	if err := rsyncCmd.Run(); err != nil {
+		os.RemoveAll(tempDir)
+		return "", fmt.Errorf("rsync copy failed: %w", err)
+	}
+
+	// Mount temp directory to target
+	bindfsCmd := exec.Command("bindfs", tempDir, target)
+	bindfsCmd.Stdout = os.Stdout
+	bindfsCmd.Stderr = os.Stderr
+	if err := bindfsCmd.Run(); err != nil {
+		os.RemoveAll(tempDir)
+		return "", fmt.Errorf("bindfs overlay mount failed: %w", err)
+	}
+
+	return tempDir, nil
+}
+
+// unmountBindfs unmounts a bindfs mount (helper for cleanup).
+func unmountBindfs(target string) error {
+	cmd := exec.Command("umount", target)
+	return cmd.Run()
+}

--- a/internal/mount/mount_test.go
+++ b/internal/mount/mount_test.go
@@ -1,0 +1,339 @@
+package mount
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/wisp/internal/deps"
+	"github.com/gofixpoint/wisp/internal/state"
+)
+
+// skipIfDepsNotInstalled skips the test if macFUSE or bindfs are not installed.
+func skipIfDepsNotInstalled(t *testing.T) {
+	t.Helper()
+	if err := deps.CheckAll(); err != nil {
+		t.Skipf("Skipping test: %v", err)
+	}
+}
+
+// setupTestDirs creates temp source, target, and state directories.
+// Returns source dir, target dir, state instance, and cleanup function.
+func setupTestDirs(t *testing.T) (srcDir, targetDir string, st state.State, cleanup func()) {
+	t.Helper()
+
+	// Create temp base directory
+	baseDir, err := os.MkdirTemp("", "wisp-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp base directory: %v", err)
+	}
+
+	srcDir = filepath.Join(baseDir, "source")
+	targetDir = filepath.Join(baseDir, "target")
+	stateDir := filepath.Join(baseDir, "state")
+
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		os.RemoveAll(baseDir)
+		t.Fatalf("Failed to create source directory: %v", err)
+	}
+
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		os.RemoveAll(baseDir)
+		t.Fatalf("Failed to create state directory: %v", err)
+	}
+
+	st = state.NewState(stateDir, ".wispstate")
+
+	cleanup = func() {
+		// Try to unmount if still mounted (cleanup on test failure)
+		if st.MountExists(targetDir) {
+			Unmount(targetDir, st)
+		}
+		os.RemoveAll(baseDir)
+	}
+
+	return srcDir, targetDir, st, cleanup
+}
+
+// TestValidateMode tests mode validation (no deps needed).
+func TestValidateMode(t *testing.T) {
+	tests := []struct {
+		mode    string
+		wantErr bool
+	}{
+		{"ro", false},
+		{"rw", false},
+		{"overlay", false},
+		{"invalid", true},
+		{"", true},
+		{"RO", true}, // case sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			err := ValidateMode(tt.mode)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateMode(%q) error = %v, wantErr %v", tt.mode, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestMountReadOnly tests mounting in read-only mode.
+func TestMountReadOnly(t *testing.T) {
+	skipIfDepsNotInstalled(t)
+
+	srcDir, targetDir, st, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	// Create test file in source
+	testFile := filepath.Join(srcDir, "test.txt")
+	testContent := []byte("hello world")
+	if err := os.WriteFile(testFile, testContent, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Mount in read-only mode
+	if err := Mount(srcDir, targetDir, "ro", st); err != nil {
+		t.Fatalf("Mount failed: %v", err)
+	}
+
+	// Verify can read file from target
+	targetFile := filepath.Join(targetDir, "test.txt")
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Errorf("Failed to read file from target: %v", err)
+	}
+	if string(content) != string(testContent) {
+		t.Errorf("Content mismatch: got %q, want %q", content, testContent)
+	}
+
+	// Verify cannot write to target (read-only)
+	newFile := filepath.Join(targetDir, "new.txt")
+	err = os.WriteFile(newFile, []byte("new content"), 0644)
+	if err == nil {
+		t.Error("Expected write to read-only mount to fail, but it succeeded")
+	}
+
+	// Verify mount exists in state
+	if !st.MountExists(targetDir) {
+		t.Error("Mount not found in state")
+	}
+
+	// Unmount
+	if err := Unmount(targetDir, st); err != nil {
+		t.Errorf("Unmount failed: %v", err)
+	}
+
+	// Verify mount removed from state
+	if st.MountExists(targetDir) {
+		t.Error("Mount still exists in state after unmount")
+	}
+}
+
+// TestMountReadWrite tests mounting in read-write mode.
+func TestMountReadWrite(t *testing.T) {
+	skipIfDepsNotInstalled(t)
+
+	srcDir, targetDir, st, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	// Create test file in source
+	testFile := filepath.Join(srcDir, "test.txt")
+	testContent := []byte("hello world")
+	if err := os.WriteFile(testFile, testContent, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Mount in read-write mode
+	if err := Mount(srcDir, targetDir, "rw", st); err != nil {
+		t.Fatalf("Mount failed: %v", err)
+	}
+
+	// Verify can read file from target
+	targetFile := filepath.Join(targetDir, "test.txt")
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Errorf("Failed to read file from target: %v", err)
+	}
+	if string(content) != string(testContent) {
+		t.Errorf("Content mismatch: got %q, want %q", content, testContent)
+	}
+
+	// Write new file to target
+	newFile := filepath.Join(targetDir, "new.txt")
+	newContent := []byte("new content")
+	if err := os.WriteFile(newFile, newContent, 0644); err != nil {
+		t.Errorf("Failed to write new file to target: %v", err)
+	}
+
+	// Verify file appears in source (writes sync back)
+	sourceNewFile := filepath.Join(srcDir, "new.txt")
+	content, err = os.ReadFile(sourceNewFile)
+	if err != nil {
+		t.Errorf("New file not found in source: %v", err)
+	}
+	if string(content) != string(newContent) {
+		t.Errorf("New file content mismatch in source: got %q, want %q", content, newContent)
+	}
+
+	// Unmount
+	if err := Unmount(targetDir, st); err != nil {
+		t.Errorf("Unmount failed: %v", err)
+	}
+
+	// Verify mount removed from state
+	if st.MountExists(targetDir) {
+		t.Error("Mount still exists in state after unmount")
+	}
+}
+
+// TestMountOverlay tests mounting in overlay mode.
+func TestMountOverlay(t *testing.T) {
+	skipIfDepsNotInstalled(t)
+
+	srcDir, targetDir, st, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	// Create test file in source
+	testFile := filepath.Join(srcDir, "test.txt")
+	testContent := []byte("hello world")
+	if err := os.WriteFile(testFile, testContent, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Mount in overlay mode
+	if err := Mount(srcDir, targetDir, "overlay", st); err != nil {
+		t.Fatalf("Mount failed: %v", err)
+	}
+
+	// Verify can read file from target
+	targetFile := filepath.Join(targetDir, "test.txt")
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Errorf("Failed to read file from target: %v", err)
+	}
+	if string(content) != string(testContent) {
+		t.Errorf("Content mismatch: got %q, want %q", content, testContent)
+	}
+
+	// Write new file to target
+	newFile := filepath.Join(targetDir, "new.txt")
+	newContent := []byte("new content")
+	if err := os.WriteFile(newFile, newContent, 0644); err != nil {
+		t.Errorf("Failed to write new file to target: %v", err)
+	}
+
+	// Verify file does NOT appear in source (isolated)
+	sourceNewFile := filepath.Join(srcDir, "new.txt")
+	if _, err := os.Stat(sourceNewFile); err == nil {
+		t.Error("File written to overlay target should not appear in source")
+	} else if !os.IsNotExist(err) {
+		t.Errorf("Unexpected error checking source: %v", err)
+	}
+
+	// Get mount info to check temp dir
+	info, err := st.GetMount(targetDir)
+	if err != nil {
+		t.Fatalf("Failed to get mount info: %v", err)
+	}
+	if info.TempDir == "" {
+		t.Error("Overlay mount should have TempDir set")
+	}
+	tempDir := info.TempDir
+
+	// Verify temp dir exists
+	if _, err := os.Stat(tempDir); err != nil {
+		t.Errorf("Temp directory should exist: %v", err)
+	}
+
+	// Unmount
+	if err := Unmount(targetDir, st); err != nil {
+		t.Errorf("Unmount failed: %v", err)
+	}
+
+	// Verify temp dir is cleaned up
+	if _, err := os.Stat(tempDir); err == nil {
+		t.Error("Temp directory should be removed after unmount")
+	} else if !os.IsNotExist(err) {
+		t.Errorf("Unexpected error checking temp dir: %v", err)
+	}
+
+	// Verify mount removed from state
+	if st.MountExists(targetDir) {
+		t.Error("Mount still exists in state after unmount")
+	}
+}
+
+// TestMountSourceNotExists tests error when source doesn't exist.
+func TestMountSourceNotExists(t *testing.T) {
+	skipIfDepsNotInstalled(t)
+
+	_, targetDir, st, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	nonExistentSource := "/nonexistent/path/that/does/not/exist"
+
+	err := Mount(nonExistentSource, targetDir, "ro", st)
+	if err == nil {
+		t.Error("Expected error when mounting non-existent source")
+	}
+
+	// Verify error message mentions source doesn't exist
+	if err != nil && !strings.Contains(err.Error(), "source directory does not exist") {
+		t.Errorf("Expected 'source directory does not exist' error, got: %v", err)
+	}
+}
+
+// TestMountTargetAlreadyMounted tests error when target is already mounted.
+func TestMountTargetAlreadyMounted(t *testing.T) {
+	skipIfDepsNotInstalled(t)
+
+	srcDir, targetDir, st, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	// Create test file
+	if err := os.WriteFile(filepath.Join(srcDir, "test.txt"), []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// First mount should succeed
+	if err := Mount(srcDir, targetDir, "ro", st); err != nil {
+		t.Fatalf("First mount failed: %v", err)
+	}
+
+	// Second mount should fail
+	err := Mount(srcDir, targetDir, "ro", st)
+	if err == nil {
+		t.Error("Expected error when mounting already mounted target")
+	}
+
+	// Verify error message mentions already mounted
+	if err != nil && !strings.Contains(err.Error(), "already mounted") {
+		t.Errorf("Expected 'already mounted' error, got: %v", err)
+	}
+
+	// Cleanup: unmount
+	if err := Unmount(targetDir, st); err != nil {
+		t.Errorf("Cleanup unmount failed: %v", err)
+	}
+}
+
+// TestUnmountNotMounted tests error when trying to unmount a path that isn't mounted.
+func TestUnmountNotMounted(t *testing.T) {
+	skipIfDepsNotInstalled(t)
+
+	_, targetDir, st, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	err := Unmount(targetDir, st)
+	if err == nil {
+		t.Error("Expected error when unmounting path that isn't mounted")
+	}
+
+	// Verify error message mentions not mounted
+	if err != nil && !strings.Contains(err.Error(), "not mounted") {
+		t.Errorf("Expected 'not mounted' error, got: %v", err)
+	}
+}

--- a/internal/mount/unmount.go
+++ b/internal/mount/unmount.go
@@ -1,0 +1,59 @@
+package mount
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/gofixpoint/wisp/internal/state"
+)
+
+// Unmount unmounts a target and cleans up any associated resources.
+func Unmount(target string, st state.State) error {
+	// Get mount info from state
+	info, err := st.GetMount(target)
+	if err != nil {
+		return fmt.Errorf("target is not mounted: %s", target)
+	}
+
+	// Unmount the bindfs mount
+	if err := doUnmount(target); err != nil {
+		return fmt.Errorf("failed to unmount %s: %w", target, err)
+	}
+
+	// If overlay mode, clean up temp directory
+	if info.Mode == string(ModeOverlay) && info.TempDir != "" {
+		if err := os.RemoveAll(info.TempDir); err != nil {
+			// Log warning but don't fail
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove temp directory %s: %v\n", info.TempDir, err)
+		}
+	}
+
+	// Remove mount from state
+	if err := st.RemoveMount(target); err != nil {
+		return fmt.Errorf("failed to remove mount from state: %w", err)
+	}
+
+	return nil
+}
+
+// doUnmount performs the actual unmount operation.
+func doUnmount(target string) error {
+	var cmd *exec.Cmd
+
+	if runtime.GOOS == "darwin" {
+		// On macOS, use diskutil unmount for better compatibility
+		cmd = exec.Command("diskutil", "unmount", target)
+	} else {
+		// On Linux and others, use umount
+		cmd = exec.Command("umount", target)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", err, string(output))
+	}
+
+	return nil
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,207 @@
+package state
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MountInfo represents information about an active mount.
+type MountInfo struct {
+	Source  string `json:"source"`
+	Target  string `json:"target"`
+	Mode    string `json:"mode"`
+	TempDir string `json:"tempDir,omitempty"` // Only used for overlay mode
+}
+
+// State provides an interface for managing mount state.
+type State interface {
+	// StateDir returns the path to the state directory.
+	StateDir() string
+	// SaveMount saves mount information to the state file.
+	SaveMount(info MountInfo) error
+	// GetMount retrieves mount information for a given target path.
+	GetMount(target string) (MountInfo, error)
+	// RemoveMount removes mount information for a given target path.
+	RemoveMount(target string) error
+	// ListMounts returns all active mounts.
+	ListMounts() ([]MountInfo, error)
+	// MountExists checks if a mount exists for the given target.
+	MountExists(target string) bool
+}
+
+// fileState implements State using a JSONL file.
+type fileState struct {
+	dirname  string // parent directory (e.g., "/Users/foo")
+	basename string // directory name (e.g., ".wispbase")
+}
+
+// NewState creates a new State instance.
+// dirname is the parent directory path (e.g., "/Users/foo").
+// basename is the state directory name (e.g., ".wispbase").
+func NewState(dirname string, basename string) State {
+	return &fileState{
+		dirname:  dirname,
+		basename: basename,
+	}
+}
+
+// NewStateInHomeDir creates a new State instance in ~/.wispbase.
+func NewStateInHomeDir() (State, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return NewState(home, ".wispbase"), nil
+}
+
+// StateDir returns the path to the state directory.
+func (s *fileState) StateDir() string {
+	return filepath.Join(s.dirname, s.basename)
+}
+
+// mountsFilePath returns the path to the mounts.jsonl file.
+func (s *fileState) mountsFilePath() string {
+	return filepath.Join(s.StateDir(), "mounts.jsonl")
+}
+
+// readAllMounts reads all mounts from the JSONL file.
+func (s *fileState) readAllMounts() ([]MountInfo, error) {
+	filePath := s.mountsFilePath()
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []MountInfo{}, nil
+		}
+		return nil, fmt.Errorf("failed to open mounts file: %w", err)
+	}
+	defer file.Close()
+
+	var mounts []MountInfo
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var info MountInfo
+		if err := json.Unmarshal([]byte(line), &info); err != nil {
+			continue // Skip malformed lines
+		}
+		mounts = append(mounts, info)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read mounts file: %w", err)
+	}
+
+	return mounts, nil
+}
+
+// writeAllMounts writes all mounts to the JSONL file.
+func (s *fileState) writeAllMounts(mounts []MountInfo) error {
+	dir := s.StateDir()
+
+	// Ensure state directory exists
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	filePath := s.mountsFilePath()
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create mounts file: %w", err)
+	}
+	defer file.Close()
+
+	for _, info := range mounts {
+		data, err := json.Marshal(info)
+		if err != nil {
+			return fmt.Errorf("failed to marshal mount info: %w", err)
+		}
+		if _, err := file.Write(data); err != nil {
+			return fmt.Errorf("failed to write mount info: %w", err)
+		}
+		if _, err := file.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write newline: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// SaveMount saves mount information to the state file.
+func (s *fileState) SaveMount(info MountInfo) error {
+	mounts, err := s.readAllMounts()
+	if err != nil {
+		return err
+	}
+
+	// Replace existing mount with same target, or append
+	found := false
+	for i, m := range mounts {
+		if m.Target == info.Target {
+			mounts[i] = info
+			found = true
+			break
+		}
+	}
+	if !found {
+		mounts = append(mounts, info)
+	}
+
+	return s.writeAllMounts(mounts)
+}
+
+// GetMount retrieves mount information for a given target path.
+func (s *fileState) GetMount(target string) (MountInfo, error) {
+	mounts, err := s.readAllMounts()
+	if err != nil {
+		return MountInfo{}, err
+	}
+
+	for _, m := range mounts {
+		if m.Target == target {
+			return m, nil
+		}
+	}
+
+	return MountInfo{}, fmt.Errorf("no mount found for target: %s", target)
+}
+
+// RemoveMount removes mount information for a given target path.
+func (s *fileState) RemoveMount(target string) error {
+	mounts, err := s.readAllMounts()
+	if err != nil {
+		return err
+	}
+
+	// Filter out the mount with matching target
+	var filtered []MountInfo
+	for _, m := range mounts {
+		if m.Target != target {
+			filtered = append(filtered, m)
+		}
+	}
+
+	// If nothing changed, no need to write
+	if len(filtered) == len(mounts) {
+		return nil
+	}
+
+	return s.writeAllMounts(filtered)
+}
+
+// ListMounts returns all active mounts.
+func (s *fileState) ListMounts() ([]MountInfo, error) {
+	return s.readAllMounts()
+}
+
+// MountExists checks if a mount exists for the given target.
+func (s *fileState) MountExists(target string) bool {
+	_, err := s.GetMount(target)
+	return err == nil
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,308 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupTestDir(t *testing.T) (string, func()) {
+	t.Helper()
+
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "wisp-state-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	cleanup := func() {
+		os.RemoveAll(tmpDir)
+	}
+
+	return tmpDir, cleanup
+}
+
+func TestNewState(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+
+	expected := filepath.Join(tmpDir, ".wispbase")
+	if s.StateDir() != expected {
+		t.Errorf("StateDir mismatch: got %s, want %s", s.StateDir(), expected)
+	}
+}
+
+func TestNewStateInHomeDir(t *testing.T) {
+	// Override HOME for this test
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	s, err := NewStateInHomeDir()
+	if err != nil {
+		t.Fatalf("NewStateInHomeDir failed: %v", err)
+	}
+
+	expected := filepath.Join(tmpDir, ".wispbase")
+	if s.StateDir() != expected {
+		t.Errorf("StateDir mismatch: got %s, want %s", s.StateDir(), expected)
+	}
+}
+
+func TestSaveAndGetMount(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+
+	info := MountInfo{
+		Source:  "/path/to/source",
+		Target:  "/path/to/target",
+		Mode:    "overlay",
+		TempDir: "/tmp/wisp-1234",
+	}
+
+	// Save mount
+	if err := s.SaveMount(info); err != nil {
+		t.Fatalf("SaveMount failed: %v", err)
+	}
+
+	// Get mount
+	retrieved, err := s.GetMount(info.Target)
+	if err != nil {
+		t.Fatalf("GetMount failed: %v", err)
+	}
+
+	if retrieved.Source != info.Source {
+		t.Errorf("Source mismatch: got %s, want %s", retrieved.Source, info.Source)
+	}
+	if retrieved.Target != info.Target {
+		t.Errorf("Target mismatch: got %s, want %s", retrieved.Target, info.Target)
+	}
+	if retrieved.Mode != info.Mode {
+		t.Errorf("Mode mismatch: got %s, want %s", retrieved.Mode, info.Mode)
+	}
+	if retrieved.TempDir != info.TempDir {
+		t.Errorf("TempDir mismatch: got %s, want %s", retrieved.TempDir, info.TempDir)
+	}
+
+	// Verify the file exists
+	mountsFile := filepath.Join(tmpDir, ".wispbase", "mounts.jsonl")
+	if _, err := os.Stat(mountsFile); os.IsNotExist(err) {
+		t.Error("mounts.jsonl file should exist after SaveMount")
+	}
+}
+
+func TestSaveMountUpdatesExisting(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+
+	info := MountInfo{
+		Source: "/path/to/source",
+		Target: "/path/to/target",
+		Mode:   "ro",
+	}
+
+	// Save mount
+	if err := s.SaveMount(info); err != nil {
+		t.Fatalf("SaveMount failed: %v", err)
+	}
+
+	// Update the mount
+	info.Mode = "rw"
+	if err := s.SaveMount(info); err != nil {
+		t.Fatalf("SaveMount (update) failed: %v", err)
+	}
+
+	// Get mount and verify update
+	retrieved, err := s.GetMount(info.Target)
+	if err != nil {
+		t.Fatalf("GetMount failed: %v", err)
+	}
+
+	if retrieved.Mode != "rw" {
+		t.Errorf("Mode should be updated to 'rw', got %s", retrieved.Mode)
+	}
+
+	// Should still only have one mount
+	mounts, err := s.ListMounts()
+	if err != nil {
+		t.Fatalf("ListMounts failed: %v", err)
+	}
+	if len(mounts) != 1 {
+		t.Errorf("expected 1 mount after update, got %d", len(mounts))
+	}
+}
+
+func TestGetMountNotFound(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+
+	_, err := s.GetMount("/nonexistent/target")
+	if err == nil {
+		t.Error("expected error for nonexistent mount, got nil")
+	}
+}
+
+func TestRemoveMount(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+
+	info := MountInfo{
+		Source: "/path/to/source",
+		Target: "/path/to/target",
+		Mode:   "ro",
+	}
+
+	// Save mount
+	if err := s.SaveMount(info); err != nil {
+		t.Fatalf("SaveMount failed: %v", err)
+	}
+
+	// Remove mount
+	if err := s.RemoveMount(info.Target); err != nil {
+		t.Fatalf("RemoveMount failed: %v", err)
+	}
+
+	// Verify it's gone
+	_, err := s.GetMount(info.Target)
+	if err == nil {
+		t.Error("expected error after removing mount, got nil")
+	}
+}
+
+func TestRemoveMountNonexistent(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+
+	// Removing nonexistent mount should not error
+	if err := s.RemoveMount("/nonexistent/target"); err != nil {
+		t.Errorf("RemoveMount of nonexistent target should not error: %v", err)
+	}
+}
+
+func TestListMounts(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+
+	// Initially empty
+	mounts, err := s.ListMounts()
+	if err != nil {
+		t.Fatalf("ListMounts failed: %v", err)
+	}
+	if len(mounts) != 0 {
+		t.Errorf("expected 0 mounts, got %d", len(mounts))
+	}
+
+	// Add some mounts
+	infos := []MountInfo{
+		{Source: "/src1", Target: "/target1", Mode: "ro"},
+		{Source: "/src2", Target: "/target2", Mode: "rw"},
+		{Source: "/src3", Target: "/target3", Mode: "overlay", TempDir: "/tmp/test"},
+	}
+
+	for _, info := range infos {
+		if err := s.SaveMount(info); err != nil {
+			t.Fatalf("SaveMount failed: %v", err)
+		}
+	}
+
+	// List should return all
+	mounts, err = s.ListMounts()
+	if err != nil {
+		t.Fatalf("ListMounts failed: %v", err)
+	}
+	if len(mounts) != 3 {
+		t.Errorf("expected 3 mounts, got %d", len(mounts))
+	}
+}
+
+func TestMountExists(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+	target := "/path/to/target"
+
+	// Should not exist initially
+	if s.MountExists(target) {
+		t.Error("mount should not exist initially")
+	}
+
+	// Save mount
+	info := MountInfo{
+		Source: "/path/to/source",
+		Target: target,
+		Mode:   "ro",
+	}
+	if err := s.SaveMount(info); err != nil {
+		t.Fatalf("SaveMount failed: %v", err)
+	}
+
+	// Should exist now
+	if !s.MountExists(target) {
+		t.Error("mount should exist after save")
+	}
+
+	// Remove mount
+	if err := s.RemoveMount(target); err != nil {
+		t.Fatalf("RemoveMount failed: %v", err)
+	}
+
+	// Should not exist after removal
+	if s.MountExists(target) {
+		t.Error("mount should not exist after removal")
+	}
+}
+
+func TestStateDir(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s := NewState(tmpDir, ".wispbase")
+
+	expected := filepath.Join(tmpDir, ".wispbase")
+	if s.StateDir() != expected {
+		t.Errorf("StateDir mismatch: got %s, want %s", s.StateDir(), expected)
+	}
+}
+
+func TestDifferentBasenames(t *testing.T) {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	s1 := NewState(tmpDir, ".wispbase")
+	s2 := NewState(tmpDir, ".wisptest")
+
+	dir1 := s1.StateDir()
+	dir2 := s2.StateDir()
+
+	if dir1 == dir2 {
+		t.Error("different basenames should produce different state directories")
+	}
+
+	expectedDir1 := filepath.Join(tmpDir, ".wispbase")
+	expectedDir2 := filepath.Join(tmpDir, ".wisptest")
+
+	if dir1 != expectedDir1 {
+		t.Errorf("dir1 mismatch: got %s, want %s", dir1, expectedDir1)
+	}
+	if dir2 != expectedDir2 {
+		t.Errorf("dir2 mismatch: got %s, want %s", dir2, expectedDir2)
+	}
+}

--- a/specs/000-v0-cli-spec.md
+++ b/specs/000-v0-cli-spec.md
@@ -106,7 +106,23 @@ The CLI must check for these dependencies at startup and display helpful error m
 
 ## State Management
 
-Active mounts are tracked in `~/.wispbase/` directory. This enables:
+Active mounts are tracked in `~/.wispbase/mounts.jsonl`. This is a JSON Lines file where each line is a mount entry serialized as JSON.
+
+**File format** (`~/.wispbase/mounts.jsonl`):
+```jsonl
+{"source":"/path/to/src1","target":"/path/to/target1","mode":"ro"}
+{"source":"/path/to/src2","target":"/path/to/target2","mode":"overlay","tempDir":"/tmp/wisp-xxxx"}
+```
+
+**Mount entry fields:**
+| Field | Required | Description |
+|-------|----------|-------------|
+| `source` | Yes | Source directory path |
+| `target` | Yes | Target mount path |
+| `mode` | Yes | Mount mode: `ro`, `rw`, or `overlay` |
+| `tempDir` | No | Temporary directory path (only for overlay mode) |
+
+This enables:
 
 - Listing active mounts
 - Proper cleanup on unmount (especially for overlay mode temp directories)

--- a/specs/000-v0-cli-spec.md
+++ b/specs/000-v0-cli-spec.md
@@ -1,0 +1,128 @@
+# Wisp v0 CLI Specification
+
+## Overview
+
+Wisp v0 provides filesystem mounting and script execution with output materialization. The v0 implementation targets macOS using bindfs and macFUSE.
+
+## Commands
+
+### `wisp v0 materialize`
+
+Runs a script and copies output files to a destination directory. This simulates a sandboxed execution model where the script runs in isolation and its outputs are "materialized" to the host.
+
+```
+wisp v0 materialize \
+    --script <path> \
+    --workdir <path> \
+    --outdir <path> \
+    --destdir <path>
+```
+
+**Arguments:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--script` | Yes | Path to the script to execute |
+| `--workdir` | Yes | Working directory for script execution |
+| `--outdir` | Yes | Directory where the script writes output files |
+| `--destdir` | Yes | Host directory where output files are copied after script completes |
+
+**Behavior:**
+
+1. Execute `script` with `workdir` as the current working directory
+2. Wait for script to complete
+3. Copy all files from `outdir` to `destdir`
+
+**Note:** In v0, there is no actual sandbox. The script runs directly on the host. Future versions may introduce real sandboxing.
+
+---
+
+### `wisp v0 mount`
+
+Mounts a source directory to a target path with specified access mode.
+
+```
+wisp v0 mount <src> <target> --mode <mode>
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `src` | Yes | Source directory to mount |
+| `target` | Yes | Target path where source will be mounted |
+| `--mode` | Yes | Access mode: `ro`, `rw`, or `overlay` |
+
+**Modes:**
+
+| Mode | Description |
+|------|-------------|
+| `ro` | Read-only access to source files |
+| `rw` | Read-write access; writes go directly to source |
+| `overlay` | Read-write access; writes do not affect source |
+
+**Implementation Details:**
+
+- `ro` and `rw` modes use bindfs directly
+- `overlay` mode:
+  1. Copies `src` to a temporary directory via rsync
+  2. Mounts the temporary directory to `target` via bindfs
+  3. Temporary directory is cleaned up on unmount
+
+---
+
+### `wisp v0 unmount`
+
+Unmounts a previously mounted target.
+
+```
+wisp v0 unmount <target>
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `target` | Yes | Target path to unmount |
+
+**Behavior:**
+
+1. Unmount the bindfs mount at `target`
+2. If the mount was in `overlay` mode, clean up the associated temporary directory
+3. Remove the mount from state tracking
+
+---
+
+## Dependencies
+
+Wisp v0 requires the following dependencies on macOS:
+
+- **macFUSE**: Provides FUSE support on macOS
+- **bindfs**: FUSE filesystem for mounting directories
+
+The CLI must check for these dependencies at startup and display helpful error messages if they are missing, including installation instructions.
+
+---
+
+## State Management
+
+Active mounts are tracked in `~/.wispbase/` directory. This enables:
+
+- Listing active mounts
+- Proper cleanup on unmount (especially for overlay mode temp directories)
+- Recovery/cleanup after unexpected termination
+
+---
+
+## Platform Support
+
+v0 targets **macOS only**. Linux and other platforms may be supported in future versions.
+
+---
+
+## Future Considerations
+
+- Actual sandboxing for `materialize` command
+- True overlayfs support for `overlay` mode (instead of rsync + bindfs)
+- Linux support
+- Mount persistence across reboots (optional)


### PR DESCRIPTION
## Summary

- Add cobra CLI framework with `wisp v0` subcommand group containing `mount`, `unmount`, and `materialize` commands
- Implement three mount modes: read-only (`ro`), read-write (`rw`), and overlay (copy-on-write with isolated writes)
- Add mount state tracking via `~/.wispbase/mounts.jsonl` with full CRUD operations
- Add dependency checking for macFUSE and bindfs on macOS with helpful installation instructions
- Implement `materialize` command to execute a script in a working directory and copy outputs to a destination
- Add comprehensive tests for mount/unmount (skipped when macFUSE/bindfs not installed) and state management
- Include v0 CLI spec document

## Test plan

- [x] Run `go test ./...` to verify all tests pass
- [x] On macOS with macFUSE and bindfs installed, manually test `wisp v0 mount` in all three modes (ro, rw, overlay)
- [x] Verify `wisp v0 unmount` cleanly removes mounts and temp directories
- [x] Test `wisp v0 materialize` with a simple script that produces output files