### PR TITLE
Add coder preset with Claude, Codex, and OpenCode tools

### DIFF
--- a/cmd/amika/materialize.go
+++ b/cmd/amika/materialize.go
@@ -60,7 +60,7 @@ Examples:
 			Image:              image,
 			Preset:             preset,
 			ImageFlagChanged:   cmd.Flags().Changed("image"),
-			DefaultBuildPreset: "claude",
+			DefaultBuildPreset: "coder",
 		})
 		if err != nil {
 			return err
@@ -77,7 +77,7 @@ Examples:
 		}
 
 		// Auto-mount host Claude config for the claude preset
-		if preset == "claude" {
+		if preset == "claude" || preset == "coder" {
 			homeDir, err := os.UserHomeDir()
 			if err == nil {
 				claudeDir := filepath.Join(homeDir, ".claude")
@@ -216,8 +216,8 @@ func init() {
 	topMaterializeCmd.Flags().String("cmd", "", "Bash command string to execute (mutually exclusive with --script)")
 	topMaterializeCmd.Flags().String("outdir", "", "Container directory to copy from (default: workdir)")
 	topMaterializeCmd.Flags().String("destdir", "", "Host directory where output files are copied")
-	topMaterializeCmd.Flags().String("image", "amika-claude:latest", "Docker image to use")
-	topMaterializeCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"claude\")")
+	topMaterializeCmd.Flags().String("image", sandbox.DefaultCoderImage, "Docker image to use")
+	topMaterializeCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"coder\" or \"claude\")")
 	topMaterializeCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
 	topMaterializeCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	topMaterializeCmd.Flags().BoolP("interactive", "i", false, "Run interactively with TTY (for programs like claude)")

--- a/cmd/amika/materialize_test.go
+++ b/cmd/amika/materialize_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const runExpensiveTestsEnv = "AMIKA_RUN_EXPENSIVE_TESTS"
+
 // buildAmika builds the amika binary for integration tests and returns its path.
 func buildAmika(t *testing.T) string {
 	t.Helper()
@@ -166,7 +168,7 @@ func TestTopMaterialize_Script(t *testing.T) {
 }
 
 func TestTopMaterialize_PresetAgentsAvailableOnPath(t *testing.T) {
-	requireDocker(t)
+	requireExpensiveDockerTests(t)
 
 	bin := buildAmika(t)
 	prefix := fmt.Sprintf("amika-test-%d", time.Now().UnixNano())
@@ -218,6 +220,16 @@ func TestTopMaterialize_PresetAgentsAvailableOnPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func requireExpensiveDockerTests(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv(runExpensiveTestsEnv) != "1" {
+		t.Skipf("set %s=1 to run expensive Docker rebuild tests", runExpensiveTestsEnv)
+	}
+
+	requireDocker(t)
 }
 
 func requireDocker(t *testing.T) {

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -57,7 +57,7 @@ var sandboxCreateCmd = &cobra.Command{
 			Image:              image,
 			Preset:             preset,
 			ImageFlagChanged:   cmd.Flags().Changed("image"),
-			DefaultBuildPreset: "claude",
+			DefaultBuildPreset: "coder",
 		})
 		if err != nil {
 			return err
@@ -772,8 +772,8 @@ func init() {
 	// Create flags
 	sandboxCreateCmd.Flags().String("provider", "docker", "Sandbox provider")
 	sandboxCreateCmd.Flags().String("name", "", "Name for the sandbox (auto-generated if not set)")
-	sandboxCreateCmd.Flags().String("image", "amika-claude:latest", "Docker image to use")
-	sandboxCreateCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"claude\")")
+	sandboxCreateCmd.Flags().String("image", sandbox.DefaultCoderImage, "Docker image to use")
+	sandboxCreateCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"coder\" or \"claude\")")
 	sandboxCreateCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rwcopy)")
 	sandboxCreateCmd.Flags().StringArray("volume", nil, "Mount an existing named volume (name:target[:mode], mode defaults to rw)")
 	sandboxCreateCmd.Flags().String("git", "", "Mount the current git repo root (or repo containing PATH) into /home/amika/workspace/{repo}")

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -85,7 +85,7 @@ find "$tmp/out" -maxdepth 3 -type f | head
 
 ```bash
 tmp="$(mktemp -d)"
-./dist/amika materialize --preset claude --cmd "echo ok > smoke.txt" --destdir "$tmp/out"
+./dist/amika materialize --preset coder --cmd "echo ok > smoke.txt" --destdir "$tmp/out"
 cat "$tmp/out/smoke.txt"
 ```
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -102,3 +102,11 @@ Run the full Go test suite after smoke checks:
 ```bash
 go test ./...
 ```
+
+## Expensive Docker Rebuild Test (Opt-in)
+
+The preset image rebuild integration test is skipped by default. Run it explicitly:
+
+```bash
+AMIKA_RUN_EXPENSIVE_TESTS=1 go test ./cmd/amika -run TestTopMaterialize_PresetAgentsAvailableOnPath -count=1
+```

--- a/internal/sandbox/image_resolution.go
+++ b/internal/sandbox/image_resolution.go
@@ -6,6 +6,9 @@ import (
 	"os"
 )
 
+// DefaultCoderImage is the default Docker image used for coder/claude presets.
+const DefaultCoderImage = "amika/coder:latest"
+
 // PresetImageOptions controls how image/preset resolution and auto-build work.
 type PresetImageOptions struct {
 	Image              string
@@ -39,11 +42,12 @@ func ResolveAndEnsureImage(opts PresetImageOptions) (PresetImageResult, error) {
 	}
 
 	if opts.Preset != "" {
-		result.EffectivePreset = opts.Preset
-		result.BuildPreset = opts.Preset
-		result.Image = "amika-" + opts.Preset + ":latest"
+		normalizedPreset := normalizePresetName(opts.Preset)
+		result.EffectivePreset = normalizedPreset
+		result.BuildPreset = normalizedPreset
+		result.Image = presetImageName(normalizedPreset)
 	} else if !opts.ImageFlagChanged && opts.DefaultBuildPreset != "" {
-		result.BuildPreset = opts.DefaultBuildPreset
+		result.BuildPreset = normalizePresetName(opts.DefaultBuildPreset)
 	}
 
 	if result.BuildPreset != "" && !dockerImageExistsFn(result.Image) {
@@ -58,4 +62,13 @@ func ResolveAndEnsureImage(opts PresetImageOptions) (PresetImageResult, error) {
 	}
 
 	return result, nil
+}
+
+func presetImageName(preset string) string {
+	switch preset {
+	case "coder":
+		return DefaultCoderImage
+	default:
+		return "amika/" + preset + ":latest"
+	}
 }

--- a/internal/sandbox/image_resolution.go
+++ b/internal/sandbox/image_resolution.go
@@ -6,7 +6,9 @@ import (
 	"os"
 )
 
-// DefaultCoderImage is the default Docker image used for coder/claude presets.
+const presetImagePrefixEnv = "AMIKA_PRESET_IMAGE_PREFIX"
+
+// DefaultCoderImage is the default Docker image used for the coder preset.
 const DefaultCoderImage = "amika/coder:latest"
 
 // PresetImageOptions controls how image/preset resolution and auto-build work.
@@ -42,12 +44,12 @@ func ResolveAndEnsureImage(opts PresetImageOptions) (PresetImageResult, error) {
 	}
 
 	if opts.Preset != "" {
-		normalizedPreset := normalizePresetName(opts.Preset)
-		result.EffectivePreset = normalizedPreset
-		result.BuildPreset = normalizedPreset
-		result.Image = presetImageName(normalizedPreset)
+		result.EffectivePreset = opts.Preset
+		result.BuildPreset = opts.Preset
+		result.Image = presetImageName(opts.Preset)
 	} else if !opts.ImageFlagChanged && opts.DefaultBuildPreset != "" {
-		result.BuildPreset = normalizePresetName(opts.DefaultBuildPreset)
+		result.BuildPreset = opts.DefaultBuildPreset
+		result.Image = presetImageName(opts.DefaultBuildPreset)
 	}
 
 	if result.BuildPreset != "" && !dockerImageExistsFn(result.Image) {
@@ -65,6 +67,9 @@ func ResolveAndEnsureImage(opts PresetImageOptions) (PresetImageResult, error) {
 }
 
 func presetImageName(preset string) string {
+	if prefix := os.Getenv(presetImagePrefixEnv); prefix != "" {
+		return prefix + "-" + preset + ":latest"
+	}
 	switch preset {
 	case "coder":
 		return DefaultCoderImage

--- a/internal/sandbox/image_resolution_test.go
+++ b/internal/sandbox/image_resolution_test.go
@@ -17,7 +17,7 @@ func TestResolveAndEnsureImage_PresetAndImageMutuallyExclusive(t *testing.T) {
 	}
 }
 
-func TestResolveAndEnsureImage_ExplicitPresetBuildsWhenMissing(t *testing.T) {
+func TestResolveAndEnsureImage_ExplicitClaudePresetBuildsWhenMissing(t *testing.T) {
 	resetImageResolutionStubs(t)
 
 	var builtImage string
@@ -33,27 +33,27 @@ func TestResolveAndEnsureImage_ExplicitPresetBuildsWhenMissing(t *testing.T) {
 	}
 
 	res, err := ResolveAndEnsureImage(PresetImageOptions{
-		Image:              DefaultCoderImage,
+		Image:              "amika/claude:latest",
 		Preset:             "claude",
 		DefaultBuildPreset: "coder",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Image != DefaultCoderImage {
-		t.Fatalf("image = %q, want %q", res.Image, DefaultCoderImage)
+	if res.Image != "amika/claude:latest" {
+		t.Fatalf("image = %q, want %q", res.Image, "amika/claude:latest")
 	}
-	if res.EffectivePreset != "coder" {
-		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder")
+	if res.EffectivePreset != "claude" {
+		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "claude")
 	}
-	if res.BuildPreset != "coder" {
-		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder")
+	if res.BuildPreset != "claude" {
+		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "claude")
 	}
-	if gotBuildPreset != "coder" {
-		t.Fatalf("dockerfile preset = %q, want %q", gotBuildPreset, "coder")
+	if gotBuildPreset != "claude" {
+		t.Fatalf("dockerfile preset = %q, want %q", gotBuildPreset, "claude")
 	}
-	if builtImage != DefaultCoderImage {
-		t.Fatalf("built image = %q, want %q", builtImage, DefaultCoderImage)
+	if builtImage != "amika/claude:latest" {
+		t.Fatalf("built image = %q, want %q", builtImage, "amika/claude:latest")
 	}
 }
 
@@ -118,6 +118,9 @@ func TestResolveAndEnsureImage_DefaultBuildPresetWhenImageNotChanged(t *testing.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if res.Image != DefaultCoderImage {
+		t.Fatalf("image = %q, want %q", res.Image, DefaultCoderImage)
+	}
 	if res.BuildPreset != "coder" {
 		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder")
 	}
@@ -152,6 +155,38 @@ func TestResolveAndEnsureImage_NoDefaultBuildWhenImageChanged(t *testing.T) {
 	}
 	if buildCalled {
 		t.Fatal("build should not have been called")
+	}
+}
+
+func TestResolveAndEnsureImage_CustomImageNoPresetSkipsPresetBuildAndNormalization(t *testing.T) {
+	resetImageResolutionStubs(t)
+
+	dockerImageExistsFn = func(_ string) bool { return false }
+	getPresetDockerfileFn = func(_ string) ([]byte, error) {
+		t.Fatal("getPresetDockerfileFn should not be called")
+		return nil, nil
+	}
+	buildDockerImageFn = func(_ string, _ []byte) error {
+		t.Fatal("buildDockerImageFn should not be called")
+		return nil
+	}
+
+	res, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:              "ghcr.io/acme/custom:dev",
+		ImageFlagChanged:   true,
+		DefaultBuildPreset: "coder",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Image != "ghcr.io/acme/custom:dev" {
+		t.Fatalf("image = %q, want %q", res.Image, "ghcr.io/acme/custom:dev")
+	}
+	if res.EffectivePreset != "" {
+		t.Fatalf("effective preset = %q, want empty", res.EffectivePreset)
+	}
+	if res.BuildPreset != "" {
+		t.Fatalf("build preset = %q, want empty", res.BuildPreset)
 	}
 }
 
@@ -192,6 +227,43 @@ func TestResolveAndEnsureImage_SkipsBuildWhenImageExists(t *testing.T) {
 	}
 	if buildCalled {
 		t.Fatal("build should not have been called")
+	}
+}
+
+func TestResolveAndEnsureImage_UsesPresetImagePrefixOverride(t *testing.T) {
+	resetImageResolutionStubs(t)
+	t.Setenv(presetImagePrefixEnv, "amika-test-123")
+
+	dockerImageExistsFn = func(_ string) bool { return true }
+
+	res, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:  DefaultCoderImage,
+		Preset: "coder",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Image != "amika-test-123-coder:latest" {
+		t.Fatalf("image = %q, want %q", res.Image, "amika-test-123-coder:latest")
+	}
+}
+
+func TestResolveAndEnsureImage_UsesPresetImagePrefixOverrideForDefaultBuildPreset(t *testing.T) {
+	resetImageResolutionStubs(t)
+	t.Setenv(presetImagePrefixEnv, "amika-test-456")
+
+	dockerImageExistsFn = func(_ string) bool { return true }
+
+	res, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:              DefaultCoderImage,
+		ImageFlagChanged:   false,
+		DefaultBuildPreset: "coder",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Image != "amika-test-456-coder:latest" {
+		t.Fatalf("image = %q, want %q", res.Image, "amika-test-456-coder:latest")
 	}
 }
 

--- a/internal/sandbox/image_resolution_test.go
+++ b/internal/sandbox/image_resolution_test.go
@@ -33,27 +33,67 @@ func TestResolveAndEnsureImage_ExplicitPresetBuildsWhenMissing(t *testing.T) {
 	}
 
 	res, err := ResolveAndEnsureImage(PresetImageOptions{
-		Image:              "amika-claude:latest",
+		Image:              DefaultCoderImage,
 		Preset:             "claude",
-		DefaultBuildPreset: "claude",
+		DefaultBuildPreset: "coder",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Image != "amika-claude:latest" {
-		t.Fatalf("image = %q, want %q", res.Image, "amika-claude:latest")
+	if res.Image != DefaultCoderImage {
+		t.Fatalf("image = %q, want %q", res.Image, DefaultCoderImage)
 	}
-	if res.EffectivePreset != "claude" {
-		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "claude")
+	if res.EffectivePreset != "coder" {
+		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder")
 	}
-	if res.BuildPreset != "claude" {
-		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "claude")
+	if res.BuildPreset != "coder" {
+		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder")
 	}
-	if gotBuildPreset != "claude" {
-		t.Fatalf("dockerfile preset = %q, want %q", gotBuildPreset, "claude")
+	if gotBuildPreset != "coder" {
+		t.Fatalf("dockerfile preset = %q, want %q", gotBuildPreset, "coder")
 	}
-	if builtImage != "amika-claude:latest" {
-		t.Fatalf("built image = %q, want %q", builtImage, "amika-claude:latest")
+	if builtImage != DefaultCoderImage {
+		t.Fatalf("built image = %q, want %q", builtImage, DefaultCoderImage)
+	}
+}
+
+func TestResolveAndEnsureImage_ExplicitCoderPresetBuildsWhenMissing(t *testing.T) {
+	resetImageResolutionStubs(t)
+
+	var builtImage string
+	var gotBuildPreset string
+	dockerImageExistsFn = func(_ string) bool { return false }
+	getPresetDockerfileFn = func(name string) ([]byte, error) {
+		gotBuildPreset = name
+		return []byte("FROM scratch"), nil
+	}
+	buildDockerImageFn = func(name string, _ []byte) error {
+		builtImage = name
+		return nil
+	}
+
+	res, err := ResolveAndEnsureImage(PresetImageOptions{
+		Image:              DefaultCoderImage,
+		Preset:             "coder",
+		DefaultBuildPreset: "coder",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Image != DefaultCoderImage {
+		t.Fatalf("image = %q, want %q", res.Image, DefaultCoderImage)
+	}
+	if res.EffectivePreset != "coder" {
+		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder")
+	}
+	if res.BuildPreset != "coder" {
+		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder")
+	}
+	if gotBuildPreset != "coder" {
+		t.Fatalf("dockerfile preset = %q, want %q", gotBuildPreset, "coder")
+	}
+	if builtImage != DefaultCoderImage {
+		t.Fatalf("built image = %q, want %q", builtImage, DefaultCoderImage)
 	}
 }
 
@@ -71,15 +111,15 @@ func TestResolveAndEnsureImage_DefaultBuildPresetWhenImageNotChanged(t *testing.
 	}
 
 	res, err := ResolveAndEnsureImage(PresetImageOptions{
-		Image:              "amika-claude:latest",
+		Image:              DefaultCoderImage,
 		ImageFlagChanged:   false,
-		DefaultBuildPreset: "claude",
+		DefaultBuildPreset: "coder",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.BuildPreset != "claude" {
-		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "claude")
+	if res.BuildPreset != "coder" {
+		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder")
 	}
 	if !built {
 		t.Fatal("expected build to run")
@@ -102,7 +142,7 @@ func TestResolveAndEnsureImage_NoDefaultBuildWhenImageChanged(t *testing.T) {
 	res, err := ResolveAndEnsureImage(PresetImageOptions{
 		Image:              "ubuntu:latest",
 		ImageFlagChanged:   true,
-		DefaultBuildPreset: "claude",
+		DefaultBuildPreset: "coder",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -124,8 +164,8 @@ func TestResolveAndEnsureImage_UnknownPreset(t *testing.T) {
 	}
 
 	_, err := ResolveAndEnsureImage(PresetImageOptions{
-		Image:  "amika-claude:latest",
-		Preset: "claude",
+		Image:  DefaultCoderImage,
+		Preset: "nope",
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -143,9 +183,9 @@ func TestResolveAndEnsureImage_SkipsBuildWhenImageExists(t *testing.T) {
 	}
 
 	_, err := ResolveAndEnsureImage(PresetImageOptions{
-		Image:              "amika-claude:latest",
+		Image:              DefaultCoderImage,
 		ImageFlagChanged:   false,
-		DefaultBuildPreset: "claude",
+		DefaultBuildPreset: "coder",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/sandbox/presets.go
+++ b/internal/sandbox/presets.go
@@ -8,9 +8,19 @@ import (
 //go:embed presets/*/Dockerfile
 var presetFS embed.FS
 
+func normalizePresetName(name string) string {
+	switch name {
+	case "claude":
+		return "coder"
+	default:
+		return name
+	}
+}
+
 // GetPresetDockerfile returns the Dockerfile content for the given preset name.
 func GetPresetDockerfile(name string) ([]byte, error) {
-	data, err := presetFS.ReadFile("presets/" + name + "/Dockerfile")
+	presetName := normalizePresetName(name)
+	data, err := presetFS.ReadFile("presets/" + presetName + "/Dockerfile")
 	if err != nil {
 		return nil, fmt.Errorf("unknown preset %q", name)
 	}

--- a/internal/sandbox/presets.go
+++ b/internal/sandbox/presets.go
@@ -8,19 +8,9 @@ import (
 //go:embed presets/*/Dockerfile
 var presetFS embed.FS
 
-func normalizePresetName(name string) string {
-	switch name {
-	case "claude":
-		return "coder"
-	default:
-		return name
-	}
-}
-
 // GetPresetDockerfile returns the Dockerfile content for the given preset name.
 func GetPresetDockerfile(name string) ([]byte, error) {
-	presetName := normalizePresetName(name)
-	data, err := presetFS.ReadFile("presets/" + presetName + "/Dockerfile")
+	data, err := presetFS.ReadFile("presets/" + name + "/Dockerfile")
 	if err != nil {
 		return nil, fmt.Errorf("unknown preset %q", name)
 	}

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HOME=/home/amika
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    zsh \
+    build-essential \
+    python3 \
+    python3-pip \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 22
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install coding agent CLIs.
+RUN npm install -g typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai
+
+RUN mkdir -p /home/amika
+WORKDIR /home/amika

--- a/internal/sandbox/presets_test.go
+++ b/internal/sandbox/presets_test.go
@@ -1,0 +1,47 @@
+package sandbox
+
+import "testing"
+
+func TestGetPresetDockerfile_CoderReturnsDockerfile(t *testing.T) {
+	data, err := GetPresetDockerfile("coder")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty Dockerfile")
+	}
+}
+
+func TestGetPresetDockerfile_ClaudeReturnsDockerfile(t *testing.T) {
+	data, err := GetPresetDockerfile("claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty Dockerfile")
+	}
+}
+
+func TestGetPresetDockerfile_CoderAndClaudeDiffer(t *testing.T) {
+	coderData, err := GetPresetDockerfile("coder")
+	if err != nil {
+		t.Fatalf("unexpected error loading coder preset: %v", err)
+	}
+	claudeData, err := GetPresetDockerfile("claude")
+	if err != nil {
+		t.Fatalf("unexpected error loading claude preset: %v", err)
+	}
+	if string(coderData) == string(claudeData) {
+		t.Fatal("expected coder and claude Dockerfiles to differ")
+	}
+}
+
+func TestGetPresetDockerfile_UnknownPresetErrors(t *testing.T) {
+	data, err := GetPresetDockerfile("missing-preset")
+	if err == nil {
+		t.Fatal("expected error for unknown preset")
+	}
+	if len(data) != 0 {
+		t.Fatal("expected empty data for unknown preset")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a new `coder` preset image that installs `claude`, `codex`, and `opencode` CLI tools, replacing `claude` as the default build preset for both `sandbox create` and `materialize`
- Keep the existing `claude` preset (Claude-only) as a separate option for lighter images
- Introduce `AMIKA_PRESET_IMAGE_PREFIX` env var for test isolation so preset image builds don't collide
- Change image naming convention from `amika-{preset}:latest` to `amika/{preset}:latest`
- Add opt-in expensive Docker rebuild tests gated behind `AMIKA_RUN_EXPENSIVE_TESTS=1`

## Test plan
- [x] Unit tests for preset Dockerfile loading (coder, claude, unknown preset)
- [x] Unit tests verifying coder and claude Dockerfiles differ
- [x] Image resolution tests updated for new default preset and naming convention
- [x] Tests for custom image flag, prefix override, and skip-build-when-exists paths
- [x] Opt-in integration test `TestTopMaterialize_PresetAgentsAvailableOnPath` verifies agent CLIs are on PATH