### PR TITLE
Claude image presets + env variable passing

### DIFF
--- a/cmd/clawbox/materialize.go
+++ b/cmd/clawbox/materialize.go
@@ -45,6 +45,7 @@ Examples:
 		destdir, _ := cmd.Flags().GetString("destdir")
 		image, _ := cmd.Flags().GetString("image")
 		mountStrs, _ := cmd.Flags().GetStringArray("mount")
+		envStrs, _ := cmd.Flags().GetStringArray("env")
 
 		if err := validateScriptCmdFlags(script, cmdStr, args); err != nil {
 			return err
@@ -91,6 +92,11 @@ Examples:
 				vol += ":ro"
 			}
 			dockerArgs = append(dockerArgs, "-v", vol)
+		}
+
+		// Environment variables
+		for _, e := range envStrs {
+			dockerArgs = append(dockerArgs, "-e", e)
 		}
 
 		// Script auto-mount and command
@@ -149,5 +155,6 @@ func init() {
 	topMaterializeCmd.Flags().String("destdir", "", "Host directory where output files are copied (required)")
 	topMaterializeCmd.Flags().String("image", "ubuntu:latest", "Docker image to use")
 	topMaterializeCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
+	topMaterializeCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	topMaterializeCmd.MarkFlagRequired("destdir")
 }

--- a/cmd/clawbox/materialize.go
+++ b/cmd/clawbox/materialize.go
@@ -153,7 +153,7 @@ func init() {
 	topMaterializeCmd.Flags().String("cmd", "", "Bash command string to execute (mutually exclusive with --script)")
 	topMaterializeCmd.Flags().String("outdir", "", "Container directory to copy from (default: workdir)")
 	topMaterializeCmd.Flags().String("destdir", "", "Host directory where output files are copied (required)")
-	topMaterializeCmd.Flags().String("image", "ubuntu:latest", "Docker image to use")
+	topMaterializeCmd.Flags().String("image", "clawbox-claude:latest", "Docker image to use")
 	topMaterializeCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
 	topMaterializeCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	topMaterializeCmd.MarkFlagRequired("destdir")

--- a/cmd/clawbox/sandbox.go
+++ b/cmd/clawbox/sandbox.go
@@ -228,7 +228,7 @@ func init() {
 	// Create flags
 	sandboxCreateCmd.Flags().String("provider", "docker", "Sandbox provider")
 	sandboxCreateCmd.Flags().String("name", "", "Name for the sandbox (auto-generated if not set)")
-	sandboxCreateCmd.Flags().String("image", "ubuntu:latest", "Docker image to use")
+	sandboxCreateCmd.Flags().String("image", "clawbox-claude:latest", "Docker image to use")
 	sandboxCreateCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"claude\")")
 	sandboxCreateCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -2,13 +2,14 @@ package sandbox
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
 
 // CreateDockerSandbox creates a long-running Docker container with the given
 // name, image, and optional bind mounts. Returns the container ID.
-func CreateDockerSandbox(name, image string, mounts []MountBinding) (string, error) {
+func CreateDockerSandbox(name, image string, mounts []MountBinding, env []string) (string, error) {
 	args := []string{"run", "-d", "--name", name}
 	for _, m := range mounts {
 		vol := m.Source + ":" + m.Target
@@ -16,6 +17,9 @@ func CreateDockerSandbox(name, image string, mounts []MountBinding) (string, err
 			vol += ":ro"
 		}
 		args = append(args, "-v", vol)
+	}
+	for _, e := range env {
+		args = append(args, "-e", e)
 	}
 	args = append(args, image, "tail", "-f", "/dev/null")
 
@@ -25,6 +29,34 @@ func CreateDockerSandbox(name, image string, mounts []MountBinding) (string, err
 		return "", fmt.Errorf("failed to create docker sandbox: %s", strings.TrimSpace(string(out)))
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// DockerImageExists checks if a Docker image exists locally.
+func DockerImageExists(name string) bool {
+	cmd := exec.Command("docker", "image", "inspect", name)
+	return cmd.Run() == nil
+}
+
+// BuildDockerImage builds a Docker image from the given Dockerfile content.
+func BuildDockerImage(name string, dockerfile []byte) error {
+	tmpDir, err := os.MkdirTemp("", "clawbox-build-*")
+	if err != nil {
+		return fmt.Errorf("failed to create build context: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dockerfilePath := tmpDir + "/Dockerfile"
+	if err := os.WriteFile(dockerfilePath, dockerfile, 0644); err != nil {
+		return fmt.Errorf("failed to write Dockerfile: %w", err)
+	}
+
+	cmd := exec.Command("docker", "build", "-t", name, "-f", dockerfilePath, tmpDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to build image %q: %w", name, err)
+	}
+	return nil
 }
 
 // RemoveDockerSandbox stops and removes the Docker container with the given name.

--- a/internal/sandbox/presets.go
+++ b/internal/sandbox/presets.go
@@ -1,0 +1,18 @@
+package sandbox
+
+import (
+	"embed"
+	"fmt"
+)
+
+//go:embed presets/*/Dockerfile
+var presetFS embed.FS
+
+// GetPresetDockerfile returns the Dockerfile content for the given preset name.
+func GetPresetDockerfile(name string) ([]byte, error) {
+	data, err := presetFS.ReadFile("presets/" + name + "/Dockerfile")
+	if err != nil {
+		return nil, fmt.Errorf("unknown preset %q", name)
+	}
+	return data, nil
+}

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    build-essential \
+    python3 \
+    python3-pip \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 22
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI
+RUN npm install -g @anthropic-ai/claude-code

--- a/internal/sandbox/store.go
+++ b/internal/sandbox/store.go
@@ -22,7 +22,9 @@ type SandboxInfo struct {
 	ContainerID string         `json:"containerId"`
 	Image       string         `json:"image"`
 	CreatedAt   string         `json:"createdAt"`
+	Preset      string         `json:"preset,omitempty"`
 	Mounts      []MountBinding `json:"mounts,omitempty"`
+	Env         []string       `json:"env,omitempty"`
 }
 
 // SandboxStore manages sandbox state persistence.


### PR DESCRIPTION
Add --preset flag and "claude" preset for sandbox create
   Presets use embedded Dockerfiles (via Go's embed package) to build
   pre-configured container images. This approach is preferred over
   post-creation setup (docker exec) because Dockerfile layers are cached
   by Docker — the image only builds once, and subsequent sandbox
   creations are instant. It also ensures reproducible, declarative
   environments compared to imperative shell provisioning.

   The "claude" preset includes a full dev environment: Ubuntu 24.04,
   Node.js 22, Python 3, git, build-essential, and the Claude Code CLI.

   Also adds --env flag to sandbox create and materialize for passing
   environment variables (e.g. API keys) into containers.

   Usage:

     # First run builds the image (~1-2 min), then creates the container
     clawbox sandbox create --preset claude --name agent-sandbox

     # Subsequent runs use the cached image
     clawbox sandbox create --preset claude --name another-sandbox

     # Pass API key to the container
     clawbox sandbox create --preset claude --name my-sandbox \
       --env ANTHROPIC_API_KEY=...