### PR TITLE
Add --setup-script flag to sandbox create and materialize

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -56,6 +56,7 @@ var sandboxCreateCmd = &cobra.Command{
 		envStrs, _ := cmd.Flags().GetStringArray("env")
 		yes, _ := cmd.Flags().GetBool("yes")
 		connect, _ := cmd.Flags().GetBool("connect")
+		setupScript, _ := cmd.Flags().GetString("setup-script")
 		gitFlagChanged := cmd.Flags().Changed("git")
 
 		if provider != "docker" {
@@ -100,6 +101,21 @@ var sandboxCreateCmd = &cobra.Command{
 				agentMounts := agentconfig.RWCopyMounts(agentconfig.AllMounts(homeDir))
 				mounts = append(mounts, agentMounts...)
 			}
+		}
+		if setupScript != "" {
+			absSetupScript, err := filepath.Abs(setupScript)
+			if err != nil {
+				return fmt.Errorf("failed to resolve setup-script path %q: %w", setupScript, err)
+			}
+			if _, err := os.Stat(absSetupScript); err != nil {
+				return fmt.Errorf("setup-script %q is not accessible: %w", absSetupScript, err)
+			}
+			mounts = append(mounts, sandbox.MountBinding{
+				Type:   "bind",
+				Source: absSetupScript,
+				Target: "/opt/setup.sh",
+				Mode:   "ro",
+			})
 		}
 		if err := validateMountTargets(mounts, volumeMounts); err != nil {
 			return err
@@ -1062,6 +1078,7 @@ func init() {
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 	sandboxCreateCmd.Flags().Bool("connect", false, "Connect to the sandbox shell immediately after creation")
+	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /opt/setup.sh in the container (read-only)")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -1,0 +1,47 @@
+# Sandbox Configuration
+
+## Setup Scripts
+
+The `--setup-script` flag lets you mount a local script into the container at `/opt/setup.sh`. The script runs automatically when the container starts, before the main command (CMD).
+
+### Usage
+
+```bash
+# sandbox create
+amika sandbox create --setup-script ./my-setup.sh
+
+# materialize
+amika materialize --setup-script ./my-setup.sh --cmd "echo done" --destdir /tmp/out
+```
+
+### Writing a setup script
+
+Your script just needs to do its setup work and exit 0. You do **not** need to chain into the next command — the container's ENTRYPOINT handles that automatically.
+
+```bash
+#!/bin/bash
+set -e
+
+apt-get update && apt-get install -y ripgrep
+pip install numpy
+```
+
+The script is mounted read-only, so it cannot be modified from inside the container.
+
+### How it works
+
+Preset images (coder, claude) bake a no-op `/opt/setup.sh` into the image and declare an ENTRYPOINT that runs it before execing into CMD:
+
+```dockerfile
+RUN printf '#!/bin/bash\nexit 0\n' > /opt/setup.sh \
+    && chmod +x /opt/setup.sh
+ENTRYPOINT ["/bin/bash", "-c", "/opt/setup.sh && exec \"$@\"", "--"]
+```
+
+When you pass `--setup-script`, your script is bind-mounted over the no-op, so the ENTRYPOINT runs your script instead.
+
+### Notes
+
+- The script must be executable (`chmod +x`).
+- If the script exits with a non-zero status, the container's main command will not run.
+- Preset images are cached locally. If you have an existing preset image from before this feature was added, you need to rebuild it by removing the old image first: `docker rmi amika/coder:latest`.

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -24,3 +24,10 @@ RUN npm install -g typescript tsx @anthropic-ai/claude-code
 
 RUN mkdir -p /home/amika
 WORKDIR /home/amika
+
+# Default no-op setup script; users can shadow it via --setup-script.
+# The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
+# don't need to include `exec "$@"` themselves.
+RUN printf '#!/bin/bash\nexit 0\n' > /opt/setup.sh \
+    && chmod +x /opt/setup.sh
+ENTRYPOINT ["/bin/bash", "-c", "/opt/setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -24,3 +24,10 @@ RUN npm install -g typescript tsx @anthropic-ai/claude-code @openai/codex openco
 
 RUN mkdir -p /home/amika
 WORKDIR /home/amika
+
+# Default no-op setup script; users can shadow it via --setup-script.
+# The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
+# don't need to include `exec "$@"` themselves.
+RUN printf '#!/bin/bash\nexit 0\n' > /opt/setup.sh \
+    && chmod +x /opt/setup.sh
+ENTRYPOINT ["/bin/bash", "-c", "/opt/setup.sh && exec \"$@\"", "--"]


### PR DESCRIPTION
Mount a user-provided script to /opt/setup.sh that runs automatically at container start via ENTRYPOINT, before the main CMD. Preset Dockerfiles include a no-op default so the ENTRYPOINT is always valid.