### PR TITLE
Improve Docker sandbox ergonomics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 dist/
 scratch/
-.amika/
 .DS_Store

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -9,11 +9,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/sandbox"
 	"github.com/spf13/cobra"
 )
-
-const sandboxStoreDir = ".amika"
 
 var sandboxCmd = &cobra.Command{
 	Use:   "sandbox",
@@ -71,7 +70,11 @@ var sandboxCreateCmd = &cobra.Command{
 			return err
 		}
 
-		store := sandbox.NewSandboxStore(sandboxStoreDir)
+		stateDir, err := config.StateDir()
+		if err != nil {
+			return err
+		}
+		store := sandbox.NewSandboxStore(stateDir)
 
 		// Generate a name if not provided
 		if name == "" {
@@ -134,7 +137,11 @@ var sandboxDeleteCmd = &cobra.Command{
 
 		name := args[0]
 
-		store := sandbox.NewSandboxStore(sandboxStoreDir)
+		stateDir, err := config.StateDir()
+		if err != nil {
+			return err
+		}
+		store := sandbox.NewSandboxStore(stateDir)
 
 		info, err := store.Get(name)
 		if err != nil {
@@ -160,7 +167,11 @@ var sandboxListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all sandboxes",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		store := sandbox.NewSandboxStore(sandboxStoreDir)
+		stateDir, err := config.StateDir()
+		if err != nil {
+			return err
+		}
+		store := sandbox.NewSandboxStore(stateDir)
 
 		sandboxes, err := store.List()
 		if err != nil {

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -125,13 +125,14 @@ var sandboxCreateCmd = &cobra.Command{
 }
 
 var sandboxDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   "delete <name>",
 	Short: "Delete a sandbox",
 	Long:  `Delete a sandbox and remove its backing container.`,
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		name, _ := cmd.Flags().GetString("name")
+		name := args[0]
 
 		store := sandbox.NewSandboxStore(sandboxStoreDir)
 
@@ -242,7 +243,4 @@ func init() {
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 
-	// Delete flags
-	sandboxDeleteCmd.Flags().String("name", "", "Name of the sandbox to delete (required)")
-	sandboxDeleteCmd.MarkFlagRequired("name")
 }

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -46,15 +46,23 @@ var sandboxCreateCmd = &cobra.Command{
 				return fmt.Errorf("--preset and --image are mutually exclusive")
 			}
 			image = "amika-" + preset + ":latest"
-			if !sandbox.DockerImageExists(image) {
-				dockerfile, err := sandbox.GetPresetDockerfile(preset)
-				if err != nil {
-					return err
-				}
-				fmt.Printf("Building %q preset image (this may take a few minutes)...\n", preset)
-				if err := sandbox.BuildDockerImage(image, dockerfile); err != nil {
-					return err
-				}
+		}
+
+		// If using a preset (explicit or default), auto-build the image if it
+		// doesn't exist locally. When no --preset and no --image are specified,
+		// the default image is amika-claude:latest which uses the "claude" preset.
+		buildPreset := preset
+		if buildPreset == "" && !cmd.Flags().Changed("image") {
+			buildPreset = "claude"
+		}
+		if buildPreset != "" && !sandbox.DockerImageExists(image) {
+			dockerfile, err := sandbox.GetPresetDockerfile(buildPreset)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Building %q preset image (this may take a few minutes)...\n", buildPreset)
+			if err := sandbox.BuildDockerImage(image, dockerfile); err != nil {
+				return err
 			}
 		}
 

--- a/cmd/amika/v0.go
+++ b/cmd/amika/v0.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/materialize"
 	"github.com/gofixpoint/amika/internal/mount"
 	"github.com/gofixpoint/amika/internal/state"
@@ -44,10 +45,11 @@ Modes:
 		}
 
 		// Create state manager
-		st, err := state.NewStateInHomeDir()
+		stateDir, err := config.StateDir()
 		if err != nil {
 			return err
 		}
+		st := state.NewState(stateDir)
 
 		// Perform mount
 		if err := mount.Mount(absSrc, absTarget, mode, st); err != nil {
@@ -75,10 +77,11 @@ var unmountCmd = &cobra.Command{
 		}
 
 		// Create state manager
-		st, err := state.NewStateInHomeDir()
+		stateDir, err := config.StateDir()
 		if err != nil {
 			return err
 		}
+		st := state.NewState(stateDir)
 
 		// Perform unmount
 		if err := mount.Unmount(absTarget, st); err != nil {

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -41,7 +41,7 @@ Mount a source directory to a target path with a specified access mode:
 - **`rw`**: Read-write via bindfs (writes go to source)
 - **`overlay`**: Copies source to a temp directory and mounts that; writes are isolated from the original
 
-Mount state is tracked in `~/.amikabase/mounts.jsonl`.
+Mount state is tracked in `~/.local/state/amika/mounts.jsonl` (override with `AMIKA_STATE_DIRECTORY`).
 
 ### `amika v0 unmount <target>`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// DefaultStateDir is the default state directory relative to the user's home directory.
+	DefaultStateDir = ".local/state/amika"
+
+	// EnvStateDirectory is the environment variable that overrides the default state directory.
+	EnvStateDirectory = "AMIKA_STATE_DIRECTORY"
+)
+
+// StateDir returns the resolved amika state directory path.
+// It checks AMIKA_STATE_DIRECTORY first, falling back to ~/.local/state/amika.
+func StateDir() (string, error) {
+	if dir := os.Getenv(EnvStateDirectory); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, DefaultStateDir), nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStateDir_Default(t *testing.T) {
+	// Unset the env var to test default behavior
+	orig := os.Getenv(EnvStateDirectory)
+	os.Unsetenv(EnvStateDirectory)
+	defer func() {
+		if orig != "" {
+			os.Setenv(EnvStateDirectory, orig)
+		}
+	}()
+
+	dir, err := StateDir()
+	if err != nil {
+		t.Fatalf("StateDir() error: %v", err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir() error: %v", err)
+	}
+
+	expected := filepath.Join(home, DefaultStateDir)
+	if dir != expected {
+		t.Errorf("StateDir() = %q, want %q", dir, expected)
+	}
+}
+
+func TestStateDir_EnvOverride(t *testing.T) {
+	override := "/tmp/custom-amika-state"
+
+	orig := os.Getenv(EnvStateDirectory)
+	os.Setenv(EnvStateDirectory, override)
+	defer func() {
+		if orig != "" {
+			os.Setenv(EnvStateDirectory, orig)
+		} else {
+			os.Unsetenv(EnvStateDirectory)
+		}
+	}()
+
+	dir, err := StateDir()
+	if err != nil {
+		t.Fatalf("StateDir() error: %v", err)
+	}
+
+	if dir != override {
+		t.Errorf("StateDir() = %q, want %q", dir, override)
+	}
+}

--- a/internal/mount/mount_test.go
+++ b/internal/mount/mount_test.go
@@ -43,7 +43,7 @@ func setupTestDirs(t *testing.T) (srcDir, targetDir string, st state.State, clea
 		t.Fatalf("Failed to create state directory: %v", err)
 	}
 
-	st = state.NewState(stateDir, ".amikastate")
+	st = state.NewState(stateDir)
 
 	cleanup = func() {
 		// Try to unmount if still mounted (cleanup on test failure)

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Claude Code CLI
-RUN npm install -g @anthropic-ai/claude-code
+# Install TypeScript and Claude Code CLI
+RUN npm install -g typescript tsx @anthropic-ai/claude-code
 

--- a/internal/sandbox/store.go
+++ b/internal/sandbox/store.go
@@ -36,7 +36,7 @@ type SandboxStore interface {
 }
 
 type fileSandboxStore struct {
-	dir string // e.g. ".amika"
+	dir string // the amika state directory path
 }
 
 // NewSandboxStore creates a SandboxStore backed by a JSONL file in the given directory.

--- a/internal/sandbox/store_test.go
+++ b/internal/sandbox/store_test.go
@@ -115,7 +115,7 @@ func TestSandboxStore_List(t *testing.T) {
 }
 
 func TestSandboxStore_CreatesDirectory(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "nested", ".amika")
+	dir := filepath.Join(t.TempDir(), "nested", "amika-state")
 	store := NewSandboxStore(dir)
 
 	if err := store.Save(SandboxInfo{Name: "sb1"}); err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -34,32 +34,20 @@ type State interface {
 
 // fileState implements State using a JSONL file.
 type fileState struct {
-	dirname  string // parent directory (e.g., "/Users/foo")
-	basename string // directory name (e.g., ".amikabase")
+	stateDir string // amika state directory path
 }
 
 // NewState creates a new State instance.
-// dirname is the parent directory path (e.g., "/Users/foo").
-// basename is the state directory name (e.g., ".amikabase").
-func NewState(dirname string, basename string) State {
+// stateDir is the full path to the amika state directory.
+func NewState(stateDir string) State {
 	return &fileState{
-		dirname:  dirname,
-		basename: basename,
+		stateDir: stateDir,
 	}
-}
-
-// NewStateInHomeDir creates a new State instance in ~/.amikabase.
-func NewStateInHomeDir() (State, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get home directory: %w", err)
-	}
-	return NewState(home, ".amikabase"), nil
 }
 
 // StateDir returns the path to the state directory.
 func (s *fileState) StateDir() string {
-	return filepath.Join(s.dirname, s.basename)
+	return s.stateDir
 }
 
 // mountsFilePath returns the path to the mounts.jsonl file.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -26,31 +26,11 @@ func TestNewState(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	stateDir := filepath.Join(tmpDir, "amika-state")
+	s := NewState(stateDir)
 
-	expected := filepath.Join(tmpDir, ".amikabase")
-	if s.StateDir() != expected {
-		t.Errorf("StateDir mismatch: got %s, want %s", s.StateDir(), expected)
-	}
-}
-
-func TestNewStateInHomeDir(t *testing.T) {
-	// Override HOME for this test
-	tmpDir, cleanup := setupTestDir(t)
-	defer cleanup()
-
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
-
-	s, err := NewStateInHomeDir()
-	if err != nil {
-		t.Fatalf("NewStateInHomeDir failed: %v", err)
-	}
-
-	expected := filepath.Join(tmpDir, ".amikabase")
-	if s.StateDir() != expected {
-		t.Errorf("StateDir mismatch: got %s, want %s", s.StateDir(), expected)
+	if s.StateDir() != stateDir {
+		t.Errorf("StateDir mismatch: got %s, want %s", s.StateDir(), stateDir)
 	}
 }
 
@@ -58,7 +38,8 @@ func TestSaveAndGetMount(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	stateDir := filepath.Join(tmpDir, "amika-state")
+	s := NewState(stateDir)
 
 	info := MountInfo{
 		Source:  "/path/to/source",
@@ -92,7 +73,7 @@ func TestSaveAndGetMount(t *testing.T) {
 	}
 
 	// Verify the file exists
-	mountsFile := filepath.Join(tmpDir, ".amikabase", "mounts.jsonl")
+	mountsFile := filepath.Join(stateDir, "mounts.jsonl")
 	if _, err := os.Stat(mountsFile); os.IsNotExist(err) {
 		t.Error("mounts.jsonl file should exist after SaveMount")
 	}
@@ -102,7 +83,7 @@ func TestSaveMountUpdatesExisting(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	s := NewState(tmpDir)
 
 	info := MountInfo{
 		Source: "/path/to/source",
@@ -145,7 +126,7 @@ func TestGetMountNotFound(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	s := NewState(tmpDir)
 
 	_, err := s.GetMount("/nonexistent/target")
 	if err == nil {
@@ -157,7 +138,7 @@ func TestRemoveMount(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	s := NewState(tmpDir)
 
 	info := MountInfo{
 		Source: "/path/to/source",
@@ -186,7 +167,7 @@ func TestRemoveMountNonexistent(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	s := NewState(tmpDir)
 
 	// Removing nonexistent mount should not error
 	if err := s.RemoveMount("/nonexistent/target"); err != nil {
@@ -198,7 +179,7 @@ func TestListMounts(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	s := NewState(tmpDir)
 
 	// Initially empty
 	mounts, err := s.ListMounts()
@@ -236,7 +217,7 @@ func TestMountExists(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	s := NewState(tmpDir)
 	target := "/path/to/target"
 
 	// Should not exist initially
@@ -274,35 +255,9 @@ func TestStateDir(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	s := NewState(tmpDir, ".amikabase")
+	s := NewState(tmpDir)
 
-	expected := filepath.Join(tmpDir, ".amikabase")
-	if s.StateDir() != expected {
-		t.Errorf("StateDir mismatch: got %s, want %s", s.StateDir(), expected)
-	}
-}
-
-func TestDifferentBasenames(t *testing.T) {
-	tmpDir, cleanup := setupTestDir(t)
-	defer cleanup()
-
-	s1 := NewState(tmpDir, ".amikabase")
-	s2 := NewState(tmpDir, ".amikatest")
-
-	dir1 := s1.StateDir()
-	dir2 := s2.StateDir()
-
-	if dir1 == dir2 {
-		t.Error("different basenames should produce different state directories")
-	}
-
-	expectedDir1 := filepath.Join(tmpDir, ".amikabase")
-	expectedDir2 := filepath.Join(tmpDir, ".amikatest")
-
-	if dir1 != expectedDir1 {
-		t.Errorf("dir1 mismatch: got %s, want %s", dir1, expectedDir1)
-	}
-	if dir2 != expectedDir2 {
-		t.Errorf("dir2 mismatch: got %s, want %s", dir2, expectedDir2)
+	if s.StateDir() != tmpDir {
+		t.Errorf("StateDir mismatch: got %s, want %s", s.StateDir(), tmpDir)
 	}
 }

--- a/specs/000-v0-cli-spec.md
+++ b/specs/000-v0-cli-spec.md
@@ -106,9 +106,9 @@ The CLI must check for these dependencies at startup and display helpful error m
 
 ## State Management
 
-Active mounts are tracked in `~/.amikabase/mounts.jsonl`. This is a JSON Lines file where each line is a mount entry serialized as JSON.
+Active mounts are tracked in `~/.local/state/amika/mounts.jsonl` (override with `AMIKA_STATE_DIRECTORY`). This is a JSON Lines file where each line is a mount entry serialized as JSON.
 
-**File format** (`~/.amikabase/mounts.jsonl`):
+**File format** (`~/.local/state/amika/mounts.jsonl`):
 ```jsonl
 {"source":"/path/to/src1","target":"/path/to/target1","mode":"ro"}
 {"source":"/path/to/src2","target":"/path/to/target2","mode":"overlay","tempDir":"/tmp/amika-xxxx"}


### PR DESCRIPTION
## Summary
- Auto-build the default Docker image when not explicitly specified, so sandbox create works out of the box without a prior build step
- Add TypeScript (typescript, tsx) to the Claude sandbox preset Dockerfile
- Change sandbox delete to use a positional argument instead of --name flag
- Unify all state storage under ~/.local/state/amika (configurable via AMIKA_STATE_DIRECTORY), replacing the previous .amika and .amikabase directories

## Test plan
- [x] Run go test ./... to verify all tests pass
- [x] Test amika sandbox create without a pre-built image to confirm auto-build
- [x] Test amika sandbox delete name with positional arg
- [x] Verify state files are written to ~/.local/state/amika
- [x] Verify AMIKA_STATE_DIRECTORY override works