### PR TITLE
Add specs for file-based rwcopy mounts and agent config auto-mounting

### DIFF
--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -86,6 +86,12 @@ func DockerVolumeExists(name string) bool {
 }
 
 // CopyHostDirToVolume copies hostDir contents into the root of volumeName.
+//
+// Docker named volumes live in Docker-managed storage and are not directly
+// accessible from the host filesystem. To populate a volume from host data,
+// we spin up a throwaway Alpine container with two mounts: the host directory
+// (read-only) and the target volume (read-write). The container runs cp -a to
+// copy everything from one to the other, then exits and is removed.
 func CopyHostDirToVolume(volumeName, hostDir string) error {
 	if hostDir == "" {
 		return fmt.Errorf("host directory is required")

--- a/specs/003-file-based-rwcopy-mounts.md
+++ b/specs/003-file-based-rwcopy-mounts.md
@@ -1,0 +1,293 @@
+# File-Based rwcopy Mounts
+
+## Overview
+
+This spec extends the rwcopy mount system (spec 002) to support **single-file mounts** alongside the existing directory-based Docker volume mounts.
+
+Docker named volumes are directory-level constructs — they cannot represent a single file. When a source path for an rwcopy mount is a file (e.g., `~/.claude.json`), Amika must use a different backing mechanism: a host-side copy stored in the Amika state directory, bind-mounted into the container.
+
+File-based rwcopy mounts provide the same isolation guarantee as Docker volume rwcopy: the sandbox gets its own editable copy and changes do not propagate back to the host original.
+
+## Motivation
+
+The immediate use case is agent config auto-mounting for sandboxes. Claude Code stores configuration in two locations:
+
+| Host path        | Type      | Purpose                              |
+| ---------------- | --------- | ------------------------------------ |
+| `~/.claude/`     | Directory | Settings, credentials, project state |
+| `~/.claude.json` | File      | API keys and preferences             |
+
+The directory (`~/.claude/`) can use the existing Docker volume rwcopy flow. The file (`~/.claude.json`) cannot, because:
+
+1. **Docker named volumes always mount as directories.** Mounting a volume at `/home/amika/.claude.json` creates a _directory_ called `.claude.json`, not a file.
+2. **A plain bind mount of the file** (rw or ro) either exposes the host file to mutation or prevents the sandbox from modifying its own copy.
+3. **Wrapping the file in a Docker volume** (by copying it into a volume and mounting the volume at the parent directory) would shadow other mounts and content at that parent path.
+
+File-based rwcopy mounts solve this by copying the file into Amika's state directory and bind-mounting the copy.
+
+## Goals
+
+1. Extend `rwcopy` mode to accept single files, not only directories.
+2. Store file copies in a structured, cleanable location under the Amika state directory.
+3. Track file-based mounts with the same lifecycle semantics as Docker volumes (sandbox refs, in-use protection, cleanup on sandbox delete).
+4. Surface file-based mounts in `amika volume list` and `amika volume delete` alongside Docker volumes, with a type indicator to distinguish them.
+
+## Non-Goals
+
+1. Syncing file changes back to the host (this is explicitly not rwcopy behavior).
+2. Supporting file-based rwcopy for _directories_ (Docker volumes remain the mechanism for directories).
+3. Deduplication across sandboxes — each sandbox gets its own copy.
+
+## Relationship to Docker Volumes
+
+Docker volume rwcopy (spec 002) and file-based rwcopy (this spec) use different backing stores but share identical lifecycle semantics.
+
+**Backing store differences:**
+
+|                                  | Docker volume rwcopy (spec 002)        | File-based rwcopy (this spec)                               |
+| -------------------------------- | -------------------------------------- | ----------------------------------------------------------- |
+| **Source type**                  | Directory                              | Single file                                                 |
+| **Backing store**                | Docker named volume                    | File in Amika state directory                               |
+| **How data is copied**           | Transient Alpine container (see below) | Go `os.ReadFile`/`os.WriteFile` copies the file on the host |
+| **Container mount type**         | Volume mount (`-v volumeName:/target`) | Bind mount (`-v /state/copy:/target`)                       |
+| **Tracked in**                   | `volumes.jsonl`                        | `rwcopy-mounts.jsonl` (separate file)                       |
+| **How backing store is deleted** | `docker volume rm`                     | `os.RemoveAll` on copy directory                            |
+
+**Shared lifecycle semantics (identical for both):**
+
+- Sandbox references track which sandboxes use each mount
+- In-use protection prevents deletion of mounts referenced by sandboxes
+- `amika volume list` shows both (Docker volumes as `directory`, file mounts as `file`)
+- `amika volume delete` works for both, with `--force` to override in-use protection
+- `sandbox delete` follows `--keep-volumes` / `--delete-volumes` flags for both, with an interactive prompt when neither flag is set and exclusive mounts exist
+
+### The Alpine copy trick (Docker volume rwcopy)
+
+Docker named volumes live in Docker-managed storage and are not directly accessible from the host filesystem. To copy host files into a volume, the existing rwcopy implementation (`CopyHostDirToVolume` in `internal/sandbox/docker.go`) uses a transient Alpine container as an intermediary:
+
+```
+docker run --rm \
+  -v /host/source/dir:/src:ro \
+  -v myVolumeName:/dst \
+  alpine:3.20 \
+  sh -c "cp -a /src/. /dst/"
+```
+
+This spins up a throwaway container with two mounts: the host directory (read-only) and the Docker volume (read-write). The `cp -a` inside the container copies everything from one to the other, then the container is removed. It's the only way to populate a Docker named volume from host data without a running container.
+
+File-based rwcopy mounts avoid this indirection entirely — since the backing store is just a file on the host filesystem, a simple Go file copy suffices.
+
+## Data Model and State
+
+### New State File
+
+Path (same resolution as `volumes.jsonl`):
+
+- `${AMIKA_STATE_DIRECTORY}/rwcopy-mounts.jsonl`
+- or `${XDG_STATE_HOME:-~/.local/state}/amika/rwcopy-mounts.jsonl`
+
+### New Data Directory
+
+File copies are stored under:
+
+- `${AMIKA_STATE_DIRECTORY}/rwcopy-mounts.d/{mount-name}/{filename}`
+- or `${XDG_STATE_HOME:-~/.local/state}/amika/rwcopy-mounts.d/{mount-name}/{filename}`
+
+Each mount gets its own subdirectory to avoid filename collisions and simplify cleanup (`os.RemoveAll` on the mount directory).
+
+### File Mount State Entry
+
+Each line in `rwcopy-mounts.jsonl` stores one record:
+
+| Field         | Type     | Description                          |
+| ------------- | -------- | ------------------------------------ |
+| `name`        | string   | Unique mount name (generated)        |
+| `type`        | string   | `"file"`                             |
+| `createdAt`   | string   | RFC 3339 timestamp                   |
+| `createdBy`   | string   | `"rwcopy"`                           |
+| `sourcePath`  | string   | Original host file path              |
+| `copyPath`    | string   | Absolute path to the local copy      |
+| `sandboxRefs` | []string | Sandbox names referencing this mount |
+
+### Mount Naming Convention
+
+Format: `amika-rwcopy-file-{sandboxName}-{sanitizedTarget}-{nanoTimestamp}`
+
+This parallels the Docker volume naming (`amika-rwcopy-{sandboxName}-{sanitizedTarget}-{nanoTimestamp}`) with a `-file-` infix to distinguish the two types.
+
+### Filesystem Layout Example
+
+```
+$XDG_STATE_HOME/amika/
+├── volumes.jsonl                          # Docker volume state (existing)
+├── rwcopy-mounts.jsonl                    # File mount state (new)
+└── rwcopy-mounts.d/                       # File copy storage (new)
+    └── amika-rwcopy-file-coral-tokyo-home-amika--claude-json-1709312400000000000/
+        └── .claude.json                   # Copied file
+```
+
+## Runtime Semantics
+
+### Creation Flow
+
+During `sandbox create`, when processing an rwcopy mount whose source is a regular file (not a directory):
+
+1. Generate a unique mount name.
+2. Create the mount directory under `rwcopy-mounts.d/`.
+3. Copy the source file into the mount directory, preserving permissions.
+4. Save the `FileMountInfo` record to `rwcopy-mounts.jsonl`.
+5. Add a runtime bind mount: the copied file maps to the container target path, read-write.
+
+### Failure and Rollback
+
+If sandbox creation fails after creating file mount resources:
+
+1. Remove all newly created mount directories (`os.RemoveAll`).
+2. Remove corresponding state entries from `rwcopy-mounts.jsonl`.
+3. This runs alongside the existing Docker volume rollback — both rollbacks execute.
+
+### Sandbox Deletion
+
+File-based rwcopy mounts follow the same deletion behavior as Docker volumes:
+
+1. If `--keep-volumes` is set: preserve all mounts, remove sandbox references only.
+2. If `--delete-volumes` is set: delete unreferenced mounts, remove sandbox references.
+3. If neither flag is set: check for mounts exclusively referenced by this sandbox (across both Docker volumes and file mounts). If any exist, prompt the user interactively. If none are exclusive, silently preserve.
+4. Report outcomes for each mount (`preserved`, `deleted`, `delete-failed`) in the same output block as Docker volume outcomes.
+
+Deleting a file-based mount means:
+
+- `os.RemoveAll` on the mount's copy directory (the directory under `rwcopy-mounts.d/`)
+- Remove the state entry from `rwcopy-mounts.jsonl`
+
+### Atomicity
+
+File copy operations use a create-directory-then-copy-file sequence. On failure at any step, the rollback function removes the partially created directory. The JSONL store's read-all/write-all pattern ensures state file consistency.
+
+## CLI Changes
+
+### `amika volume list`
+
+Add a `TYPE` column:
+
+```
+NAME                                        TYPE       CREATED               IN_USE  SANDBOXES    SOURCE
+amika-rwcopy-coral-tokyo-home-amika-...     directory  2026-01-02T00:00:00Z  yes     coral-tokyo  /Users/me/.claude
+amika-rwcopy-file-coral-tokyo-home-...      file       2026-01-02T00:00:00Z  yes     coral-tokyo  /Users/me/.claude.json
+```
+
+- Docker volumes display as `directory`.
+- File-based mounts display as `file`.
+- "No volumes found." only appears when both stores are empty.
+
+### `amika volume delete <name>`
+
+Lookup order:
+
+1. Check `volumes.jsonl` (Docker volume). If found, use existing delete flow.
+2. Check `rwcopy-mounts.jsonl` (file mount). If found, delete the copy directory and state entry.
+3. If neither, return "not found" error.
+
+In-use protection and `--force` semantics apply identically to both types.
+
+## Internal Architecture Changes
+
+### `internal/sandbox/file_mount_store.go` (new)
+
+JSONL-backed store following the `volume_store.go` pattern:
+
+```go
+type FileMountStore interface {
+    Save(info FileMountInfo) error
+    Get(name string) (FileMountInfo, error)
+    Remove(name string) error
+    List() ([]FileMountInfo, error)
+    AddSandboxRef(name, sandbox string) error
+    RemoveSandboxRef(name, sandbox string) error
+    FileMountsForSandbox(sandbox string) ([]FileMountInfo, error)
+    IsInUse(name string) (bool, error)
+}
+```
+
+### `internal/basedir/basedir.go`
+
+Add to `Paths` interface and `xdgPaths`:
+
+- `FileMountsStateFile()` — returns `$stateDir/rwcopy-mounts.jsonl`
+- `FileMountsDir()` — returns `$stateDir/rwcopy-mounts.d`
+
+Add public helpers:
+
+- `FileMountsStateFileIn(stateDir string) string`
+- `FileMountsDirIn(stateDir string) string`
+
+### `internal/config/config.go`
+
+Add `FileMountsStateFile()` and `FileMountsDir()` with `AMIKA_STATE_DIRECTORY` override support.
+
+### `cmd/amika/sandbox.go`
+
+- Extend the rwcopy processing loop to branch on `stat.IsDir()` vs regular file.
+- Directory sources: existing Docker volume flow (unchanged).
+- File sources: new file-based rwcopy flow (this spec).
+- Expand rollback function to clean up file mounts alongside Docker volumes.
+- Extend `resolveDeleteVolumes` to consider exclusive file mounts alongside exclusive Docker volumes when prompting.
+- Add `cleanupSandboxFileMounts` paralleling `cleanupSandboxVolumes`, called from the delete handler.
+
+### `cmd/amika/volume.go`
+
+- `volume list`: read from both stores, merge, display with TYPE column.
+- `volume delete`: try both stores in sequence.
+
+## Test Plan
+
+### Store and State
+
+1. `FileMountStore` save/get/list/remove round-trip.
+2. Sandbox ref add/remove behavior.
+3. `FileMountsForSandbox` returns correct subset.
+4. `IsInUse` returns true when refs exist, false otherwise.
+5. Path resolution for `rwcopy-mounts.jsonl` and `rwcopy-mounts.d` with default and env override.
+
+### Creation and Rollback
+
+1. File-based rwcopy creates the correct directory structure and file copy.
+2. Copied file preserves source permissions.
+3. On creation failure, rollback removes the mount directory and state entry.
+4. Mixed creation (one Docker volume rwcopy + one file rwcopy) rolls back both on failure.
+
+### CLI Commands
+
+1. `volume list` shows both Docker volumes and file mounts with correct TYPE values.
+2. `volume list` with no entries prints "No volumes found."
+3. `volume delete` on a file mount removes the copy directory and state entry.
+4. `volume delete` on an in-use file mount fails without `--force`.
+5. `volume delete --force` on an in-use file mount succeeds.
+
+### Sandbox Delete
+
+1. `sandbox delete` with neither flag removes file mount sandbox refs and preserves mounts.
+2. `sandbox delete` with exclusive file mounts and no flags prompts the user.
+3. `sandbox delete --delete-volumes` deletes unreferenced file mounts from disk.
+4. `sandbox delete --keep-volumes` preserves file mounts and removes refs only.
+5. `sandbox delete --delete-volumes` preserves file mounts still referenced by other sandboxes.
+
+## Acceptance Criteria
+
+1. `--mount /path/to/file:/target:rwcopy` creates a file-based rwcopy mount (not a Docker volume).
+2. The sandbox can read and write the mounted file; changes do not affect the host original.
+3. File mounts appear in `amika volume list` with type `file`.
+4. `amika volume delete` works for both Docker volumes and file mounts.
+5. Sandbox deletion handles file mount cleanup with the same `--keep-volumes` / `--delete-volumes` / interactive prompt semantics as Docker volumes.
+6. All file operations are cleaned up on creation failure.
+
+## Dependencies
+
+1. Existing Amika state directory and JSONL persistence patterns (spec 002).
+2. `os.ReadFile`/`os.WriteFile` for file copying (no Docker dependency for file mounts).
+
+## Future Considerations
+
+1. Directory-based file mounts — if a future use case requires rwcopy of a directory without Docker, the `rwcopy-mounts.d` structure already supports filesystem trees.
+2. Deduplication — multiple sandboxes from the same source could share a single copy with copy-on-write semantics, but this adds complexity for limited benefit.
+3. Checksums — storing a hash of the source file at copy time would allow detecting whether the host original has changed since the snapshot.

--- a/specs/004-agent-config-auto-mounting.md
+++ b/specs/004-agent-config-auto-mounting.md
@@ -1,0 +1,172 @@
+# Agent Config Auto-Mounting
+
+## Overview
+
+This spec defines automatic mounting of coding agent configuration files (e.g., Claude Code settings) into sandboxes and materialized containers. The logic is extracted into a shared `internal/agentconfig` package so both `amika sandbox create` and `amika materialize` use the same discovery and mounting behavior.
+
+## Motivation
+
+Coding agents like Claude Code store configuration on the host that they need at runtime:
+
+| Host path        | Type      | Contents                             |
+| ---------------- | --------- | ------------------------------------ |
+| `~/.claude/`     | Directory | Settings, credentials, project state |
+| `~/.claude.json` | File      | API keys and preferences             |
+
+Currently, only `amika materialize` auto-mounts these files, and it mounts them to the wrong container path (`/root/.claude` instead of `/home/amika/.claude`, which is where `$HOME` points in the preset Dockerfiles). The `sandbox create` command does not mount agent config at all, requiring users to manually pass `--mount` flags.
+
+This spec:
+
+1. Extracts config discovery into a shared package.
+2. Fixes the container target path to match `$HOME` in the preset images.
+3. Adds auto-mounting to both `sandbox create` and `materialize` using rwcopy for isolation (Docker volumes for directories, file-based rwcopy for files per spec 003).
+
+## Goals
+
+1. Auto-mount agent config for the `claude` and `coder` presets in both `sandbox create` and `materialize`.
+2. Use rwcopy isolation for both commands — the container gets its own copy and changes do not propagate back to the host.
+3. Fix container target paths to `/home/amika/.claude` and `/home/amika/.claude.json`.
+4. Make discovery logic testable and reusable.
+
+## Non-Goals
+
+1. Supporting agent config for non-Claude tools (e.g., Codex, OpenCode config files). This can be added later by extending the discovery functions.
+2. Automatically detecting the container `$HOME` — the target path is a constant derived from the preset Dockerfiles.
+3. Mounting agent config for custom (non-preset) images.
+
+## Agent Config Discovery
+
+### New Package: `internal/agentconfig`
+
+This package discovers agent configuration files on the host and produces mount specifications. It has no CLI dependencies and is consumed by both command handlers.
+
+### `MountSpec` Type
+
+```go
+type MountSpec struct {
+    HostPath      string // absolute path on host
+    ContainerPath string // absolute path in container
+    IsDir         bool   // true = directory, false = file
+}
+```
+
+### Discovery Function
+
+`ClaudeMounts(homeDir string) []MountSpec`
+
+Takes the user's home directory as a parameter (for testability). Returns mount specs for Claude config files that exist on disk:
+
+1. Checks if `{homeDir}/.claude/` exists and is a directory. If so, adds a spec with `ContainerPath: "/home/amika/.claude"`, `IsDir: true`.
+2. Checks if `{homeDir}/.claude.json` exists and is a regular file. If so, adds a spec with `ContainerPath: "/home/amika/.claude.json"`, `IsDir: false`.
+
+Returns nil if neither exists. Does not return errors for missing files — absence is normal.
+
+### Conversion Function
+
+`RWCopyMounts(specs []MountSpec) []sandbox.MountBinding`
+
+- Converts specs to rwcopy mounts (Type="bind", Mode="rwcopy").
+- Used by both `sandbox create` and `materialize`. The rwcopy processing loop handles these: directories become Docker volumes, files become file-based rwcopy mounts (spec 003).
+
+### Preset Check
+
+`IsAgentPreset(preset string) bool`
+
+- Returns true for `"claude"` and `"coder"`.
+- Callers use this to decide whether to invoke discovery.
+
+## Container Target Paths
+
+The preset Dockerfiles (`internal/sandbox/presets/claude/Dockerfile` and `internal/sandbox/presets/coder/Dockerfile`) both set `ENV HOME=/home/amika`. Agent config is mounted relative to this home directory:
+
+| Host             | Container                  |
+| ---------------- | -------------------------- |
+| `~/.claude/`     | `/home/amika/.claude`      |
+| `~/.claude.json` | `/home/amika/.claude.json` |
+
+This fixes the current `materialize` behavior which incorrectly mounts to `/root/.claude`.
+
+## Integration: `sandbox create`
+
+In the sandbox create handler, after parsing user-specified mounts and before `validateMountTargets`:
+
+```go
+if agentconfig.IsAgentPreset(preset) {
+    homeDir, err := os.UserHomeDir()
+    if err == nil {
+        agentMounts := agentconfig.RWCopyMounts(agentconfig.ClaudeMounts(homeDir))
+        mounts = append(mounts, agentMounts...)
+    }
+}
+```
+
+The appended mounts have Mode="rwcopy" and flow through the existing processing loop:
+
+- `~/.claude/` (IsDir=true) → Docker volume rwcopy (existing spec 002 flow)
+- `~/.claude.json` (IsDir=false) → file-based rwcopy (spec 003 flow)
+
+Agent config mounts are appended before target validation, so user-specified `--mount` flags that conflict with agent config paths will produce a clear duplicate-target error.
+
+## Integration: `materialize`
+
+Replace the inline Claude config block (`cmd/amika/materialize.go` lines 79-100) with:
+
+```go
+if agentconfig.IsAgentPreset(preset) {
+    homeDir, err := os.UserHomeDir()
+    if err == nil {
+        agentMounts := agentconfig.RWCopyMounts(agentconfig.ClaudeMounts(homeDir))
+        mounts = append(mounts, agentMounts...)
+    }
+}
+```
+
+This uses rwcopy so the container gets its own isolated copy — changes inside the ephemeral container do not propagate back to the host's `~/.claude/` or `~/.claude.json`. The materialize command must process rwcopy mounts the same way `sandbox create` does (creating Docker volumes for directories, file-based copies for files).
+
+### Cleanup
+
+Unlike `sandbox create`, materialize runs ephemeral containers (`docker run --rm`) that are not tracked in `sandboxes.jsonl`. The rwcopy resources created for agent config (Docker volumes and file-based copies) must be cleaned up unconditionally after the container exits, regardless of whether the container succeeded or failed. This means:
+
+- **Docker volumes** created for directory rwcopy: `docker volume rm` after the container exits.
+- **File-based copies** created for file rwcopy: `os.RemoveAll` on the copy directory after the container exits.
+- **No state tracking**: since these are ephemeral, they should not be saved to `volumes.jsonl` or `rwcopy-mounts.jsonl`. They are created before the container runs and deleted after it exits, using `defer` for reliability.
+- **On creation failure** (before the container runs): the same rollback logic applies — clean up any partially created volumes or file copies.
+
+## Test Plan
+
+### `internal/agentconfig` Unit Tests
+
+1. `ClaudeMounts` with both `~/.claude/` and `~/.claude.json` present — returns two specs with correct paths and IsDir values.
+2. `ClaudeMounts` with only `~/.claude/` present — returns one directory spec.
+3. `ClaudeMounts` with only `~/.claude.json` present — returns one file spec.
+4. `ClaudeMounts` with neither present — returns nil.
+5. `RWCopyMounts` conversion — produces MountBindings with Type="bind", Mode="rwcopy".
+6. `IsAgentPreset` — true for "claude" and "coder", false for "", "custom", etc.
+7. Container paths use `/home/amika/`, not `/root/`.
+
+### Integration (in `cmd/amika/` tests)
+
+1. Agent config mounts are included for "claude" and "coder" presets.
+2. Agent config mounts are not included for non-preset or custom-image sandboxes.
+3. User-specified mount to `/home/amika/.claude` conflicts with agent config and produces a duplicate-target error.
+
+## Acceptance Criteria
+
+1. `amika sandbox create --preset coder` with `~/.claude/` and `~/.claude.json` present auto-mounts both as rwcopy.
+2. `amika sandbox create --preset coder` without Claude config on host creates the sandbox normally (no error).
+3. `amika materialize --preset claude --cmd "ls /home/amika/.claude"` succeeds (config is at correct path, not `/root/.claude`).
+4. `amika materialize` uses rwcopy — changes inside the container do not modify the host's `~/.claude/` or `~/.claude.json`.
+5. rwcopy volumes and file mounts created by `materialize` are cleaned up after the ephemeral container exits.
+6. Both mounts appear in `amika volume list` after sandbox creation (one directory, one file).
+
+## Dependencies
+
+1. File-based rwcopy mounts (spec 003) for handling `~/.claude.json` in `sandbox create`.
+2. Existing Docker volume rwcopy (spec 002) for handling `~/.claude/` in `sandbox create`.
+3. Preset Dockerfiles with `ENV HOME=/home/amika`.
+
+## Future Considerations
+
+1. Additional agent configs (Codex, OpenCode) can be added by writing new discovery functions in `internal/agentconfig` and calling them alongside `ClaudeMounts`.
+2. Per-project agent config (e.g., `.claude/` inside a git repo) could be handled separately from home-directory config.
+3. The container home path could be made configurable per-preset rather than a constant, if future presets use different home directories.


### PR DESCRIPTION
## Summary
- Add spec 003: file-based rwcopy mounts, extending the rwcopy system to support single-file mounts alongside directory-based Docker volume mounts
- Add spec 004: agent config auto-mounting, defining automatic mounting of coding agent config files (e.g., Claude Code settings) into sandboxes and materialized containers
- Add doc comment explaining the Alpine copy trick in `CopyHostDirToVolume`

## Test plan
- [x] Specs are well-formed markdown and consistent with existing specs