### PR TITLE
refactor: share preset image resolution for materialize and sandbox

### DIFF
--- a/internal/sandbox/image_resolution.go
+++ b/internal/sandbox/image_resolution.go
@@ -1,0 +1,61 @@
+package sandbox
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// PresetImageOptions controls how image/preset resolution and auto-build work.
+type PresetImageOptions struct {
+	Image              string
+	Preset             string
+	ImageFlagChanged   bool
+	DefaultBuildPreset string
+}
+
+// PresetImageResult is the resolved image and preset/build metadata.
+type PresetImageResult struct {
+	Image           string
+	EffectivePreset string
+	BuildPreset     string
+}
+
+var (
+	dockerImageExistsFn             = DockerImageExists
+	getPresetDockerfileFn           = GetPresetDockerfile
+	buildDockerImageFn              = BuildDockerImage
+	buildMessageWriter    io.Writer = os.Stdout
+)
+
+// ResolveAndEnsureImage resolves image/preset behavior and auto-builds presets when needed.
+func ResolveAndEnsureImage(opts PresetImageOptions) (PresetImageResult, error) {
+	if opts.Preset != "" && opts.ImageFlagChanged {
+		return PresetImageResult{}, fmt.Errorf("--preset and --image are mutually exclusive")
+	}
+
+	result := PresetImageResult{
+		Image: opts.Image,
+	}
+
+	if opts.Preset != "" {
+		result.EffectivePreset = opts.Preset
+		result.BuildPreset = opts.Preset
+		result.Image = "amika-" + opts.Preset + ":latest"
+	} else if !opts.ImageFlagChanged && opts.DefaultBuildPreset != "" {
+		result.BuildPreset = opts.DefaultBuildPreset
+	}
+
+	if result.BuildPreset != "" && !dockerImageExistsFn(result.Image) {
+		dockerfile, err := getPresetDockerfileFn(result.BuildPreset)
+		if err != nil {
+			return PresetImageResult{}, err
+		}
+		fmt.Fprintf(buildMessageWriter, "Building %q preset image (this may take a few minutes)...\n", result.BuildPreset)
+		if err := buildDockerImageFn(result.Image, dockerfile); err != nil {
+			return PresetImageResult{}, err
+		}
+	}
+
+	return result, nil
+}

