### PR TITLE
Add pre-commit hook and setup-repo.sh for git hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build and Development Commands
 
 ```bash
+# Set up git hooks (one-time after clone)
+make setup
+
 # Run all CI checks locally (fmt, vet, lint, build, test)
 make ci
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@
 
 - Go 1.21 or later
 
+## Setup
+
+After cloning, configure git hooks:
+
+```bash
+make setup
+```
+
 ## Development
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet fmt fmtcheck lint ci
+.PHONY: build test vet fmt fmtcheck lint ci setup
 
 build:
 	go build ./...
@@ -24,3 +24,6 @@ lint:
 	go run github.com/mgechev/revive@v1.14.0 -set_exit_status -config revive.toml ./...
 
 ci: fmtcheck vet lint build test
+
+setup:
+	./setup-repo.sh

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-commit checks..."
+
+make fmtcheck
+make vet
+make lint

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+git config core.hooksPath "$REPO_ROOT/githooks"
+
+echo "Git hooks path configured to: $REPO_ROOT/githooks"


### PR DESCRIPTION
Add a githooks/ directory with a pre-commit hook that runs fmtcheck, vet, and lint on every commit. Add setup-repo.sh to configure core.hooksPath (using absolute paths for worktree compatibility) and a `make setup` target to invoke it. Document the setup step in AGENTS.md and CONTRIBUTING.md.