### PR TITLE
Add --connect flag, volume deletion prompt, and delete aliases

### DIFF
--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -622,6 +622,16 @@ func TestSandboxDeleteAliases(t *testing.T) {
 	}
 }
 
+func TestSandboxCreateHasConnectFlag(t *testing.T) {
+	flag := sandboxCreateCmd.Flags().Lookup("connect")
+	if flag == nil {
+		t.Fatal("sandbox create command must define --connect")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Fatalf("connect flag type = %q, want bool", flag.Value.Type())
+	}
+}
+
 func createGitRepo(t *testing.T, remotes map[string]string) string {
 	t.Helper()
 

--- a/cmd/amika/volume.go
+++ b/cmd/amika/volume.go
@@ -58,9 +58,10 @@ var volumeListCmd = &cobra.Command{
 }
 
 var volumeDeleteCmd = &cobra.Command{
-	Use:   "delete <name>",
-	Short: "Delete a tracked volume",
-	Args:  cobra.ExactArgs(1),
+	Use:     "delete <name>",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete a tracked volume",
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		force, _ := cmd.Flags().GetBool("force")

--- a/cmd/amika/volume_test.go
+++ b/cmd/amika/volume_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -80,5 +81,14 @@ func TestVolumeListCmd_PrintsTrackedVolumes(t *testing.T) {
 	}
 	if !strings.Contains(out, "sb-a") {
 		t.Fatalf("expected sandbox refs in output, got:\n%s", out)
+	}
+}
+
+func TestVolumeDeleteAliases(t *testing.T) {
+	if !slices.Contains(volumeDeleteCmd.Aliases, "rm") {
+		t.Fatal("volume delete command must include alias \"rm\"")
+	}
+	if !slices.Contains(volumeDeleteCmd.Aliases, "remove") {
+		t.Fatal("volume delete command must include alias \"remove\"")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `--connect` flag to `sandbox create` that immediately opens a zsh shell after the sandbox is created
- Prompt the user to delete exclusively-owned volumes when running `sandbox delete` without `--delete-volumes` or `--keep-volumes`
- Add `rm` and `remove` aliases to both `sandbox delete` and `volume delete` commands
- Extract `runSandboxConnect` as a testable function shared between `sandbox connect` and `sandbox create --connect`

## Test plan
- [x] Unit tests for `validateDeleteVolumeFlags` (mutual exclusivity, explicit false rejection)
- [x] Unit tests for `resolveDeleteVolumes` (flag precedence, prompt on exclusive volumes, no prompt when shared)
- [x] Unit tests verifying `rm`/`remove` aliases on `sandbox delete` and `volume delete`
- [x] Unit test verifying `--connect` flag exists on `sandbox create`
- [x] Manual: `amika sandbox create --connect --git` creates and immediately connects
- [x] Manual: `amika sandbox delete <name>` prompts when volumes are exclusive