### PR TITLE
Add --git flag to mount repository into sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ amika sandbox create --name dev-sandbox \
   --mount ./src:/workspace/src:ro \
   --mount ./out:/workspace/out
 
+# Mount the current git repository to /home/amika/workspace/{repo_name}
+# Uses a clean snapshot by default (committed HEAD content)
+amika sandbox create --name dev-sandbox --git
+
+# Mount repo containing the specified path
+amika sandbox create --name dev-sandbox --git ./src
+
+# Include untracked working-tree files in the snapshot
+amika sandbox create --name dev-sandbox --git --no-clean
+
 # Attach an existing tracked volume
 amika sandbox create --name dev-sandbox-2 \
   --volume amika-rwcopy-dev-sandbox-workspace-out-123:/workspace/out:rw
@@ -148,6 +158,10 @@ amika sandbox delete dev-sandbox --delete-volumes
 - `ro`: read-only bind mount from host
 - `rw`: read-write bind mount from host (writes sync to host)
 - `rwcopy`: read-write snapshot in Docker volume (default; no host sync back)
+
+Preferred in-sandbox workspace directory: `/home/amika/workspace`.
+When using `--git`, Amika mounts the detected repository to
+`/home/amika/workspace/{repo_name}`.
 
 ### `amika volume list|delete`
 

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -410,4 +411,46 @@ func TestPrepareGitMount_CleanClone(t *testing.T) {
 	if _, err := os.Stat(filepath.Dir(clonedDst)); !os.IsNotExist(err) {
 		t.Fatalf("expected temp git clone directory to be removed, err=%v", err)
 	}
+}
+
+func TestPromptForConfirmation(t *testing.T) {
+	t.Run("yes", func(t *testing.T) {
+		ok, err := promptForConfirmation(bufio.NewReader(strings.NewReader("y\n")))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected confirmation")
+		}
+	})
+
+	t.Run("no", func(t *testing.T) {
+		ok, err := promptForConfirmation(bufio.NewReader(strings.NewReader("n\n")))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok {
+			t.Fatal("expected rejection")
+		}
+	})
+
+	t.Run("blank then yes reprompts", func(t *testing.T) {
+		ok, err := promptForConfirmation(bufio.NewReader(strings.NewReader("\nYES\n")))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected confirmation after reprompt")
+		}
+	})
+
+	t.Run("invalid then no reprompts", func(t *testing.T) {
+		ok, err := promptForConfirmation(bufio.NewReader(strings.NewReader("maybe\nno\n")))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok {
+			t.Fatal("expected rejection after reprompt")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Add `--git` flag to `sandbox create` that detects the git repository root and mounts it into the sandbox at `/home/amika/workspace/{repo_name}` as an `rwcopy` volume
- By default, mounts a clean snapshot (committed HEAD via `git clone --local`); `--no-clean` copies the full working tree including untracked files
- Rewrite remotes in the prepared repo to only include network URLs (https, ssh, scp-style), filtering out local filesystem paths that won't work inside the container
- Change confirmation prompt from `[y/N]` default-no to an explicit `[y/n]` loop that requires a clear yes or no answer

## Test plan
- [x] Unit tests for `resolveGitRoot` (nested dir, .git file, file path input, no-repo error)
- [x] Unit tests for `prepareGitMount` in both clean and no-clean modes
- [x] Unit tests for `syncGitRemotes` and `isNetworkRemoteURL`
- [x] Unit tests for `promptForConfirmation` (yes, no, blank reprompt, invalid reprompt)
- [x] Unit tests for `validateGitFlags`
- [x] Manual: `amika sandbox create --name test --git` mounts current repo cleanly
- [x] Manual: `amika sandbox create --name test --git --no-clean` includes untracked files