### PR TITLE
 Add interactive TTY mode and auto-mount Claude config in materialize

### DIFF
--- a/cmd/clawbox/materialize.go
+++ b/cmd/clawbox/materialize.go
@@ -74,8 +74,8 @@ Examples:
 			}
 		}
 
-		if !interactive && destdir == "" {
-			return fmt.Errorf("--destdir is required (or use --interactive)")
+		if destdir == "" {
+			return fmt.Errorf("--destdir is required")
 		}
 
 		mounts, err := parseMountFlags(mountStrs)

--- a/cmd/clawbox/materialize.go
+++ b/cmd/clawbox/materialize.go
@@ -30,10 +30,13 @@ The --outdir flag controls which container directory gets copied to --destdir:
 Host directories can be mounted into the container using --mount:
   --mount /host/path:/container/path:ro
 
+Use --interactive (-i) to connect stdin/stdout for interactive programs like Claude:
+  clawbox materialize -i --cmd claude --mount $(pwd):/workspace
+
 Examples:
   clawbox materialize --cmd "echo hi > result.txt" --destdir /tmp/dest
   clawbox materialize --script ./hello.sh --destdir /tmp/dest
-  clawbox materialize --mount /Users/me/data:/data:ro --cmd "cp /data/file.txt ." --destdir /tmp/dest`,
+  clawbox materialize -i --cmd claude --mount $(pwd):/workspace --env ANTHROPIC_API_KEY=...`,
 	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -44,11 +47,35 @@ Examples:
 		outdir, _ := cmd.Flags().GetString("outdir")
 		destdir, _ := cmd.Flags().GetString("destdir")
 		image, _ := cmd.Flags().GetString("image")
+		preset, _ := cmd.Flags().GetString("preset")
 		mountStrs, _ := cmd.Flags().GetStringArray("mount")
 		envStrs, _ := cmd.Flags().GetStringArray("env")
+		interactive, _ := cmd.Flags().GetBool("interactive")
 
 		if err := validateScriptCmdFlags(script, cmdStr, args); err != nil {
 			return err
+		}
+
+		// Handle preset: build image if needed, override --image
+		if preset != "" {
+			if cmd.Flags().Changed("image") {
+				return fmt.Errorf("--preset and --image are mutually exclusive")
+			}
+			image = "clawbox-" + preset + ":latest"
+			if !sandbox.DockerImageExists(image) {
+				dockerfile, err := sandbox.GetPresetDockerfile(preset)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Building %q preset image (this may take a few minutes)...\n", preset)
+				if err := sandbox.BuildDockerImage(image, dockerfile); err != nil {
+					return err
+				}
+			}
+		}
+
+		if !interactive && destdir == "" {
+			return fmt.Errorf("--destdir is required (or use --interactive)")
 		}
 
 		mounts, err := parseMountFlags(mountStrs)
@@ -56,9 +83,27 @@ Examples:
 			return err
 		}
 
-		absDestdir, err := filepath.Abs(destdir)
-		if err != nil {
-			return fmt.Errorf("failed to resolve destdir path: %w", err)
+		// Auto-mount host Claude config for the claude preset
+		if preset == "claude" {
+			homeDir, err := os.UserHomeDir()
+			if err == nil {
+				claudeDir := filepath.Join(homeDir, ".claude")
+				if _, err := os.Stat(claudeDir); err == nil {
+					mounts = append(mounts, sandbox.MountBinding{
+						Source: claudeDir,
+						Target: "/root/.claude",
+						Mode:   "rw",
+					})
+					claudeJSON := filepath.Join(homeDir, ".claude.json")
+					if _, err := os.Stat(claudeJSON); err == nil {
+						mounts = append(mounts, sandbox.MountBinding{
+							Source: claudeJSON,
+							Target: "/root/.claude.json",
+							Mode:   "rw",
+						})
+					}
+				}
+			}
 		}
 
 		// Resolve outdir inside the container
@@ -72,18 +117,27 @@ Examples:
 			}
 		}
 
