### PR TITLE
Add rwcopy mount mode and volume lifecycle management

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -33,6 +34,7 @@ var sandboxCreateCmd = &cobra.Command{
 		image, _ := cmd.Flags().GetString("image")
 		preset, _ := cmd.Flags().GetString("preset")
 		mountStrs, _ := cmd.Flags().GetStringArray("mount")
+		volumeStrs, _ := cmd.Flags().GetStringArray("volume")
 		envStrs, _ := cmd.Flags().GetStringArray("env")
 		yes, _ := cmd.Flags().GetBool("yes")
 
@@ -55,12 +57,24 @@ var sandboxCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		volumeMounts, err := parseVolumeFlags(volumeStrs)
+		if err != nil {
+			return err
+		}
+		if err := validateMountTargets(mounts, volumeMounts); err != nil {
+			return err
+		}
 
 		sandboxesFile, err := config.SandboxesStateFile()
 		if err != nil {
 			return err
 		}
 		store := sandbox.NewStore(sandboxesFile)
+		volumesFile, err := config.VolumesStateFile()
+		if err != nil {
+			return err
+		}
+		volumeStore := sandbox.NewVolumeStore(volumesFile)
 
 		// Generate a name if not provided
 		if name == "" {
@@ -74,10 +88,13 @@ var sandboxCreateCmd = &cobra.Command{
 			return fmt.Errorf("sandbox %q already exists", name)
 		}
 
-		if len(mounts) > 0 && !yes {
+		if (len(mounts) > 0 || len(volumeMounts) > 0) && !yes {
 			fmt.Println("You are about to mount:")
 			for _, m := range mounts {
 				fmt.Printf("  %s -> %s:%s (%s)\n", m.Source, name, m.Target, m.Mode)
+			}
+			for _, v := range volumeMounts {
+				fmt.Printf("  volume %s -> %s:%s (%s)\n", v.Volume, name, v.Target, v.Mode)
 			}
 			fmt.Print("Continue? [y/N] ")
 			reader := bufio.NewReader(os.Stdin)
@@ -89,8 +106,85 @@ var sandboxCreateCmd = &cobra.Command{
 			}
 		}
 
-		containerID, err := sandbox.CreateDockerSandbox(name, image, mounts, envStrs)
+		var runtimeMounts []sandbox.MountBinding
+		createdVolumes := make([]string, 0)
+		addedRefs := make(map[string]bool)
+		rollbackVolumeState := func() {
+			for volumeName := range addedRefs {
+				_ = volumeStore.RemoveSandboxRef(volumeName, name)
+			}
+			for _, volumeName := range createdVolumes {
+				_ = volumeStore.Remove(volumeName)
+				_ = sandbox.RemoveDockerVolume(volumeName)
+			}
+		}
+
+		for _, m := range mounts {
+			if m.Mode != "rwcopy" {
+				runtimeMounts = append(runtimeMounts, m)
+				continue
+			}
+
+			stat, err := os.Stat(m.Source)
+			if err != nil {
+				rollbackVolumeState()
+				return fmt.Errorf("rwcopy source %q is not accessible: %w", m.Source, err)
+			}
+			if !stat.IsDir() {
+				rollbackVolumeState()
+				return fmt.Errorf("rwcopy source %q must be a directory", m.Source)
+			}
+
+			volumeName := generateRWCopyVolumeName(name, m.Target)
+			if err := sandbox.CreateDockerVolume(volumeName); err != nil {
+				rollbackVolumeState()
+				return err
+			}
+			createdVolumes = append(createdVolumes, volumeName)
+
+			if err := sandbox.CopyHostDirToVolume(volumeName, m.Source); err != nil {
+				rollbackVolumeState()
+				return err
+			}
+
+			info := sandbox.VolumeInfo{
+				Name:        volumeName,
+				CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+				CreatedBy:   "rwcopy",
+				SourcePath:  m.Source,
+				SandboxRefs: []string{name},
+			}
+			if err := volumeStore.Save(info); err != nil {
+				rollbackVolumeState()
+				return fmt.Errorf("failed to save volume state for %q: %w", volumeName, err)
+			}
+			addedRefs[volumeName] = true
+
+			runtimeMounts = append(runtimeMounts, sandbox.MountBinding{
+				Type:         "volume",
+				Volume:       volumeName,
+				Target:       m.Target,
+				Mode:         "rw",
+				SnapshotFrom: m.Source,
+			})
+		}
+
+		for _, v := range volumeMounts {
+			if _, err := volumeStore.Get(v.Volume); err != nil {
+				rollbackVolumeState()
+				return fmt.Errorf("volume %q is not tracked; create via rwcopy first", v.Volume)
+			}
+			if err := volumeStore.AddSandboxRef(v.Volume, name); err != nil {
+				rollbackVolumeState()
+				return fmt.Errorf("failed to attach volume %q: %w", v.Volume, err)
+			}
+			addedRefs[v.Volume] = true
+			runtimeMounts = append(runtimeMounts, v)
+		}
+
+		containerID, err := sandbox.CreateDockerSandbox(name, image, runtimeMounts, envStrs)
 		if err != nil {
+			rollbackVolumeState()
 			return err
 		}
 
@@ -101,7 +195,7 @@ var sandboxCreateCmd = &cobra.Command{
 			Image:       image,
 			CreatedAt:   time.Now().UTC().Format(time.RFC3339),
 			Preset:      preset,
-			Mounts:      mounts,
+			Mounts:      runtimeMounts,
 			Env:         envStrs,
 		}
 		if err := store.Save(info); err != nil {
@@ -179,7 +273,7 @@ var sandboxListCmd = &cobra.Command{
 }
 
 // parseMountFlags parses --mount flag values in the format source:target[:mode].
-// Mode defaults to "rw" if omitted.
+// Mode defaults to "rwcopy" if omitted.
 func parseMountFlags(flags []string) ([]sandbox.MountBinding, error) {
 	var mounts []sandbox.MountBinding
 	seen := make(map[string]bool)
@@ -192,7 +286,7 @@ func parseMountFlags(flags []string) ([]sandbox.MountBinding, error) {
 
 		source := parts[0]
 		target := parts[1]
-		mode := "rw"
+		mode := "rwcopy"
 		if len(parts) == 3 {
 			mode = parts[2]
 		}
@@ -206,8 +300,8 @@ func parseMountFlags(flags []string) ([]sandbox.MountBinding, error) {
 			return nil, fmt.Errorf("mount target %q must be an absolute path", target)
 		}
 
-		if mode != "ro" && mode != "rw" {
-			return nil, fmt.Errorf("invalid mount mode %q: must be \"ro\" or \"rw\"", mode)
+		if mode != "ro" && mode != "rw" && mode != "rwcopy" {
+			return nil, fmt.Errorf("invalid mount mode %q: must be \"ro\", \"rw\", or \"rwcopy\"", mode)
 		}
 
 		if seen[target] {
@@ -216,12 +310,78 @@ func parseMountFlags(flags []string) ([]sandbox.MountBinding, error) {
 		seen[target] = true
 
 		mounts = append(mounts, sandbox.MountBinding{
+			Type:   "bind",
 			Source: absSource,
 			Target: target,
 			Mode:   mode,
 		})
 	}
 	return mounts, nil
+}
+
+// parseVolumeFlags parses --volume flag values in the format name:target[:mode].
+// Mode defaults to "rw" if omitted.
+func parseVolumeFlags(flags []string) ([]sandbox.MountBinding, error) {
+	var mounts []sandbox.MountBinding
+	seen := make(map[string]bool)
+
+	for _, raw := range flags {
+		parts := strings.SplitN(raw, ":", 3)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid volume format %q: expected name:target[:mode]", raw)
+		}
+
+		name := strings.TrimSpace(parts[0])
+		target := parts[1]
+		mode := "rw"
+		if len(parts) == 3 {
+			mode = parts[2]
+		}
+
+		if name == "" {
+			return nil, fmt.Errorf("volume name must not be empty in %q", raw)
+		}
+		if !strings.HasPrefix(target, "/") {
+			return nil, fmt.Errorf("mount target %q must be an absolute path", target)
+		}
+		if mode != "ro" && mode != "rw" {
+			return nil, fmt.Errorf("invalid volume mount mode %q: must be \"ro\" or \"rw\"", mode)
+		}
+		if seen[target] {
+			return nil, fmt.Errorf("duplicate mount target %q", target)
+		}
+		seen[target] = true
+
+		mounts = append(mounts, sandbox.MountBinding{
+			Type:   "volume",
+			Volume: name,
+			Target: target,
+			Mode:   mode,
+		})
+	}
+	return mounts, nil
+}
+
+func validateMountTargets(bindMounts, volumeMounts []sandbox.MountBinding) error {
+	seen := make(map[string]bool, len(bindMounts)+len(volumeMounts))
+	for _, m := range bindMounts {
+		seen[m.Target] = true
+	}
+	for _, m := range volumeMounts {
+		if seen[m.Target] {
+			return fmt.Errorf("duplicate mount target %q", m.Target)
+		}
+		seen[m.Target] = true
+	}
+	return nil
+}
+
+func generateRWCopyVolumeName(sandboxName, target string) string {
+	sanitizedTarget := strings.NewReplacer("/", "-", "_", "-", ".", "-").Replace(strings.TrimPrefix(target, "/"))
+	if sanitizedTarget == "" {
+		sanitizedTarget = "root"
+	}
+	return "amika-rwcopy-" + sandboxName + "-" + sanitizedTarget + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 }
 
 func init() {
@@ -235,7 +395,8 @@ func init() {
 	sandboxCreateCmd.Flags().String("name", "", "Name for the sandbox (auto-generated if not set)")
 	sandboxCreateCmd.Flags().String("image", "amika-claude:latest", "Docker image to use")
 	sandboxCreateCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"claude\")")
-	sandboxCreateCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
+	sandboxCreateCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rwcopy)")
+	sandboxCreateCmd.Flags().StringArray("volume", nil, "Mount an existing named volume (name:target[:mode], mode defaults to rw)")
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/gofixpoint/amika/internal/sandbox"
@@ -163,5 +165,106 @@ func TestValidateMountTargets_DuplicateAcrossMountAndVolume(t *testing.T) {
 
 	if err := validateMountTargets(bind, vol); err == nil {
 		t.Fatal("expected duplicate target error")
+	}
+}
+
+func TestCleanupSandboxVolumes_PreserveDefault(t *testing.T) {
+	dir := t.TempDir()
+	store := sandbox.NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	if err := store.Save(sandbox.VolumeInfo{Name: "vol-1", SandboxRefs: []string{"sb-1"}}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	lines, err := cleanupSandboxVolumes(store, "sb-1", false, func(string) error {
+		t.Fatal("removeVolumeFn should not be called in preserve mode")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("cleanupSandboxVolumes error: %v", err)
+	}
+	if len(lines) != 1 || lines[0] != "volume vol-1: preserved" {
+		t.Fatalf("lines = %v", lines)
+	}
+
+	info, err := store.Get("vol-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if len(info.SandboxRefs) != 0 {
+		t.Fatalf("SandboxRefs = %v, want empty", info.SandboxRefs)
+	}
+}
+
+func TestCleanupSandboxVolumes_DeleteUnused(t *testing.T) {
+	dir := t.TempDir()
+	store := sandbox.NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	if err := store.Save(sandbox.VolumeInfo{Name: "vol-1", SandboxRefs: []string{"sb-1"}}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	called := 0
+	lines, err := cleanupSandboxVolumes(store, "sb-1", true, func(name string) error {
+		called++
+		if name != "vol-1" {
+			t.Fatalf("unexpected volume: %s", name)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("cleanupSandboxVolumes error: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("removeVolumeFn called %d times, want 1", called)
+	}
+	if len(lines) != 1 || lines[0] != "volume vol-1: deleted" {
+		t.Fatalf("lines = %v", lines)
+	}
+	if _, err := store.Get("vol-1"); err == nil {
+		t.Fatal("volume state entry should be removed")
+	}
+}
+
+func TestCleanupSandboxVolumes_PreserveStillReferenced(t *testing.T) {
+	dir := t.TempDir()
+	store := sandbox.NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	if err := store.Save(sandbox.VolumeInfo{Name: "vol-1", SandboxRefs: []string{"sb-1", "sb-2"}}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	lines, err := cleanupSandboxVolumes(store, "sb-1", true, func(string) error {
+		t.Fatal("removeVolumeFn should not be called for still-referenced volume")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("cleanupSandboxVolumes error: %v", err)
+	}
+	if len(lines) != 1 || lines[0] != "volume vol-1: preserved (still referenced)" {
+		t.Fatalf("lines = %v", lines)
+	}
+
+	info, err := store.Get("vol-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if len(info.SandboxRefs) != 1 || info.SandboxRefs[0] != "sb-2" {
+		t.Fatalf("SandboxRefs = %v, want [sb-2]", info.SandboxRefs)
+	}
+}
+
+func TestCleanupSandboxVolumes_DeleteFailureReported(t *testing.T) {
+	dir := t.TempDir()
+	store := sandbox.NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	if err := store.Save(sandbox.VolumeInfo{Name: "vol-1", SandboxRefs: []string{"sb-1"}}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	lines, err := cleanupSandboxVolumes(store, "sb-1", true, func(string) error {
+		return fmt.Errorf("boom")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(lines) != 1 || lines[0] != "volume vol-1: delete-failed: boom" {
+		t.Fatalf("lines = %v", lines)
 	}
 }

--- a/cmd/amika/volume.go
+++ b/cmd/amika/volume.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/gofixpoint/amika/internal/config"
+	"github.com/gofixpoint/amika/internal/sandbox"
+	"github.com/spf13/cobra"
+)
+
+var volumeCmd = &cobra.Command{
+	Use:   "volume",
+	Short: "Manage tracked sandbox volumes",
+}
+
+var volumeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List tracked volumes",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		volumesFile, err := config.VolumesStateFile()
+		if err != nil {
+			return err
+		}
+		store := sandbox.NewVolumeStore(volumesFile)
+
+		volumes, err := store.List()
+		if err != nil {
+			return err
+		}
+		if len(volumes) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No volumes found.")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tCREATED\tIN_USE\tSANDBOXES\tSOURCE")
+		for _, v := range volumes {
+			inUse := "no"
+			if len(v.SandboxRefs) > 0 {
+				inUse = "yes"
+			}
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\n",
+				v.Name,
+				v.CreatedAt,
+				inUse,
+				strings.Join(v.SandboxRefs, ","),
+				v.SourcePath,
+			)
+		}
+		w.Flush()
+		return nil
+	},
+}
+
+var volumeDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a tracked volume",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		force, _ := cmd.Flags().GetBool("force")
+
+		volumesFile, err := config.VolumesStateFile()
+		if err != nil {
+			return err
+		}
+		store := sandbox.NewVolumeStore(volumesFile)
+		if err := deleteTrackedVolume(store, name, force, sandbox.RemoveDockerVolume); err != nil {
+			return err
+		}
+		fmt.Printf("Volume %q deleted\n", name)
+		return nil
+	},
+}
+
+func deleteTrackedVolume(
+	store sandbox.VolumeStore,
+	name string,
+	force bool,
+	removeVolumeFn func(string) error,
+) error {
+	volume, err := store.Get(name)
+	if err != nil {
+		return err
+	}
+
+	if len(volume.SandboxRefs) > 0 && !force {
+		return fmt.Errorf("volume %q is in use by sandboxes: %s (use --force to delete)", name, strings.Join(volume.SandboxRefs, ", "))
+	}
+
+	if err := removeVolumeFn(name); err != nil {
+		return err
+	}
+	if err := store.Remove(name); err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(volumeCmd)
+	volumeCmd.AddCommand(volumeListCmd)
+	volumeCmd.AddCommand(volumeDeleteCmd)
+	volumeDeleteCmd.Flags().Bool("force", false, "Delete volume even if referenced by sandboxes")
+}

--- a/cmd/amika/volume_test.go
+++ b/cmd/amika/volume_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/amika/internal/sandbox"
+)
+
+func TestDeleteTrackedVolume_InUseRequiresForce(t *testing.T) {
+	store := sandbox.NewVolumeStore(filepath.Join(t.TempDir(), "volumes.jsonl"))
+	if err := store.Save(sandbox.VolumeInfo{Name: "vol-1", SandboxRefs: []string{"sb-a"}}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	err := deleteTrackedVolume(store, "vol-1", false, func(string) error { return nil })
+	if err == nil {
+		t.Fatal("expected in-use error")
+	}
+	if !strings.Contains(err.Error(), "use --force") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteTrackedVolume_ForceDeletes(t *testing.T) {
+	store := sandbox.NewVolumeStore(filepath.Join(t.TempDir(), "volumes.jsonl"))
+	if err := store.Save(sandbox.VolumeInfo{Name: "vol-1", SandboxRefs: []string{"sb-a"}}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	called := 0
+	err := deleteTrackedVolume(store, "vol-1", true, func(name string) error {
+		called++
+		if name != "vol-1" {
+			t.Fatalf("unexpected volume name: %s", name)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("deleteTrackedVolume failed: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("removeVolumeFn called %d times, want 1", called)
+	}
+	if _, err := store.Get("vol-1"); err == nil {
+		t.Fatal("volume should be removed from state")
+	}
+}
+
+func TestVolumeListCmd_PrintsTrackedVolumes(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+
+	store := sandbox.NewVolumeStore(filepath.Join(stateDir, "volumes.jsonl"))
+	_ = store.Save(sandbox.VolumeInfo{
+		Name:       "vol-1",
+		CreatedAt:  "2026-01-02T00:00:00Z",
+		SourcePath: "/host/data",
+		SandboxRefs: []string{
+			"sb-a",
+		},
+	})
+
+	buf := &bytes.Buffer{}
+	volumeListCmd.SetOut(buf)
+	volumeListCmd.SetErr(buf)
+
+	if err := volumeListCmd.RunE(volumeListCmd, nil); err != nil {
+		t.Fatalf("volume list failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "vol-1") {
+		t.Fatalf("expected volume name in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "yes") {
+		t.Fatalf("expected in-use marker in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "sb-a") {
+		t.Fatalf("expected sandbox refs in output, got:\n%s", out)
+	}
+}

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -16,8 +16,10 @@ Amika does not use a legacy `~/.amika` fallback for these files.
 
 - `mounts.jsonl`: `${XDG_STATE_HOME:-~/.local/state}/amika/mounts.jsonl`
 - `sandboxes.jsonl`: `${XDG_STATE_HOME:-~/.local/state}/amika/sandboxes.jsonl`
+- `volumes.jsonl`: `${XDG_STATE_HOME:-~/.local/state}/amika/volumes.jsonl`
 
 If `AMIKA_STATE_DIRECTORY` is set, state files are stored there instead:
 
 - `${AMIKA_STATE_DIRECTORY}/mounts.jsonl`
 - `${AMIKA_STATE_DIRECTORY}/sandboxes.jsonl`
+- `${AMIKA_STATE_DIRECTORY}/volumes.jsonl`

--- a/internal/basedir/basedir.go
+++ b/internal/basedir/basedir.go
@@ -14,6 +14,7 @@ const (
 	oauthFile        = "oauth.json"
 	mountsStateFile  = "mounts.jsonl"
 	sandboxesFile    = "sandboxes.jsonl"
+	volumesStateFile = "volumes.jsonl"
 	envXDGConfigHome = "XDG_CONFIG_HOME"
 	envXDGDataHome   = "XDG_DATA_HOME"
 	envXDGCacheHome  = "XDG_CACHE_HOME"
@@ -38,6 +39,7 @@ type Paths interface {
 	AuthOAuthFile() (string, error)
 	MountsStateFile() (string, error)
 	SandboxesStateFile() (string, error)
+	VolumesStateFile() (string, error)
 }
 
 type xdgPaths struct {
@@ -177,6 +179,14 @@ func (p *xdgPaths) SandboxesStateFile() (string, error) {
 	return SandboxesStateFileIn(dir), nil
 }
 
+func (p *xdgPaths) VolumesStateFile() (string, error) {
+	dir, err := p.AmikaStateDir()
+	if err != nil {
+		return "", err
+	}
+	return VolumesStateFileIn(dir), nil
+}
+
 // MountsStateFileIn returns the mounts state file path under the given state directory.
 func MountsStateFileIn(stateDir string) string {
 	return filepath.Join(stateDir, mountsStateFile)
@@ -185,4 +195,9 @@ func MountsStateFileIn(stateDir string) string {
 // SandboxesStateFileIn returns the sandboxes state file path under the given state directory.
 func SandboxesStateFileIn(stateDir string) string {
 	return filepath.Join(stateDir, sandboxesFile)
+}
+
+// VolumesStateFileIn returns the volumes state file path under the given state directory.
+func VolumesStateFileIn(stateDir string) string {
+	return filepath.Join(stateDir, volumesStateFile)
 }

--- a/internal/basedir/basedir_test.go
+++ b/internal/basedir/basedir_test.go
@@ -66,6 +66,9 @@ func TestPaths_XDGOverrides(t *testing.T) {
 	if got, _ := p.SandboxesStateFile(); got != filepath.Join(state, "amika", "sandboxes.jsonl") {
 		t.Fatalf("SandboxesStateFile = %q", got)
 	}
+	if got, _ := p.VolumesStateFile(); got != filepath.Join(state, "amika", "volumes.jsonl") {
+		t.Fatalf("VolumesStateFile = %q", got)
+	}
 }
 
 func TestStateFileHelpers(t *testing.T) {
@@ -76,6 +79,9 @@ func TestStateFileHelpers(t *testing.T) {
 	}
 	if got := SandboxesStateFileIn(stateDir); got != filepath.Join(stateDir, "sandboxes.jsonl") {
 		t.Fatalf("SandboxesStateFileIn = %q", got)
+	}
+	if got := VolumesStateFileIn(stateDir); got != filepath.Join(stateDir, "volumes.jsonl") {
+		t.Fatalf("VolumesStateFileIn = %q", got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,3 +37,11 @@ func SandboxesStateFile() (string, error) {
 	}
 	return basedir.New("").SandboxesStateFile()
 }
+
+// VolumesStateFile returns the resolved volumes state file path.
+func VolumesStateFile() (string, error) {
+	if dir := os.Getenv(EnvStateDirectory); dir != "" {
+		return basedir.VolumesStateFileIn(dir), nil
+	}
+	return basedir.New("").VolumesStateFile()
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -174,3 +174,48 @@ func TestSandboxesStateFile_EnvOverride(t *testing.T) {
 		t.Errorf("SandboxesStateFile() = %q, want %q", got, want)
 	}
 }
+
+func TestVolumesStateFile_Default(t *testing.T) {
+	orig := os.Getenv(EnvStateDirectory)
+	_ = os.Unsetenv(EnvStateDirectory)
+	defer func() {
+		if orig != "" {
+			_ = os.Setenv(EnvStateDirectory, orig)
+		}
+	}()
+
+	got, err := VolumesStateFile()
+	if err != nil {
+		t.Fatalf("VolumesStateFile() error: %v", err)
+	}
+
+	want, err := basedir.New("").VolumesStateFile()
+	if err != nil {
+		t.Fatalf("basedir VolumesStateFile() error: %v", err)
+	}
+	if got != want {
+		t.Errorf("VolumesStateFile() = %q, want %q", got, want)
+	}
+}
+
+func TestVolumesStateFile_EnvOverride(t *testing.T) {
+	override := t.TempDir()
+	orig := os.Getenv(EnvStateDirectory)
+	_ = os.Setenv(EnvStateDirectory, override)
+	defer func() {
+		if orig != "" {
+			_ = os.Setenv(EnvStateDirectory, orig)
+		} else {
+			_ = os.Unsetenv(EnvStateDirectory)
+		}
+	}()
+
+	got, err := VolumesStateFile()
+	if err != nil {
+		t.Fatalf("VolumesStateFile() error: %v", err)
+	}
+	want := basedir.VolumesStateFileIn(override)
+	if got != want {
+		t.Errorf("VolumesStateFile() = %q, want %q", got, want)
+	}
+}

--- a/internal/sandbox/docker_test.go
+++ b/internal/sandbox/docker_test.go
@@ -1,0 +1,39 @@
+package sandbox
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildDockerRunArgs_MixedMounts(t *testing.T) {
+	mounts := []MountBinding{
+		{Type: "bind", Source: "/host/src", Target: "/workspace/src", Mode: "ro"},
+		{Type: "volume", Volume: "amika-vol-1", Target: "/workspace/cache", Mode: "rw"},
+	}
+	env := []string{"A=1", "B=2"}
+
+	got := buildDockerRunArgs("sb1", "ubuntu:latest", mounts, env)
+	want := []string{
+		"run", "-d", "--name", "sb1",
+		"-v", "/host/src:/workspace/src:ro",
+		"-v", "amika-vol-1:/workspace/cache",
+		"-e", "A=1",
+		"-e", "B=2",
+		"ubuntu:latest", "tail", "-f", "/dev/null",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestMountVolumeSpec_EmptyIgnored(t *testing.T) {
+	tests := []MountBinding{
+		{Type: "bind", Target: "/x"},
+		{Type: "volume", Volume: "vol", Target: ""},
+	}
+	for _, tt := range tests {
+		if got := mountVolumeSpec(tt); got != "" {
+			t.Fatalf("mountVolumeSpec(%+v) = %q, want empty", tt, got)
+		}
+	}
+}

--- a/internal/sandbox/volume_store.go
+++ b/internal/sandbox/volume_store.go
@@ -11,10 +11,10 @@ import (
 
 // VolumeInfo represents a tracked docker volume.
 type VolumeInfo struct {
-	Name       string   `json:"name"`
-	CreatedAt  string   `json:"createdAt"`
-	CreatedBy  string   `json:"createdBy,omitempty"`
-	SourcePath string   `json:"sourcePath,omitempty"`
+	Name        string   `json:"name"`
+	CreatedAt   string   `json:"createdAt"`
+	CreatedBy   string   `json:"createdBy,omitempty"`
+	SourcePath  string   `json:"sourcePath,omitempty"`
 	SandboxRefs []string `json:"sandboxRefs,omitempty"`
 }
 

--- a/internal/sandbox/volume_store.go
+++ b/internal/sandbox/volume_store.go
@@ -1,0 +1,206 @@
+package sandbox
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+// VolumeInfo represents a tracked docker volume.
+type VolumeInfo struct {
+	Name       string   `json:"name"`
+	CreatedAt  string   `json:"createdAt"`
+	CreatedBy  string   `json:"createdBy,omitempty"`
+	SourcePath string   `json:"sourcePath,omitempty"`
+	SandboxRefs []string `json:"sandboxRefs,omitempty"`
+}
+
+// VolumeStore manages volume state persistence.
+type VolumeStore interface {
+	Save(info VolumeInfo) error
+	Get(name string) (VolumeInfo, error)
+	Remove(name string) error
+	List() ([]VolumeInfo, error)
+	AddSandboxRef(name, sandbox string) error
+	RemoveSandboxRef(name, sandbox string) error
+	VolumesForSandbox(sandbox string) ([]VolumeInfo, error)
+	IsInUse(name string) (bool, error)
+}
+
+type fileVolumeStore struct {
+	filePath string
+}
+
+// NewVolumeStore creates a VolumeStore backed by the provided volumes JSONL file path.
+func NewVolumeStore(filePath string) VolumeStore {
+	return &fileVolumeStore{filePath: filePath}
+}
+
+func (s *fileVolumeStore) readAll() ([]VolumeInfo, error) {
+	f, err := os.Open(s.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open volumes file: %w", err)
+	}
+	defer f.Close()
+
+	var volumes []VolumeInfo
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var info VolumeInfo
+		if err := json.Unmarshal([]byte(line), &info); err != nil {
+			continue
+		}
+		volumes = append(volumes, info)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read volumes file: %w", err)
+	}
+	return volumes, nil
+}
+
+func (s *fileVolumeStore) writeAll(volumes []VolumeInfo) error {
+	if err := os.MkdirAll(filepath.Dir(s.filePath), 0755); err != nil {
+		return fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	f, err := os.Create(s.filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create volumes file: %w", err)
+	}
+	defer f.Close()
+
+	for _, info := range volumes {
+		data, err := json.Marshal(info)
+		if err != nil {
+			return fmt.Errorf("failed to marshal volume info: %w", err)
+		}
+		if _, err := f.Write(data); err != nil {
+			return fmt.Errorf("failed to write volume info: %w", err)
+		}
+		if _, err := f.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write newline: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *fileVolumeStore) Save(info VolumeInfo) error {
+	volumes, err := s.readAll()
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i := range volumes {
+		if volumes[i].Name == info.Name {
+			volumes[i] = info
+			found = true
+			break
+		}
+	}
+	if !found {
+		volumes = append(volumes, info)
+	}
+
+	return s.writeAll(volumes)
+}
+
+func (s *fileVolumeStore) Get(name string) (VolumeInfo, error) {
+	volumes, err := s.readAll()
+	if err != nil {
+		return VolumeInfo{}, err
+	}
+
+	for _, v := range volumes {
+		if v.Name == name {
+			return v, nil
+		}
+	}
+	return VolumeInfo{}, fmt.Errorf("no volume found with name: %s", name)
+}
+
+func (s *fileVolumeStore) Remove(name string) error {
+	volumes, err := s.readAll()
+	if err != nil {
+		return err
+	}
+
+	var filtered []VolumeInfo
+	for _, v := range volumes {
+		if v.Name != name {
+			filtered = append(filtered, v)
+		}
+	}
+
+	if len(filtered) == len(volumes) {
+		return nil
+	}
+
+	return s.writeAll(filtered)
+}
+
+func (s *fileVolumeStore) List() ([]VolumeInfo, error) {
+	return s.readAll()
+}
+
+func (s *fileVolumeStore) AddSandboxRef(name, sandbox string) error {
+	info, err := s.Get(name)
+	if err != nil {
+		return err
+	}
+
+	if !slices.Contains(info.SandboxRefs, sandbox) {
+		info.SandboxRefs = append(info.SandboxRefs, sandbox)
+	}
+	return s.Save(info)
+}
+
+func (s *fileVolumeStore) RemoveSandboxRef(name, sandbox string) error {
+	info, err := s.Get(name)
+	if err != nil {
+		return err
+	}
+
+	refs := info.SandboxRefs[:0]
+	for _, ref := range info.SandboxRefs {
+		if ref != sandbox {
+			refs = append(refs, ref)
+		}
+	}
+	info.SandboxRefs = refs
+	return s.Save(info)
+}
+
+func (s *fileVolumeStore) VolumesForSandbox(sandbox string) ([]VolumeInfo, error) {
+	volumes, err := s.readAll()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []VolumeInfo
+	for _, v := range volumes {
+		if slices.Contains(v.SandboxRefs, sandbox) {
+			result = append(result, v)
+		}
+	}
+	return result, nil
+}
+
+func (s *fileVolumeStore) IsInUse(name string) (bool, error) {
+	info, err := s.Get(name)
+	if err != nil {
+		return false, err
+	}
+	return len(info.SandboxRefs) > 0, nil
+}

--- a/internal/sandbox/volume_store_test.go
+++ b/internal/sandbox/volume_store_test.go
@@ -1,0 +1,144 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVolumeStore_SaveAndGet(t *testing.T) {
+	dir := t.TempDir()
+	store := NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+
+	info := VolumeInfo{
+		Name:       "vol-1",
+		CreatedAt:  "2026-01-01T00:00:00Z",
+		CreatedBy:  "rwcopy",
+		SourcePath: "/host/data",
+	}
+	if err := store.Save(info); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	got, err := store.Get("vol-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.Name != "vol-1" {
+		t.Fatalf("Name = %q, want %q", got.Name, "vol-1")
+	}
+	if got.SourcePath != "/host/data" {
+		t.Fatalf("SourcePath = %q, want %q", got.SourcePath, "/host/data")
+	}
+}
+
+func TestVolumeStore_SaveReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	store := NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+
+	_ = store.Save(VolumeInfo{Name: "vol-1", CreatedBy: "rwcopy"})
+	_ = store.Save(VolumeInfo{Name: "vol-1", CreatedBy: "manual-attach"})
+
+	got, err := store.Get("vol-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.CreatedBy != "manual-attach" {
+		t.Fatalf("CreatedBy = %q, want %q", got.CreatedBy, "manual-attach")
+	}
+}
+
+func TestVolumeStore_Remove(t *testing.T) {
+	dir := t.TempDir()
+	store := NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+
+	_ = store.Save(VolumeInfo{Name: "vol-1"})
+	_ = store.Save(VolumeInfo{Name: "vol-2"})
+
+	if err := store.Remove("vol-1"); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if _, err := store.Get("vol-1"); err == nil {
+		t.Fatal("expected not found after remove")
+	}
+	if _, err := store.Get("vol-2"); err != nil {
+		t.Fatalf("vol-2 should still exist: %v", err)
+	}
+}
+
+func TestVolumeStore_AddRemoveSandboxRef(t *testing.T) {
+	dir := t.TempDir()
+	store := NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+
+	_ = store.Save(VolumeInfo{Name: "vol-1"})
+
+	if err := store.AddSandboxRef("vol-1", "sb-a"); err != nil {
+		t.Fatalf("AddSandboxRef failed: %v", err)
+	}
+	if err := store.AddSandboxRef("vol-1", "sb-a"); err != nil {
+		t.Fatalf("AddSandboxRef duplicate failed: %v", err)
+	}
+
+	got, err := store.Get("vol-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if len(got.SandboxRefs) != 1 || got.SandboxRefs[0] != "sb-a" {
+		t.Fatalf("SandboxRefs = %v, want [sb-a]", got.SandboxRefs)
+	}
+
+	if err := store.RemoveSandboxRef("vol-1", "sb-a"); err != nil {
+		t.Fatalf("RemoveSandboxRef failed: %v", err)
+	}
+
+	got, _ = store.Get("vol-1")
+	if len(got.SandboxRefs) != 0 {
+		t.Fatalf("SandboxRefs = %v, want empty", got.SandboxRefs)
+	}
+}
+
+func TestVolumeStore_VolumesForSandboxAndInUse(t *testing.T) {
+	dir := t.TempDir()
+	store := NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+
+	_ = store.Save(VolumeInfo{Name: "vol-1", SandboxRefs: []string{"sb-a", "sb-b"}})
+	_ = store.Save(VolumeInfo{Name: "vol-2", SandboxRefs: []string{"sb-b"}})
+	_ = store.Save(VolumeInfo{Name: "vol-3"})
+
+	got, err := store.VolumesForSandbox("sb-a")
+	if err != nil {
+		t.Fatalf("VolumesForSandbox failed: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "vol-1" {
+		t.Fatalf("VolumesForSandbox(sb-a) = %+v, want vol-1", got)
+	}
+
+	inUse, err := store.IsInUse("vol-2")
+	if err != nil {
+		t.Fatalf("IsInUse failed: %v", err)
+	}
+	if !inUse {
+		t.Fatal("vol-2 should be in use")
+	}
+
+	inUse, err = store.IsInUse("vol-3")
+	if err != nil {
+		t.Fatalf("IsInUse failed: %v", err)
+	}
+	if inUse {
+		t.Fatal("vol-3 should not be in use")
+	}
+}
+
+func TestVolumeStore_CreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "amika-state")
+	store := NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+
+	if err := store.Save(VolumeInfo{Name: "vol-1"}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("directory should have been created: %v", err)
+	}
+}

--- a/specs/002-sandbox-rwcopy-volume-management.md
+++ b/specs/002-sandbox-rwcopy-volume-management.md
@@ -1,0 +1,250 @@
+# Sandbox `rwcopy` and Volume Management Spec
+
+## Overview
+
+This spec defines a new `rwcopy` mode for `amika sandbox create` and introduces first-class volume lifecycle management in Amika state and CLI.
+
+`rwcopy` provides a read-write filesystem view in the sandbox by snapshot-copying a host directory into a Docker volume at sandbox creation time. Changes inside the sandbox do not sync back to host files.
+
+This spec also adds tracked volume operations (`list`, `delete`) and updates sandbox deletion behavior to preserve or delete associated volumes based on an explicit flag.
+
+## Goals
+
+1. Add `rwcopy` as a supported sandbox mount mode.
+2. Make `rwcopy` the default mode when `--mount` mode is omitted.
+3. Store and manage volume metadata separately from sandbox metadata.
+4. Support re-attaching existing tracked volumes to new sandboxes.
+5. Add safe volume lifecycle commands with in-use protection.
+6. Keep behavior backward-compatible for existing sandbox state entries.
+
+## Non-Goals
+
+1. Exposing a public `amika volume create` command.
+2. Continuous sync between host and sandbox for `rwcopy`.
+3. Remote/container-provider support beyond Docker in this iteration.
+
+## CLI Changes
+
+### `amika sandbox create`
+
+#### Existing Flag
+
+- `--mount source:target[:mode]`
+- Supported modes become: `ro`, `rw`, `rwcopy`
+- **Default mode changes from `rw` to `rwcopy`** when `:mode` is omitted
+
+#### New Flag
+
+- `--volume name:target[:mode]`
+- Attaches an existing tracked Docker volume by name
+- Supported modes: `rw` (default), `ro`
+
+#### Validation Rules
+
+1. `target` must be absolute.
+2. Mount targets must be unique across both `--mount` and `--volume`.
+3. `rwcopy` source must exist and be a directory.
+4. Volume name for `--volume` must exist in tracked volume state (and preferably in Docker).
+
+### `amika sandbox delete <name>`
+
+#### New Flag
+
+- `--delete-volumes` (default: `false`)
+
+#### Behavior
+
+1. Remove container as today.
+2. Resolve associated volumes via volume state references.
+3. If `--delete-volumes=false`: preserve volumes, remove sandbox references.
+4. If `--delete-volumes=true`: attempt to delete associated volumes, remove references.
+5. Always print associated volumes and status (`deleted`, `preserved`, `delete-failed`).
+
+### New Top-Level Command: `amika volume`
+
+#### `amika volume list`
+
+Print tracked volumes with:
+
+- name
+- created timestamp
+- source/provenance (if available)
+- in-use status
+- associated sandbox names
+
+#### `amika volume delete <name>`
+
+- Default: fail if volume is referenced by one or more sandboxes.
+- `--force`: allow deletion even if in use.
+- On success: remove Docker volume and remove state entry.
+
+## Data Model and State
+
+### New State File
+
+- `volumes.jsonl` in same state dir as `sandboxes.jsonl`
+- Path:
+  - `${XDG_STATE_HOME:-~/.local/state}/amika/volumes.jsonl`
+  - or `${AMIKA_STATE_DIRECTORY}/volumes.jsonl`
+
+### Volume State Entry
+
+Each line stores one volume record, including:
+
+- `name`
+- `createdAt`
+- `createdBy` (e.g., `rwcopy`, `manual-attach`)
+- `sourcePath` (optional, for rwcopy provenance)
+- `sandboxRefs` (`[]string`)
+- optional attach/update timestamps
+
+### Sandbox State (`sandboxes.jsonl`)
+
+Extend mount representation to support both:
+
+- bind mounts (host path source)
+- volume mounts (volume name source)
+
+Use explicit mount type to avoid ambiguity in mixed configurations.
+
+Backward compatibility:
+
+- Existing entries without new fields must continue to parse.
+
+## Runtime Semantics
+
+### `rwcopy` Creation Flow
+
+For each `--mount <source>:<target>:rwcopy` (or omitted mode):
+
+1. Create auto-generated Docker volume name.
+2. Snapshot-copy host directory content into volume using transient container.
+3. Mount volume into sandbox at target as read-write.
+4. Record volume in `volumes.jsonl`.
+5. Add sandbox reference to that volume.
+
+### Reattach Existing Volume Flow (`--volume`)
+
+1. Validate tracked volume exists.
+2. Mount volume at target with selected mode.
+3. Add sandbox reference.
+
+### Failure and Rollback
+
+If sandbox creation fails after creating resources:
+
+1. Best-effort remove newly created rwcopy volumes.
+2. Revert volume state entries/refs created for this operation.
+3. Return actionable error.
+
+## Internal Architecture Changes
+
+### `cmd/amika/sandbox.go`
+
+1. Extend mount parsing to allow `rwcopy`.
+2. Change default `--mount` mode to `rwcopy`.
+3. Add parsing for `--volume`.
+4. Enforce target uniqueness across all mounts.
+5. Integrate volume lifecycle handling into create and delete flows.
+
+### `cmd/amika/volume.go` (new)
+
+Add `volume list` and `volume delete` command handlers and wiring to root command.
+
+### `internal/sandbox/docker.go` and new volume helpers
+
+Add Docker helpers for:
+
+- create volume
+- remove volume
+- copy host dir into volume
+- mixed bind + volume mount support during container creation
+
+### `internal/sandbox/volume_store.go` (new)
+
+Add persistent store for volume records and reference management.
+
+### `internal/basedir/basedir.go`
+
+Add:
+
+- `volumes.jsonl` constant
+- `VolumesStateFile()` path method
+- `VolumesStateFileIn(stateDir)` helper
+
+### `internal/config/config.go`
+
+Add:
+
+- `VolumesStateFile()` resolution with `AMIKA_STATE_DIRECTORY` override support
+
+## Output and UX Behavior
+
+### `sandbox create` Confirmation Prompt
+
+When mounts are present, prompt should display resolved mount type clearly:
+
+- bind host mount (`ro`/`rw`)
+- rwcopy snapshot mount (`rwcopy`)
+- existing volume mount (`--volume`)
+
+### `sandbox delete` Output
+
+Always include associated volume outcome lines, for example:
+
+- `volume <name>: preserved`
+- `volume <name>: deleted`
+- `volume <name>: delete failed: <reason>`
+
+## Test Plan
+
+### Command Parsing and Validation
+
+1. `--mount /src:/dst` defaults to `rwcopy`.
+2. `rwcopy` accepted; unknown modes rejected.
+3. `--volume` parse supports optional mode default `rw`.
+4. Duplicate target across `--mount` and `--volume` is rejected.
+
+### Store and State
+
+1. Volume store save/get/list/remove.
+2. Reference add/remove behavior.
+3. In-use detection based on refs.
+4. Path resolution tests for `volumes.jsonl` default and env override.
+5. Sandbox store round-trip for mixed mount types.
+
+### Delete Semantics
+
+1. `sandbox delete` default preserves volumes and clears refs.
+2. `sandbox delete --delete-volumes` deletes volumes and clears refs.
+3. Partial volume deletion failures are surfaced in output without state corruption.
+
+### Volume Command
+
+1. `volume list` shows usage and associations.
+2. `volume delete` fails when in use.
+3. `volume delete --force` succeeds.
+
+## Acceptance Criteria
+
+1. `--mount` without explicit mode behaves as `rwcopy`.
+2. Files changed in rwcopy mount inside sandbox do not modify host source files.
+3. Created rwcopy volumes are tracked in `volumes.jsonl`.
+4. `amika volume list` reflects tracked volume usage accurately.
+5. `amika volume delete` enforces in-use protection unless `--force`.
+6. `sandbox delete` preserves volumes by default and reports outcomes.
+7. `sandbox delete --delete-volumes` attempts cleanup and reports outcomes.
+8. Existing sandboxes state remains readable after upgrade.
+
+## Dependencies
+
+1. Docker volume support (`docker volume create/rm`).
+2. Transient copy container image availability (e.g., `alpine`) for snapshot copy.
+3. Existing Amika state directory and JSONL persistence patterns.
+
+## Future Considerations
+
+1. Optional `volume prune` command for unreferenced volumes.
+2. Optional checksum/metadata for rwcopy snapshot provenance.
+3. Optional reuse strategy for repeated rwcopy from same source.
+4. Support for non-Docker providers with equivalent volume abstractions.


### PR DESCRIPTION
## Summary
- Add `rwcopy` as the default mount mode for `sandbox create`, which snapshots a host directory into a Docker named volume so the sandbox gets a writable copy without syncing writes back to the host
- Add a volume state store (`volumes.jsonl`) to track named volumes, their source paths, and sandbox references
- Add `amika volume list` and `amika volume delete` commands for inspecting and cleaning up tracked volumes
- Add `--volume` flag on `sandbox create` to attach an existing tracked volume, and `--delete-volumes` flag on `sandbox delete` to clean up unreferenced volumes
- Include rollback logic so partially-created volumes are cleaned up on failure

## Test plan
- [x] Unit tests for `parseVolumeFlags`, `validateMountTargets`, `cleanupSandboxVolumes`, `deleteTrackedVolume`
- [x] Unit tests for `VolumeStore` (save, get, list, remove, sandbox refs)
- [x] Existing `parseMountFlags` tests updated for new `rwcopy` default
- [x] Manual: `amika sandbox create --mount /tmp/demo:/workspace/data` creates a volume and tracks it
- [x] Manual: `amika volume list` shows tracked volumes
- [x] Manual: `amika sandbox delete <name> --delete-volumes` removes unreferenced volumes