### PR TITLE
Add agent config auto-mounting to sandbox create and materialize

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -14,6 +14,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/gofixpoint/amika/internal/agentconfig"
 	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/sandbox"
 	"github.com/spf13/cobra"
@@ -92,6 +93,13 @@ var sandboxCreateCmd = &cobra.Command{
 			defer cleanupGitMount()
 			gitMountInfo = &info
 			mounts = append(mounts, info.Mount)
+		}
+		if agentconfig.IsAgentPreset(preset) {
+			homeDir, err := os.UserHomeDir()
+			if err == nil {
+				agentMounts := agentconfig.RWCopyMounts(agentconfig.ClaudeMounts(homeDir))
+				mounts = append(mounts, agentMounts...)
+			}
 		}
 		if err := validateMountTargets(mounts, volumeMounts); err != nil {
 			return err

--- a/internal/agentconfig/agentconfig.go
+++ b/internal/agentconfig/agentconfig.go
@@ -1,0 +1,66 @@
+// Package agentconfig discovers coding agent configuration files on the host
+// and produces mount specifications for sandboxes and ephemeral containers.
+package agentconfig
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gofixpoint/amika/internal/sandbox"
+)
+
+// containerHome is the home directory inside preset container images.
+const containerHome = "/home/amika"
+
+// MountSpec describes a host path to mount into a container.
+type MountSpec struct {
+	HostPath      string // absolute path on host
+	ContainerPath string // absolute path in container
+	IsDir         bool   // true = directory, false = file
+}
+
+// ClaudeMounts returns mount specs for Claude Code configuration files that
+// exist under homeDir. Returns nil if neither ~/.claude/ nor ~/.claude.json
+// exists.
+func ClaudeMounts(homeDir string) []MountSpec {
+	var specs []MountSpec
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	if info, err := os.Stat(claudeDir); err == nil && info.IsDir() {
+		specs = append(specs, MountSpec{
+			HostPath:      claudeDir,
+			ContainerPath: containerHome + "/.claude",
+			IsDir:         true,
+		})
+	}
+
+	claudeJSON := filepath.Join(homeDir, ".claude.json")
+	if info, err := os.Stat(claudeJSON); err == nil && !info.IsDir() {
+		specs = append(specs, MountSpec{
+			HostPath:      claudeJSON,
+			ContainerPath: containerHome + "/.claude.json",
+			IsDir:         false,
+		})
+	}
+
+	return specs
+}
+
+// RWCopyMounts converts MountSpecs into sandbox MountBindings with rwcopy mode.
+func RWCopyMounts(specs []MountSpec) []sandbox.MountBinding {
+	mounts := make([]sandbox.MountBinding, 0, len(specs))
+	for _, s := range specs {
+		mounts = append(mounts, sandbox.MountBinding{
+			Type:   "bind",
+			Source: s.HostPath,
+			Target: s.ContainerPath,
+			Mode:   "rwcopy",
+		})
+	}
+	return mounts
+}
+
+// IsAgentPreset returns true for presets that use agent configuration files.
+func IsAgentPreset(preset string) bool {
+	return preset == "claude" || preset == "coder"
+}

