### PR TITLE
Add top-level materialize command with sandbox package

### DIFF
--- a/cmd/wisp/materialize.go
+++ b/cmd/wisp/materialize.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gofixpoint/wisp/internal/materialize"
+	"github.com/spf13/cobra"
+)
+
+const sandboxWorkdir = "/home/wisp/workspace"
+
+// resolveSandboxOutdir resolves the outdir flag relative to the sandbox.
+//   - Empty → returns workdir (default: script CWD)
+//   - Absolute → relative to sandbox root (e.g. /output → sandboxRoot/output)
+//   - Relative → relative to workdir (e.g. out → workdir/out)
+func resolveSandboxOutdir(outdir, sandboxRoot, workdir string) string {
+	if outdir == "" {
+		return workdir
+	}
+	if filepath.IsAbs(outdir) {
+		return filepath.Join(sandboxRoot, strings.TrimPrefix(outdir, "/"))
+	}
+	return filepath.Join(workdir, outdir)
+}
+
+var topMaterializeCmd = &cobra.Command{
+	Use:   "materialize [-- script-args...]",
+	Short: "Run a script or command in a temp sandbox and copy outputs to a destination",
+	Long: `Run a script or command in an auto-created temporary sandbox and copy output
+files to a destination directory.
+
+The sandbox mimics a filesystem root with an implicit working directory at
+/home/wisp/workspace. The script/command runs with CWD set to this workdir.
+
+Exactly one of --script or --cmd must be specified.
+
+The --outdir flag controls which sandbox directory gets copied to --destdir:
+  (default)    The workdir itself (script CWD)
+  Absolute     Resolved relative to sandbox root (e.g. /output)
+  Relative     Resolved relative to workdir (e.g. out)
+
+The WISP_SANDBOX_ROOT environment variable is set for the child process,
+pointing to the sandbox root directory.
+
+Examples:
+  wisp materialize --cmd "echo hi > result.txt" --destdir /tmp/dest
+  wisp materialize --script ./gen.sh --destdir /tmp/dest -- arg1 arg2
+  wisp materialize --cmd "echo hi > $WISP_SANDBOX_ROOT/output/r.txt" --outdir /output --destdir /tmp/dest`,
+	Args: cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
+		script, _ := cmd.Flags().GetString("script")
+		cmdStr, _ := cmd.Flags().GetString("cmd")
+		outdir, _ := cmd.Flags().GetString("outdir")
+		destdir, _ := cmd.Flags().GetString("destdir")
+
+		if err := validateScriptCmdFlags(script, cmdStr, args); err != nil {
+			return err
+		}
+
+		// Create sandbox root
+		sandboxRoot, err := os.MkdirTemp("", "wisp-sandbox-*")
+		if err != nil {
+			return fmt.Errorf("failed to create sandbox: %w", err)
+		}
+		defer os.RemoveAll(sandboxRoot)
+
+		// Create workdir inside sandbox
+		workdir := filepath.Join(sandboxRoot, sandboxWorkdir[1:]) // trim leading /
+		if err := os.MkdirAll(workdir, 0755); err != nil {
+			return fmt.Errorf("failed to create sandbox workdir: %w", err)
+		}
+
+		// Resolve outdir and destdir
+		absOutdir := resolveSandboxOutdir(outdir, sandboxRoot, workdir)
+		absDestdir, err := filepath.Abs(destdir)
+		if err != nil {
+			return fmt.Errorf("failed to resolve destdir path: %w", err)
+		}
+
+		opts := materialize.Options{
+			Cmd:     cmdStr,
+			Workdir: workdir,
+			Outdir:  absOutdir,
+			Destdir: absDestdir,
+			Env:     []string{"WISP_SANDBOX_ROOT=" + sandboxRoot},
+		}
+
+		if script != "" {
+			absScript, err := filepath.Abs(script)
+			if err != nil {
+				return fmt.Errorf("failed to resolve script path: %w", err)
+			}
+			opts.Script = absScript
+			opts.ScriptArgs = args
+		}
+
+		if err := materialize.Run(opts); err != nil {
+			return err
+		}
+
+		fmt.Printf("Materialized output from %s to %s\n", absOutdir, absDestdir)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(topMaterializeCmd)
+
+	topMaterializeCmd.Flags().String("script", "", "Path to the script to execute (mutually exclusive with --cmd)")
+	topMaterializeCmd.Flags().String("cmd", "", "Bash command string to execute (mutually exclusive with --script)")
+	topMaterializeCmd.Flags().String("outdir", "", "Sandbox directory to copy from (default: workdir)")
+	topMaterializeCmd.Flags().String("destdir", "", "Host directory where output files are copied (required)")
+	topMaterializeCmd.MarkFlagRequired("destdir")
+}