-		// Create host temp dir to capture outputs
-		tmpDir, err := os.MkdirTemp("", "clawbox-materialize-*")
-		if err != nil {
-			return fmt.Errorf("failed to create temp dir: %w", err)
+		// If destdir is set, create temp dir for output capture
+		var tmpDir string
+		if destdir != "" {
+			tmpDir, err = os.MkdirTemp("", "clawbox-materialize-*")
+			if err != nil {
+				return fmt.Errorf("failed to create temp dir: %w", err)
+			}
+			defer os.RemoveAll(tmpDir)
 		}
-		defer os.RemoveAll(tmpDir)
 
 		// Build docker run args
-		dockerArgs := []string{"run", "--rm", "-w", workdir}
+		dockerArgs := []string{"run", "--rm"}
+		if interactive {
+			dockerArgs = append(dockerArgs, "-it")
+		}
+		dockerArgs = append(dockerArgs, "-w", workdir)
 
-		// Mount temp dir as the outdir inside the container
-		dockerArgs = append(dockerArgs, "-v", tmpDir+":"+containerOutdir)
+		// Mount temp dir as the outdir inside the container (only if capturing output)
+		if tmpDir != "" {
+			dockerArgs = append(dockerArgs, "-v", tmpDir+":"+containerOutdir)
+		}
 
 		// User mounts
 		for _, m := range mounts {
@@ -109,39 +163,55 @@ Examples:
 			dockerArgs = append(dockerArgs, image, "/.clawbox/script")
 			dockerArgs = append(dockerArgs, args...)
 		} else {
-			dockerArgs = append(dockerArgs, image, "bash", "-c", cmdStr)
+			if interactive {
+				// In interactive mode, run the command directly (not via bash -c)
+				// so the TTY works properly with programs like claude
+				dockerArgs = append(dockerArgs, image)
+				dockerArgs = append(dockerArgs, strings.Fields(cmdStr)...)
+			} else {
+				dockerArgs = append(dockerArgs, image, "bash", "-c", cmdStr)
+			}
 		}
 
 		// Run the container
 		dockerCmd := exec.Command("docker", dockerArgs...)
 		dockerCmd.Stdout = os.Stdout
 		dockerCmd.Stderr = os.Stderr
+		if interactive {
+			dockerCmd.Stdin = os.Stdin
+		}
 
-		if script != "" {
-			cmdLine := strings.Join(append([]string{script}, args...), " ")
-			fmt.Fprintf(os.Stderr, "Running script in container:\n\n> %s\n\n", cmdLine)
-		} else {
-			fmt.Fprintf(os.Stderr, "Running command in container:\n\n> %s\n\n", cmdStr)
+		if !interactive {
+			if script != "" {
+				cmdLine := strings.Join(append([]string{script}, args...), " ")
+				fmt.Fprintf(os.Stderr, "Running script in container:\n\n> %s\n\n", cmdLine)
+			} else {
+				fmt.Fprintf(os.Stderr, "Running command in container:\n\n> %s\n\n", cmdStr)
+			}
 		}
 
 		if err := dockerCmd.Run(); err != nil {
 			return fmt.Errorf("container execution failed: %w", err)
 		}
 
-		// Create destdir if needed
-		if err := os.MkdirAll(absDestdir, 0755); err != nil {
-			return fmt.Errorf("failed to create destdir: %w", err)
+		// Rsync outputs to destdir if requested
+		if destdir != "" {
+			absDestdir, err := filepath.Abs(destdir)
+			if err != nil {
+				return fmt.Errorf("failed to resolve destdir path: %w", err)
+			}
+			if err := os.MkdirAll(absDestdir, 0755); err != nil {
+				return fmt.Errorf("failed to create destdir: %w", err)
+			}
+			rsyncCmd := exec.Command("rsync", "-a", tmpDir+"/", absDestdir+"/")
+			rsyncCmd.Stdout = os.Stdout
+			rsyncCmd.Stderr = os.Stderr
+			if err := rsyncCmd.Run(); err != nil {
+				return fmt.Errorf("failed to copy output files: %w", err)
+			}
+			fmt.Printf("Materialized output to %s\n", absDestdir)
 		}
 
-		// Rsync outputs to destdir
-		rsyncCmd := exec.Command("rsync", "-a", tmpDir+"/", absDestdir+"/")
-		rsyncCmd.Stdout = os.Stdout
-		rsyncCmd.Stderr = os.Stderr
-		if err := rsyncCmd.Run(); err != nil {
-			return fmt.Errorf("failed to copy output files: %w", err)
-		}
-
-		fmt.Printf("Materialized output to %s\n", absDestdir)
 		return nil
 	},
 }
@@ -152,9 +222,10 @@ func init() {
 	topMaterializeCmd.Flags().String("script", "", "Path to the script to execute (mutually exclusive with --cmd)")
 	topMaterializeCmd.Flags().String("cmd", "", "Bash command string to execute (mutually exclusive with --script)")
 	topMaterializeCmd.Flags().String("outdir", "", "Container directory to copy from (default: workdir)")
-	topMaterializeCmd.Flags().String("destdir", "", "Host directory where output files are copied (required)")
+	topMaterializeCmd.Flags().String("destdir", "", "Host directory where output files are copied")
 	topMaterializeCmd.Flags().String("image", "clawbox-claude:latest", "Docker image to use")
+	topMaterializeCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"claude\")")
 	topMaterializeCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
 	topMaterializeCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
-	topMaterializeCmd.MarkFlagRequired("destdir")
+	topMaterializeCmd.Flags().BoolP("interactive", "i", false, "Run interactively with TTY (for programs like claude)")
 }

