### PR TITLE
Implement service layer, HTTP API and CLI integration for sandboxes/volumes

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gofixpoint/amika/internal/agentconfig"
 	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/sandbox"
+	"github.com/gofixpoint/amika/pkg/amika"
 	"github.com/spf13/cobra"
 )
 
@@ -429,25 +430,19 @@ var sandboxListCmd = &cobra.Command{
 	Short: "List all sandboxes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		sandboxesFile, err := config.SandboxesStateFile()
-		if err != nil {
-			return err
-		}
-		store := sandbox.NewStore(sandboxesFile)
-
-		sandboxes, err := store.List()
+		result, err := amika.NewService(amika.Options{}).ListSandboxes(cmd.Context(), amika.ListSandboxesRequest{})
 		if err != nil {
 			return err
 		}
 
-		if len(sandboxes) == 0 {
+		if len(result.Items) == 0 {
 			fmt.Println("No sandboxes found.")
 			return nil
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
 		fmt.Fprintln(w, "NAME\tPROVIDER\tIMAGE\tCREATED")
-		for _, sb := range sandboxes {
+		for _, sb := range result.Items {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", sb.Name, sb.Provider, sb.Image, sb.CreatedAt)
 		}
 		w.Flush()

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -14,6 +14,16 @@ import (
 	"github.com/gofixpoint/amika/internal/sandbox"
 )
 
+func runRootCommand(args ...string) (string, error) {
+	buf := &strings.Builder{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	rootCmd.SetArgs(nil)
+	return buf.String(), err
+}
+
 func TestParseMountFlags(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -823,5 +833,25 @@ func runGitCmd(t *testing.T, repo string, args ...string) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func TestSandboxListCommand_PrintsRows(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", dir)
+	store := sandbox.NewStore(filepath.Join(dir, "sandboxes.jsonl"))
+	if err := store.Save(sandbox.Info{Name: "sb-a", Provider: "docker", Image: "img", CreatedAt: "now"}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runRootCommand("sandbox", "list")
+	if err != nil {
+		t.Fatalf("sandbox list failed: %v", err)
+	}
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "PROVIDER") {
+		t.Fatalf("missing header: %s", out)
+	}
+	if !strings.Contains(out, "sb-a") {
+		t.Fatalf("missing sandbox row: %s", out)
 	}
 }

--- a/internal/app/service_impl.go
+++ b/internal/app/service_impl.go
@@ -3,7 +3,14 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
 
+	"github.com/gofixpoint/amika/internal/auth"
+	"github.com/gofixpoint/amika/internal/materialize"
 	"github.com/gofixpoint/amika/internal/ports"
 	"github.com/gofixpoint/amika/pkg/amika"
 )
@@ -36,42 +43,240 @@ func NewService(deps Dependencies) (*Service, error) {
 // Ensure Service satisfies the public service interface.
 var _ amika.Service = (*Service)(nil)
 
-// CreateSandbox is a placeholder while behavior is migrated from CLI adapters.
-func (s *Service) CreateSandbox(context.Context, amika.CreateSandboxRequest) (amika.Sandbox, error) {
-	return amika.Sandbox{}, amika.ErrUnimplemented
+// CreateSandbox creates and persists a sandbox record after creating the backing runtime sandbox.
+func (s *Service) CreateSandbox(_ context.Context, req amika.CreateSandboxRequest) (amika.Sandbox, error) {
+	provider := req.Provider
+	if provider == "" {
+		provider = "docker"
+	}
+	if provider != "docker" {
+		return amika.Sandbox{}, fmt.Errorf("%w: unsupported provider %q", amika.ErrInvalidArgument, provider)
+	}
+	if req.Name == "" {
+		return amika.Sandbox{}, fmt.Errorf("%w: sandbox name is required", amika.ErrInvalidArgument)
+	}
+	if _, err := s.deps.Sandboxes.Get(req.Name); err == nil {
+		return amika.Sandbox{}, fmt.Errorf("%w: sandbox %q already exists", amika.ErrInvalidArgument, req.Name)
+	}
+
+	containerID, err := s.deps.Docker.CreateSandbox(req.Name, req.Image, toPortMounts(req.Mounts, req.Volumes), req.Env)
+	if err != nil {
+		return amika.Sandbox{}, fmt.Errorf("%w: %v", amika.ErrDependency, err)
+	}
+
+	now := time.Now().UTC()
+	if s.deps.Clock != nil {
+		now = s.deps.Clock.Now().UTC()
+	}
+	rec := ports.SandboxRecord{
+		Name:        req.Name,
+		Provider:    provider,
+		ContainerID: containerID,
+		Image:       req.Image,
+		CreatedAt:   now.Format(time.RFC3339),
+		Preset:      req.Preset,
+		Mounts:      toPortMounts(req.Mounts, req.Volumes),
+		Env:         req.Env,
+	}
+	if err := s.deps.Sandboxes.Save(rec); err != nil {
+		return amika.Sandbox{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
+	}
+
+	return amika.Sandbox{
+		Name:        rec.Name,
+		Provider:    rec.Provider,
+		ContainerID: rec.ContainerID,
+		Image:       rec.Image,
+		CreatedAt:   rec.CreatedAt,
+		Preset:      rec.Preset,
+		Mounts:      toPublicMounts(rec.Mounts),
+		Env:         rec.Env,
+	}, nil
 }
 
-// DeleteSandbox is a placeholder while behavior is migrated from CLI adapters.
-func (s *Service) DeleteSandbox(context.Context, amika.DeleteSandboxRequest) (amika.DeleteSandboxResult, error) {
-	return amika.DeleteSandboxResult{}, amika.ErrUnimplemented
+// DeleteSandbox removes one or more sandboxes and their backing runtime sandboxes.
+func (s *Service) DeleteSandbox(_ context.Context, req amika.DeleteSandboxRequest) (amika.DeleteSandboxResult, error) {
+	deleted := make([]string, 0, len(req.Names))
+	for _, name := range req.Names {
+		rec, err := s.deps.Sandboxes.Get(name)
+		if err != nil {
+			return amika.DeleteSandboxResult{}, fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, name)
+		}
+		if rec.Provider == "docker" {
+			if err := s.deps.Docker.RemoveSandbox(name); err != nil {
+				return amika.DeleteSandboxResult{}, fmt.Errorf("%w: %v", amika.ErrDependency, err)
+			}
+		}
+		if err := s.deps.Sandboxes.Remove(name); err != nil {
+			return amika.DeleteSandboxResult{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
+		}
+		deleted = append(deleted, name)
+	}
+
+	return amika.DeleteSandboxResult{Deleted: deleted}, nil
 }
 
-// ListSandboxes is a placeholder while behavior is migrated from CLI adapters.
+// ListSandboxes lists persisted sandbox records.
 func (s *Service) ListSandboxes(context.Context, amika.ListSandboxesRequest) (amika.ListSandboxesResult, error) {
-	return amika.ListSandboxesResult{}, amika.ErrUnimplemented
+	recs, err := s.deps.Sandboxes.List()
+	if err != nil {
+		return amika.ListSandboxesResult{}, fmt.Errorf("%w: list sandboxes: %v", amika.ErrInternal, err)
+	}
+	items := make([]amika.Sandbox, 0, len(recs))
+	for _, rec := range recs {
+		items = append(items, amika.Sandbox{
+			Name:        rec.Name,
+			Provider:    rec.Provider,
+			ContainerID: rec.ContainerID,
+			Image:       rec.Image,
+			CreatedAt:   rec.CreatedAt,
+			Preset:      rec.Preset,
+			Mounts:      toPublicMounts(rec.Mounts),
+			Env:         rec.Env,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	return amika.ListSandboxesResult{Items: items}, nil
 }
 
-// ConnectSandbox is a placeholder while behavior is migrated from CLI adapters.
-func (s *Service) ConnectSandbox(context.Context, amika.ConnectSandboxRequest) error {
-	return amika.ErrUnimplemented
+// ConnectSandbox opens an interactive shell in an existing sandbox.
+func (s *Service) ConnectSandbox(ctx context.Context, req amika.ConnectSandboxRequest) error {
+	if req.Name == "" {
+		return fmt.Errorf("%w: sandbox name is required", amika.ErrInvalidArgument)
+	}
+	if req.Shell == "" {
+		req.Shell = "zsh"
+	}
+	rec, err := s.deps.Sandboxes.Get(req.Name)
+	if err != nil {
+		return fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, req.Name)
+	}
+	if rec.Provider != "docker" {
+		return fmt.Errorf("%w: unsupported provider %q", amika.ErrInvalidArgument, rec.Provider)
+	}
+	if s.deps.Runner == nil {
+		return fmt.Errorf("%w: command runner unavailable", amika.ErrDependency)
+	}
+	args := []string{"exec", "-it", "-w", "/home/amika", req.Name, req.Shell}
+	if _, err := s.deps.Runner.Run(ctx, "docker", args, ports.RunOptions{}); err != nil {
+		return fmt.Errorf("%w: %v", amika.ErrDependency, err)
+	}
+	return nil
 }
 
-// Materialize is a placeholder while behavior is migrated from CLI adapters.
-func (s *Service) Materialize(context.Context, amika.MaterializeRequest) (amika.MaterializeResult, error) {
-	return amika.MaterializeResult{}, amika.ErrUnimplemented
+// Materialize runs local materialization flow.
+func (s *Service) Materialize(_ context.Context, req amika.MaterializeRequest) (amika.MaterializeResult, error) {
+	if req.Destdir == "" {
+		return amika.MaterializeResult{}, fmt.Errorf("%w: --destdir is required", amika.ErrInvalidArgument)
+	}
+	if req.Script == "" && req.Cmd == "" {
+		return amika.MaterializeResult{}, fmt.Errorf("%w: exactly one of script or cmd must be specified", amika.ErrInvalidArgument)
+	}
+	if req.Script != "" && req.Cmd != "" {
+		return amika.MaterializeResult{}, fmt.Errorf("%w: --script and --cmd are mutually exclusive", amika.ErrInvalidArgument)
+	}
+	workdir, err := os.MkdirTemp("", "amika-materialize-work-*")
+	if err != nil {
+		return amika.MaterializeResult{}, fmt.Errorf("%w: create temp workdir: %v", amika.ErrInternal, err)
+	}
+	defer os.RemoveAll(workdir)
+	outdir := req.Outdir
+	if outdir == "" {
+		outdir = filepath.Join(workdir, "out")
+	}
+	err = materialize.Run(materialize.Options{Script: req.Script, ScriptArgs: req.ScriptArgs, Cmd: req.Cmd, Workdir: workdir, Outdir: outdir, Destdir: req.Destdir, Env: req.Env})
+	if err != nil {
+		return amika.MaterializeResult{}, fmt.Errorf("%w: %v", amika.ErrDependency, err)
+	}
+	return amika.MaterializeResult{Destdir: req.Destdir}, nil
 }
 
-// ListVolumes is a placeholder while behavior is migrated from CLI adapters.
+// ListVolumes lists tracked directory and file mount volumes.
 func (s *Service) ListVolumes(context.Context, amika.ListVolumesRequest) (amika.ListVolumesResult, error) {
-	return amika.ListVolumesResult{}, amika.ErrUnimplemented
+	vols, err := s.deps.Volumes.List()
+	if err != nil {
+		return amika.ListVolumesResult{}, fmt.Errorf("%w: list volumes: %v", amika.ErrInternal, err)
+	}
+	fms, err := s.deps.FileMounts.List()
+	if err != nil {
+		return amika.ListVolumesResult{}, fmt.Errorf("%w: list file mounts: %v", amika.ErrInternal, err)
+	}
+	items := make([]amika.Volume, 0, len(vols)+len(fms))
+	for _, v := range vols {
+		items = append(items, toPublicVolume(v, "directory"))
+	}
+	for _, v := range fms {
+		items = append(items, toPublicVolume(v, "file"))
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	return amika.ListVolumesResult{Items: items}, nil
 }
 
-// DeleteVolume is a placeholder while behavior is migrated from CLI adapters.
-func (s *Service) DeleteVolume(context.Context, amika.DeleteVolumeRequest) (amika.DeleteVolumeResult, error) {
-	return amika.DeleteVolumeResult{}, amika.ErrUnimplemented
+// DeleteVolume deletes tracked volumes or file mounts.
+func (s *Service) DeleteVolume(_ context.Context, req amika.DeleteVolumeRequest) (amika.DeleteVolumeResult, error) {
+	deleted := make([]string, 0, len(req.Names))
+	for _, name := range req.Names {
+		if vol, err := s.deps.Volumes.Get(name); err == nil {
+			if len(vol.SandboxRefs) > 0 && !req.Force {
+				return amika.DeleteVolumeResult{}, fmt.Errorf("%w: volume %q is in use", amika.ErrInvalidArgument, name)
+			}
+			if err := s.deps.Docker.RemoveVolume(name); err != nil {
+				return amika.DeleteVolumeResult{}, fmt.Errorf("%w: %v", amika.ErrDependency, err)
+			}
+			if err := s.deps.Volumes.Remove(name); err != nil {
+				return amika.DeleteVolumeResult{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
+			}
+			deleted = append(deleted, name)
+			continue
+		}
+		if fm, err := s.deps.FileMounts.Get(name); err == nil {
+			if len(fm.SandboxRefs) > 0 && !req.Force {
+				return amika.DeleteVolumeResult{}, fmt.Errorf("%w: volume %q is in use", amika.ErrInvalidArgument, name)
+			}
+			if fm.CopyPath != "" {
+				if err := os.RemoveAll(filepath.Dir(fm.CopyPath)); err != nil {
+					return amika.DeleteVolumeResult{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
+				}
+			}
+			if err := s.deps.FileMounts.Remove(name); err != nil {
+				return amika.DeleteVolumeResult{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
+			}
+			deleted = append(deleted, name)
+			continue
+		}
+		return amika.DeleteVolumeResult{}, fmt.Errorf("%w: volume %q", amika.ErrNotFound, name)
+	}
+	return amika.DeleteVolumeResult{Deleted: deleted}, nil
 }
 
-// ExtractAuth is a placeholder while behavior is migrated from CLI adapters.
-func (s *Service) ExtractAuth(context.Context, amika.AuthExtractRequest) (amika.AuthExtractResult, error) {
-	return amika.AuthExtractResult{}, amika.ErrUnimplemented
+// ExtractAuth extracts auth env assignment lines.
+func (s *Service) ExtractAuth(_ context.Context, req amika.AuthExtractRequest) (amika.AuthExtractResult, error) {
+	result, err := auth.Discover(auth.Options{HomeDir: req.HomeDir, IncludeOAuth: !req.NoOAuth})
+	if err != nil {
+		return amika.AuthExtractResult{}, fmt.Errorf("%w: %v", amika.ErrDependency, err)
+	}
+	return amika.AuthExtractResult{Lines: auth.BuildEnvMap(result).Lines(req.WithExport)}, nil
+}
+
+func toPublicMounts(mounts []ports.Mount) []amika.Mount {
+	out := make([]amika.Mount, 0, len(mounts))
+	for _, m := range mounts {
+		out = append(out, amika.Mount{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
+	}
+	return out
+}
+
+func toPublicVolume(v ports.VolumeRecord, typ string) amika.Volume {
+	return amika.Volume{Name: v.Name, Type: typ, CreatedAt: v.CreatedAt, InUse: len(v.SandboxRefs) > 0, Sandboxes: v.SandboxRefs, SourcePath: v.SourcePath}
+}
+
+func toPortMounts(mounts []amika.Mount, volumes []amika.Mount) []ports.Mount {
+	out := make([]ports.Mount, 0, len(mounts)+len(volumes))
+	for _, m := range mounts {
+		out = append(out, ports.Mount{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
+	}
+	for _, m := range volumes {
+		out = append(out, ports.Mount{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
+	}
+	return out
 }

--- a/internal/app/service_impl_test.go
+++ b/internal/app/service_impl_test.go
@@ -13,7 +13,7 @@ import (
 type stubDocker struct{}
 
 func (stubDocker) CreateSandbox(string, string, []ports.Mount, []string) (string, error) {
-	return "", nil
+	return "container-123", nil
 }
 func (stubDocker) RemoveSandbox(string) error               { return nil }
 func (stubDocker) CreateVolume(string) error                { return nil }
@@ -22,10 +22,12 @@ func (stubDocker) CopyHostDirToVolume(string, string) error { return nil }
 
 type stubSandboxStore struct{}
 
-func (stubSandboxStore) Save(ports.SandboxRecord) error          { return nil }
-func (stubSandboxStore) Get(string) (ports.SandboxRecord, error) { return ports.SandboxRecord{}, nil }
-func (stubSandboxStore) Remove(string) error                     { return nil }
-func (stubSandboxStore) List() ([]ports.SandboxRecord, error)    { return nil, nil }
+func (stubSandboxStore) Save(ports.SandboxRecord) error { return nil }
+func (stubSandboxStore) Get(name string) (ports.SandboxRecord, error) {
+	return ports.SandboxRecord{}, errors.New("not found")
+}
+func (stubSandboxStore) Remove(string) error                  { return nil }
+func (stubSandboxStore) List() ([]ports.SandboxRecord, error) { return nil, nil }
 
 type stubVolumeStore struct{}
 
@@ -60,6 +62,7 @@ func TestNewService_ImplementsPublicService(t *testing.T) {
 		Sandboxes:   stubSandboxStore{},
 		Volumes:     stubVolumeStore{},
 		FileMounts:  stubFileMountStore{},
+		Runner:      stubRunner{},
 		Clock:       stubClock{},
 		IDGenerator: stubIDGenerator{},
 	})
@@ -68,10 +71,25 @@ func TestNewService_ImplementsPublicService(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if _, err := svc.CreateSandbox(ctx, amika.CreateSandboxRequest{}); !errors.Is(err, amika.ErrUnimplemented) {
-		t.Fatalf("CreateSandbox err = %v, want ErrUnimplemented", err)
+	if _, err := svc.CreateSandbox(ctx, amika.CreateSandboxRequest{}); !errors.Is(err, amika.ErrInvalidArgument) {
+		t.Fatalf("CreateSandbox err = %v, want ErrInvalidArgument", err)
 	}
-	if _, err := svc.ExtractAuth(ctx, amika.AuthExtractRequest{}); !errors.Is(err, amika.ErrUnimplemented) {
-		t.Fatalf("ExtractAuth err = %v, want ErrUnimplemented", err)
+	if _, err := svc.CreateSandbox(ctx, amika.CreateSandboxRequest{Name: "new-sb", Provider: "docker", Image: "img"}); err != nil {
+		t.Fatalf("CreateSandbox unexpected err = %v", err)
 	}
+	if _, err := svc.DeleteSandbox(ctx, amika.DeleteSandboxRequest{Names: []string{"missing"}}); !errors.Is(err, amika.ErrNotFound) {
+		t.Fatalf("DeleteSandbox err = %v, want ErrNotFound", err)
+	}
+	if err := svc.ConnectSandbox(ctx, amika.ConnectSandboxRequest{Name: "missing"}); !errors.Is(err, amika.ErrNotFound) {
+		t.Fatalf("ConnectSandbox err = %v, want ErrNotFound", err)
+	}
+	if _, err := svc.ExtractAuth(ctx, amika.AuthExtractRequest{}); err != nil {
+		t.Fatalf("ExtractAuth err = %v, want nil", err)
+	}
+}
+
+type stubRunner struct{}
+
+func (stubRunner) Run(context.Context, string, []string, ports.RunOptions) (ports.RunResult, error) {
+	return ports.RunResult{}, nil
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -22,6 +22,11 @@ func NewHandler(service amika.Service) http.Handler {
 	api := humago.New(mux, config)
 	registerHealth(api)
 	registerListSandboxes(api, service)
+	registerCreateSandbox(api, service)
+	registerDeleteSandbox(api, service)
+	registerListVolumes(api, service)
+	registerDeleteVolume(api, service)
+	registerAuthExtract(api, service)
 	registerMaterialize(api, service)
 	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -45,9 +50,7 @@ func registerHealth(api huma.API) {
 	})
 }
 
-type listSandboxesOutput struct {
-	Body amika.ListSandboxesResult
-}
+type listSandboxesOutput struct{ Body amika.ListSandboxesResult }
 
 func registerListSandboxes(api huma.API, service amika.Service) {
 	huma.Get(api, "/v1/sandboxes", func(ctx context.Context, _ *struct{}) (*listSandboxesOutput, error) {
@@ -59,13 +62,76 @@ func registerListSandboxes(api huma.API, service amika.Service) {
 	})
 }
 
-type materializeInput struct {
-	Body amika.MaterializeRequest
+type createSandboxInput struct{ Body amika.CreateSandboxRequest }
+type createSandboxOutput struct{ Body amika.Sandbox }
+
+func registerCreateSandbox(api huma.API, service amika.Service) {
+	huma.Post(api, "/v1/sandboxes", func(ctx context.Context, input *createSandboxInput) (*createSandboxOutput, error) {
+		result, err := service.CreateSandbox(ctx, input.Body)
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &createSandboxOutput{Body: result}, nil
+	})
 }
 
-type materializeOutput struct {
-	Body amika.MaterializeResult
+type deleteSandboxInput struct {
+	Name string `path:"name"`
 }
+type deleteSandboxOutput struct{ Body amika.DeleteSandboxResult }
+
+func registerDeleteSandbox(api huma.API, service amika.Service) {
+	huma.Delete(api, "/v1/sandboxes/{name}", func(ctx context.Context, input *deleteSandboxInput) (*deleteSandboxOutput, error) {
+		result, err := service.DeleteSandbox(ctx, amika.DeleteSandboxRequest{Names: []string{input.Name}})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &deleteSandboxOutput{Body: result}, nil
+	})
+}
+
+type listVolumesOutput struct{ Body amika.ListVolumesResult }
+
+func registerListVolumes(api huma.API, service amika.Service) {
+	huma.Get(api, "/v1/volumes", func(ctx context.Context, _ *struct{}) (*listVolumesOutput, error) {
+		result, err := service.ListVolumes(ctx, amika.ListVolumesRequest{})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &listVolumesOutput{Body: result}, nil
+	})
+}
+
+type deleteVolumeInput struct {
+	Name string `path:"name"`
+}
+type deleteVolumeOutput struct{ Body amika.DeleteVolumeResult }
+
+func registerDeleteVolume(api huma.API, service amika.Service) {
+	huma.Delete(api, "/v1/volumes/{name}", func(ctx context.Context, input *deleteVolumeInput) (*deleteVolumeOutput, error) {
+		result, err := service.DeleteVolume(ctx, amika.DeleteVolumeRequest{Names: []string{input.Name}})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &deleteVolumeOutput{Body: result}, nil
+	})
+}
+
+type authExtractInput struct{ Body amika.AuthExtractRequest }
+type authExtractOutput struct{ Body amika.AuthExtractResult }
+
+func registerAuthExtract(api huma.API, service amika.Service) {
+	huma.Post(api, "/v1/auth/extract", func(ctx context.Context, input *authExtractInput) (*authExtractOutput, error) {
+		result, err := service.ExtractAuth(ctx, input.Body)
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &authExtractOutput{Body: result}, nil
+	})
+}
+
+type materializeInput struct{ Body amika.MaterializeRequest }
+type materializeOutput struct{ Body amika.MaterializeResult }
 
 func registerMaterialize(api huma.API, service amika.Service) {
 	huma.Post(api, "/v1/materialize", func(ctx context.Context, input *materializeInput) (*materializeOutput, error) {

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -1,6 +1,8 @@
 package httpapi
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,48 +11,83 @@ import (
 	"github.com/gofixpoint/amika/pkg/amika"
 )
 
-func TestHealthEndpoint(t *testing.T) {
-	h := NewHandler(amika.NewService(amika.Options{}))
+type stubService struct{}
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
-	res := httptest.NewRecorder()
-	h.ServeHTTP(res, req)
+func (stubService) CreateSandbox(context.Context, amika.CreateSandboxRequest) (amika.Sandbox, error) {
+	return amika.Sandbox{}, amika.ErrUnimplemented
+}
+func (stubService) DeleteSandbox(context.Context, amika.DeleteSandboxRequest) (amika.DeleteSandboxResult, error) {
+	return amika.DeleteSandboxResult{}, amika.ErrUnimplemented
+}
+func (stubService) ListSandboxes(context.Context, amika.ListSandboxesRequest) (amika.ListSandboxesResult, error) {
+	return amika.ListSandboxesResult{Items: []amika.Sandbox{{Name: "sb"}}}, nil
+}
+func (stubService) ConnectSandbox(context.Context, amika.ConnectSandboxRequest) error {
+	return amika.ErrUnimplemented
+}
+func (stubService) Materialize(context.Context, amika.MaterializeRequest) (amika.MaterializeResult, error) {
+	return amika.MaterializeResult{}, amika.ErrInvalidArgument
+}
+func (stubService) ListVolumes(context.Context, amika.ListVolumesRequest) (amika.ListVolumesResult, error) {
+	return amika.ListVolumesResult{Items: []amika.Volume{{Name: "v"}}}, nil
+}
+func (stubService) DeleteVolume(context.Context, amika.DeleteVolumeRequest) (amika.DeleteVolumeResult, error) {
+	return amika.DeleteVolumeResult{}, amika.ErrUnimplemented
+}
+func (stubService) ExtractAuth(context.Context, amika.AuthExtractRequest) (amika.AuthExtractResult, error) {
+	return amika.AuthExtractResult{Lines: []string{"A='1'"}}, nil
+}
 
-	if res.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+func TestEndpoints(t *testing.T) {
+	h := NewHandler(stubService{})
+	cases := []struct {
+		m, u string
+		code int
+	}{
+		{http.MethodGet, "/v1/health", 200},
+		{http.MethodGet, "/v1/sandboxes", 200},
+		{http.MethodPost, "/v1/sandboxes", 422},
+		{http.MethodDelete, "/v1/sandboxes/sb", 501},
+		{http.MethodGet, "/v1/volumes", 200},
+		{http.MethodDelete, "/v1/volumes/v", 501},
+		{http.MethodPost, "/v1/auth/extract", 422},
 	}
-
-	var body struct {
-		Status string `json:"status"`
-	}
-	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
-		t.Fatalf("failed to unmarshal health payload: %v", err)
-	}
-	if body.Status != "ok" {
-		t.Fatalf("status body = %q, want %q", body.Status, "ok")
+	for _, tc := range cases {
+		req := httptest.NewRequest(tc.m, tc.u, bytes.NewReader([]byte(`{}`)))
+		res := httptest.NewRecorder()
+		h.ServeHTTP(res, req)
+		if res.Code != tc.code {
+			t.Fatalf("%s %s status=%d want=%d body=%s", tc.m, tc.u, res.Code, tc.code, res.Body.String())
+		}
 	}
 }
 
-func TestOpenAPIServed(t *testing.T) {
-	h := NewHandler(amika.NewService(amika.Options{}))
+func TestMaterializeBadRequestMaps400(t *testing.T) {
+	h := NewHandler(stubService{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/materialize", bytes.NewReader([]byte(`{}`)))
+	res := httptest.NewRecorder()
+	h.ServeHTTP(res, req)
+	if res.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d body=%s", res.Code, res.Body.String())
+	}
+}
 
+func TestOpenAPIIncludesV1Paths(t *testing.T) {
+	h := NewHandler(stubService{})
 	req := httptest.NewRequest(http.MethodGet, "/openapi.json", nil)
 	res := httptest.NewRecorder()
 	h.ServeHTTP(res, req)
-
 	if res.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+		t.Fatalf("status=%d", res.Code)
 	}
-}
-
-func TestUnimplementedServiceMapsTo501(t *testing.T) {
-	h := NewHandler(amika.NewService(amika.Options{}))
-
-	req := httptest.NewRequest(http.MethodGet, "/v1/sandboxes", nil)
-	res := httptest.NewRecorder()
-	h.ServeHTTP(res, req)
-
-	if res.Code != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want %d", res.Code, http.StatusNotImplemented)
+	var doc map[string]any
+	if err := json.Unmarshal(res.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	paths := doc["paths"].(map[string]any)
+	for _, p := range []string{"/v1/sandboxes", "/v1/volumes", "/v1/auth/extract", "/v1/materialize"} {
+		if _, ok := paths[p]; !ok {
+			t.Fatalf("missing path %s", p)
+		}
 	}
 }

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -1,6 +1,19 @@
 package amika
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/gofixpoint/amika/internal/auth"
+	"github.com/gofixpoint/amika/internal/config"
+	"github.com/gofixpoint/amika/internal/materialize"
+	"github.com/gofixpoint/amika/internal/sandbox"
+)
 
 // Service defines the public API surface for running Amika operations from Go.
 type Service interface {
@@ -8,54 +21,257 @@ type Service interface {
 	DeleteSandbox(ctx context.Context, req DeleteSandboxRequest) (DeleteSandboxResult, error)
 	ListSandboxes(ctx context.Context, req ListSandboxesRequest) (ListSandboxesResult, error)
 	ConnectSandbox(ctx context.Context, req ConnectSandboxRequest) error
-
 	Materialize(ctx context.Context, req MaterializeRequest) (MaterializeResult, error)
-
 	ListVolumes(ctx context.Context, req ListVolumesRequest) (ListVolumesResult, error)
 	DeleteVolume(ctx context.Context, req DeleteVolumeRequest) (DeleteVolumeResult, error)
-
 	ExtractAuth(ctx context.Context, req AuthExtractRequest) (AuthExtractResult, error)
 }
 
 // Options controls construction of a public Amika service.
 type Options struct{}
 
-// NewService returns a service implementation. The current implementation is a
-// skeleton to establish the public API before wiring concrete behavior.
+// NewService returns a service implementation.
 func NewService(_ Options) Service {
-	return &unimplementedService{}
+	sandboxesFile, err := config.SandboxesStateFile()
+	if err != nil {
+		return &initErrorService{err: fmt.Errorf("%w: %v", ErrDependency, err)}
+	}
+	volumesFile, err := config.VolumesStateFile()
+	if err != nil {
+		return &initErrorService{err: fmt.Errorf("%w: %v", ErrDependency, err)}
+	}
+	fileMountsFile, err := config.FileMountsStateFile()
+	if err != nil {
+		return &initErrorService{err: fmt.Errorf("%w: %v", ErrDependency, err)}
+	}
+	return &serviceImpl{
+		sandboxes:  sandbox.NewStore(sandboxesFile),
+		volumes:    sandbox.NewVolumeStore(volumesFile),
+		fileMounts: sandbox.NewFileMountStore(fileMountsFile),
+	}
 }
 
-type unimplementedService struct{}
-
-func (s *unimplementedService) CreateSandbox(context.Context, CreateSandboxRequest) (Sandbox, error) {
-	return Sandbox{}, ErrUnimplemented
+type serviceImpl struct {
+	sandboxes  sandbox.Store
+	volumes    sandbox.VolumeStore
+	fileMounts sandbox.FileMountStore
 }
 
-func (s *unimplementedService) DeleteSandbox(context.Context, DeleteSandboxRequest) (DeleteSandboxResult, error) {
-	return DeleteSandboxResult{}, ErrUnimplemented
+func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest) (Sandbox, error) {
+	provider := req.Provider
+	if provider == "" {
+		provider = "docker"
+	}
+	if provider != "docker" {
+		return Sandbox{}, fmt.Errorf("%w: unsupported provider %q", ErrInvalidArgument, provider)
+	}
+	name := req.Name
+	if name == "" {
+		for {
+			name = sandbox.GenerateName()
+			if _, err := s.sandboxes.Get(name); err != nil {
+				break
+			}
+		}
+	} else if _, err := s.sandboxes.Get(name); err == nil {
+		return Sandbox{}, fmt.Errorf("%w: sandbox %q already exists", ErrInvalidArgument, name)
+	}
+	mounts := toSandboxMountBindings(req.Mounts, req.Volumes)
+	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env)
+	if err != nil {
+		return Sandbox{}, fmt.Errorf("%w: %v", ErrDependency, err)
+	}
+	info := sandbox.Info{Name: name, Provider: provider, ContainerID: containerID, Image: req.Image, CreatedAt: time.Now().UTC().Format(time.RFC3339), Preset: req.Preset, Mounts: mounts, Env: req.Env}
+	if err := s.sandboxes.Save(info); err != nil {
+		return Sandbox{}, fmt.Errorf("%w: %v", ErrInternal, err)
+	}
+	return Sandbox{Name: info.Name, Provider: info.Provider, ContainerID: info.ContainerID, Image: info.Image, CreatedAt: info.CreatedAt, Preset: info.Preset, Mounts: toMounts(info.Mounts), Env: info.Env}, nil
+}
+func (s *serviceImpl) DeleteSandbox(_ context.Context, req DeleteSandboxRequest) (DeleteSandboxResult, error) {
+	deleted := make([]string, 0, len(req.Names))
+	for _, name := range req.Names {
+		info, err := s.sandboxes.Get(name)
+		if err != nil {
+			return DeleteSandboxResult{}, fmt.Errorf("%w: sandbox %q", ErrNotFound, name)
+		}
+		if info.Provider == "docker" {
+			if err := sandbox.RemoveDockerSandbox(name); err != nil {
+				return DeleteSandboxResult{}, fmt.Errorf("%w: %v", ErrDependency, err)
+			}
+		}
+		if err := s.sandboxes.Remove(name); err != nil {
+			return DeleteSandboxResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+		}
+		deleted = append(deleted, name)
+	}
+	return DeleteSandboxResult{Deleted: deleted}, nil
+}
+func (s *serviceImpl) ConnectSandbox(ctx context.Context, req ConnectSandboxRequest) error {
+	if req.Name == "" {
+		return fmt.Errorf("%w: sandbox name is required", ErrInvalidArgument)
+	}
+	if req.Shell == "" {
+		req.Shell = "zsh"
+	}
+	info, err := s.sandboxes.Get(req.Name)
+	if err != nil {
+		return fmt.Errorf("%w: sandbox %q", ErrNotFound, req.Name)
+	}
+	if info.Provider != "docker" {
+		return fmt.Errorf("%w: unsupported provider %q", ErrInvalidArgument, info.Provider)
+	}
+	args := []string{"exec", "-it", "-w", "/home/amika", req.Name, req.Shell}
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %v", ErrDependency, err)
+	}
+	return nil
 }
 
-func (s *unimplementedService) ListSandboxes(context.Context, ListSandboxesRequest) (ListSandboxesResult, error) {
-	return ListSandboxesResult{}, ErrUnimplemented
+func (s *serviceImpl) ListSandboxes(context.Context, ListSandboxesRequest) (ListSandboxesResult, error) {
+	items, err := s.sandboxes.List()
+	if err != nil {
+		return ListSandboxesResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+	}
+	out := make([]Sandbox, 0, len(items))
+	for _, it := range items {
+		out = append(out, Sandbox{Name: it.Name, Provider: it.Provider, ContainerID: it.ContainerID, Image: it.Image, CreatedAt: it.CreatedAt, Preset: it.Preset, Mounts: toMounts(it.Mounts), Env: it.Env})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return ListSandboxesResult{Items: out}, nil
 }
 
-func (s *unimplementedService) ConnectSandbox(context.Context, ConnectSandboxRequest) error {
-	return ErrUnimplemented
+func (s *serviceImpl) Materialize(_ context.Context, req MaterializeRequest) (MaterializeResult, error) {
+	if req.Destdir == "" {
+		return MaterializeResult{}, fmt.Errorf("%w: --destdir is required", ErrInvalidArgument)
+	}
+	if req.Script == "" && req.Cmd == "" {
+		return MaterializeResult{}, fmt.Errorf("%w: exactly one of script or cmd must be specified", ErrInvalidArgument)
+	}
+	if req.Script != "" && req.Cmd != "" {
+		return MaterializeResult{}, fmt.Errorf("%w: --script and --cmd are mutually exclusive", ErrInvalidArgument)
+	}
+	workdir, err := os.MkdirTemp("", "amika-materialize-work-*")
+	if err != nil {
+		return MaterializeResult{}, fmt.Errorf("%w: create temp workdir: %v", ErrInternal, err)
+	}
+	defer os.RemoveAll(workdir)
+	outdir := req.Outdir
+	if outdir == "" {
+		outdir = filepath.Join(workdir, "out")
+	}
+	if err := materialize.Run(materialize.Options{Script: req.Script, ScriptArgs: req.ScriptArgs, Cmd: req.Cmd, Workdir: workdir, Outdir: outdir, Destdir: req.Destdir, Env: req.Env}); err != nil {
+		return MaterializeResult{}, fmt.Errorf("%w: %v", ErrDependency, err)
+	}
+	return MaterializeResult{Destdir: req.Destdir}, nil
 }
 
-func (s *unimplementedService) Materialize(context.Context, MaterializeRequest) (MaterializeResult, error) {
-	return MaterializeResult{}, ErrUnimplemented
+func (s *serviceImpl) ListVolumes(context.Context, ListVolumesRequest) (ListVolumesResult, error) {
+	vols, err := s.volumes.List()
+	if err != nil {
+		return ListVolumesResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+	}
+	fms, err := s.fileMounts.List()
+	if err != nil {
+		return ListVolumesResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+	}
+	out := make([]Volume, 0, len(vols)+len(fms))
+	for _, v := range vols {
+		out = append(out, Volume{Name: v.Name, Type: "directory", CreatedAt: v.CreatedAt, InUse: len(v.SandboxRefs) > 0, Sandboxes: v.SandboxRefs, SourcePath: v.SourcePath})
+	}
+	for _, v := range fms {
+		out = append(out, Volume{Name: v.Name, Type: "file", CreatedAt: v.CreatedAt, InUse: len(v.SandboxRefs) > 0, Sandboxes: v.SandboxRefs, SourcePath: v.SourcePath})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return ListVolumesResult{Items: out}, nil
 }
 
-func (s *unimplementedService) ListVolumes(context.Context, ListVolumesRequest) (ListVolumesResult, error) {
-	return ListVolumesResult{}, ErrUnimplemented
+func (s *serviceImpl) DeleteVolume(_ context.Context, req DeleteVolumeRequest) (DeleteVolumeResult, error) {
+	deleted := make([]string, 0, len(req.Names))
+	for _, name := range req.Names {
+		if vol, err := s.volumes.Get(name); err == nil {
+			if len(vol.SandboxRefs) > 0 && !req.Force {
+				return DeleteVolumeResult{}, fmt.Errorf("%w: volume %q is in use", ErrInvalidArgument, name)
+			}
+			if err := sandbox.RemoveDockerVolume(name); err != nil {
+				return DeleteVolumeResult{}, fmt.Errorf("%w: %v", ErrDependency, err)
+			}
+			if err := s.volumes.Remove(name); err != nil {
+				return DeleteVolumeResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+			}
+			deleted = append(deleted, name)
+			continue
+		}
+		if fm, err := s.fileMounts.Get(name); err == nil {
+			if len(fm.SandboxRefs) > 0 && !req.Force {
+				return DeleteVolumeResult{}, fmt.Errorf("%w: volume %q is in use", ErrInvalidArgument, name)
+			}
+			if fm.CopyPath != "" {
+				if err := os.RemoveAll(filepath.Dir(fm.CopyPath)); err != nil {
+					return DeleteVolumeResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+				}
+			}
+			if err := s.fileMounts.Remove(name); err != nil {
+				return DeleteVolumeResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+			}
+			deleted = append(deleted, name)
+			continue
+		}
+		return DeleteVolumeResult{}, fmt.Errorf("%w: volume %q", ErrNotFound, name)
+	}
+	return DeleteVolumeResult{Deleted: deleted}, nil
+}
+func (s *serviceImpl) ExtractAuth(_ context.Context, req AuthExtractRequest) (AuthExtractResult, error) {
+	result, err := auth.Discover(auth.Options{HomeDir: req.HomeDir, IncludeOAuth: !req.NoOAuth})
+	if err != nil {
+		return AuthExtractResult{}, fmt.Errorf("%w: %v", ErrDependency, err)
+	}
+	return AuthExtractResult{Lines: auth.BuildEnvMap(result).Lines(req.WithExport)}, nil
 }
 
-func (s *unimplementedService) DeleteVolume(context.Context, DeleteVolumeRequest) (DeleteVolumeResult, error) {
-	return DeleteVolumeResult{}, ErrUnimplemented
+func toSandboxMountBindings(mounts []Mount, volumes []Mount) []sandbox.MountBinding {
+	out := make([]sandbox.MountBinding, 0, len(mounts)+len(volumes))
+	for _, m := range mounts {
+		out = append(out, sandbox.MountBinding{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
+	}
+	for _, m := range volumes {
+		out = append(out, sandbox.MountBinding{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
+	}
+	return out
 }
 
-func (s *unimplementedService) ExtractAuth(context.Context, AuthExtractRequest) (AuthExtractResult, error) {
-	return AuthExtractResult{}, ErrUnimplemented
+type initErrorService struct{ err error }
+
+func (s *initErrorService) CreateSandbox(context.Context, CreateSandboxRequest) (Sandbox, error) {
+	return Sandbox{}, s.err
+}
+func (s *initErrorService) DeleteSandbox(context.Context, DeleteSandboxRequest) (DeleteSandboxResult, error) {
+	return DeleteSandboxResult{}, s.err
+}
+func (s *initErrorService) ListSandboxes(context.Context, ListSandboxesRequest) (ListSandboxesResult, error) {
+	return ListSandboxesResult{}, s.err
+}
+func (s *initErrorService) ConnectSandbox(context.Context, ConnectSandboxRequest) error { return s.err }
+func (s *initErrorService) Materialize(context.Context, MaterializeRequest) (MaterializeResult, error) {
+	return MaterializeResult{}, s.err
+}
+func (s *initErrorService) ListVolumes(context.Context, ListVolumesRequest) (ListVolumesResult, error) {
+	return ListVolumesResult{}, s.err
+}
+func (s *initErrorService) DeleteVolume(context.Context, DeleteVolumeRequest) (DeleteVolumeResult, error) {
+	return DeleteVolumeResult{}, s.err
+}
+func (s *initErrorService) ExtractAuth(context.Context, AuthExtractRequest) (AuthExtractResult, error) {
+	return AuthExtractResult{}, s.err
+}
+
+func toMounts(in []sandbox.MountBinding) []Mount {
+	out := make([]Mount, 0, len(in))
+	for _, m := range in {
+		out = append(out, Mount{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
+	}
+	return out
 }

--- a/pkg/amika/service_test.go
+++ b/pkg/amika/service_test.go
@@ -3,42 +3,94 @@ package amika
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/gofixpoint/amika/internal/sandbox"
 )
 
 func TestNewService_ReturnsService(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	svc := NewService(Options{})
 	if svc == nil {
 		t.Fatal("expected service, got nil")
 	}
+	if _, err := svc.ListSandboxes(context.Background(), ListSandboxesRequest{}); err != nil {
+		t.Fatalf("ListSandboxes err = %v", err)
+	}
 }
 
-func TestUnimplementedService_ReturnsUnimplementedError(t *testing.T) {
+func TestNewService_InitFailureMapsToDependencyError(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMIKA_STATE_DIRECTORY", f)
 	svc := NewService(Options{})
-	ctx := context.Background()
+	_, err := svc.ListSandboxes(context.Background(), ListSandboxesRequest{})
+	if !errors.Is(err, ErrInternal) {
+		t.Fatalf("expected internal error, got %v", err)
+	}
+}
 
-	if _, err := svc.CreateSandbox(ctx, CreateSandboxRequest{}); !errors.Is(err, ErrUnimplemented) {
-		t.Fatalf("CreateSandbox err = %v, want ErrUnimplemented", err)
+func TestCreateSandbox_InvalidProvider(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	_, err := svc.CreateSandbox(context.Background(), CreateSandboxRequest{Provider: "podman"})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("expected invalid argument, got %v", err)
 	}
-	if _, err := svc.DeleteSandbox(ctx, DeleteSandboxRequest{}); !errors.Is(err, ErrUnimplemented) {
-		t.Fatalf("DeleteSandbox err = %v, want ErrUnimplemented", err)
+}
+
+func TestCreateSandbox_DuplicateName(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", dir)
+	store := sandbox.NewStore(filepath.Join(dir, "sandboxes.jsonl"))
+	if err := store.Save(sandbox.Info{Name: "dup", Provider: "docker"}); err != nil {
+		t.Fatal(err)
 	}
-	if _, err := svc.ListSandboxes(ctx, ListSandboxesRequest{}); !errors.Is(err, ErrUnimplemented) {
-		t.Fatalf("ListSandboxes err = %v, want ErrUnimplemented", err)
+	svc := NewService(Options{})
+	_, err := svc.CreateSandbox(context.Background(), CreateSandboxRequest{Provider: "docker", Name: "dup"})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("expected invalid argument, got %v", err)
 	}
-	if err := svc.ConnectSandbox(ctx, ConnectSandboxRequest{}); !errors.Is(err, ErrUnimplemented) {
-		t.Fatalf("ConnectSandbox err = %v, want ErrUnimplemented", err)
+}
+
+func TestDeleteSandbox_NotFound(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	_, err := svc.DeleteSandbox(context.Background(), DeleteSandboxRequest{Names: []string{"missing"}})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected not found, got %v", err)
 	}
-	if _, err := svc.Materialize(ctx, MaterializeRequest{}); !errors.Is(err, ErrUnimplemented) {
-		t.Fatalf("Materialize err = %v, want ErrUnimplemented", err)
+}
+
+func TestConnectSandbox_Validation(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	if err := svc.ConnectSandbox(context.Background(), ConnectSandboxRequest{}); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("expected invalid argument, got %v", err)
 	}
-	if _, err := svc.ListVolumes(ctx, ListVolumesRequest{}); !errors.Is(err, ErrUnimplemented) {
-		t.Fatalf("ListVolumes err = %v, want ErrUnimplemented", err)
+	if err := svc.ConnectSandbox(context.Background(), ConnectSandboxRequest{Name: "missing"}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected not found, got %v", err)
 	}
-	if _, err := svc.DeleteVolume(ctx, DeleteVolumeRequest{}); !errors.Is(err, ErrUnimplemented) {
-		t.Fatalf("DeleteVolume err = %v, want ErrUnimplemented", err)
+}
+
+func TestMaterialize_RequiresDestdir(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	_, err := svc.Materialize(context.Background(), MaterializeRequest{Cmd: "echo hi"})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("expected invalid argument, got %v", err)
 	}
-	if _, err := svc.ExtractAuth(ctx, AuthExtractRequest{}); !errors.Is(err, ErrUnimplemented) {
-		t.Fatalf("ExtractAuth err = %v, want ErrUnimplemented", err)
+}
+
+func TestDeleteVolume_NotFound(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	_, err := svc.DeleteVolume(context.Background(), DeleteVolumeRequest{Names: []string{"missing"}})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected not found, got %v", err)
 	}
 }

--- a/test/contract/service_http_contract_test.go
+++ b/test/contract/service_http_contract_test.go
@@ -1,0 +1,57 @@
+package contract_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofixpoint/amika/internal/httpapi"
+	"github.com/gofixpoint/amika/internal/sandbox"
+	"github.com/gofixpoint/amika/pkg/amika"
+)
+
+func TestServiceHTTPParity_ListSandboxes(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", dir)
+	store := sandbox.NewStore(filepath.Join(dir, "sandboxes.jsonl"))
+	_ = store.Save(sandbox.Info{Name: "sb-a", Provider: "docker", Image: "img", CreatedAt: "now"})
+	svc := amika.NewService(amika.Options{})
+	direct, err := svc.ListSandboxes(context.Background(), amika.ListSandboxesRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := httpapi.NewHandler(svc)
+	res := httptest.NewRecorder()
+	h.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/v1/sandboxes", nil))
+	if res.Code != http.StatusOK {
+		t.Fatalf("status=%d", res.Code)
+	}
+	var body amika.ListSandboxesResult
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Items) != len(direct.Items) {
+		t.Fatalf("len mismatch %d %d", len(body.Items), len(direct.Items))
+	}
+}
+
+func TestServiceHTTPParity_MaterializeInvalid(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := amika.NewService(amika.Options{})
+	_, err := svc.Materialize(context.Background(), amika.MaterializeRequest{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	h := httpapi.NewHandler(svc)
+	res := httptest.NewRecorder()
+	h.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/v1/materialize", bytes.NewReader([]byte(`{}`))))
+	if res.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d body=%s", res.Code, res.Body.String())
+	}
+}

--- a/test/coverage-baseline.env
+++ b/test/coverage-baseline.env
@@ -1,3 +1,3 @@
 # Coverage thresholds used by scripts/test/check_coverage.sh
 AMIKA_MIN_INTERNAL_COVERAGE=70.0
-AMIKA_MIN_CMD_COVERAGE=35.0
+AMIKA_MIN_CMD_COVERAGE=50.0


### PR DESCRIPTION
### Motivation

- Replace placeholder/unimplemented service behavior with a concrete application service implementation to centralize sandbox, volume and materialize logic.
- Expose the service functionality over an HTTP API so clients can manage sandboxes, volumes and auth extraction programmatically.
- Wire the CLI to the public `amika` service so command handlers reuse the same business logic and state stores.
- Improve test coverage for command and HTTP layers and raise the CMD coverage threshold.

### Description

- Implemented application service methods in `internal/app/service_impl.go` including `CreateSandbox`, `DeleteSandbox`, `ListSandboxes`, `ConnectSandbox`, `Materialize`, `ListVolumes`, `DeleteVolume`, and `ExtractAuth`, plus helper converters and dependency/error handling.
- Implemented public `pkg/amika` service in `pkg/amika/service.go` with a concrete `serviceImpl` backed by file-based stores (`internal/sandbox`) and runtime calls (docker), and added an `initErrorService` wrapper for initialization failures.
- Added HTTP endpoints in `internal/httpapi/server.go` for creating/listing/deleting sandboxes, listing/deleting volumes, auth extraction, and materialize, and mapped service error types to appropriate HTTP status codes.
- Updated CLI to use the public service (`amika.NewService`) for listing sandboxes, added/updated many unit tests and a new HTTP contract test, and bumped `AMIKA_MIN_CMD_COVERAGE` from `35.0` to `50.0` in `test/coverage-baseline.env`.

### Testing

- Ran the test suite with `go test ./...`, covering updated and new tests in `pkg/amika`, `internal/app`, `internal/httpapi`, `cmd`, and `test/contract`, and all tests passed.
- Verified HTTP behavior via unit tests in `internal/httpapi/server_test.go`, including that OpenAPI includes v1 paths and `POST /v1/materialize` maps invalid payloads to `422`.
- Verified CLI output via `cmd/amika/sandbox_test.go` that `sandbox list` prints headers and rows when sandboxes exist.
- Added a contract test (`test/contract/service_http_contract_test.go`) to assert parity between direct service calls and the HTTP API for `ListSandboxes` and materialize error behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5190c6e68832aae9a6d92c9bcf1e0)