--- a/cmd/wisp/materialize.go
+++ b/cmd/wisp/materialize.go
@@ -78,7 +78,7 @@ Examples:
 			return err
 		}
 
-		fmt.Printf("Materialized output from %s to %s\n", sb.GetOutdir(), absDestdir)
+		fmt.Printf("Materialized output to %s\n", absDestdir)
 		return nil
 	},
 }

--- a/cmd/wisp/materialize_test.go
+++ b/cmd/wisp/materialize_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveSandboxOutdir(t *testing.T) {
+	tests := []struct {
+		name        string
+		outdir      string
+		sandboxRoot string
+		workdir     string
+		want        string
+	}{
+		{
+			name:        "empty returns workdir",
+			outdir:      "",
+			sandboxRoot: "/tmp/wisp-sandbox-abc",
+			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
+			want:        "/tmp/wisp-sandbox-abc/home/wisp/workspace",
+		},
+		{
+			name:        "absolute path resolved relative to sandbox root",
+			outdir:      "/output",
+			sandboxRoot: "/tmp/wisp-sandbox-abc",
+			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
+			want:        "/tmp/wisp-sandbox-abc/output",
+		},
+		{
+			name:        "relative path resolved relative to workdir",
+			outdir:      "output",
+			sandboxRoot: "/tmp/wisp-sandbox-abc",
+			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
+			want:        "/tmp/wisp-sandbox-abc/home/wisp/workspace/output",
+		},
+		{
+			name:        "absolute nested path",
+			outdir:      "/var/data/out",
+			sandboxRoot: "/tmp/wisp-sandbox-abc",
+			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
+			want:        "/tmp/wisp-sandbox-abc/var/data/out",
+		},
+		{
+			name:        "relative nested path",
+			outdir:      "sub/dir",
+			sandboxRoot: "/tmp/wisp-sandbox-abc",
+			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
+			want:        "/tmp/wisp-sandbox-abc/home/wisp/workspace/sub/dir",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveSandboxOutdir(tt.outdir, tt.sandboxRoot, tt.workdir)
+			if got != tt.want {
+				t.Errorf("resolveSandboxOutdir(%q, %q, %q) = %q, want %q",
+					tt.outdir, tt.sandboxRoot, tt.workdir, got, tt.want)
+			}
+		})
+	}
+}
+
+// buildWisp builds the wisp binary for integration tests and returns its path.
+func buildWisp(t *testing.T) string {
+	t.Helper()
+	binPath := filepath.Join(t.TempDir(), "wisp")
+	cmd := exec.Command("go", "build", "-o", binPath, "./")
+	cmd.Dir = filepath.Join(findModuleRoot(t), "cmd", "wisp")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build wisp: %v\n%s", err, out)
+	}
+	return binPath
+}
+
+// findModuleRoot walks up from the test file's directory to find go.mod.
+func findModuleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find module root (go.mod)")
+		}
+		dir = parent
+	}
+}
+
+func TestTopMaterialize_CmdDefaultOutdir(t *testing.T) {
+	bin := buildWisp(t)
+	destdir := t.TempDir()
+
+	cmd := exec.Command(bin, "materialize",
+		"--cmd", "echo hello > result.txt",
+		"--destdir", destdir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wisp materialize failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destdir, "result.txt"))
+	if err != nil {
+		t.Fatalf("failed to read result: %v", err)
+	}
+	if got := string(data); got != "hello\n" {
+		t.Errorf("result = %q, want %q", got, "hello\n")
+	}
+}
+
+func TestTopMaterialize_CmdAbsoluteOutdir(t *testing.T) {
+	bin := buildWisp(t)
+	destdir := t.TempDir()
+
+	cmd := exec.Command(bin, "materialize",
+		"--cmd", `mkdir -p "$WISP_SANDBOX_ROOT/output" && echo hello > "$WISP_SANDBOX_ROOT/output/result.txt"`,
+		"--outdir", "/output",
+		"--destdir", destdir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wisp materialize failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destdir, "result.txt"))
+	if err != nil {
+		t.Fatalf("failed to read result: %v", err)
+	}
+	if got := string(data); got != "hello\n" {
+		t.Errorf("result = %q, want %q", got, "hello\n")
+	}
+}
+
+func TestTopMaterialize_CmdRelativeOutdir(t *testing.T) {
+	bin := buildWisp(t)
+	destdir := t.TempDir()
+
+	cmd := exec.Command(bin, "materialize",
+		"--cmd", "mkdir -p out && echo hello > out/result.txt",
+		"--outdir", "out",
+		"--destdir", destdir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wisp materialize failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destdir, "result.txt"))
+	if err != nil {
+		t.Fatalf("failed to read result: %v", err)
+	}
+	if got := string(data); got != "hello\n" {
+		t.Errorf("result = %q, want %q", got, "hello\n")
+	}
+}
+
+func TestTopMaterialize_SandboxCleanup(t *testing.T) {
+	bin := buildWisp(t)
+	destdir := t.TempDir()
+
+	cmd := exec.Command(bin, "materialize",
+		"--cmd", "pwd > sandbox-path.txt",
+		"--destdir", destdir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wisp materialize failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destdir, "sandbox-path.txt"))
+	if err != nil {
+		t.Fatalf("failed to read sandbox path: %v", err)
+	}
+
+	sandboxWorkdirPath := strings.TrimRight(string(data), "\n")
+
+	// The sandbox directory should have been cleaned up
+	if _, err := os.Stat(sandboxWorkdirPath); !os.IsNotExist(err) {
+		t.Errorf("sandbox workdir %q still exists after execution", sandboxWorkdirPath)
+	}
+}
+
+func TestTopMaterialize_Script(t *testing.T) {
+	bin := buildWisp(t)
+	destdir := t.TempDir()
+	scriptDir := t.TempDir()
+	script := filepath.Join(scriptDir, "gen.sh")
+
+	if err := os.WriteFile(script, []byte("#!/bin/bash\necho \"$@\" > result.txt\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin, "materialize",
+		"--script", script,
+		"--destdir", destdir,
+		"--", "foo", "bar",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wisp materialize failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destdir, "result.txt"))
+	if err != nil {
+		t.Fatalf("failed to read result: %v", err)
+	}
+	if got := string(data); got != "foo bar\n" {
+		t.Errorf("result = %q, want %q", got, "foo bar\n")
+	}
+}

