### PR TITLE
feat: add setup script text, published ports, and preset improvements

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -55,6 +55,8 @@ var sandboxCreateCmd = &cobra.Command{
 		gitPath, _ := cmd.Flags().GetString("git")
 		noClean, _ := cmd.Flags().GetBool("no-clean")
 		envStrs, _ := cmd.Flags().GetStringArray("env")
+		portStrs, _ := cmd.Flags().GetStringArray("port")
+		portHostIP, _ := cmd.Flags().GetString("port-host-ip")
 		yes, _ := cmd.Flags().GetBool("yes")
 		connect, _ := cmd.Flags().GetBool("connect")
 		setupScript, _ := cmd.Flags().GetString("setup-script")
@@ -83,6 +85,10 @@ var sandboxCreateCmd = &cobra.Command{
 			return err
 		}
 		volumeMounts, err := parseVolumeFlags(volumeStrs)
+		if err != nil {
+			return err
+		}
+		publishedPorts, err := parsePortFlags(portStrs, portHostIP)
 		if err != nil {
 			return err
 		}
@@ -307,7 +313,7 @@ var sandboxCreateCmd = &cobra.Command{
 			runtimeMounts = append(runtimeMounts, v)
 		}
 
-		containerID, err := sandbox.CreateDockerSandbox(name, image, runtimeMounts, envStrs)
+		containerID, err := sandbox.CreateDockerSandbox(name, image, runtimeMounts, envStrs, publishedPorts)
 		if err != nil {
 			rollbackAll()
 			return err
@@ -322,12 +328,19 @@ var sandboxCreateCmd = &cobra.Command{
 			Preset:      preset,
 			Mounts:      runtimeMounts,
 			Env:         envStrs,
+			Ports:       publishedPorts,
 		}
 		if err := store.Save(info); err != nil {
 			return fmt.Errorf("sandbox created but failed to save state: %w", err)
 		}
 
 		fmt.Printf("Sandbox %q created (container %s)\n", name, containerID[:12])
+		if len(publishedPorts) > 0 {
+			fmt.Println("Published ports:")
+			for _, p := range publishedPorts {
+				fmt.Printf("  %s\n", formatPortBinding(p))
+			}
+		}
 		if connect {
 			if err := runSandboxConnect(name, "zsh", os.Stdin, os.Stdout, os.Stderr); err != nil {
 				return fmt.Errorf("sandbox %q created but failed to connect with shell %q: %w", name, "zsh", err)
@@ -441,9 +454,9 @@ var sandboxListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tPROVIDER\tIMAGE\tCREATED")
+		fmt.Fprintln(w, "NAME\tPROVIDER\tIMAGE\tPORTS\tCREATED")
 		for _, sb := range result.Items {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", sb.Name, sb.Provider, sb.Image, sb.CreatedAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.Provider, sb.Image, formatPortBindings(sb.Ports), sb.CreatedAt)
 		}
 		w.Flush()
 		return nil
@@ -482,6 +495,97 @@ var sandboxConnectCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// parsePortFlags parses --port flag values in the format hostPort:containerPort[/protocol].
+func parsePortFlags(flags []string, hostIP string) ([]sandbox.PortBinding, error) {
+	hostIP = strings.TrimSpace(hostIP)
+	if hostIP == "" {
+		return nil, fmt.Errorf("--port-host-ip must not be empty")
+	}
+
+	ports := make([]sandbox.PortBinding, 0, len(flags))
+	seen := make(map[string]bool, len(flags))
+	for _, raw := range flags {
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			return nil, fmt.Errorf("invalid port format %q: expected hostPort:containerPort[/protocol]", raw)
+		}
+
+		mainPart := value
+		protocol := "tcp"
+		if strings.Contains(value, "/") {
+			parts := strings.SplitN(value, "/", 2)
+			mainPart = parts[0]
+			protocol = strings.ToLower(strings.TrimSpace(parts[1]))
+		}
+		if protocol != "tcp" && protocol != "udp" {
+			return nil, fmt.Errorf("invalid port protocol %q: must be \"tcp\" or \"udp\"", protocol)
+		}
+
+		parts := strings.SplitN(mainPart, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid port format %q: expected hostPort:containerPort[/protocol]", raw)
+		}
+		hostPort, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return nil, fmt.Errorf("invalid host port in %q: %w", raw, err)
+		}
+		containerPort, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return nil, fmt.Errorf("invalid container port in %q: %w", raw, err)
+		}
+		if hostPort < 1 || hostPort > 65535 {
+			return nil, fmt.Errorf("host port %d must be between 1 and 65535", hostPort)
+		}
+		if containerPort < 1 || containerPort > 65535 {
+			return nil, fmt.Errorf("container port %d must be between 1 and 65535", containerPort)
+		}
+
+		key := fmt.Sprintf("%s:%d/%s", hostIP, hostPort, protocol)
+		if seen[key] {
+			return nil, fmt.Errorf("duplicate published port binding %s", key)
+		}
+		seen[key] = true
+		ports = append(ports, sandbox.PortBinding{
+			HostIP:        hostIP,
+			HostPort:      hostPort,
+			ContainerPort: containerPort,
+			Protocol:      protocol,
+		})
+	}
+	return ports, nil
+}
+
+func formatPortBindings(bindings []amika.PortBinding) string {
+	if len(bindings) == 0 {
+		return "-"
+	}
+	out := make([]string, 0, len(bindings))
+	for _, p := range bindings {
+		hostIP := p.HostIP
+		if strings.TrimSpace(hostIP) == "" {
+			hostIP = "127.0.0.1"
+		}
+		protocol := p.Protocol
+		if strings.TrimSpace(protocol) == "" {
+			protocol = "tcp"
+		}
+		out = append(out, fmt.Sprintf("%s:%d->%d/%s", hostIP, p.HostPort, p.ContainerPort, protocol))
+	}
+	return strings.Join(out, ",")
+}
+
+func formatPortBinding(binding sandbox.PortBinding) string {
+	hostIP := binding.HostIP
+	if strings.TrimSpace(hostIP) == "" {
+		hostIP = "127.0.0.1"
+	}
+	protocol := binding.Protocol
+	if strings.TrimSpace(protocol) == "" {
+		protocol = "tcp"
+	}
+	return fmt.Sprintf("%s:%d->%d/%s", hostIP, binding.HostPort, binding.ContainerPort, protocol)
 }
 
 // parseMountFlags parses --mount flag values in the format source:target[:mode].
@@ -1067,6 +1171,8 @@ func init() {
 	sandboxCreateCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"coder\" or \"claude\")")
 	sandboxCreateCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rwcopy)")
 	sandboxCreateCmd.Flags().StringArray("volume", nil, "Mount an existing named volume (name:target[:mode], mode defaults to rw)")
