### PR TITLE
Add per-repo .amika/config.toml support for sandbox setup script

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -105,19 +105,12 @@ var sandboxCreateCmd = &cobra.Command{
 		}
 		// Read .amika/config.toml from git repo root, unless --setup-script was explicitly provided.
 		if gitMountInfo != nil && !cmd.Flags().Changed("setup-script") {
-			cfg, err := amikaconfig.LoadConfig(gitMountInfo.RepoRoot)
+			mount, err := setupScriptMountFromConfig(gitMountInfo.RepoRoot)
 			if err != nil {
-				return fmt.Errorf("failed to read .amika/config.toml: %w", err)
+				return err
 			}
-			if cfg != nil && cfg.Lifecycle.SetupScript != "" {
-				scriptPath := cfg.Lifecycle.SetupScript
-				if !filepath.IsAbs(scriptPath) {
-					scriptPath = filepath.Join(gitMountInfo.RepoRoot, scriptPath)
-				}
-				if _, err := os.Stat(scriptPath); err != nil {
-					return fmt.Errorf("setup_script %q from .amika/config.toml is not accessible: %w", cfg.Lifecycle.SetupScript, err)
-				}
-				mounts = append(mounts, setupScriptBindMount(scriptPath))
+			if mount != nil {
+				mounts = append(mounts, *mount)
 			}
 		}
 		{
@@ -948,6 +941,28 @@ func generateRWCopyFileMountName(sandboxName, target string) string {
 		sanitizedTarget = "root"
 	}
 	return "amika-rwcopy-file-" + sandboxName + "-" + sanitizedTarget + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+// setupScriptMountFromConfig reads repoRoot/.amika/config.toml and returns a
+// bind mount for lifecycle.setup_script if one is configured. Returns nil, nil
+// when the file is absent or no setup_script is set.
+func setupScriptMountFromConfig(repoRoot string) (*sandbox.MountBinding, error) {
+	cfg, err := amikaconfig.LoadConfig(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read .amika/config.toml: %w", err)
+	}
+	if cfg == nil || cfg.Lifecycle.SetupScript == "" {
+		return nil, nil
+	}
+	scriptPath := cfg.Lifecycle.SetupScript
+	if !filepath.IsAbs(scriptPath) {
+		scriptPath = filepath.Join(repoRoot, scriptPath)
+	}
+	if _, err := os.Stat(scriptPath); err != nil {
+		return nil, fmt.Errorf("setup_script %q from .amika/config.toml is not accessible: %w", cfg.Lifecycle.SetupScript, err)
+	}
+	m := setupScriptBindMount(scriptPath)
+	return &m, nil
 }
 
 // setupScriptBindMount returns a read-only bind mount for absPath to /opt/setup.sh.

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gofixpoint/amika/internal/agentconfig"
+	"github.com/gofixpoint/amika/internal/amikaconfig"
 	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/sandbox"
 	"github.com/gofixpoint/amika/pkg/amika"
@@ -101,6 +102,28 @@ var sandboxCreateCmd = &cobra.Command{
 			defer cleanupGitMount()
 			gitMountInfo = &info
 			mounts = append(mounts, info.Mount)
+		}
+		// Read .amika/config.toml from git repo root, unless --setup-script was explicitly provided.
+		if gitMountInfo != nil && !cmd.Flags().Changed("setup-script") {
+			cfg, err := amikaconfig.LoadConfig(gitMountInfo.RepoRoot)
+			if err != nil {
+				return fmt.Errorf("failed to read .amika/config.toml: %w", err)
+			}
+			if cfg != nil && cfg.Lifecycle.SetupScript != "" {
+				scriptPath := cfg.Lifecycle.SetupScript
+				if !filepath.IsAbs(scriptPath) {
+					scriptPath = filepath.Join(gitMountInfo.RepoRoot, scriptPath)
+				}
+				if _, err := os.Stat(scriptPath); err != nil {
+					return fmt.Errorf("setup_script %q from .amika/config.toml is not accessible: %w", cfg.Lifecycle.SetupScript, err)
+				}
+				mounts = append(mounts, sandbox.MountBinding{
+					Type:   "bind",
+					Source: scriptPath,
+					Target: "/opt/setup.sh",
+					Mode:   "ro",
+				})
+			}
 		}
 		{
 			homeDir, err := os.UserHomeDir()

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -117,12 +117,7 @@ var sandboxCreateCmd = &cobra.Command{
 				if _, err := os.Stat(scriptPath); err != nil {
 					return fmt.Errorf("setup_script %q from .amika/config.toml is not accessible: %w", cfg.Lifecycle.SetupScript, err)
 				}
-				mounts = append(mounts, sandbox.MountBinding{
-					Type:   "bind",
-					Source: scriptPath,
-					Target: "/opt/setup.sh",
-					Mode:   "ro",
-				})
+				mounts = append(mounts, setupScriptBindMount(scriptPath))
 			}
 		}
 		{
@@ -140,12 +135,7 @@ var sandboxCreateCmd = &cobra.Command{
 			if _, err := os.Stat(absSetupScript); err != nil {
 				return fmt.Errorf("setup-script %q is not accessible: %w", absSetupScript, err)
 			}
-			mounts = append(mounts, sandbox.MountBinding{
-				Type:   "bind",
-				Source: absSetupScript,
-				Target: "/opt/setup.sh",
-				Mode:   "ro",
-			})
+			mounts = append(mounts, setupScriptBindMount(absSetupScript))
 		}
 		if err := validateMountTargets(mounts, volumeMounts); err != nil {
 			return err
@@ -958,6 +948,16 @@ func generateRWCopyFileMountName(sandboxName, target string) string {
 		sanitizedTarget = "root"
 	}
 	return "amika-rwcopy-file-" + sandboxName + "-" + sanitizedTarget + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+// setupScriptBindMount returns a read-only bind mount for absPath to /opt/setup.sh.
+func setupScriptBindMount(absPath string) sandbox.MountBinding {
+	return sandbox.MountBinding{
+		Type:   "bind",
+		Source: absPath,
+		Target: "/opt/setup.sh",
+		Mode:   "ro",
+	}
 }
 
 func copyFile(src, dst string) error {

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -46,6 +46,57 @@ When you pass `--setup-script`, your script is bind-mounted over the no-op, so t
 - If the script exits with a non-zero status, the container's main command will not run.
 - Preset images are cached locally. If you have an existing preset image from before the setup script feature was added, you need to rebuild your images by removing the old image first: `docker rmi amika/coder:latest`.
 
+## Per-repo configuration: `.amika/config.toml`
+
+When you use `--git`, Amika looks for a `.amika/config.toml` file at the root of the repository and applies it automatically. This lets you commit sandbox configuration alongside your code so every collaborator gets the same environment without passing extra flags.
+
+### File location
+
+```
+<repo-root>/
+  .amika/
+    config.toml
+```
+
+### Supported fields
+
+```toml
+[lifecycle]
+# Path to an executable that is mounted into the container at /opt/setup.sh.
+# Relative paths are resolved from the repository root.
+setup_script = "scripts/setup.sh"
+```
+
+#### `[lifecycle].setup_script`
+
+Works exactly like `--setup-script`: the script is bind-mounted read-only at `/opt/setup.sh` and the container's ENTRYPOINT runs it before the main command.
+
+**Path resolution:** if the value is a relative path it is resolved from the repository root (the directory containing `.git`). Absolute paths are used as-is.
+
+### Interaction with `--setup-script`
+
+`--setup-script` always takes priority. When that flag is passed explicitly, `.amika/config.toml` is not consulted for the setup script.
+
+| Flags passed | Source used |
+|---|---|
+| `--git` only | `.amika/config.toml` (if present) |
+| `--git --setup-script /path/script.sh` | `--setup-script` flag |
+| `--setup-script /path/script.sh` (no `--git`) | `--setup-script` flag |
+
+### Example
+
+Given this repository layout:
+
+```
+my-project/
+  .amika/
+    config.toml       # setup_script = "scripts/setup.sh"
+  scripts/
+    setup.sh          # must be executable (chmod +x)
+```
+
+Running `amika sandbox create --git` from anywhere inside `my-project` will automatically mount `scripts/setup.sh` to `/opt/setup.sh` in the container.
+
 ## Agent Credential Auto-Mounting
 
 When creating a sandbox or running materialize, Amika automatically discovers credential files for supported coding agents on the host and mounts them into the container as `rwcopy` snapshots. This means agents running inside containers can authenticate without manual configuration.

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -77,11 +77,11 @@ Works exactly like `--setup-script`: the script is bind-mounted read-only at `/o
 
 `--setup-script` always takes priority. When that flag is passed explicitly, `.amika/config.toml` is not consulted for the setup script.
 
-| Flags passed | Source used |
-|---|---|
-| `--git` only | `.amika/config.toml` (if present) |
-| `--git --setup-script /path/script.sh` | `--setup-script` flag |
-| `--setup-script /path/script.sh` (no `--git`) | `--setup-script` flag |
+| Flags passed                                  | Source used                       |
+| --------------------------------------------- | --------------------------------- |
+| `--git` only                                  | `.amika/config.toml` (if present) |
+| `--git --setup-script /path/script.sh`        | `--setup-script` flag             |
+| `--setup-script /path/script.sh` (no `--git`) | `--setup-script` flag             |
 
 ### Example
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -17,14 +17,14 @@ Amika does not use a legacy `~/.amika` fallback for these files.
 - `sandboxes.jsonl`: `${XDG_STATE_HOME:-~/.local/state}/amika/sandboxes.jsonl`
 - `volumes.jsonl`: `${XDG_STATE_HOME:-~/.local/state}/amika/volumes.jsonl`
 - `rwcopy-mounts.jsonl`: `${XDG_STATE_HOME:-~/.local/state}/amika/rwcopy-mounts.jsonl`
-- `mounts.jsonl`: `${XDG_STATE_HOME:-~/.local/state}/amika/mounts.jsonl` *(v0 legacy commands only)*
+- `mounts.jsonl`: `${XDG_STATE_HOME:-~/.local/state}/amika/mounts.jsonl` _(v0 legacy commands only)_
 
 If `AMIKA_STATE_DIRECTORY` is set, state files are stored there instead:
 
 - `${AMIKA_STATE_DIRECTORY}/sandboxes.jsonl`
 - `${AMIKA_STATE_DIRECTORY}/volumes.jsonl`
 - `${AMIKA_STATE_DIRECTORY}/rwcopy-mounts.jsonl`
-- `${AMIKA_STATE_DIRECTORY}/mounts.jsonl` *(v0 legacy commands only)*
+- `${AMIKA_STATE_DIRECTORY}/mounts.jsonl` _(v0 legacy commands only)_
 
 ## File Mount Copies
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/danielgtaylor/huma/v2 v2.37.2 h1:Nf9vjy2sxBJFaupPlthXL/Hy2+LurfVbaKHmCMEI7xE=
 github.com/danielgtaylor/huma/v2 v2.37.2/go.mod h1:95S04G/lExFRYlBkKaBaZm9lVmxRmqX9f2CgoOZ11AM=

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -1,0 +1,41 @@
+// Package amikaconfig loads per-repo Amika configuration from .amika/config.toml.
+package amikaconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config is the parsed .amika/config.toml file.
+type Config struct {
+	Lifecycle LifecycleConfig `toml:"lifecycle"`
+}
+
+// LifecycleConfig holds sandbox lifecycle hooks.
+type LifecycleConfig struct {
+	// SetupScript is the path to an executable to mount at /opt/setup.sh.
+	// Relative paths are resolved from the repo root.
+	SetupScript string `toml:"setup_script"`
+}
+
+// LoadConfig reads $repoRoot/.amika/config.toml.
+// Returns nil, nil if the file does not exist.
+func LoadConfig(repoRoot string) (*Config, error) {
+	path := filepath.Join(repoRoot, ".amika", "config.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var cfg Config
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &cfg, nil
+}

--- a/internal/amikaconfig/config_test.go
+++ b/internal/amikaconfig/config_test.go
@@ -1,0 +1,85 @@
+package amikaconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofixpoint/amika/internal/amikaconfig"
+)
+
+func TestLoadConfig_NotExist(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := amikaconfig.LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config, got %+v", cfg)
+	}
+}
+
+func TestLoadConfig_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	amikaDir := filepath.Join(dir, ".amika")
+	if err := os.Mkdir(amikaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `[lifecycle]
+setup_script = "scripts/setup.sh"
+`
+	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := amikaconfig.LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.Lifecycle.SetupScript != "scripts/setup.sh" {
+		t.Errorf("expected setup_script %q, got %q", "scripts/setup.sh", cfg.Lifecycle.SetupScript)
+	}
+}
+
+func TestLoadConfig_MalformedTOML(t *testing.T) {
+	dir := t.TempDir()
+	amikaDir := filepath.Join(dir, ".amika")
+	if err := os.Mkdir(amikaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte("not = valid [[["), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := amikaconfig.LoadConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for malformed TOML, got nil")
+	}
+}
+
+func TestLoadConfig_EmptyLifecycleSection(t *testing.T) {
+	dir := t.TempDir()
+	amikaDir := filepath.Join(dir, ".amika")
+	if err := os.Mkdir(amikaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `[lifecycle]
+`
+	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := amikaconfig.LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.Lifecycle.SetupScript != "" {
+		t.Errorf("expected empty setup_script, got %q", cfg.Lifecycle.SetupScript)
+	}
+}


### PR DESCRIPTION
## Summary

- Introduce a new `internal/amikaconfig` package that loads per-repo configuration from `.amika/config.toml`
- When `--git` is used and `--setup-script` is not explicitly passed, automatically read `lifecycle.setup_script` from the repo's `.amika/config.toml` and bind-mount it into the container
- Document the `.amika/config.toml` schema and its interaction with `--setup-script` in `docs/sandbox-configuration.md`

## Motivation

Users want to commit sandbox configuration alongside their code so every collaborator gets a consistent container environment without having to pass extra CLI flags. By supporting a `.amika/config.toml` at the repo root, the setup script path becomes part of the repository itself rather than a per-user CLI invocation detail.

## Changes

- `internal/amikaconfig/config.go` — new package with `Config`, `LifecycleConfig` structs and `LoadConfig(repoRoot)` function using `github.com/BurntSushi/toml`
- `internal/amikaconfig/config_test.go` — unit tests covering missing file, valid config, malformed TOML, and empty lifecycle section
- `cmd/amika/sandbox.go` — integrate `amikaconfig.LoadConfig` into `sandbox create`; extract `setupScriptMountFromConfig` and `setupScriptBindMount` helpers to reduce duplication
- `docs/sandbox-configuration.md` — new "Per-repo configuration: `.amika/config.toml`" section with schema reference, path resolution rules, flag priority table, and example
- `go.mod` / `go.sum` — add `github.com/BurntSushi/toml v1.6.0` dependency

## Test plan

- [x] `make build` succeeds — both `dist/amika` and `dist/amika-server` produced
- [x] `go test ./internal/amikaconfig/...` — all four unit tests pass (missing file, valid config, malformed TOML, empty lifecycle section)
- [x] All other package tests pass; the one pre-existing failure in `internal/app` (`TestNewService_ImplementsPublicService`) is unrelated to this PR — it is caused by a malformed local `~/.claude/.credentials.json` and reproduces identically on `main`
- [x] `--git` without `--setup-script` uses `.amika/config.toml`: verified by code — `gitMountInfo != nil && !cmd.Flags().Changed("setup-script")` guard at line 107 of `sandbox.go`
- [x] `--setup-script` overrides `.amika/config.toml`: verified by code — when `--setup-script` is set `cmd.Flags().Changed("setup-script")` is true, so the config block is skipped entirely and the flag mount is appended instead
- [x] `amika sandbox create` without `--git` ignores `.amika/config.toml`: verified by code — `gitMountInfo` is nil when `--git` is not passed, so the config block is never reached