### PR TITLE
Add file-based rwcopy mount support

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -107,6 +107,15 @@ var sandboxCreateCmd = &cobra.Command{
 			return err
 		}
 		volumeStore := sandbox.NewVolumeStore(volumesFile)
+		fileMountsFile, err := config.FileMountsStateFile()
+		if err != nil {
+			return err
+		}
+		fileMountStore := sandbox.NewFileMountStore(fileMountsFile)
+		fileMountsBaseDir, err := config.FileMountsDir()
+		if err != nil {
+			return err
+		}
 
 		// Generate a name if not provided
 		if name == "" {
@@ -157,13 +166,21 @@ var sandboxCreateCmd = &cobra.Command{
 		var runtimeMounts []sandbox.MountBinding
 		createdVolumes := make([]string, 0)
 		addedRefs := make(map[string]bool)
-		rollbackVolumeState := func() {
+		createdFileMountDirs := make([]string, 0)
+		addedFileRefs := make(map[string]bool)
+		rollbackAll := func() {
 			for volumeName := range addedRefs {
 				_ = volumeStore.RemoveSandboxRef(volumeName, name)
 			}
 			for _, volumeName := range createdVolumes {
 				_ = volumeStore.Remove(volumeName)
 				_ = sandbox.RemoveDockerVolume(volumeName)
+			}
+			for mountName := range addedFileRefs {
+				_ = fileMountStore.Remove(mountName)
+			}
+			for _, dir := range createdFileMountDirs {
+				_ = os.RemoveAll(dir)
 			}
 		}
 
@@ -175,55 +192,90 @@ var sandboxCreateCmd = &cobra.Command{
 
 			stat, err := os.Stat(m.Source)
 			if err != nil {
-				rollbackVolumeState()
+				rollbackAll()
 				return fmt.Errorf("rwcopy source %q is not accessible: %w", m.Source, err)
 			}
-			if !stat.IsDir() {
-				rollbackVolumeState()
-				return fmt.Errorf("rwcopy source %q must be a directory", m.Source)
-			}
 
-			volumeName := generateRWCopyVolumeName(name, m.Target)
-			if err := sandbox.CreateDockerVolume(volumeName); err != nil {
-				rollbackVolumeState()
-				return err
-			}
-			createdVolumes = append(createdVolumes, volumeName)
+			if stat.IsDir() {
+				volumeName := generateRWCopyVolumeName(name, m.Target)
+				if err := sandbox.CreateDockerVolume(volumeName); err != nil {
+					rollbackAll()
+					return err
+				}
+				createdVolumes = append(createdVolumes, volumeName)
 
-			if err := sandbox.CopyHostDirToVolume(volumeName, m.Source); err != nil {
-				rollbackVolumeState()
-				return err
-			}
+				if err := sandbox.CopyHostDirToVolume(volumeName, m.Source); err != nil {
+					rollbackAll()
+					return err
+				}
 
-			info := sandbox.VolumeInfo{
-				Name:        volumeName,
-				CreatedAt:   time.Now().UTC().Format(time.RFC3339),
-				CreatedBy:   "rwcopy",
-				SourcePath:  m.Source,
-				SandboxRefs: []string{name},
-			}
-			if err := volumeStore.Save(info); err != nil {
-				rollbackVolumeState()
-				return fmt.Errorf("failed to save volume state for %q: %w", volumeName, err)
-			}
-			addedRefs[volumeName] = true
+				volInfo := sandbox.VolumeInfo{
+					Name:        volumeName,
+					CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+					CreatedBy:   "rwcopy",
+					SourcePath:  m.Source,
+					SandboxRefs: []string{name},
+				}
+				if err := volumeStore.Save(volInfo); err != nil {
+					rollbackAll()
+					return fmt.Errorf("failed to save volume state for %q: %w", volumeName, err)
+				}
+				addedRefs[volumeName] = true
 
-			runtimeMounts = append(runtimeMounts, sandbox.MountBinding{
-				Type:         "volume",
-				Volume:       volumeName,
-				Target:       m.Target,
-				Mode:         "rw",
-				SnapshotFrom: m.Source,
-			})
+				runtimeMounts = append(runtimeMounts, sandbox.MountBinding{
+					Type:         "volume",
+					Volume:       volumeName,
+					Target:       m.Target,
+					Mode:         "rw",
+					SnapshotFrom: m.Source,
+				})
+			} else {
+				mountName := generateRWCopyFileMountName(name, m.Target)
+				copyDir := filepath.Join(fileMountsBaseDir, mountName)
+				if err := os.MkdirAll(copyDir, 0755); err != nil {
+					rollbackAll()
+					return fmt.Errorf("failed to create file mount directory for %q: %w", mountName, err)
+				}
+				createdFileMountDirs = append(createdFileMountDirs, copyDir)
+
+				copyPath := filepath.Join(copyDir, filepath.Base(m.Source))
+				if err := copyFile(m.Source, copyPath); err != nil {
+					rollbackAll()
+					return fmt.Errorf("failed to copy file for rwcopy mount %q: %w", m.Source, err)
+				}
+
+				fmInfo := sandbox.FileMountInfo{
+					Name:        mountName,
+					Type:        "file",
+					CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+					CreatedBy:   "rwcopy",
+					SourcePath:  m.Source,
+					CopyPath:    copyPath,
+					SandboxRefs: []string{name},
+				}
+				if err := fileMountStore.Save(fmInfo); err != nil {
+					rollbackAll()
+					return fmt.Errorf("failed to save file mount state for %q: %w", mountName, err)
+				}
+				addedFileRefs[mountName] = true
+
+				runtimeMounts = append(runtimeMounts, sandbox.MountBinding{
+					Type:         "bind",
+					Source:       copyPath,
+					Target:       m.Target,
+					Mode:         "rw",
+					SnapshotFrom: m.Source,
+				})
+			}
 		}
 
 		for _, v := range volumeMounts {
 			if _, err := volumeStore.Get(v.Volume); err != nil {
-				rollbackVolumeState()
+				rollbackAll()
 				return fmt.Errorf("volume %q is not tracked; create via rwcopy first", v.Volume)
 			}
 			if err := volumeStore.AddSandboxRef(v.Volume, name); err != nil {
-				rollbackVolumeState()
+				rollbackAll()
 				return fmt.Errorf("failed to attach volume %q: %w", v.Volume, err)
 			}
 			addedRefs[v.Volume] = true
@@ -232,7 +284,7 @@ var sandboxCreateCmd = &cobra.Command{
 
 		containerID, err := sandbox.CreateDockerSandbox(name, image, runtimeMounts, envStrs)
 		if err != nil {
-			rollbackVolumeState()
+			rollbackAll()
 			return err
 		}
 
@@ -285,6 +337,11 @@ var sandboxDeleteCmd = &cobra.Command{
 			return err
 		}
 		volumeStore := sandbox.NewVolumeStore(volumesFile)
+		fileMountsFile, err := config.FileMountsStateFile()
+		if err != nil {
+			return err
+		}
+		fileMountStore := sandbox.NewFileMountStore(fileMountsFile)
 
 		var errs []string
 		for _, name := range args {
@@ -296,6 +353,7 @@ var sandboxDeleteCmd = &cobra.Command{
 
 			deleteVols, err := resolveDeleteVolumes(
 				volumeStore,
+				fileMountStore,
 				name,
 				deleteVolumesSet,
 				keepVolumesSet,
@@ -314,6 +372,7 @@ var sandboxDeleteCmd = &cobra.Command{
 			}
 
 			volumeStatuses, volumeErr := cleanupSandboxVolumes(volumeStore, name, deleteVols, sandbox.RemoveDockerVolume)
+			fileMountStatuses, fileMountErr := cleanupSandboxFileMounts(fileMountStore, name, deleteVols)
 
 			if err := store.Remove(name); err != nil {
 				errs = append(errs, fmt.Sprintf("sandbox %q: container removed but failed to update state: %v", name, err))
@@ -324,8 +383,14 @@ var sandboxDeleteCmd = &cobra.Command{
 			for _, line := range volumeStatuses {
 				fmt.Println(line)
 			}
+			for _, line := range fileMountStatuses {
+				fmt.Println(line)
+			}
 			if volumeErr != nil {
 				errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, volumeErr))
+			}
+			if fileMountErr != nil {
+				errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, fileMountErr))
 			}
 		}
 		if len(errs) > 0 {
@@ -741,6 +806,29 @@ func generateRWCopyVolumeName(sandboxName, target string) string {
 	return "amika-rwcopy-" + sandboxName + "-" + sanitizedTarget + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 }
 
+func generateRWCopyFileMountName(sandboxName, target string) string {
+	sanitizedTarget := strings.NewReplacer("/", "-", "_", "-", ".", "-").Replace(strings.TrimPrefix(target, "/"))
+	if sanitizedTarget == "" {
+		sanitizedTarget = "root"
+	}
+	return "amika-rwcopy-file-" + sandboxName + "-" + sanitizedTarget + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+func copyFile(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat source file %q: %w", src, err)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("failed to read source file %q: %w", src, err)
+	}
+	if err := os.WriteFile(dst, data, srcInfo.Mode()); err != nil {
+		return fmt.Errorf("failed to write destination file %q: %w", dst, err)
+	}
+	return nil
+}
+
 func cleanupSandboxVolumes(
 	volumeStore sandbox.VolumeStore,
 	sandboxName string,
@@ -800,6 +888,64 @@ func cleanupSandboxVolumes(
 	return statuses, nil
 }
 
+func cleanupSandboxFileMounts(
+	fileMountStore sandbox.FileMountStore,
+	sandboxName string,
+	deleteMounts bool,
+) ([]string, error) {
+	mounts, err := fileMountStore.FileMountsForSandbox(sandboxName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load associated file mounts: %w", err)
+	}
+	if len(mounts) == 0 {
+		return nil, nil
+	}
+
+	statuses := make([]string, 0, len(mounts))
+	var errs []string
+
+	for _, fm := range mounts {
+		if err := fileMountStore.RemoveSandboxRef(fm.Name, sandboxName); err != nil {
+			statuses = append(statuses, fmt.Sprintf("file-mount %s: delete-failed: failed to update refs", fm.Name))
+			errs = append(errs, fmt.Sprintf("failed to remove sandbox ref for file mount %q: %v", fm.Name, err))
+			continue
+		}
+
+		if !deleteMounts {
+			statuses = append(statuses, fmt.Sprintf("file-mount %s: preserved", fm.Name))
+			continue
+		}
+
+		inUse, err := fileMountStore.IsInUse(fm.Name)
+		if err != nil {
+			statuses = append(statuses, fmt.Sprintf("file-mount %s: delete-failed: failed to check usage", fm.Name))
+			errs = append(errs, fmt.Sprintf("failed to check usage for file mount %q: %v", fm.Name, err))
+			continue
+		}
+		if inUse {
+			statuses = append(statuses, fmt.Sprintf("file-mount %s: preserved (still referenced)", fm.Name))
+			continue
+		}
+
+		if err := os.RemoveAll(filepath.Dir(fm.CopyPath)); err != nil {
+			statuses = append(statuses, fmt.Sprintf("file-mount %s: delete-failed: %v", fm.Name, err))
+			errs = append(errs, fmt.Sprintf("failed to delete file mount directory for %q: %v", fm.Name, err))
+			continue
+		}
+		if err := fileMountStore.Remove(fm.Name); err != nil {
+			statuses = append(statuses, fmt.Sprintf("file-mount %s: delete-failed: failed to remove state entry", fm.Name))
+			errs = append(errs, fmt.Sprintf("failed to remove file mount state for %q: %v", fm.Name, err))
+			continue
+		}
+		statuses = append(statuses, fmt.Sprintf("file-mount %s: deleted", fm.Name))
+	}
+
+	if len(errs) > 0 {
+		return statuses, fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return statuses, nil
+}
+
 func validateDeleteVolumeFlags(
 	deleteVolumesSet bool,
 	deleteVolumes bool,
@@ -826,6 +972,7 @@ func validateDeleteVolumeFlags(
 //     attached volume.
 func resolveDeleteVolumes(
 	volumeStore sandbox.VolumeStore,
+	fileMountStore sandbox.FileMountStore,
 	sandboxName string,
 	deleteVolumesSet bool,
 	keepVolumesSet bool,
@@ -856,6 +1003,24 @@ func resolveDeleteVolumes(
 			exclusive = append(exclusive, volume.Name)
 		}
 	}
+
+	fileMounts, err := fileMountStore.FileMountsForSandbox(sandboxName)
+	if err != nil {
+		return false, fmt.Errorf("failed to load associated file mounts: %w", err)
+	}
+	for _, fm := range fileMounts {
+		exclusiveToSandbox := true
+		for _, ref := range fm.SandboxRefs {
+			if ref != sandboxName {
+				exclusiveToSandbox = false
+				break
+			}
+		}
+		if exclusiveToSandbox {
+			exclusive = append(exclusive, fm.Name)
+		}
+	}
+
 	if len(exclusive) == 0 {
 		return false, nil
 	}

--- a/cmd/amika/volume.go
+++ b/cmd/amika/volume.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 
@@ -26,17 +28,27 @@ var volumeListCmd = &cobra.Command{
 		}
 		store := sandbox.NewVolumeStore(volumesFile)
 
+		fileMountsFile, err := config.FileMountsStateFile()
+		if err != nil {
+			return err
+		}
+		fmStore := sandbox.NewFileMountStore(fileMountsFile)
+
 		volumes, err := store.List()
 		if err != nil {
 			return err
 		}
-		if len(volumes) == 0 {
+		fileMounts, err := fmStore.List()
+		if err != nil {
+			return err
+		}
+		if len(volumes) == 0 && len(fileMounts) == 0 {
 			fmt.Fprintln(cmd.OutOrStdout(), "No volumes found.")
 			return nil
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tCREATED\tIN_USE\tSANDBOXES\tSOURCE")
+		fmt.Fprintln(w, "NAME\tTYPE\tCREATED\tIN_USE\tSANDBOXES\tSOURCE")
 		for _, v := range volumes {
 			inUse := "no"
 			if len(v.SandboxRefs) > 0 {
@@ -44,12 +56,29 @@ var volumeListCmd = &cobra.Command{
 			}
 			fmt.Fprintf(
 				w,
-				"%s\t%s\t%s\t%s\t%s\n",
+				"%s\t%s\t%s\t%s\t%s\t%s\n",
 				v.Name,
+				"directory",
 				v.CreatedAt,
 				inUse,
 				strings.Join(v.SandboxRefs, ","),
 				v.SourcePath,
+			)
+		}
+		for _, fm := range fileMounts {
+			inUse := "no"
+			if len(fm.SandboxRefs) > 0 {
+				inUse = "yes"
+			}
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\t%s\n",
+				fm.Name,
+				"file",
+				fm.CreatedAt,
+				inUse,
+				strings.Join(fm.SandboxRefs, ","),
+				fm.SourcePath,
 			)
 		}
 		w.Flush()
@@ -71,13 +100,33 @@ var volumeDeleteCmd = &cobra.Command{
 		}
 		store := sandbox.NewVolumeStore(volumesFile)
 
+		fileMountsFile, err := config.FileMountsStateFile()
+		if err != nil {
+			return err
+		}
+		fmStore := sandbox.NewFileMountStore(fileMountsFile)
+
 		var errs []string
 		for _, name := range args {
-			if err := deleteTrackedVolume(store, name, force, sandbox.RemoveDockerVolume); err != nil {
-				errs = append(errs, fmt.Sprintf("volume %q: %v", name, err))
+			if _, err := store.Get(name); err == nil {
+				if err := deleteTrackedVolume(store, name, force, sandbox.RemoveDockerVolume); err != nil {
+					errs = append(errs, fmt.Sprintf("volume %q: %v", name, err))
+					continue
+				}
+				fmt.Printf("Volume %q deleted\n", name)
 				continue
 			}
-			fmt.Printf("Volume %q deleted\n", name)
+
+			if _, err := fmStore.Get(name); err == nil {
+				if err := deleteTrackedFileMount(fmStore, name, force); err != nil {
+					errs = append(errs, fmt.Sprintf("volume %q: %v", name, err))
+					continue
+				}
+				fmt.Printf("Volume %q deleted\n", name)
+				continue
+			}
+
+			errs = append(errs, fmt.Sprintf("no volume found with name: %s", name))
 		}
 		if len(errs) > 0 {
 			return fmt.Errorf("%s", strings.Join(errs, "\n"))
@@ -103,6 +152,29 @@ func deleteTrackedVolume(
 
 	if err := removeVolumeFn(name); err != nil {
 		return err
+	}
+	if err := store.Remove(name); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteTrackedFileMount(
+	store sandbox.FileMountStore,
+	name string,
+	force bool,
+) error {
+	fm, err := store.Get(name)
+	if err != nil {
+		return err
+	}
+
+	if len(fm.SandboxRefs) > 0 && !force {
+		return fmt.Errorf("volume %q is in use by sandboxes: %s (use --force to delete)", name, strings.Join(fm.SandboxRefs, ", "))
+	}
+
+	if err := os.RemoveAll(filepath.Dir(fm.CopyPath)); err != nil {
+		return fmt.Errorf("failed to remove file mount directory: %w", err)
 	}
 	if err := store.Remove(name); err != nil {
 		return err

--- a/cmd/amika/volume_test.go
+++ b/cmd/amika/volume_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -76,11 +77,112 @@ func TestVolumeListCmd_PrintsTrackedVolumes(t *testing.T) {
 	if !strings.Contains(out, "vol-1") {
 		t.Fatalf("expected volume name in output, got:\n%s", out)
 	}
+	if !strings.Contains(out, "TYPE") {
+		t.Fatalf("expected TYPE header in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "directory") {
+		t.Fatalf("expected directory type in output, got:\n%s", out)
+	}
 	if !strings.Contains(out, "yes") {
 		t.Fatalf("expected in-use marker in output, got:\n%s", out)
 	}
 	if !strings.Contains(out, "sb-a") {
 		t.Fatalf("expected sandbox refs in output, got:\n%s", out)
+	}
+}
+
+func TestVolumeListCmd_PrintsBothTypes(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+
+	volStore := sandbox.NewVolumeStore(filepath.Join(stateDir, "volumes.jsonl"))
+	_ = volStore.Save(sandbox.VolumeInfo{
+		Name:       "vol-1",
+		CreatedAt:  "2026-01-01T00:00:00Z",
+		SourcePath: "/host/data",
+	})
+
+	fmStore := sandbox.NewFileMountStore(filepath.Join(stateDir, "rwcopy-mounts.jsonl"))
+	_ = fmStore.Save(sandbox.FileMountInfo{
+		Name:       "fm-1",
+		Type:       "file",
+		CreatedAt:  "2026-01-02T00:00:00Z",
+		SourcePath: "/host/config.yaml",
+		CopyPath:   "/state/rwcopy-mounts.d/fm-1/config.yaml",
+	})
+
+	buf := &bytes.Buffer{}
+	volumeListCmd.SetOut(buf)
+	volumeListCmd.SetErr(buf)
+
+	if err := volumeListCmd.RunE(volumeListCmd, nil); err != nil {
+		t.Fatalf("volume list failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "directory") {
+		t.Fatalf("expected directory type in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "file") {
+		t.Fatalf("expected file type in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vol-1") {
+		t.Fatalf("expected vol-1 in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "fm-1") {
+		t.Fatalf("expected fm-1 in output, got:\n%s", out)
+	}
+}
+
+func TestDeleteTrackedFileMount_InUseRequiresForce(t *testing.T) {
+	dir := t.TempDir()
+	store := sandbox.NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+	if err := store.Save(sandbox.FileMountInfo{
+		Name:        "fm-1",
+		CopyPath:    filepath.Join(dir, "fm-1", "file.yaml"),
+		SandboxRefs: []string{"sb-a"},
+	}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	err := deleteTrackedFileMount(store, "fm-1", false)
+	if err == nil {
+		t.Fatal("expected in-use error")
+	}
+	if !strings.Contains(err.Error(), "use --force") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteTrackedFileMount_ForceDeletes(t *testing.T) {
+	dir := t.TempDir()
+	store := sandbox.NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+
+	copyDir := filepath.Join(dir, "fm-1")
+	if err := os.MkdirAll(copyDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	copyPath := filepath.Join(copyDir, "file.yaml")
+	if err := os.WriteFile(copyPath, []byte("data"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	if err := store.Save(sandbox.FileMountInfo{
+		Name:        "fm-1",
+		CopyPath:    copyPath,
+		SandboxRefs: []string{"sb-a"},
+	}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if err := deleteTrackedFileMount(store, "fm-1", true); err != nil {
+		t.Fatalf("deleteTrackedFileMount failed: %v", err)
+	}
+	if _, err := store.Get("fm-1"); err == nil {
+		t.Fatal("file mount should be removed from state")
+	}
+	if _, err := os.Stat(copyDir); !os.IsNotExist(err) {
+		t.Fatal("copy directory should have been removed")
 	}
 }
 

--- a/internal/basedir/basedir.go
+++ b/internal/basedir/basedir.go
@@ -8,17 +8,19 @@ import (
 )
 
 const (
-	appName          = "amika"
-	envCacheFile     = "env-cache.json"
-	keychainFile     = "keychain.json"
-	oauthFile        = "oauth.json"
-	mountsStateFile  = "mounts.jsonl"
-	sandboxesFile    = "sandboxes.jsonl"
-	volumesStateFile = "volumes.jsonl"
-	envXDGConfigHome = "XDG_CONFIG_HOME"
-	envXDGDataHome   = "XDG_DATA_HOME"
-	envXDGCacheHome  = "XDG_CACHE_HOME"
-	envXDGStateHome  = "XDG_STATE_HOME"
+	appName             = "amika"
+	envCacheFile        = "env-cache.json"
+	keychainFile        = "keychain.json"
+	oauthFile           = "oauth.json"
+	mountsStateFile     = "mounts.jsonl"
+	sandboxesFile       = "sandboxes.jsonl"
+	volumesStateFile    = "volumes.jsonl"
+	fileMountsStateFile = "rwcopy-mounts.jsonl"
+	fileMountsDir       = "rwcopy-mounts.d"
+	envXDGConfigHome    = "XDG_CONFIG_HOME"
+	envXDGDataHome      = "XDG_DATA_HOME"
+	envXDGCacheHome     = "XDG_CACHE_HOME"
+	envXDGStateHome     = "XDG_STATE_HOME"
 )
 
 // Paths resolves XDG base directories and Amika-managed file locations.
@@ -40,6 +42,8 @@ type Paths interface {
 	MountsStateFile() (string, error)
 	SandboxesStateFile() (string, error)
 	VolumesStateFile() (string, error)
+	FileMountsStateFile() (string, error)
+	FileMountsDir() (string, error)
 }
 
 type xdgPaths struct {
@@ -187,6 +191,22 @@ func (p *xdgPaths) VolumesStateFile() (string, error) {
 	return VolumesStateFileIn(dir), nil
 }
 
+func (p *xdgPaths) FileMountsStateFile() (string, error) {
+	dir, err := p.AmikaStateDir()
+	if err != nil {
+		return "", err
+	}
+	return FileMountsStateFileIn(dir), nil
+}
+
+func (p *xdgPaths) FileMountsDir() (string, error) {
+	dir, err := p.AmikaStateDir()
+	if err != nil {
+		return "", err
+	}
+	return FileMountsDirIn(dir), nil
+}
+
 // MountsStateFileIn returns the mounts state file path under the given state directory.
 func MountsStateFileIn(stateDir string) string {
 	return filepath.Join(stateDir, mountsStateFile)
@@ -200,4 +220,14 @@ func SandboxesStateFileIn(stateDir string) string {
 // VolumesStateFileIn returns the volumes state file path under the given state directory.
 func VolumesStateFileIn(stateDir string) string {
 	return filepath.Join(stateDir, volumesStateFile)
+}
+
+// FileMountsStateFileIn returns the file mounts state file path under the given state directory.
+func FileMountsStateFileIn(stateDir string) string {
+	return filepath.Join(stateDir, fileMountsStateFile)
+}
+
+// FileMountsDirIn returns the file mounts directory path under the given state directory.
+func FileMountsDirIn(stateDir string) string {
+	return filepath.Join(stateDir, fileMountsDir)
 }

--- a/internal/basedir/basedir_test.go
+++ b/internal/basedir/basedir_test.go
@@ -69,6 +69,12 @@ func TestPaths_XDGOverrides(t *testing.T) {
 	if got, _ := p.VolumesStateFile(); got != filepath.Join(state, "amika", "volumes.jsonl") {
 		t.Fatalf("VolumesStateFile = %q", got)
 	}
+	if got, _ := p.FileMountsStateFile(); got != filepath.Join(state, "amika", "rwcopy-mounts.jsonl") {
+		t.Fatalf("FileMountsStateFile = %q", got)
+	}
+	if got, _ := p.FileMountsDir(); got != filepath.Join(state, "amika", "rwcopy-mounts.d") {
+		t.Fatalf("FileMountsDir = %q", got)
+	}
 }
 
 func TestStateFileHelpers(t *testing.T) {
@@ -82,6 +88,12 @@ func TestStateFileHelpers(t *testing.T) {
 	}
 	if got := VolumesStateFileIn(stateDir); got != filepath.Join(stateDir, "volumes.jsonl") {
 		t.Fatalf("VolumesStateFileIn = %q", got)
+	}
+	if got := FileMountsStateFileIn(stateDir); got != filepath.Join(stateDir, "rwcopy-mounts.jsonl") {
+		t.Fatalf("FileMountsStateFileIn = %q", got)
+	}
+	if got := FileMountsDirIn(stateDir); got != filepath.Join(stateDir, "rwcopy-mounts.d") {
+		t.Fatalf("FileMountsDirIn = %q", got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,3 +45,19 @@ func VolumesStateFile() (string, error) {
 	}
 	return basedir.New("").VolumesStateFile()
 }
+
+// FileMountsStateFile returns the resolved file mounts state file path.
+func FileMountsStateFile() (string, error) {
+	if dir := os.Getenv(EnvStateDirectory); dir != "" {
+		return basedir.FileMountsStateFileIn(dir), nil
+	}
+	return basedir.New("").FileMountsStateFile()
+}
+
+// FileMountsDir returns the resolved file mounts directory path.
+func FileMountsDir() (string, error) {
+	if dir := os.Getenv(EnvStateDirectory); dir != "" {
+		return basedir.FileMountsDirIn(dir), nil
+	}
+	return basedir.New("").FileMountsDir()
+}

--- a/internal/sandbox/file_mount_store.go
+++ b/internal/sandbox/file_mount_store.go
@@ -1,0 +1,208 @@
+package sandbox
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+// FileMountInfo represents a tracked file-based rwcopy mount.
+type FileMountInfo struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	CreatedAt   string   `json:"createdAt"`
+	CreatedBy   string   `json:"createdBy,omitempty"`
+	SourcePath  string   `json:"sourcePath,omitempty"`
+	CopyPath    string   `json:"copyPath"`
+	SandboxRefs []string `json:"sandboxRefs,omitempty"`
+}
+
+// FileMountStore manages file mount state persistence.
+type FileMountStore interface {
+	Save(info FileMountInfo) error
+	Get(name string) (FileMountInfo, error)
+	Remove(name string) error
+	List() ([]FileMountInfo, error)
+	AddSandboxRef(name, sandbox string) error
+	RemoveSandboxRef(name, sandbox string) error
+	FileMountsForSandbox(sandbox string) ([]FileMountInfo, error)
+	IsInUse(name string) (bool, error)
+}
+
+type fileFileMountStore struct {
+	filePath string
+}
+
+// NewFileMountStore creates a FileMountStore backed by the provided JSONL file path.
+func NewFileMountStore(filePath string) FileMountStore {
+	return &fileFileMountStore{filePath: filePath}
+}
+
+func (s *fileFileMountStore) readAll() ([]FileMountInfo, error) {
+	f, err := os.Open(s.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open file mounts file: %w", err)
+	}
+	defer f.Close()
+
+	var mounts []FileMountInfo
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var info FileMountInfo
+		if err := json.Unmarshal([]byte(line), &info); err != nil {
+			continue
+		}
+		mounts = append(mounts, info)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read file mounts file: %w", err)
+	}
+	return mounts, nil
+}
+
+func (s *fileFileMountStore) writeAll(mounts []FileMountInfo) error {
+	if err := os.MkdirAll(filepath.Dir(s.filePath), 0755); err != nil {
+		return fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	f, err := os.Create(s.filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file mounts file: %w", err)
+	}
+	defer f.Close()
+
+	for _, info := range mounts {
+		data, err := json.Marshal(info)
+		if err != nil {
+			return fmt.Errorf("failed to marshal file mount info: %w", err)
+		}
+		if _, err := f.Write(data); err != nil {
+			return fmt.Errorf("failed to write file mount info: %w", err)
+		}
+		if _, err := f.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write newline: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *fileFileMountStore) Save(info FileMountInfo) error {
+	mounts, err := s.readAll()
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i := range mounts {
+		if mounts[i].Name == info.Name {
+			mounts[i] = info
+			found = true
+			break
+		}
+	}
+	if !found {
+		mounts = append(mounts, info)
+	}
+
+	return s.writeAll(mounts)
+}
+
+func (s *fileFileMountStore) Get(name string) (FileMountInfo, error) {
+	mounts, err := s.readAll()
+	if err != nil {
+		return FileMountInfo{}, err
+	}
+
+	for _, m := range mounts {
+		if m.Name == name {
+			return m, nil
+		}
+	}
+	return FileMountInfo{}, fmt.Errorf("no file mount found with name: %s", name)
+}
+
+func (s *fileFileMountStore) Remove(name string) error {
+	mounts, err := s.readAll()
+	if err != nil {
+		return err
+	}
+
+	var filtered []FileMountInfo
+	for _, m := range mounts {
+		if m.Name != name {
+			filtered = append(filtered, m)
+		}
+	}
+
+	if len(filtered) == len(mounts) {
+		return nil
+	}
+
+	return s.writeAll(filtered)
+}
+
+func (s *fileFileMountStore) List() ([]FileMountInfo, error) {
+	return s.readAll()
+}
+
+func (s *fileFileMountStore) AddSandboxRef(name, sandbox string) error {
+	info, err := s.Get(name)
+	if err != nil {
+		return err
+	}
+
+	if !slices.Contains(info.SandboxRefs, sandbox) {
+		info.SandboxRefs = append(info.SandboxRefs, sandbox)
+	}
+	return s.Save(info)
+}
+
+func (s *fileFileMountStore) RemoveSandboxRef(name, sandbox string) error {
+	info, err := s.Get(name)
+	if err != nil {
+		return err
+	}
+
+	refs := info.SandboxRefs[:0]
+	for _, ref := range info.SandboxRefs {
+		if ref != sandbox {
+			refs = append(refs, ref)
+		}
+	}
+	info.SandboxRefs = refs
+	return s.Save(info)
+}
+
+func (s *fileFileMountStore) FileMountsForSandbox(sandbox string) ([]FileMountInfo, error) {
+	mounts, err := s.readAll()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []FileMountInfo
+	for _, m := range mounts {
+		if slices.Contains(m.SandboxRefs, sandbox) {
+			result = append(result, m)
+		}
+	}
+	return result, nil
+}
+
+func (s *fileFileMountStore) IsInUse(name string) (bool, error) {
+	info, err := s.Get(name)
+	if err != nil {
+		return false, err
+	}
+	return len(info.SandboxRefs) > 0, nil
+}

--- a/internal/sandbox/file_mount_store_test.go
+++ b/internal/sandbox/file_mount_store_test.go
@@ -1,0 +1,152 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileMountStore_SaveAndGet(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+
+	info := FileMountInfo{
+		Name:       "fm-1",
+		Type:       "file",
+		CreatedAt:  "2026-01-01T00:00:00Z",
+		CreatedBy:  "rwcopy",
+		SourcePath: "/host/config.yaml",
+		CopyPath:   "/state/rwcopy-mounts.d/fm-1/config.yaml",
+	}
+	if err := store.Save(info); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	got, err := store.Get("fm-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.Name != "fm-1" {
+		t.Fatalf("Name = %q, want %q", got.Name, "fm-1")
+	}
+	if got.SourcePath != "/host/config.yaml" {
+		t.Fatalf("SourcePath = %q, want %q", got.SourcePath, "/host/config.yaml")
+	}
+	if got.CopyPath != "/state/rwcopy-mounts.d/fm-1/config.yaml" {
+		t.Fatalf("CopyPath = %q, want %q", got.CopyPath, "/state/rwcopy-mounts.d/fm-1/config.yaml")
+	}
+	if got.Type != "file" {
+		t.Fatalf("Type = %q, want %q", got.Type, "file")
+	}
+}
+
+func TestFileMountStore_SaveReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+
+	_ = store.Save(FileMountInfo{Name: "fm-1", CreatedBy: "rwcopy"})
+	_ = store.Save(FileMountInfo{Name: "fm-1", CreatedBy: "manual"})
+
+	got, err := store.Get("fm-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.CreatedBy != "manual" {
+		t.Fatalf("CreatedBy = %q, want %q", got.CreatedBy, "manual")
+	}
+}
+
+func TestFileMountStore_Remove(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+
+	_ = store.Save(FileMountInfo{Name: "fm-1"})
+	_ = store.Save(FileMountInfo{Name: "fm-2"})
+
+	if err := store.Remove("fm-1"); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if _, err := store.Get("fm-1"); err == nil {
+		t.Fatal("expected not found after remove")
+	}
+	if _, err := store.Get("fm-2"); err != nil {
+		t.Fatalf("fm-2 should still exist: %v", err)
+	}
+}
+
+func TestFileMountStore_AddRemoveSandboxRef(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+
+	_ = store.Save(FileMountInfo{Name: "fm-1"})
+
+	if err := store.AddSandboxRef("fm-1", "sb-a"); err != nil {
+		t.Fatalf("AddSandboxRef failed: %v", err)
+	}
+	if err := store.AddSandboxRef("fm-1", "sb-a"); err != nil {
+		t.Fatalf("AddSandboxRef duplicate failed: %v", err)
+	}
+
+	got, err := store.Get("fm-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if len(got.SandboxRefs) != 1 || got.SandboxRefs[0] != "sb-a" {
+		t.Fatalf("SandboxRefs = %v, want [sb-a]", got.SandboxRefs)
+	}
+
+	if err := store.RemoveSandboxRef("fm-1", "sb-a"); err != nil {
+		t.Fatalf("RemoveSandboxRef failed: %v", err)
+	}
+
+	got, _ = store.Get("fm-1")
+	if len(got.SandboxRefs) != 0 {
+		t.Fatalf("SandboxRefs = %v, want empty", got.SandboxRefs)
+	}
+}
+
+func TestFileMountStore_FileMountsForSandboxAndInUse(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+
+	_ = store.Save(FileMountInfo{Name: "fm-1", SandboxRefs: []string{"sb-a", "sb-b"}})
+	_ = store.Save(FileMountInfo{Name: "fm-2", SandboxRefs: []string{"sb-b"}})
+	_ = store.Save(FileMountInfo{Name: "fm-3"})
+
+	got, err := store.FileMountsForSandbox("sb-a")
+	if err != nil {
+		t.Fatalf("FileMountsForSandbox failed: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "fm-1" {
+		t.Fatalf("FileMountsForSandbox(sb-a) = %+v, want fm-1", got)
+	}
+
+	inUse, err := store.IsInUse("fm-2")
+	if err != nil {
+		t.Fatalf("IsInUse failed: %v", err)
+	}
+	if !inUse {
+		t.Fatal("fm-2 should be in use")
+	}
+
+	inUse, err = store.IsInUse("fm-3")
+	if err != nil {
+		t.Fatalf("IsInUse failed: %v", err)
+	}
+	if inUse {
+		t.Fatal("fm-3 should not be in use")
+	}
+}
+
+func TestFileMountStore_CreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "amika-state")
+	store := NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+
+	if err := store.Save(FileMountInfo{Name: "fm-1"}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("directory should have been created: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `FileMountStore` with JSONL-backed persistence for file-based rwcopy mounts, following the same pattern as the existing volume store
- Add `basedir` and `config` path helpers for `rwcopy-mounts.jsonl` and `rwcopy-mounts.d/`
- Extend `sandbox create` to handle rwcopy of single files (not just directories) by copying to the Amika state directory and bind-mounting
- Extend `sandbox delete` to clean up file-based mounts alongside Docker volumes
- Add file mounts to `volume list` (with TYPE column) and `volume delete`

## Test plan
- [x] `make ci` passes
- [x] `FileMountStore` unit tests (save/get/list/remove round-trip, sandbox refs, in-use checks)
- [x] Sandbox create/delete tests for file-based rwcopy
- [x] Volume list/delete tests for file mounts