+	sandboxCreateCmd.Flags().StringArray("port", nil, "Publish a container port (hostPort:containerPort[/protocol], protocol defaults to tcp)")
+	sandboxCreateCmd.Flags().String("port-host-ip", "127.0.0.1", "Host IP address to bind published ports")
 	sandboxCreateCmd.Flags().String("git", "", "Mount the current git repo root (or repo containing PATH) into /home/amika/workspace/{repo}")
 	sandboxCreateCmd.Flags().Lookup("git").NoOptDefVal = "."
 	sandboxCreateCmd.Flags().Bool("no-clean", false, "With --git, include untracked files from working tree instead of a clean clone")

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -184,6 +184,71 @@ func TestValidateMountTargets_DuplicateAcrossMountAndVolume(t *testing.T) {
 	}
 }
 
+func TestParsePortFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   []string
+		hostIP  string
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name:    "single port with protocol",
+			flags:   []string{"8080:80/tcp"},
+			hostIP:  "127.0.0.1",
+			wantLen: 1,
+		},
+		{
+			name:    "default protocol",
+			flags:   []string{"5353:5353"},
+			hostIP:  "127.0.0.1",
+			wantLen: 1,
+		},
+		{
+			name:    "invalid protocol",
+			flags:   []string{"8080:80/sctp"},
+			hostIP:  "127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			flags:   []string{"8080"},
+			hostIP:  "127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "duplicate host binding",
+			flags:   []string{"8080:80/tcp", "8080:81/tcp"},
+			hostIP:  "127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "empty host ip",
+			flags:   []string{"8080:80"},
+			hostIP:  " ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ports, err := parsePortFlags(tt.flags, tt.hostIP)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(ports) != tt.wantLen {
+				t.Fatalf("expected %d ports, got %d", tt.wantLen, len(ports))
+			}
+		})
+	}
+}
+
 func TestCleanupSandboxVolumes_PreserveDefault(t *testing.T) {
 	dir := t.TempDir()
 	store := sandbox.NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
@@ -840,7 +905,15 @@ func TestSandboxListCommand_PrintsRows(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("AMIKA_STATE_DIRECTORY", dir)
 	store := sandbox.NewStore(filepath.Join(dir, "sandboxes.jsonl"))
-	if err := store.Save(sandbox.Info{Name: "sb-a", Provider: "docker", Image: "img", CreatedAt: "now"}); err != nil {
+	if err := store.Save(sandbox.Info{
+		Name:      "sb-a",
+		Provider:  "docker",
+		Image:     "img",
+		CreatedAt: "now",
+		Ports: []sandbox.PortBinding{
+			{HostIP: "127.0.0.1", HostPort: 8080, ContainerPort: 80, Protocol: "tcp"},
+		},
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -848,10 +921,13 @@ func TestSandboxListCommand_PrintsRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sandbox list failed: %v", err)
 	}
-	if !strings.Contains(out, "NAME") || !strings.Contains(out, "PROVIDER") {
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "PROVIDER") || !strings.Contains(out, "PORTS") {
 		t.Fatalf("missing header: %s", out)
 	}
 	if !strings.Contains(out, "sb-a") {
 		t.Fatalf("missing sandbox row: %s", out)
+	}
+	if !strings.Contains(out, "127.0.0.1:8080->80/tcp") {
+		t.Fatalf("missing ports in row: %s", out)
 	}
 }

--- a/internal/app/service_impl.go
+++ b/internal/app/service_impl.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/gofixpoint/amika/internal/auth"
@@ -58,8 +59,12 @@ func (s *Service) CreateSandbox(_ context.Context, req amika.CreateSandboxReques
 	if _, err := s.deps.Sandboxes.Get(req.Name); err == nil {
 		return amika.Sandbox{}, fmt.Errorf("%w: sandbox %q already exists", amika.ErrInvalidArgument, req.Name)
 	}
+	publishedPorts, err := normalizePortBindings(req.Ports)
+	if err != nil {
+		return amika.Sandbox{}, err
+	}
 
-	containerID, err := s.deps.Docker.CreateSandbox(req.Name, req.Image, toPortMounts(req.Mounts, req.Volumes), req.Env)
+	containerID, err := s.deps.Docker.CreateSandbox(req.Name, req.Image, toPortMounts(req.Mounts, req.Volumes), req.Env, toPortBindings(publishedPorts))
 	if err != nil {
 		return amika.Sandbox{}, fmt.Errorf("%w: %v", amika.ErrDependency, err)
 	}
@@ -77,6 +82,7 @@ func (s *Service) CreateSandbox(_ context.Context, req amika.CreateSandboxReques
 		Preset:      req.Preset,
 		Mounts:      toPortMounts(req.Mounts, req.Volumes),
 		Env:         req.Env,
+		Ports:       toPortBindings(publishedPorts),
 	}
 	if err := s.deps.Sandboxes.Save(rec); err != nil {
 		return amika.Sandbox{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
@@ -91,6 +97,7 @@ func (s *Service) CreateSandbox(_ context.Context, req amika.CreateSandboxReques
 		Preset:      rec.Preset,
 		Mounts:      toPublicMounts(rec.Mounts),
 		Env:         rec.Env,
+		Ports:       toPublicPorts(rec.Ports),
 	}, nil
 }
 
@@ -133,6 +140,7 @@ func (s *Service) ListSandboxes(context.Context, amika.ListSandboxesRequest) (am
 			Preset:      rec.Preset,
 			Mounts:      toPublicMounts(rec.Mounts),
 			Env:         rec.Env,
+			Ports:       toPublicPorts(rec.Ports),
 		})
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
@@ -266,6 +274,19 @@ func toPublicMounts(mounts []ports.Mount) []amika.Mount {
 	return out
 }
 
+func toPublicPorts(bindings []ports.PortBinding) []amika.PortBinding {
+	out := make([]amika.PortBinding, 0, len(bindings))
+	for _, p := range bindings {
+		out = append(out, amika.PortBinding{
+			HostIP:        p.HostIP,
+			HostPort:      p.HostPort,
+			ContainerPort: p.ContainerPort,
+			Protocol:      p.Protocol,
+		})
+	}
+	return out
+}
+
 func toPublicVolume(v ports.VolumeRecord, typ string) amika.Volume {
 	return amika.Volume{Name: v.Name, Type: typ, CreatedAt: v.CreatedAt, InUse: len(v.SandboxRefs) > 0, Sandboxes: v.SandboxRefs, SourcePath: v.SourcePath}
 }
@@ -279,4 +300,53 @@ func toPortMounts(mounts []amika.Mount, volumes []amika.Mount) []ports.Mount {
 		out = append(out, ports.Mount{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
 	}
 	return out
+}
+
+func toPortBindings(bindings []amika.PortBinding) []ports.PortBinding {
+	out := make([]ports.PortBinding, 0, len(bindings))
+	for _, p := range bindings {
+		out = append(out, ports.PortBinding{
+			HostIP:        p.HostIP,
+			HostPort:      p.HostPort,
+			ContainerPort: p.ContainerPort,
+			Protocol:      p.Protocol,
+		})
+	}
+	return out
+}
+
+func normalizePortBindings(in []amika.PortBinding) ([]amika.PortBinding, error) {
+	out := make([]amika.PortBinding, 0, len(in))
+	seen := make(map[string]bool, len(in))
+	for _, p := range in {
+		hostIP := strings.TrimSpace(p.HostIP)
+		if hostIP == "" {
+			hostIP = "127.0.0.1"
+		}
+		if p.HostPort < 1 || p.HostPort > 65535 {
+			return nil, fmt.Errorf("%w: HostPort %d must be between 1 and 65535", amika.ErrInvalidArgument, p.HostPort)
+		}
+		if p.ContainerPort < 1 || p.ContainerPort > 65535 {
+			return nil, fmt.Errorf("%w: ContainerPort %d must be between 1 and 65535", amika.ErrInvalidArgument, p.ContainerPort)
+		}
+		protocol := strings.ToLower(strings.TrimSpace(p.Protocol))
+		if protocol == "" {
+			protocol = "tcp"
+		}
+		if protocol != "tcp" && protocol != "udp" {
+			return nil, fmt.Errorf("%w: Protocol %q must be tcp or udp", amika.ErrInvalidArgument, p.Protocol)
+		}
+		key := fmt.Sprintf("%s:%d/%s", hostIP, p.HostPort, protocol)
+		if seen[key] {
+			return nil, fmt.Errorf("%w: duplicate published port binding %s", amika.ErrInvalidArgument, key)
+		}
+		seen[key] = true
+		out = append(out, amika.PortBinding{
+			HostIP:        hostIP,
+			HostPort:      p.HostPort,
+			ContainerPort: p.ContainerPort,
+			Protocol:      protocol,
+		})
+	}
+	return out, nil
 }

--- a/internal/app/service_impl_test.go
+++ b/internal/app/service_impl_test.go
@@ -12,7 +12,7 @@ import (
 
 type stubDocker struct{}
 
-func (stubDocker) CreateSandbox(string, string, []ports.Mount, []string) (string, error) {
+func (stubDocker) CreateSandbox(string, string, []ports.Mount, []string, []ports.PortBinding) (string, error) {
 	return "container-123", nil
 }
 func (stubDocker) RemoveSandbox(string) error               { return nil }
@@ -76,6 +76,16 @@ func TestNewService_ImplementsPublicService(t *testing.T) {
 	}
 	if _, err := svc.CreateSandbox(ctx, amika.CreateSandboxRequest{Name: "new-sb", Provider: "docker", Image: "img"}); err != nil {
 		t.Fatalf("CreateSandbox unexpected err = %v", err)
+	}
+	if _, err := svc.CreateSandbox(ctx, amika.CreateSandboxRequest{
+		Name:     "sb-invalid-port",
+		Provider: "docker",
+		Image:    "img",
+		Ports: []amika.PortBinding{
+			{HostPort: 0, ContainerPort: 80},
+		},
+	}); !errors.Is(err, amika.ErrInvalidArgument) {
+		t.Fatalf("CreateSandbox invalid ports err = %v, want ErrInvalidArgument", err)
 	}
 	if _, err := svc.DeleteSandbox(ctx, amika.DeleteSandboxRequest{Names: []string{"missing"}}); !errors.Is(err, amika.ErrNotFound) {
 		t.Fatalf("DeleteSandbox err = %v, want ErrNotFound", err)

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -159,4 +159,14 @@ func TestOpenAPICreateSandboxUsesPascalCaseSetupScriptFields(t *testing.T) {
 	if _, ok := props["SetupScriptText"]; !ok {
 		t.Fatalf("missing SetupScriptText property")
 	}
+
+	required, hasRequired := createReq["required"]
+	if !hasRequired {
+		return
+	}
+	for _, field := range required.([]any) {
+		if field == "SetupScript" || field == "SetupScriptText" {
+			t.Fatalf("field %v should not be required", field)
+		}
+	}
 }

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -115,6 +115,7 @@ func TestCreateSandboxBodyIncludesSetupScriptFields(t *testing.T) {
 		GitPath:         "",
 		NoClean:         false,
 		Env:             []string{},
+		Ports:           []amika.PortBinding{{HostIP: "127.0.0.1", HostPort: 8080, ContainerPort: 80, Protocol: "tcp"}},
 		SetupScript:     "/tmp/setup.sh",
 		SetupScriptText: "#!/usr/bin/env bash\necho hi\n",
 	}
@@ -133,6 +134,12 @@ func TestCreateSandboxBodyIncludesSetupScriptFields(t *testing.T) {
 	}
 	if svc.req.SetupScriptText != "#!/usr/bin/env bash\necho hi\n" {
 		t.Fatalf("SetupScriptText=%q", svc.req.SetupScriptText)
+	}
+	if len(svc.req.Ports) != 1 {
+		t.Fatalf("Ports len=%d", len(svc.req.Ports))
+	}
+	if svc.req.Ports[0].HostPort != 8080 || svc.req.Ports[0].ContainerPort != 80 {
+		t.Fatalf("Ports=%+v", svc.req.Ports)
 	}
 }
 
@@ -158,6 +165,9 @@ func TestOpenAPICreateSandboxUsesPascalCaseSetupScriptFields(t *testing.T) {
 	}
 	if _, ok := props["SetupScriptText"]; !ok {
 		t.Fatalf("missing SetupScriptText property")
+	}
+	if _, ok := props["Ports"]; !ok {
+		t.Fatalf("missing Ports property")
 	}
 
 	required, hasRequired := createReq["required"]

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -38,6 +38,16 @@ func (stubService) ExtractAuth(context.Context, amika.AuthExtractRequest) (amika
 	return amika.AuthExtractResult{Lines: []string{"A='1'"}}, nil
 }
 
+type captureCreateSandboxService struct {
+	stubService
+	req amika.CreateSandboxRequest
+}
+
+func (s *captureCreateSandboxService) CreateSandbox(_ context.Context, req amika.CreateSandboxRequest) (amika.Sandbox, error) {
+	s.req = req
+	return amika.Sandbox{Name: req.Name}, nil
+}
+
 func TestEndpoints(t *testing.T) {
 	h := NewHandler(stubService{})
 	cases := []struct {
@@ -89,5 +99,64 @@ func TestOpenAPIIncludesV1Paths(t *testing.T) {
 		if _, ok := paths[p]; !ok {
 			t.Fatalf("missing path %s", p)
 		}
+	}
+}
+
+func TestCreateSandboxBodyIncludesSetupScriptFields(t *testing.T) {
+	svc := &captureCreateSandboxService{}
+	h := NewHandler(svc)
+	payload := amika.CreateSandboxRequest{
+		Provider:        "docker",
+		Name:            "sb",
+		Image:           "",
+		Preset:          "",
+		Mounts:          []amika.Mount{},
+		Volumes:         []amika.Mount{},
+		GitPath:         "",
+		NoClean:         false,
+		Env:             []string{},
+		SetupScript:     "/tmp/setup.sh",
+		SetupScriptText: "#!/usr/bin/env bash\necho hi\n",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", bytes.NewReader(body))
+	res := httptest.NewRecorder()
+	h.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", res.Code, res.Body.String())
+	}
+	if svc.req.SetupScript != "/tmp/setup.sh" {
+		t.Fatalf("SetupScript=%q", svc.req.SetupScript)
+	}
+	if svc.req.SetupScriptText != "#!/usr/bin/env bash\necho hi\n" {
+		t.Fatalf("SetupScriptText=%q", svc.req.SetupScriptText)
+	}
+}
+
+func TestOpenAPICreateSandboxUsesPascalCaseSetupScriptFields(t *testing.T) {
+	h := NewHandler(stubService{})
+	req := httptest.NewRequest(http.MethodGet, "/openapi.json", nil)
+	res := httptest.NewRecorder()
+	h.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status=%d", res.Code)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(res.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	components := doc["components"].(map[string]any)
+	schemas := components["schemas"].(map[string]any)
+	createReq := schemas["CreateSandboxRequest"].(map[string]any)
+	props := createReq["properties"].(map[string]any)
+	if _, ok := props["SetupScript"]; !ok {
+		t.Fatalf("missing SetupScript property")
+	}
+	if _, ok := props["SetupScriptText"]; !ok {
+		t.Fatalf("missing SetupScriptText property")
 	}
 }

--- a/internal/ports/docker.go
+++ b/internal/ports/docker.go
@@ -10,9 +10,17 @@ type Mount struct {
 	SnapshotFrom string
 }
 
+// PortBinding describes a published container port at the infrastructure boundary.
+type PortBinding struct {
+	HostIP        string
+	HostPort      int
+	ContainerPort int
+	Protocol      string
+}
+
 // DockerClient defines operations the app layer needs from Docker.
 type DockerClient interface {
-	CreateSandbox(name, image string, mounts []Mount, env []string) (string, error)
+	CreateSandbox(name, image string, mounts []Mount, env []string, ports []PortBinding) (string, error)
 	RemoveSandbox(name string) error
 	CreateVolume(name string) error
 	RemoveVolume(name string) error

--- a/internal/ports/store.go
+++ b/internal/ports/store.go
@@ -10,6 +10,7 @@ type SandboxRecord struct {
 	Preset      string
 	Mounts      []Mount
 	Env         []string
+	Ports       []PortBinding
 }
 
 // VolumeRecord stores tracked volume metadata.

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -11,8 +11,8 @@ import (
 
 // CreateDockerSandbox creates a long-running Docker container with the given
 // name, image, and optional bind mounts. Returns the container ID.
-func CreateDockerSandbox(name, image string, mounts []MountBinding, env []string) (string, error) {
-	args := buildDockerRunArgs(name, image, mounts, env)
+func CreateDockerSandbox(name, image string, mounts []MountBinding, env []string, ports []PortBinding) (string, error) {
+	args := buildDockerRunArgs(name, image, mounts, env, ports)
 	cmd := exec.Command("docker", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -115,7 +115,7 @@ func CopyHostDirToVolume(volumeName, hostDir string) error {
 	return nil
 }
 
-func buildDockerRunArgs(name, image string, mounts []MountBinding, env []string) []string {
+func buildDockerRunArgs(name, image string, mounts []MountBinding, env []string, ports []PortBinding) []string {
 	args := []string{"run", "-d", "--name", name}
 	for _, m := range mounts {
 		vol := mountVolumeSpec(m)
@@ -124,11 +124,33 @@ func buildDockerRunArgs(name, image string, mounts []MountBinding, env []string)
 		}
 		args = append(args, "-v", vol)
 	}
+	for _, p := range ports {
+		spec := portPublishSpec(p)
+		if spec == "" {
+			continue
+		}
+		args = append(args, "-p", spec)
+	}
 	for _, e := range env {
 		args = append(args, "-e", e)
 	}
 	args = append(args, image, "tail", "-f", "/dev/null")
 	return args
+}
+
+func portPublishSpec(p PortBinding) string {
+	if p.HostPort <= 0 || p.ContainerPort <= 0 {
+		return ""
+	}
+	protocol := strings.ToLower(strings.TrimSpace(p.Protocol))
+	if protocol == "" {
+		protocol = "tcp"
+	}
+	hostIP := strings.TrimSpace(p.HostIP)
+	if hostIP == "" {
+		return fmt.Sprintf("%d:%d/%s", p.HostPort, p.ContainerPort, protocol)
+	}
+	return fmt.Sprintf("%s:%d:%d/%s", hostIP, p.HostPort, p.ContainerPort, protocol)
 }
 
 func mountVolumeSpec(m MountBinding) string {

--- a/internal/sandbox/docker_test.go
+++ b/internal/sandbox/docker_test.go
@@ -11,12 +11,18 @@ func TestBuildDockerRunArgs_MixedMounts(t *testing.T) {
 		{Type: "volume", Volume: "amika-vol-1", Target: "/workspace/cache", Mode: "rw"},
 	}
 	env := []string{"A=1", "B=2"}
+	ports := []PortBinding{
+		{HostIP: "127.0.0.1", HostPort: 8080, ContainerPort: 80, Protocol: "tcp"},
+		{HostPort: 5353, ContainerPort: 5353, Protocol: "udp"},
+	}
 
-	got := buildDockerRunArgs("sb1", "ubuntu:latest", mounts, env)
+	got := buildDockerRunArgs("sb1", "ubuntu:latest", mounts, env, ports)
 	want := []string{
 		"run", "-d", "--name", "sb1",
 		"-v", "/host/src:/workspace/src:ro",
 		"-v", "amika-vol-1:/workspace/cache",
+		"-p", "127.0.0.1:8080:80/tcp",
+		"-p", "5353:5353/udp",
 		"-e", "A=1",
 		"-e", "B=2",
 		"ubuntu:latest", "tail", "-f", "/dev/null",
@@ -35,5 +41,11 @@ func TestMountVolumeSpec_EmptyIgnored(t *testing.T) {
 		if got := mountVolumeSpec(tt); got != "" {
 			t.Fatalf("mountVolumeSpec(%+v) = %q, want empty", tt, got)
 		}
+	}
+}
+
+func TestPortPublishSpec_EmptyIgnored(t *testing.T) {
+	if got := portPublishSpec(PortBinding{}); got != "" {
+		t.Fatalf("portPublishSpec should ignore empty binding, got %q", got)
 	}
 }

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -19,8 +19,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install TypeScript and Claude Code CLI
-RUN npm install -g typescript tsx @anthropic-ai/claude-code
+# Install pnpm, TypeScript, and Claude Code CLI
+RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code
 
 RUN mkdir -p /home/amika
 WORKDIR /home/amika

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Install coding agent CLIs.
-RUN npm install -g typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai
+RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai
 
 RUN mkdir -p /home/amika
 WORKDIR /home/amika

--- a/internal/sandbox/store.go
+++ b/internal/sandbox/store.go
@@ -18,6 +18,14 @@ type MountBinding struct {
 	SnapshotFrom string `json:"snapshotFrom,omitempty"`
 }
 
+// PortBinding represents a published container port.
+type PortBinding struct {
+	HostIP        string `json:"hostIp,omitempty"`
+	HostPort      int    `json:"hostPort"`
+	ContainerPort int    `json:"containerPort"`
+	Protocol      string `json:"protocol,omitempty"`
+}
+
 // Info represents a tracked sandbox.
 type Info struct {
 	Name        string         `json:"name"`
@@ -28,6 +36,7 @@ type Info struct {
 	Preset      string         `json:"preset,omitempty"`
 	Mounts      []MountBinding `json:"mounts,omitempty"`
 	Env         []string       `json:"env,omitempty"`
+	Ports       []PortBinding  `json:"ports,omitempty"`
 }
 
 // Store manages sandbox state persistence.

--- a/pkg/amika/requests.go
+++ b/pkg/amika/requests.go
@@ -21,8 +21,8 @@ type CreateSandboxRequest struct {
 	GitPath         string
 	NoClean         bool
 	Env             []string
-	SetupScript     string
-	SetupScriptText string
+	SetupScript     string `json:"SetupScript,omitempty"`
+	SetupScriptText string `json:"SetupScriptText,omitempty"`
 }
 
 // DeleteSandboxRequest describes sandbox deletion input.

--- a/pkg/amika/requests.go
+++ b/pkg/amika/requests.go
@@ -10,6 +10,14 @@ type Mount struct {
 	SnapshotFrom string
 }
 
+// PortBinding represents a published container port.
+type PortBinding struct {
+	HostIP        string `json:"HostIP,omitempty"`
+	HostPort      int    `json:"HostPort"`
+	ContainerPort int    `json:"ContainerPort"`
+	Protocol      string `json:"Protocol,omitempty"`
+}
+
 // CreateSandboxRequest describes sandbox creation input.
 type CreateSandboxRequest struct {
 	Provider        string
@@ -21,8 +29,9 @@ type CreateSandboxRequest struct {
 	GitPath         string
 	NoClean         bool
 	Env             []string
-	SetupScript     string `json:"SetupScript,omitempty"`
-	SetupScriptText string `json:"SetupScriptText,omitempty"`
+	Ports           []PortBinding `json:"Ports,omitempty"`
+	SetupScript     string        `json:"SetupScript,omitempty"`
+	SetupScriptText string        `json:"SetupScriptText,omitempty"`
 }
 
 // DeleteSandboxRequest describes sandbox deletion input.

--- a/pkg/amika/requests.go
+++ b/pkg/amika/requests.go
@@ -12,16 +12,17 @@ type Mount struct {
 
 // CreateSandboxRequest describes sandbox creation input.
 type CreateSandboxRequest struct {
-	Provider    string
-	Name        string
-	Image       string
-	Preset      string
-	Mounts      []Mount
-	Volumes     []Mount
-	GitPath     string
-	NoClean     bool
-	Env         []string
-	SetupScript string
+	Provider        string
+	Name            string
+	Image           string
+	Preset          string
+	Mounts          []Mount
+	Volumes         []Mount
+	GitPath         string
+	NoClean         bool
+	Env             []string
+	SetupScript     string
+	SetupScriptText string
 }
 
 // DeleteSandboxRequest describes sandbox deletion input.

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -10,6 +10,7 @@ type Sandbox struct {
 	Preset      string
 	Mounts      []Mount
 	Env         []string
+	Ports       []PortBinding
 }
 
 // DeleteSandboxResult reports sandbox deletion details.

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/gofixpoint/amika/internal/auth"
@@ -76,9 +77,23 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	} else if _, err := s.sandboxes.Get(name); err == nil {
 		return Sandbox{}, fmt.Errorf("%w: sandbox %q already exists", ErrInvalidArgument, name)
 	}
+	if req.SetupScript != "" && req.SetupScriptText != "" {
+		return Sandbox{}, fmt.Errorf("%w: SetupScript and SetupScriptText are mutually exclusive", ErrInvalidArgument)
+	}
+
 	mounts := toSandboxMountBindings(req.Mounts, req.Volumes)
+	cleanupSetupScript := func() {}
+	setupScriptMount, cleanup, err := resolveSetupScriptMount(name, req.SetupScript, req.SetupScriptText)
+	if err != nil {
+		return Sandbox{}, err
+	}
+	if setupScriptMount != nil {
+		mounts = append(mounts, *setupScriptMount)
+		cleanupSetupScript = cleanup
+	}
 	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env)
 	if err != nil {
+		cleanupSetupScript()
 		return Sandbox{}, fmt.Errorf("%w: %v", ErrDependency, err)
 	}
 	info := sandbox.Info{Name: name, Provider: provider, ContainerID: containerID, Image: req.Image, CreatedAt: time.Now().UTC().Format(time.RFC3339), Preset: req.Preset, Mounts: mounts, Env: req.Env}
@@ -241,6 +256,65 @@ func toSandboxMountBindings(mounts []Mount, volumes []Mount) []sandbox.MountBind
 		out = append(out, sandbox.MountBinding{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
 	}
 	return out
+}
+
+func resolveSetupScriptMount(name, setupScriptPath, setupScriptText string) (*sandbox.MountBinding, func(), error) {
+	const setupScriptTarget = "/opt/setup.sh"
+
+	if setupScriptPath != "" {
+		absSetupScript, err := filepath.Abs(setupScriptPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%w: failed to resolve SetupScript path %q: %v", ErrInvalidArgument, setupScriptPath, err)
+		}
+		if _, err := os.Stat(absSetupScript); err != nil {
+			return nil, nil, fmt.Errorf("%w: SetupScript %q is not accessible: %v", ErrInvalidArgument, absSetupScript, err)
+		}
+		return &sandbox.MountBinding{
+			Type:   "bind",
+			Source: absSetupScript,
+			Target: setupScriptTarget,
+			Mode:   "ro",
+		}, func() {}, nil
+	}
+	if setupScriptText == "" {
+		return nil, func() {}, nil
+	}
+
+	stateDir, err := config.StateDir()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: resolve state directory for SetupScriptText: %v", ErrInternal, err)
+	}
+	setupScriptDir := filepath.Join(stateDir, "setup-scripts")
+	if err := os.MkdirAll(setupScriptDir, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("%w: create setup scripts directory: %v", ErrInternal, err)
+	}
+
+	prefix := "inline-setup-"
+	if trimmedName := strings.TrimSpace(name); trimmedName != "" {
+		safeName := strings.NewReplacer("/", "-", "\\", "-", "*", "-").Replace(trimmedName)
+		prefix += safeName + "-"
+	}
+	tmpFile, err := os.CreateTemp(setupScriptDir, prefix+"*.sh")
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: create SetupScriptText file: %v", ErrInternal, err)
+	}
+	defer tmpFile.Close()
+
+	if _, err := tmpFile.WriteString(setupScriptText); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return nil, nil, fmt.Errorf("%w: write SetupScriptText file: %v", ErrInternal, err)
+	}
+	if err := tmpFile.Chmod(0o644); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return nil, nil, fmt.Errorf("%w: set permissions on SetupScriptText file: %v", ErrInternal, err)
+	}
+
+	return &sandbox.MountBinding{
+		Type:   "bind",
+		Source: tmpFile.Name(),
+		Target: setupScriptTarget,
+		Mode:   "ro",
+	}, func() { _ = os.Remove(tmpFile.Name()) }, nil
 }
 
 type initErrorService struct{ err error }

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -80,6 +80,10 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	if req.SetupScript != "" && req.SetupScriptText != "" {
 		return Sandbox{}, fmt.Errorf("%w: SetupScript and SetupScriptText are mutually exclusive", ErrInvalidArgument)
 	}
+	ports, err := normalizePortBindings(req.Ports)
+	if err != nil {
+		return Sandbox{}, err
+	}
 
 	mounts := toSandboxMountBindings(req.Mounts, req.Volumes)
 	cleanupSetupScript := func() {}
@@ -91,16 +95,36 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		mounts = append(mounts, *setupScriptMount)
 		cleanupSetupScript = cleanup
 	}
-	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env)
+	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env, toSandboxPortBindings(ports))
 	if err != nil {
 		cleanupSetupScript()
 		return Sandbox{}, fmt.Errorf("%w: %v", ErrDependency, err)
 	}
-	info := sandbox.Info{Name: name, Provider: provider, ContainerID: containerID, Image: req.Image, CreatedAt: time.Now().UTC().Format(time.RFC3339), Preset: req.Preset, Mounts: mounts, Env: req.Env}
+	info := sandbox.Info{
+		Name:        name,
+		Provider:    provider,
+		ContainerID: containerID,
+		Image:       req.Image,
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		Preset:      req.Preset,
+		Mounts:      mounts,
+		Env:         req.Env,
+		Ports:       toSandboxPortBindings(ports),
+	}
 	if err := s.sandboxes.Save(info); err != nil {
 		return Sandbox{}, fmt.Errorf("%w: %v", ErrInternal, err)
 	}
-	return Sandbox{Name: info.Name, Provider: info.Provider, ContainerID: info.ContainerID, Image: info.Image, CreatedAt: info.CreatedAt, Preset: info.Preset, Mounts: toMounts(info.Mounts), Env: info.Env}, nil
+	return Sandbox{
+		Name:        info.Name,
+		Provider:    info.Provider,
+		ContainerID: info.ContainerID,
+		Image:       info.Image,
+		CreatedAt:   info.CreatedAt,
+		Preset:      info.Preset,
+		Mounts:      toMounts(info.Mounts),
+		Env:         info.Env,
+		Ports:       toPortBindings(info.Ports),
+	}, nil
 }
 func (s *serviceImpl) DeleteSandbox(_ context.Context, req DeleteSandboxRequest) (DeleteSandboxResult, error) {
 	deleted := make([]string, 0, len(req.Names))
@@ -153,7 +177,17 @@ func (s *serviceImpl) ListSandboxes(context.Context, ListSandboxesRequest) (List
 	}
 	out := make([]Sandbox, 0, len(items))
 	for _, it := range items {
-		out = append(out, Sandbox{Name: it.Name, Provider: it.Provider, ContainerID: it.ContainerID, Image: it.Image, CreatedAt: it.CreatedAt, Preset: it.Preset, Mounts: toMounts(it.Mounts), Env: it.Env})
+		out = append(out, Sandbox{
+			Name:        it.Name,
+			Provider:    it.Provider,
+			ContainerID: it.ContainerID,
+			Image:       it.Image,
+			CreatedAt:   it.CreatedAt,
+			Preset:      it.Preset,
+			Mounts:      toMounts(it.Mounts),
+			Env:         it.Env,
+			Ports:       toPortBindings(it.Ports),
+		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return ListSandboxesResult{Items: out}, nil
@@ -254,6 +288,68 @@ func toSandboxMountBindings(mounts []Mount, volumes []Mount) []sandbox.MountBind
 	}
 	for _, m := range volumes {
 		out = append(out, sandbox.MountBinding{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
+	}
+	return out
+}
+
+func normalizePortBindings(in []PortBinding) ([]PortBinding, error) {
+	out := make([]PortBinding, 0, len(in))
+	seen := make(map[string]bool, len(in))
+	for _, p := range in {
+		hostIP := strings.TrimSpace(p.HostIP)
+		if hostIP == "" {
+			hostIP = "127.0.0.1"
+		}
+		if p.HostPort < 1 || p.HostPort > 65535 {
+			return nil, fmt.Errorf("%w: HostPort %d must be between 1 and 65535", ErrInvalidArgument, p.HostPort)
+		}
+		if p.ContainerPort < 1 || p.ContainerPort > 65535 {
+			return nil, fmt.Errorf("%w: ContainerPort %d must be between 1 and 65535", ErrInvalidArgument, p.ContainerPort)
+		}
+		protocol := strings.ToLower(strings.TrimSpace(p.Protocol))
+		if protocol == "" {
+			protocol = "tcp"
+		}
+		if protocol != "tcp" && protocol != "udp" {
+			return nil, fmt.Errorf("%w: Protocol %q must be tcp or udp", ErrInvalidArgument, p.Protocol)
+		}
+		key := fmt.Sprintf("%s:%d/%s", hostIP, p.HostPort, protocol)
+		if seen[key] {
+			return nil, fmt.Errorf("%w: duplicate published port binding %s", ErrInvalidArgument, key)
+		}
+		seen[key] = true
+		out = append(out, PortBinding{
+			HostIP:        hostIP,
+			HostPort:      p.HostPort,
+			ContainerPort: p.ContainerPort,
+			Protocol:      protocol,
+		})
+	}
+	return out, nil
+}
+
+func toSandboxPortBindings(in []PortBinding) []sandbox.PortBinding {
+	out := make([]sandbox.PortBinding, 0, len(in))
+	for _, p := range in {
+		out = append(out, sandbox.PortBinding{
+			HostIP:        p.HostIP,
+			HostPort:      p.HostPort,
+			ContainerPort: p.ContainerPort,
+			Protocol:      p.Protocol,
+		})
+	}
+	return out
+}
+
+func toPortBindings(in []sandbox.PortBinding) []PortBinding {
+	out := make([]PortBinding, 0, len(in))
+	for _, p := range in {
+		out = append(out, PortBinding{
+			HostIP:        p.HostIP,
+			HostPort:      p.HostPort,
+			ContainerPort: p.ContainerPort,
+			Protocol:      p.Protocol,
+		})
 	}
 	return out
 }

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -400,7 +400,7 @@ func resolveSetupScriptMount(name, setupScriptPath, setupScriptText string) (*sa
 		_ = os.Remove(tmpFile.Name())
 		return nil, nil, fmt.Errorf("%w: write SetupScriptText file: %v", ErrInternal, err)
 	}
-	if err := tmpFile.Chmod(0o644); err != nil {
+	if err := tmpFile.Chmod(0o755); err != nil {
 		_ = os.Remove(tmpFile.Name())
 		return nil, nil, fmt.Errorf("%w: set permissions on SetupScriptText file: %v", ErrInternal, err)
 	}

--- a/pkg/amika/service_test.go
+++ b/pkg/amika/service_test.go
@@ -71,6 +71,26 @@ func TestCreateSandbox_SetupScriptAndTextMutuallyExclusive(t *testing.T) {
 	}
 }
 
+func TestResolveSetupScriptMount_SetupScriptTextCreatesExecutableFile(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	mount, cleanup, err := resolveSetupScriptMount("sb", "", "#!/usr/bin/env bash\necho hi\n")
+	if err != nil {
+		t.Fatalf("resolveSetupScriptMount err = %v", err)
+	}
+	defer cleanup()
+	if mount == nil {
+		t.Fatal("expected mount, got nil")
+	}
+
+	info, err := os.Stat(mount.Source)
+	if err != nil {
+		t.Fatalf("stat setup script err = %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("expected setup script mode 0755, got %04o", info.Mode().Perm())
+	}
+}
+
 func TestCreateSandbox_InvalidPortBinding(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	svc := NewService(Options{})

--- a/pkg/amika/service_test.go
+++ b/pkg/amika/service_test.go
@@ -71,6 +71,39 @@ func TestCreateSandbox_SetupScriptAndTextMutuallyExclusive(t *testing.T) {
 	}
 }
 
+func TestCreateSandbox_InvalidPortBinding(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	_, err := svc.CreateSandbox(context.Background(), CreateSandboxRequest{
+		Provider: "docker",
+		Name:     "sb",
+		Image:    "img",
+		Ports: []PortBinding{
+			{HostPort: 0, ContainerPort: 80, Protocol: "tcp"},
+		},
+	})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+}
+
+func TestCreateSandbox_DuplicatePortBinding(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	_, err := svc.CreateSandbox(context.Background(), CreateSandboxRequest{
+		Provider: "docker",
+		Name:     "sb",
+		Image:    "img",
+		Ports: []PortBinding{
+			{HostIP: "127.0.0.1", HostPort: 8080, ContainerPort: 80, Protocol: "tcp"},
+			{HostIP: "127.0.0.1", HostPort: 8080, ContainerPort: 8080, Protocol: "tcp"},
+		},
+	})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+}
+
 func TestDeleteSandbox_NotFound(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	svc := NewService(Options{})

--- a/pkg/amika/service_test.go
+++ b/pkg/amika/service_test.go
@@ -57,6 +57,20 @@ func TestCreateSandbox_DuplicateName(t *testing.T) {
 	}
 }
 
+func TestCreateSandbox_SetupScriptAndTextMutuallyExclusive(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	_, err := svc.CreateSandbox(context.Background(), CreateSandboxRequest{
+		Provider:        "docker",
+		Name:            "sb",
+		SetupScript:     "/tmp/setup.sh",
+		SetupScriptText: "#!/usr/bin/env bash\necho hi\n",
+	})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+}
+
 func TestDeleteSandbox_NotFound(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	svc := NewService(Options{})


### PR DESCRIPTION
## Stack

1. dylan/api-exposed #43
2. codex/implement-incremental-service-improvements #44
3. dylan/setup-script-text #THIS ← you are here

## Summary

- Add SetupScriptText support for sandbox create (inline setup scripts via API)
- Make setup script fields optional in the API schema
- Add published port support for CLI (`--port`, `--port-host-ip` flags) and HTTP API
- Fix SetupScriptText to make the generated setup script executable
- Install pnpm in default Docker images (claude, coder presets)