--- a/cmd/wisp/materialize_test.go
+++ b/cmd/wisp/materialize_test.go
@@ -8,62 +8,6 @@ import (
 	"testing"
 )
 
-func TestResolveSandboxOutdir(t *testing.T) {
-	tests := []struct {
-		name        string
-		outdir      string
-		sandboxRoot string
-		workdir     string
-		want        string
-	}{
-		{
-			name:        "empty returns workdir",
-			outdir:      "",
-			sandboxRoot: "/tmp/wisp-sandbox-abc",
-			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
-			want:        "/tmp/wisp-sandbox-abc/home/wisp/workspace",
-		},
-		{
-			name:        "absolute path resolved relative to sandbox root",
-			outdir:      "/output",
-			sandboxRoot: "/tmp/wisp-sandbox-abc",
-			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
-			want:        "/tmp/wisp-sandbox-abc/output",
-		},
-		{
-			name:        "relative path resolved relative to workdir",
-			outdir:      "output",
-			sandboxRoot: "/tmp/wisp-sandbox-abc",
-			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
-			want:        "/tmp/wisp-sandbox-abc/home/wisp/workspace/output",
-		},
-		{
-			name:        "absolute nested path",
-			outdir:      "/var/data/out",
-			sandboxRoot: "/tmp/wisp-sandbox-abc",
-			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
-			want:        "/tmp/wisp-sandbox-abc/var/data/out",
-		},
-		{
-			name:        "relative nested path",
-			outdir:      "sub/dir",
-			sandboxRoot: "/tmp/wisp-sandbox-abc",
-			workdir:     "/tmp/wisp-sandbox-abc/home/wisp/workspace",
-			want:        "/tmp/wisp-sandbox-abc/home/wisp/workspace/sub/dir",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := resolveSandboxOutdir(tt.outdir, tt.sandboxRoot, tt.workdir)
-			if got != tt.want {
-				t.Errorf("resolveSandboxOutdir(%q, %q, %q) = %q, want %q",
-					tt.outdir, tt.sandboxRoot, tt.workdir, got, tt.want)
-			}
-		})
-	}
-}
-
 // buildWisp builds the wisp binary for integration tests and returns its path.
 func buildWisp(t *testing.T) string {
 	t.Helper()

--- a/cmd/wisp/v0_test.go
+++ b/cmd/wisp/v0_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidateScriptCmdFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		script       string
+		cmd          string
+		trailingArgs []string
+		wantErr      string
+	}{
+		{
+			name:   "script only",
+			script: "./foo.sh",
+		},
+		{
+			name: "cmd only",
+			cmd:  "echo hi",
+		},
+		{
+			name:    "neither script nor cmd",
+			wantErr: "exactly one of --script or --cmd must be specified",
+		},
+		{
+			name:    "both script and cmd",
+			script:  "./foo.sh",
+			cmd:     "echo hi",
+			wantErr: "--script and --cmd are mutually exclusive",
+		},
+		{
+			name:         "cmd with trailing args",
+			cmd:          "echo hi",
+			trailingArgs: []string{"arg1"},
+			wantErr:      "trailing arguments are not allowed with --cmd",
+		},
+		{
+			name:         "script with trailing args",
+			script:       "./foo.sh",
+			trailingArgs: []string{"arg1", "arg2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateScriptCmdFlags(tt.script, tt.cmd, tt.trailingArgs)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error %q, got nil", tt.wantErr)
+				} else if err.Error() != tt.wantErr {
+					t.Errorf("expected error %q, got %q", tt.wantErr, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -17,6 +17,7 @@ type Options struct {
 	Workdir    string   // Working directory for script execution
 	Outdir     string   // Directory where the script writes output files
 	Destdir    string   // Host directory where output files are copied
+	Env        []string // Extra environment variables (KEY=VALUE) for the child process
 }
 
 // Run executes a script or command and copies its output to the destination directory.
@@ -63,6 +64,9 @@ func Run(opts Options) error {
 	}
 
 	cmd.Dir = opts.Workdir
+	if len(opts.Env) > 0 {
+		cmd.Env = append(os.Environ(), opts.Env...)
+	}
 	cmd.Stdout = os.Stdout
 
 	var stderrBuf bytes.Buffer

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -1,0 +1,86 @@
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const sandboxWorkdir = "/home/wisp/workspace"
+
+type SandboxPaths interface {
+	GetRoot() string
+	GetWorkdir() string
+	GetOutdir() string
+	Cleanup() error
+}
+
+type tmpDirSandboxPaths struct {
+	Root    string // Path to the sandbox root directory
+	Workdir string // Path to the working directory within the sandbox
+	Outdir  string // Subdirectory for output within the sandbox
+}
+
+func (s *tmpDirSandboxPaths) GetRoot() string {
+	return s.Root
+}
+
+func (s *tmpDirSandboxPaths) GetWorkdir() string {
+	return s.Workdir
+}
+
+func (s *tmpDirSandboxPaths) GetOutdir() string {
+	return s.Outdir
+}
+
+func (s *tmpDirSandboxPaths) Cleanup() error {
+	return os.RemoveAll(s.Root)
+}
+
+func NewTmpDirSandboxPaths(workdir, outdir string) (SandboxPaths, error) {
+	root, err := os.MkdirTemp("", "wisp-sandbox-*")
+	if err != nil {
+		return nil, err
+	}
+	actualWorkdir := workdir
+	if actualWorkdir == "" {
+		actualWorkdir = sandboxWorkdir
+	}
+	resolved := resolveSandboxOutdir(root, outdir, actualWorkdir)
+	if err := os.MkdirAll(resolved.GetWorkdir(), 0755); err != nil {
+		os.RemoveAll(root) // clean up on failure
+		return nil, fmt.Errorf("failed to create sandbox workdir: %w", err)
+	}
+	return resolved, nil
+}
+
+// resolveSandboxOutdir resolves the outdir flag relative to the sandbox.
+//   - Empty → returns workdir (default: script CWD)
+//   - Absolute → relative to sandbox root (e.g. /output → sandboxRoot/output)
+//   - Relative → relative to workdir (e.g. out → workdir/out)
+//   - Any absolute outdir or workdir is forcibly nested under sandboxRoot for security
+func resolveSandboxOutdir(sandboxRoot, outdir, workdir string) SandboxPaths {
+	// Ensure workdir is always nested under sandboxRoot
+	cleanWorkdir := workdir
+	if filepath.IsAbs(workdir) {
+		cleanWorkdir = filepath.Join(sandboxRoot, strings.TrimPrefix(workdir, string(filepath.Separator)))
+	} else {
+		cleanWorkdir = filepath.Join(sandboxRoot, workdir)
+	}
+
+	var resolvedOutdir string
+	if outdir == "" {
+		resolvedOutdir = cleanWorkdir
+	} else if filepath.IsAbs(outdir) {
+		resolvedOutdir = filepath.Join(sandboxRoot, strings.TrimPrefix(outdir, string(filepath.Separator)))
+	} else {
+		resolvedOutdir = filepath.Join(cleanWorkdir, outdir)
+	}
+
+	return &tmpDirSandboxPaths{
+		Root:    sandboxRoot,
+		Workdir: cleanWorkdir,
+		Outdir:  resolvedOutdir,
+	}
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,0 +1,211 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveSandboxOutdir(t *testing.T) {
+	tests := []struct {
+		name    string
+		root    string
+		outdir  string
+		workdir string
+		wantW   string // expected workdir
+		wantO   string // expected outdir
+	}{
+		{
+			name:    "empty outdir with absolute workdir",
+			root:    "/tmp/sb",
+			outdir:  "",
+			workdir: "/home/wisp/workspace",
+			wantW:   "/tmp/sb/home/wisp/workspace",
+			wantO:   "/tmp/sb/home/wisp/workspace",
+		},
+		{
+			name:    "absolute outdir",
+			root:    "/tmp/sb",
+			outdir:  "/output",
+			workdir: "/home/wisp/workspace",
+			wantW:   "/tmp/sb/home/wisp/workspace",
+			wantO:   "/tmp/sb/output",
+		},
+		{
+			name:    "relative outdir",
+			root:    "/tmp/sb",
+			outdir:  "out",
+			workdir: "/home/wisp/workspace",
+			wantW:   "/tmp/sb/home/wisp/workspace",
+			wantO:   "/tmp/sb/home/wisp/workspace/out",
+		},
+		{
+			name:    "absolute nested outdir",
+			root:    "/tmp/sb",
+			outdir:  "/var/data/out",
+			workdir: "/home/wisp/workspace",
+			wantW:   "/tmp/sb/home/wisp/workspace",
+			wantO:   "/tmp/sb/var/data/out",
+		},
+		{
+			name:    "relative nested outdir",
+			root:    "/tmp/sb",
+			outdir:  "sub/dir",
+			workdir: "/home/wisp/workspace",
+			wantW:   "/tmp/sb/home/wisp/workspace",
+			wantO:   "/tmp/sb/home/wisp/workspace/sub/dir",
+		},
+		{
+			name:    "relative workdir nested under sandbox root",
+			root:    "/tmp/sb",
+			outdir:  "",
+			workdir: "work",
+			wantW:   "/tmp/sb/work",
+			wantO:   "/tmp/sb/work",
+		},
+		{
+			name:    "relative workdir with relative outdir",
+			root:    "/tmp/sb",
+			outdir:  "out",
+			workdir: "work",
+			wantW:   "/tmp/sb/work",
+			wantO:   "/tmp/sb/work/out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveSandboxOutdir(tt.root, tt.outdir, tt.workdir)
+			if got.GetWorkdir() != tt.wantW {
+				t.Errorf("workdir = %q, want %q", got.GetWorkdir(), tt.wantW)
+			}
+			if got.GetOutdir() != tt.wantO {
+				t.Errorf("outdir = %q, want %q", got.GetOutdir(), tt.wantO)
+			}
+			if got.GetRoot() != tt.root {
+				t.Errorf("root = %q, want %q", got.GetRoot(), tt.root)
+			}
+		})
+	}
+}
+
+func TestNewTmpDirSandboxPaths_DefaultWorkdir(t *testing.T) {
+	sb, err := NewTmpDirSandboxPaths("", "")
+	if err != nil {
+		t.Fatalf("NewTmpDirSandboxPaths failed: %v", err)
+	}
+	defer sb.Cleanup()
+
+	if !strings.HasSuffix(sb.GetWorkdir(), "/home/wisp/workspace") {
+		t.Errorf("workdir %q should end with /home/wisp/workspace", sb.GetWorkdir())
+	}
+
+	if !strings.HasPrefix(sb.GetWorkdir(), sb.GetRoot()) {
+		t.Errorf("workdir %q should be under root %q", sb.GetWorkdir(), sb.GetRoot())
+	}
+
+	// Verify workdir was created on disk
+	info, err := os.Stat(sb.GetWorkdir())
+	if err != nil {
+		t.Fatalf("workdir %q should exist on disk: %v", sb.GetWorkdir(), err)
+	}
+	if !info.IsDir() {
+		t.Errorf("workdir %q should be a directory", sb.GetWorkdir())
+	}
+
+	// Verify cleanup removes root
+	root := sb.GetRoot()
+	if err := sb.Cleanup(); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Errorf("root %q should not exist after Cleanup", root)
+	}
+}
+
+func TestNewTmpDirSandboxPaths_CustomWorkdir(t *testing.T) {
+	sb, err := NewTmpDirSandboxPaths("/custom/workdir", "")
+	if err != nil {
+		t.Fatalf("NewTmpDirSandboxPaths failed: %v", err)
+	}
+	defer sb.Cleanup()
+
+	expected := filepath.Join(sb.GetRoot(), "custom/workdir")
+	if sb.GetWorkdir() != expected {
+		t.Errorf("workdir = %q, want %q", sb.GetWorkdir(), expected)
+	}
+
+	// Verify workdir was created on disk
+	info, err := os.Stat(sb.GetWorkdir())
+	if err != nil {
+		t.Fatalf("workdir %q should exist on disk: %v", sb.GetWorkdir(), err)
+	}
+	if !info.IsDir() {
+		t.Errorf("workdir %q should be a directory", sb.GetWorkdir())
+	}
+}
+
+func TestNewTmpDirSandboxPaths_OutdirVariants(t *testing.T) {
+	t.Run("default outdir equals workdir", func(t *testing.T) {
+		sb, err := NewTmpDirSandboxPaths("", "")
+		if err != nil {
+			t.Fatalf("NewTmpDirSandboxPaths failed: %v", err)
+		}
+		defer sb.Cleanup()
+
+		if sb.GetOutdir() != sb.GetWorkdir() {
+			t.Errorf("outdir = %q, want workdir %q", sb.GetOutdir(), sb.GetWorkdir())
+		}
+	})
+
+	t.Run("absolute outdir nested under root", func(t *testing.T) {
+		sb, err := NewTmpDirSandboxPaths("", "/output")
+		if err != nil {
+			t.Fatalf("NewTmpDirSandboxPaths failed: %v", err)
+		}
+		defer sb.Cleanup()
+
+		expected := filepath.Join(sb.GetRoot(), "output")
+		if sb.GetOutdir() != expected {
+			t.Errorf("outdir = %q, want %q", sb.GetOutdir(), expected)
+		}
+	})
+
+	t.Run("relative outdir nested under workdir", func(t *testing.T) {
+		sb, err := NewTmpDirSandboxPaths("", "out")
+		if err != nil {
+			t.Fatalf("NewTmpDirSandboxPaths failed: %v", err)
+		}
+		defer sb.Cleanup()
+
+		expected := filepath.Join(sb.GetWorkdir(), "out")
+		if sb.GetOutdir() != expected {
+			t.Errorf("outdir = %q, want %q", sb.GetOutdir(), expected)
+		}
+	})
+}
+
+func TestCleanup(t *testing.T) {
+	sb, err := NewTmpDirSandboxPaths("", "")
+	if err != nil {
+		t.Fatalf("NewTmpDirSandboxPaths failed: %v", err)
+	}
+
+	root := sb.GetRoot()
+
+	// Verify root exists
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("root %q should exist: %v", root, err)
+	}
+
+	// Cleanup
+	if err := sb.Cleanup(); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+
+	// Verify root is gone
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Errorf("root %q should not exist after Cleanup", root)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `wisp materialize` top-level command that runs scripts/commands in a temp sandbox and copies outputs to a destination directory
- Extract sandbox path resolution into `internal/sandbox` package with proper workdir creation and cleanup
- Add `--cmd` flag, trailing script args, and improved error output to `wisp v0 materialize`
- Add example materialization scripts

## Test plan

- [x] `go build -o dist/wisp ./cmd/wisp` succeeds
- [x] `go test ./...` passes (unit + integration tests)
- [x] Manual smoke test: `wisp materialize --cmd "echo hi > result.txt" --destdir /tmp/dest`