### PR TITLE
Add --cmd flag and improve materialize error output

### DIFF
--- a/cmd/wisp/v0.go
+++ b/cmd/wisp/v0.go
@@ -107,6 +107,9 @@ With --cmd, a bash command string is executed directly:
   wisp v0 materialize --cmd "python3 helper.py --seed 42" --workdir w --outdir o --destdir d`,
 	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
 		script, _ := cmd.Flags().GetString("script")
 		cmdStr, _ := cmd.Flags().GetString("cmd")
 		workdir, _ := cmd.Flags().GetString("workdir")
@@ -159,7 +162,6 @@ With --cmd, a bash command string is executed directly:
 		}
 
 		if err := materialize.Run(opts); err != nil {
-			fmt.Fprintln(os.Stderr, "Error:", err)
 			return err
 		}
 

--- a/cmd/wisp/v0.go
+++ b/cmd/wisp/v0.go
@@ -91,23 +91,44 @@ var unmountCmd = &cobra.Command{
 }
 
 var materializeCmd = &cobra.Command{
-	Use:   "materialize",
-	Short: "Run a script and copy output files to a destination",
-	Long: `Run a script and copy output files to a destination directory.
+	Use:   "materialize [-- script-args...]",
+	Short: "Run a script or command and copy output files to a destination",
+	Long: `Run a script or command and copy output files to a destination directory.
 
-This simulates a sandboxed execution model where the script runs in isolation
-and its outputs are "materialized" to the host.`,
+This simulates a sandboxed execution model where the script/command runs in
+isolation and its outputs are "materialized" to the host.
+
+Exactly one of --script or --cmd must be specified.
+
+With --script, any arguments after -- are forwarded to the script:
+  wisp v0 materialize --script ./foo.sh --workdir w --outdir o --destdir d -- arg1 arg2
+
+With --cmd, a bash command string is executed directly:
+  wisp v0 materialize --cmd "python3 helper.py --seed 42" --workdir w --outdir o --destdir d`,
+	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		script, _ := cmd.Flags().GetString("script")
+		cmdStr, _ := cmd.Flags().GetString("cmd")
 		workdir, _ := cmd.Flags().GetString("workdir")
 		outdir, _ := cmd.Flags().GetString("outdir")
 		destdir, _ := cmd.Flags().GetString("destdir")
 
-		// Convert to absolute paths
-		absScript, err := filepath.Abs(script)
-		if err != nil {
-			return fmt.Errorf("failed to resolve script path: %w", err)
+		// Validate mutual exclusivity
+		hasScript := script != ""
+		hasCmd := cmdStr != ""
+		if !hasScript && !hasCmd {
+			return fmt.Errorf("exactly one of --script or --cmd must be specified")
 		}
+		if hasScript && hasCmd {
+			return fmt.Errorf("--script and --cmd are mutually exclusive")
+		}
+
+		// Trailing args are only allowed with --script
+		if hasCmd && len(args) > 0 {
+			return fmt.Errorf("trailing arguments are not allowed with --cmd")
+		}
+
+		// Convert to absolute paths
 		absWorkdir, err := filepath.Abs(workdir)
 		if err != nil {
 			return fmt.Errorf("failed to resolve workdir path: %w", err)
@@ -122,10 +143,19 @@ and its outputs are "materialized" to the host.`,
 		}
 
 		opts := materialize.Options{
-			Script:  absScript,
+			Cmd:     cmdStr,
 			Workdir: absWorkdir,
 			Outdir:  absOutdir,
 			Destdir: absDestdir,
+		}
+
+		if hasScript {
+			absScript, err := filepath.Abs(script)
+			if err != nil {
+				return fmt.Errorf("failed to resolve script path: %w", err)
+			}
+			opts.Script = absScript
+			opts.ScriptArgs = args
 		}
 
 		if err := materialize.Run(opts); err != nil {
@@ -152,11 +182,11 @@ func init() {
 	mountCmd.MarkFlagRequired("mode")
 
 	// Materialize command flags
-	materializeCmd.Flags().String("script", "", "Path to the script to execute (required)")
+	materializeCmd.Flags().String("script", "", "Path to the script to execute (mutually exclusive with --cmd)")
+	materializeCmd.Flags().String("cmd", "", "Bash command string to execute (mutually exclusive with --script)")
 	materializeCmd.Flags().String("workdir", "", "Working directory for script execution (required)")
 	materializeCmd.Flags().String("outdir", "", "Directory where the script writes output files (required)")
 	materializeCmd.Flags().String("destdir", "", "Host directory where output files are copied (required)")
-	materializeCmd.MarkFlagRequired("script")
 	materializeCmd.MarkFlagRequired("workdir")
 	materializeCmd.MarkFlagRequired("outdir")
 	materializeCmd.MarkFlagRequired("destdir")

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -1,0 +1,147 @@
+package materialize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRun_ScriptNoArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	workdir := filepath.Join(tmpDir, "work")
+	outdir := filepath.Join(tmpDir, "out")
+	destdir := filepath.Join(tmpDir, "dest")
+	script := filepath.Join(tmpDir, "script.sh")
+
+	// Script writes a file to outdir
+	if err := os.WriteFile(script, []byte("#!/bin/bash\necho hello > "+outdir+"/result.txt\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := Options{
+		Script:  script,
+		Workdir: workdir,
+		Outdir:  outdir,
+		Destdir: destdir,
+	}
+
+	if err := Run(opts); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Verify output was materialized
+	data, err := os.ReadFile(filepath.Join(destdir, "result.txt"))
+	if err != nil {
+		t.Fatalf("failed to read result: %v", err)
+	}
+	if got := string(data); got != "hello\n" {
+		t.Errorf("result = %q, want %q", got, "hello\n")
+	}
+}
+
+func TestRun_ScriptWithArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	workdir := filepath.Join(tmpDir, "work")
+	outdir := filepath.Join(tmpDir, "out")
+	destdir := filepath.Join(tmpDir, "dest")
+	script := filepath.Join(tmpDir, "script.sh")
+
+	// Script writes its arguments to outdir
+	if err := os.WriteFile(script, []byte("#!/bin/bash\necho \"$@\" > "+outdir+"/args.txt\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := Options{
+		Script:     script,
+		ScriptArgs: []string{"foo", "bar", "--verbose"},
+		Workdir:    workdir,
+		Outdir:     outdir,
+		Destdir:    destdir,
+	}
+
+	if err := Run(opts); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destdir, "args.txt"))
+	if err != nil {
+		t.Fatalf("failed to read result: %v", err)
+	}
+	if got := string(data); got != "foo bar --verbose\n" {
+		t.Errorf("result = %q, want %q", got, "foo bar --verbose\n")
+	}
+}
+
+func TestRun_CmdMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	workdir := filepath.Join(tmpDir, "work")
+	outdir := filepath.Join(tmpDir, "out")
+	destdir := filepath.Join(tmpDir, "dest")
+
+	opts := Options{
+		Cmd:     "echo cmd-output > " + outdir + "/cmd-result.txt",
+		Workdir: workdir,
+		Outdir:  outdir,
+		Destdir: destdir,
+	}
+
+	if err := Run(opts); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destdir, "cmd-result.txt"))
+	if err != nil {
+		t.Fatalf("failed to read result: %v", err)
+	}
+	if got := string(data); got != "cmd-output\n" {
+		t.Errorf("result = %q, want %q", got, "cmd-output\n")
+	}
+}
+
+func TestRun_ErrorNeitherScriptNorCmd(t *testing.T) {
+	opts := Options{
+		Workdir: "/tmp",
+		Outdir:  "/tmp",
+		Destdir: "/tmp",
+	}
+	err := Run(opts)
+	if err == nil {
+		t.Fatal("expected error when neither Script nor Cmd is set")
+	}
+	want := "exactly one of Script or Cmd must be set"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRun_ErrorBothScriptAndCmd(t *testing.T) {
+	opts := Options{
+		Script:  "/bin/echo",
+		Cmd:     "echo hi",
+		Workdir: "/tmp",
+		Outdir:  "/tmp",
+		Destdir: "/tmp",
+	}
+	err := Run(opts)
+	if err == nil {
+		t.Fatal("expected error when both Script and Cmd are set")
+	}
+	want := "exactly one of Script or Cmd must be set"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRun_ScriptDoesNotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	opts := Options{
+		Script:  filepath.Join(tmpDir, "nonexistent.sh"),
+		Workdir: filepath.Join(tmpDir, "work"),
+		Outdir:  filepath.Join(tmpDir, "out"),
+		Destdir: filepath.Join(tmpDir, "dest"),
+	}
+	err := Run(opts)
+	if err == nil {
+		t.Fatal("expected error for nonexistent script")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `--cmd` flag to `wisp v0 materialize` as an alternative to `--script`, allowing inline bash command strings without a separate script file
- Support forwarding trailing arguments (after `--`) to scripts via `--script` mode
- Improve error output formatting: structured "Running script/command" headers before execution and quoted stderr on failure instead of raw streaming

## Test plan
- [x] Added unit tests for script mode (with and without args), cmd mode, and error cases
- [x] Manually verify `wisp v0 materialize --cmd "echo hello" --workdir w --outdir o --destdir d`
- [x] Manually verify `wisp v0 materialize --script ./foo.sh --workdir w --outdir o --destdir d -- arg1 arg2`
- [x] Verify mutually exclusive flag validation (both flags, neither flag)