### PR TITLE
Add sandbox connect command with configurable shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ amika sandbox create --name dev-sandbox-2 \
 # List running sandboxes
 amika sandbox list
 
-# Connect to a sandbox console (zsh by default)
+# Connect to a sandbox console (zsh by default, starting in /home/amika)
 amika sandbox connect dev-sandbox
 
 # Connect using a different shell

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ amika materialize --cmd "curl -s https://api.example.com/data > result.json" --d
 amika materialize --script ./transform.sh --outdir /app/results --destdir ./output
 ```
 
-### `amika sandbox create|delete|list`
+### `amika sandbox create|delete|list|connect`
 
 Manage Docker-backed persistent sandboxes with bind mounts and named volumes.
 
@@ -145,6 +145,12 @@ amika sandbox create --name dev-sandbox-2 \
 
 # List running sandboxes
 amika sandbox list
+
+# Connect to a sandbox console (zsh by default)
+amika sandbox connect dev-sandbox
+
+# Connect using a different shell
+amika sandbox connect dev-sandbox --shell bash
 
 # Delete a sandbox (preserves associated volumes by default)
 amika sandbox delete dev-sandbox

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -24,6 +24,8 @@ var sandboxCmd = &cobra.Command{
 	Long:  `Create and delete sandboxed environments backed by container providers.`,
 }
 
+const sandboxConnectWorkdir = "/home/amika"
+
 var sandboxCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new sandbox",
@@ -479,7 +481,7 @@ func validateShell(shell string) error {
 }
 
 func buildSandboxConnectArgs(name, shell string) []string {
-	return []string{"exec", "-it", name, shell}
+	return []string{"exec", "-it", "-w", sandboxConnectWorkdir, name, shell}
 }
 
 type gitMountInfo struct {

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -295,7 +295,7 @@ func TestValidateShell(t *testing.T) {
 
 func TestBuildSandboxConnectArgs(t *testing.T) {
 	got := buildSandboxConnectArgs("sb-1", "zsh")
-	want := []string{"exec", "-it", "sb-1", "zsh"}
+	want := []string{"exec", "-it", "-w", "/home/amika", "sb-1", "zsh"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %#v, want %#v", got, want)
 	}

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -284,6 +284,23 @@ func TestValidateGitFlags(t *testing.T) {
 	}
 }
 
+func TestValidateShell(t *testing.T) {
+	if err := validateShell("zsh"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := validateShell("   "); err == nil {
+		t.Fatal("expected error for empty shell")
+	}
+}
+
+func TestBuildSandboxConnectArgs(t *testing.T) {
+	got := buildSandboxConnectArgs("sb-1", "zsh")
+	want := []string{"exec", "-it", "sb-1", "zsh"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
 func TestResolveGitRoot(t *testing.T) {
 	t.Run("finds from nested directory", func(t *testing.T) {
 		root := t.TempDir()

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -77,7 +77,7 @@ find "$tmp/out" -maxdepth 3 -type f | head
 ```bash
 ./dist/amika sandbox create --name amika-smoke --yes
 ./dist/amika sandbox list | grep amika-smoke
-docker exec -it amika-smoke /bin/bash
+./dist/amika sandbox connect amika-smoke
 ./dist/amika sandbox delete amika-smoke
 ```
 

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     git \
     curl \
+    zsh \
     build-essential \
     python3 \
     python3-pip \
@@ -19,4 +20,3 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 
 # Install TypeScript and Claude Code CLI
 RUN npm install -g typescript tsx @anthropic-ai/claude-code
-

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV HOME=/home/amika
 
 RUN apt-get update && apt-get install -y \
     git \
@@ -20,3 +21,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 
 # Install TypeScript and Claude Code CLI
 RUN npm install -g typescript tsx @anthropic-ai/claude-code
+
+RUN mkdir -p /home/amika
+WORKDIR /home/amika


### PR DESCRIPTION
## Summary
- Add `amika sandbox connect <name>` command that opens an interactive shell inside a running sandbox container via `docker exec -it`
- Default shell is `zsh` with `--shell` flag to override; working directory defaults to `/home/amika`
- Install `zsh` in the claude preset image and set `HOME=/home/amika` with a `WORKDIR` directive
- Update smoke test docs to use `sandbox connect` instead of raw `docker exec`

## Test plan
- [x] Unit tests for `validateShell` and `buildSandboxConnectArgs`
- [x] Manual: `amika sandbox connect <name>` opens a zsh session
- [x] Manual: `amika sandbox connect <name> --shell bash` opens a bash session