--- a/cmd/clawbox/materialize_test.go
+++ b/cmd/clawbox/materialize_test.go
@@ -44,7 +44,7 @@ func TestTopMaterialize_CmdDefaultOutdir(t *testing.T) {
 	bin := buildClawbox(t)
 	destdir := t.TempDir()
 
-	cmd := exec.Command(bin, "materialize",
+	cmd := exec.Command(bin, "materialize", "--image", "ubuntu:latest",
 		"--cmd", "echo hello > result.txt",
 		"--destdir", destdir,
 	)
@@ -66,7 +66,7 @@ func TestTopMaterialize_CmdAbsoluteOutdir(t *testing.T) {
 	bin := buildClawbox(t)
 	destdir := t.TempDir()
 
-	cmd := exec.Command(bin, "materialize",
+	cmd := exec.Command(bin, "materialize", "--image", "ubuntu:latest",
 		"--cmd", `mkdir -p "$CLAWBOX_SANDBOX_ROOT/output" && echo hello > "$CLAWBOX_SANDBOX_ROOT/output/result.txt"`,
 		"--outdir", "/output",
 		"--destdir", destdir,
@@ -89,7 +89,7 @@ func TestTopMaterialize_CmdRelativeOutdir(t *testing.T) {
 	bin := buildClawbox(t)
 	destdir := t.TempDir()
 
-	cmd := exec.Command(bin, "materialize",
+	cmd := exec.Command(bin, "materialize", "--image", "ubuntu:latest",
 		"--cmd", "mkdir -p out && echo hello > out/result.txt",
 		"--outdir", "out",
 		"--destdir", destdir,
@@ -112,7 +112,7 @@ func TestTopMaterialize_SandboxCleanup(t *testing.T) {
 	bin := buildClawbox(t)
 	destdir := t.TempDir()
 
-	cmd := exec.Command(bin, "materialize",
+	cmd := exec.Command(bin, "materialize", "--image", "ubuntu:latest",
 		"--cmd", "pwd > sandbox-path.txt",
 		"--destdir", destdir,
 	)
@@ -144,7 +144,7 @@ func TestTopMaterialize_Script(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command(bin, "materialize",
+	cmd := exec.Command(bin, "materialize", "--image", "ubuntu:latest",
 		"--script", script,
 		"--destdir", destdir,
 		"--", "foo", "bar",

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -19,3 +19,4 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 
 # Install Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code
+


### PR DESCRIPTION
  Add --interactive (-i) flag to materialize that allocates a pseudo-TTY
  and connects stdin, enabling interactive programs like Claude Code to
  run inside containers with full terminal UI support. In interactive mode,
  commands run directly (not wrapped in bash -c) so TTY signals propagate
  correctly, and --destdir becomes optional since the primary use case is
  the interactive session itself rather than file output.

  When --preset=claude is used, the host's Claude configuration is
  automatically propagated into the container by bind-mounting:
    - ~/.claude/  -> /root/.claude/  (rw)
    - ~/.claude.json -> /root/.claude.json (rw) This carries over auth tokens, settings, and project memory so Claude Code inside the container works with the user's existing session without manual setup. Both mounts are read-write so config changes made inside the container (e.g. new auth tokens) persist back to the host.

  Also updates tests to explicitly pass --image ubuntu:latest since the
  default image changed to clawbox-claude:latest, and removes trailing
  newline in the Claude preset Dockerfile.