--- a/internal/agentconfig/agentconfig_test.go
+++ b/internal/agentconfig/agentconfig_test.go
@@ -1,0 +1,152 @@
+package agentconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClaudeMounts_BothExist(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	specs := ClaudeMounts(home)
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(specs))
+	}
+
+	dir := specs[0]
+	if dir.HostPath != filepath.Join(home, ".claude") {
+		t.Errorf("dir HostPath = %q, want %q", dir.HostPath, filepath.Join(home, ".claude"))
+	}
+	if dir.ContainerPath != "/home/amika/.claude" {
+		t.Errorf("dir ContainerPath = %q, want /home/amika/.claude", dir.ContainerPath)
+	}
+	if !dir.IsDir {
+		t.Error("dir IsDir = false, want true")
+	}
+
+	file := specs[1]
+	if file.HostPath != filepath.Join(home, ".claude.json") {
+		t.Errorf("file HostPath = %q, want %q", file.HostPath, filepath.Join(home, ".claude.json"))
+	}
+	if file.ContainerPath != "/home/amika/.claude.json" {
+		t.Errorf("file ContainerPath = %q, want /home/amika/.claude.json", file.ContainerPath)
+	}
+	if file.IsDir {
+		t.Error("file IsDir = true, want false")
+	}
+}
+
+func TestClaudeMounts_OnlyDir(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	specs := ClaudeMounts(home)
+	if len(specs) != 1 {
+		t.Fatalf("expected 1 spec, got %d", len(specs))
+	}
+	if !specs[0].IsDir {
+		t.Error("expected IsDir = true")
+	}
+	if specs[0].ContainerPath != "/home/amika/.claude" {
+		t.Errorf("ContainerPath = %q, want /home/amika/.claude", specs[0].ContainerPath)
+	}
+}
+
+func TestClaudeMounts_OnlyFile(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	specs := ClaudeMounts(home)
+	if len(specs) != 1 {
+		t.Fatalf("expected 1 spec, got %d", len(specs))
+	}
+	if specs[0].IsDir {
+		t.Error("expected IsDir = false")
+	}
+	if specs[0].ContainerPath != "/home/amika/.claude.json" {
+		t.Errorf("ContainerPath = %q, want /home/amika/.claude.json", specs[0].ContainerPath)
+	}
+}
+
+func TestClaudeMounts_NeitherExists(t *testing.T) {
+	home := t.TempDir()
+	specs := ClaudeMounts(home)
+	if specs != nil {
+		t.Fatalf("expected nil, got %v", specs)
+	}
+}
+
+func TestClaudeMounts_ClaudeIsFile(t *testing.T) {
+	home := t.TempDir()
+	// .claude exists as a regular file, not a directory — should not be included
+	if err := os.WriteFile(filepath.Join(home, ".claude"), []byte("not a dir"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	specs := ClaudeMounts(home)
+	if specs != nil {
+		t.Fatalf("expected nil when .claude is a file, got %v", specs)
+	}
+}
+
+func TestRWCopyMounts(t *testing.T) {
+	specs := []MountSpec{
+		{HostPath: "/home/user/.claude", ContainerPath: "/home/amika/.claude", IsDir: true},
+		{HostPath: "/home/user/.claude.json", ContainerPath: "/home/amika/.claude.json", IsDir: false},
+	}
+
+	mounts := RWCopyMounts(specs)
+	if len(mounts) != 2 {
+		t.Fatalf("expected 2 mounts, got %d", len(mounts))
+	}
+
+	for i, m := range mounts {
+		if m.Type != "bind" {
+			t.Errorf("mount[%d] Type = %q, want \"bind\"", i, m.Type)
+		}
+		if m.Mode != "rwcopy" {
+			t.Errorf("mount[%d] Mode = %q, want \"rwcopy\"", i, m.Mode)
+		}
+		if m.Source != specs[i].HostPath {
+			t.Errorf("mount[%d] Source = %q, want %q", i, m.Source, specs[i].HostPath)
+		}
+		if m.Target != specs[i].ContainerPath {
+			t.Errorf("mount[%d] Target = %q, want %q", i, m.Target, specs[i].ContainerPath)
+		}
+	}
+}
+
+func TestRWCopyMounts_Empty(t *testing.T) {
+	mounts := RWCopyMounts(nil)
+	if len(mounts) != 0 {
+		t.Fatalf("expected 0 mounts, got %d", len(mounts))
+	}
+}
+
+func TestIsAgentPreset(t *testing.T) {
+	tests := []struct {
+		preset string
+		want   bool
+	}{
+		{"claude", true},
+		{"coder", true},
+		{"", false},
+		{"custom", false},
+	}
+	for _, tt := range tests {
+		if got := IsAgentPreset(tt.preset); got != tt.want {
+			t.Errorf("IsAgentPreset(%q) = %v, want %v", tt.preset, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/agentconfig` package with `ClaudeMounts`, `RWCopyMounts`, and `IsAgentPreset` for discovering and mounting Claude Code config files
- Auto-mount `~/.claude/` (directory rwcopy) and `~/.claude.json` (file rwcopy) for `claude` and `coder` presets
- Integrate into both `sandbox create` and `materialize`, fixing the container target path from `/root/.claude` to `/home/amika/.claude`
- Materialize creates ephemeral rwcopy resources cleaned up after the container exits

## Test plan
- [x] `make ci` passes
- [x] `agentconfig` unit tests (ClaudeMounts discovery, RWCopyMounts conversion, IsAgentPreset)
- [x] Integration tests for preset-gated auto-mounting in sandbox create