--- a/internal/sandbox/image_resolution_test.go
+++ b/internal/sandbox/image_resolution_test.go
@@ -1,0 +1,173 @@
+package sandbox
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestResolveAndEnsureImage_PresetAndImageMutuallyExclusive(t *testing.T) {
+	_, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:            "ubuntu:latest",
+		Preset:           "claude",
+		ImageFlagChanged: true,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestResolveAndEnsureImage_ExplicitPresetBuildsWhenMissing(t *testing.T) {
+	resetImageResolutionStubs(t)
+
+	var builtImage string
+	var gotBuildPreset string
+	dockerImageExistsFn = func(name string) bool { return false }
+	getPresetDockerfileFn = func(name string) ([]byte, error) {
+		gotBuildPreset = name
+		return []byte("FROM scratch"), nil
+	}
+	buildDockerImageFn = func(name string, dockerfile []byte) error {
+		builtImage = name
+		return nil
+	}
+
+	res, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:              "amika-claude:latest",
+		Preset:             "claude",
+		DefaultBuildPreset: "claude",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Image != "amika-claude:latest" {
+		t.Fatalf("image = %q, want %q", res.Image, "amika-claude:latest")
+	}
+	if res.EffectivePreset != "claude" {
+		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "claude")
+	}
+	if res.BuildPreset != "claude" {
+		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "claude")
+	}
+	if gotBuildPreset != "claude" {
+		t.Fatalf("dockerfile preset = %q, want %q", gotBuildPreset, "claude")
+	}
+	if builtImage != "amika-claude:latest" {
+		t.Fatalf("built image = %q, want %q", builtImage, "amika-claude:latest")
+	}
+}
+
+func TestResolveAndEnsureImage_DefaultBuildPresetWhenImageNotChanged(t *testing.T) {
+	resetImageResolutionStubs(t)
+
+	var built bool
+	dockerImageExistsFn = func(name string) bool { return false }
+	getPresetDockerfileFn = func(name string) ([]byte, error) {
+		return []byte("FROM scratch"), nil
+	}
+	buildDockerImageFn = func(name string, dockerfile []byte) error {
+		built = true
+		return nil
+	}
+
+	res, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:              "amika-claude:latest",
+		ImageFlagChanged:   false,
+		DefaultBuildPreset: "claude",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.BuildPreset != "claude" {
+		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "claude")
+	}
+	if !built {
+		t.Fatal("expected build to run")
+	}
+}
+
+func TestResolveAndEnsureImage_NoDefaultBuildWhenImageChanged(t *testing.T) {
+	resetImageResolutionStubs(t)
+
+	buildCalled := false
+	dockerImageExistsFn = func(name string) bool { return false }
+	getPresetDockerfileFn = func(name string) ([]byte, error) {
+		return []byte("FROM scratch"), nil
+	}
+	buildDockerImageFn = func(name string, dockerfile []byte) error {
+		buildCalled = true
+		return nil
+	}
+
+	res, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:              "ubuntu:latest",
+		ImageFlagChanged:   true,
+		DefaultBuildPreset: "claude",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.BuildPreset != "" {
+		t.Fatalf("build preset = %q, want empty", res.BuildPreset)
+	}
+	if buildCalled {
+		t.Fatal("build should not have been called")
+	}
+}
+
+func TestResolveAndEnsureImage_UnknownPreset(t *testing.T) {
+	resetImageResolutionStubs(t)
+
+	dockerImageExistsFn = func(name string) bool { return false }
+	getPresetDockerfileFn = func(name string) ([]byte, error) {
+		return nil, errors.New("unknown preset")
+	}
+
+	_, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:  "amika-claude:latest",
+		Preset: "claude",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestResolveAndEnsureImage_SkipsBuildWhenImageExists(t *testing.T) {
+	resetImageResolutionStubs(t)
+
+	buildCalled := false
+	dockerImageExistsFn = func(name string) bool { return true }
+	buildDockerImageFn = func(name string, dockerfile []byte) error {
+		buildCalled = true
+		return nil
+	}
+
+	_, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:              "amika-claude:latest",
+		ImageFlagChanged:   false,
+		DefaultBuildPreset: "claude",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buildCalled {
+		t.Fatal("build should not have been called")
+	}
+}
+
+func resetImageResolutionStubs(t *testing.T) {
+	t.Helper()
+
+	oldExists := dockerImageExistsFn
+	oldGetDockerfile := getPresetDockerfileFn
+	oldBuild := buildDockerImageFn
+	oldWriter := buildMessageWriter
+	buildMessageWriter = &bytes.Buffer{}
+
+	t.Cleanup(func() {
+		dockerImageExistsFn = oldExists
+		getPresetDockerfileFn = oldGetDockerfile
+		buildDockerImageFn = oldBuild
+		buildMessageWriter = oldWriter
+	})
+}


### PR DESCRIPTION
## Summary\n- extract image/preset resolution + auto-build logic into shared \n- use shared helper in  and Sandbox "red-dublin" created (container e3f2c16cc22b)\n- keep   auto-mount behavior explicit to \n- add unit tests for resolver behavior and edge-cases\n\n## Why\n and  had duplicated, divergent logic for preset/image handling. This change removes duplication and ensures default  behavior auto-builds the missing default image the same way as .\n\n## Verification\n- ok  	github.com/gofixpoint/amika/cmd/amika	(cached)
ok  	github.com/gofixpoint/amika/internal/config	(cached)
ok  	github.com/gofixpoint/amika/internal/deps	(cached)
ok  	github.com/gofixpoint/amika/internal/materialize	(cached)
ok  	github.com/gofixpoint/amika/internal/mount	(cached)
ok  	github.com/gofixpoint/amika/internal/sandbox	(cached)
ok  	github.com/gofixpoint/amika/internal/state	(cached)