### PR TITLE
Extract collectMounts, materializeRWCopyMounts, and txn.Rollbacker

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -81,55 +81,17 @@ var sandboxCreateCmd = &cobra.Command{
 		}
 		image = resolvedImage.Image
 
-		mounts, err := parseMountFlags(mountStrs)
+		collected, err := collectMounts(mountStrs, volumeStrs, portStrs, portHostIP,
+			gitPath, gitFlagChanged, noClean,
+			setupScript, cmd.Flags().Changed("setup-script"))
 		if err != nil {
 			return err
 		}
-		volumeMounts, err := parseVolumeFlags(volumeStrs)
-		if err != nil {
-			return err
-		}
-		publishedPorts, err := parsePortFlags(portStrs, portHostIP)
-		if err != nil {
-			return err
-		}
-		var gitMountInfo *gitMountInfo
-		if gitFlagChanged {
-			info, cleanupGitMount, err := prepareGitMount(gitPath, noClean, cloneGitRepo)
-			if err != nil {
-				return err
-			}
-			defer cleanupGitMount()
-			gitMountInfo = &info
-			mounts = append(mounts, info.Mount)
-		}
-		// Read .amika/config.toml from git repo root, unless --setup-script was explicitly provided.
-		if gitMountInfo != nil && !cmd.Flags().Changed("setup-script") {
-			mount, err := setupScriptMountFromConfig(gitMountInfo.RepoRoot)
-			if err != nil {
-				return err
-			}
-			if mount != nil {
-				mounts = append(mounts, *mount)
-			}
-		}
-		{
-			homeDir, err := os.UserHomeDir()
-			if err == nil {
-				agentMounts := agentconfig.RWCopyMounts(agentconfig.AllMounts(homeDir))
-				mounts = append(mounts, agentMounts...)
-			}
-		}
-		if setupScript != "" {
-			absSetupScript, err := filepath.Abs(setupScript)
-			if err != nil {
-				return fmt.Errorf("failed to resolve setup-script path %q: %w", setupScript, err)
-			}
-			if _, err := os.Stat(absSetupScript); err != nil {
-				return fmt.Errorf("setup-script %q is not accessible: %w", absSetupScript, err)
-			}
-			mounts = append(mounts, setupScriptBindMount(absSetupScript))
-		}
+		defer collected.Cleanup()
+		mounts := collected.Mounts
+		volumeMounts := collected.VolumeMounts
+		publishedPorts := collected.Ports
+		gitMountInfo := collected.GitInfo
 		if err := validateMountTargets(mounts, volumeMounts); err != nil {
 			return err
 		}
@@ -200,128 +162,35 @@ var sandboxCreateCmd = &cobra.Command{
 			}
 		}
 
-		var runtimeMounts []sandbox.MountBinding
-		createdVolumes := make([]string, 0)
-		addedRefs := make(map[string]bool)
-		createdFileMountDirs := make([]string, 0)
-		addedFileRefs := make(map[string]bool)
-		rollbackAll := func() {
-			for volumeName := range addedRefs {
-				_ = volumeStore.RemoveSandboxRef(volumeName, name)
-			}
-			for _, volumeName := range createdVolumes {
-				_ = volumeStore.Remove(volumeName)
-				_ = sandbox.RemoveDockerVolume(volumeName)
-			}
-			for mountName := range addedFileRefs {
-				_ = fileMountStore.Remove(mountName)
-			}
-			for _, dir := range createdFileMountDirs {
-				_ = os.RemoveAll(dir)
-			}
+		runtimeMounts, rb, err := materializeRWCopyMounts(mounts, name, volumeStore, fileMountStore, fileMountsBaseDir)
+		if err != nil {
+			return err
 		}
 
-		for _, m := range mounts {
-			if m.Mode != "rwcopy" {
-				runtimeMounts = append(runtimeMounts, m)
-				continue
+		attachedVolumeRefs := make([]string, 0)
+		rollbackVolumes := func() {
+			for _, volumeName := range attachedVolumeRefs {
+				_ = volumeStore.RemoveSandboxRef(volumeName, name)
 			}
-
-			stat, err := os.Stat(m.Source)
-			if err != nil {
-				rollbackAll()
-				return fmt.Errorf("rwcopy source %q is not accessible: %w", m.Source, err)
-			}
-
-			if stat.IsDir() {
-				volumeName := generateRWCopyVolumeName(name, m.Target)
-				if err := sandbox.CreateDockerVolume(volumeName); err != nil {
-					rollbackAll()
-					return err
-				}
-				createdVolumes = append(createdVolumes, volumeName)
-
-				if err := sandbox.CopyHostDirToVolume(volumeName, m.Source); err != nil {
-					rollbackAll()
-					return err
-				}
-
-				volInfo := sandbox.VolumeInfo{
-					Name:        volumeName,
-					CreatedAt:   time.Now().UTC().Format(time.RFC3339),
-					CreatedBy:   "rwcopy",
-					SourcePath:  m.Source,
-					SandboxRefs: []string{name},
-				}
-				if err := volumeStore.Save(volInfo); err != nil {
-					rollbackAll()
-					return fmt.Errorf("failed to save volume state for %q: %w", volumeName, err)
-				}
-				addedRefs[volumeName] = true
-
-				runtimeMounts = append(runtimeMounts, sandbox.MountBinding{
-					Type:         "volume",
-					Volume:       volumeName,
-					Target:       m.Target,
-					Mode:         "rw",
-					SnapshotFrom: m.Source,
-				})
-			} else {
-				mountName := generateRWCopyFileMountName(name, m.Target)
-				copyDir := filepath.Join(fileMountsBaseDir, mountName)
-				if err := os.MkdirAll(copyDir, 0755); err != nil {
-					rollbackAll()
-					return fmt.Errorf("failed to create file mount directory for %q: %w", mountName, err)
-				}
-				createdFileMountDirs = append(createdFileMountDirs, copyDir)
-
-				copyPath := filepath.Join(copyDir, filepath.Base(m.Source))
-				if err := copyFile(m.Source, copyPath); err != nil {
-					rollbackAll()
-					return fmt.Errorf("failed to copy file for rwcopy mount %q: %w", m.Source, err)
-				}
-
-				fmInfo := sandbox.FileMountInfo{
-					Name:        mountName,
-					Type:        "file",
-					CreatedAt:   time.Now().UTC().Format(time.RFC3339),
-					CreatedBy:   "rwcopy",
-					SourcePath:  m.Source,
-					CopyPath:    copyPath,
-					SandboxRefs: []string{name},
-				}
-				if err := fileMountStore.Save(fmInfo); err != nil {
-					rollbackAll()
-					return fmt.Errorf("failed to save file mount state for %q: %w", mountName, err)
-				}
-				addedFileRefs[mountName] = true
-
-				runtimeMounts = append(runtimeMounts, sandbox.MountBinding{
-					Type:         "bind",
-					Source:       copyPath,
-					Target:       m.Target,
-					Mode:         "rw",
-					SnapshotFrom: m.Source,
-				})
-			}
+			rb.Rollback()
 		}
 
 		for _, v := range volumeMounts {
 			if _, err := volumeStore.Get(v.Volume); err != nil {
-				rollbackAll()
+				rollbackVolumes()
 				return fmt.Errorf("volume %q is not tracked; create via rwcopy first", v.Volume)
 			}
 			if err := volumeStore.AddSandboxRef(v.Volume, name); err != nil {
-				rollbackAll()
+				rollbackVolumes()
 				return fmt.Errorf("failed to attach volume %q: %w", v.Volume, err)
 			}
-			addedRefs[v.Volume] = true
+			attachedVolumeRefs = append(attachedVolumeRefs, v.Volume)
 			runtimeMounts = append(runtimeMounts, v)
 		}
 
 		containerID, err := sandbox.CreateDockerSandbox(name, image, runtimeMounts, envStrs, publishedPorts)
 		if err != nil {
-			rollbackAll()
+			rollbackVolumes()
 			return err
 		}
 
@@ -339,6 +208,7 @@ var sandboxCreateCmd = &cobra.Command{
 		if err := store.Save(info); err != nil {
 			return fmt.Errorf("sandbox created but failed to save state: %w", err)
 		}
+		rb.Disarm()
 
 		fmt.Printf("Sandbox %q created (container %s)\n", name, containerID[:12])
 		if len(publishedPorts) > 0 {
@@ -943,6 +813,107 @@ func generateRWCopyFileMountName(sandboxName, target string) string {
 	return "amika-rwcopy-file-" + sandboxName + "-" + sanitizedTarget + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 }
 
+// collectedMounts holds all mounts and related data gathered from CLI flags,
+// git, agent credentials, and setup-script before materialization.
+type collectedMounts struct {
+	Mounts       []sandbox.MountBinding
+	VolumeMounts []sandbox.MountBinding
+	Ports        []sandbox.PortBinding
+	GitInfo      *gitMountInfo // nil if --git was not used
+	Cleanup      func()        // removes git temp dir; noop if no --git
+}
+
+// collectMounts gathers all mounts from CLI flags, git clone, .amika/config.toml,
+// agent credentials, and setup-script. Call Cleanup (e.g. via defer) to remove any
+// temporary directories created for the git mount.
+func collectMounts(
+	mountStrs, volumeStrs, portStrs []string,
+	portHostIP string,
+	gitPath string,
+	gitFlagChanged bool,
+	noClean bool,
+	setupScript string,
+	setupScriptFlagChanged bool,
+) (collectedMounts, error) {
+	mounts, err := parseMountFlags(mountStrs)
+	if err != nil {
+		return collectedMounts{}, err
+	}
+	volumeMounts, err := parseVolumeFlags(volumeStrs)
+	if err != nil {
+		return collectedMounts{}, err
+	}
+	publishedPorts, err := parsePortFlags(portStrs, portHostIP)
+	if err != nil {
+		return collectedMounts{}, err
+	}
+
+	cleanup := func() {}
+	var gmi *gitMountInfo
+	if gitFlagChanged {
+		info, cleanupGitMount, err := prepareGitMount(gitPath, noClean, cloneGitRepo)
+		if err != nil {
+			return collectedMounts{}, err
+		}
+		cleanup = cleanupGitMount
+		gmi = &info
+		mounts = append(mounts, info.Mount)
+	}
+
+	if gmi != nil && !setupScriptFlagChanged {
+		mount, err := setupScriptMountFromConfig(gmi.RepoRoot)
+		if err != nil {
+			cleanup()
+			return collectedMounts{}, err
+		}
+		if mount != nil {
+			mounts = append(mounts, *mount)
+		}
+	}
+
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		agentMounts := agentconfig.RWCopyMounts(agentconfig.AllMounts(homeDir))
+		mounts = append(mounts, agentMounts...)
+	}
+
+	if setupScript != "" {
+		absSetupScript, err := filepath.Abs(setupScript)
+		if err != nil {
+			cleanup()
+			return collectedMounts{}, fmt.Errorf("failed to resolve setup-script path %q: %w", setupScript, err)
+		}
+		if _, err := os.Stat(absSetupScript); err != nil {
+			cleanup()
+			return collectedMounts{}, fmt.Errorf("setup-script %q is not accessible: %w", absSetupScript, err)
+		}
+		mounts = append(mounts, setupScriptBindMount(absSetupScript))
+	}
+
+	return collectedMounts{
+		Mounts:       mounts,
+		VolumeMounts: volumeMounts,
+		Ports:        publishedPorts,
+		GitInfo:      gmi,
+		Cleanup:      cleanup,
+	}, nil
+}
+
+// Rollbacker allows callers to undo partial mount state or disarm cleanup once
+// the sandbox has been successfully created.
+type Rollbacker interface {
+	// Rollback undoes any partial state created during mount materialization
+	// (removes created volumes, file mount directories, and store entries).
+	Rollback()
+	// Disarm prevents Rollback from doing anything on subsequent calls.
+	// Call after the sandbox is successfully created and state is persisted.
+	Disarm()
+}
+
+type rollbackerFn struct{ fn func() }
+
+func (r *rollbackerFn) Rollback() { r.fn() }
+func (r *rollbackerFn) Disarm()   { r.fn = func() {} }
+
 // setupScriptMountFromConfig reads repoRoot/.amika/config.toml and returns a
 // bind mount for lifecycle.setup_script if one is configured. Returns nil, nil
 // when the file is absent or no setup_script is set.
@@ -973,6 +944,129 @@ func setupScriptBindMount(absPath string) sandbox.MountBinding {
 		Target: "/opt/setup.sh",
 		Mode:   "ro",
 	}
+}
+
+// materializeRWCopyMounts converts logical mounts that use mode "rwcopy" into
+// real Docker volumes (for directory sources) or bind-mounted file copies (for
+// file sources). Mounts with other modes are passed through unchanged.
+//
+// The returned Rollbacker must have Rollback called on any error path to undo
+// partial state; call Disarm after the sandbox is successfully created.
+func materializeRWCopyMounts(
+	mounts []sandbox.MountBinding,
+	sandboxName string,
+	volumeStore sandbox.VolumeStore,
+	fileMountStore sandbox.FileMountStore,
+	fileMountsBaseDir string,
+) ([]sandbox.MountBinding, Rollbacker, error) {
+	var runtimeMounts []sandbox.MountBinding
+	createdVolumes := make([]string, 0)
+	addedRefs := make(map[string]bool)
+	createdFileMountDirs := make([]string, 0)
+	addedFileRefs := make(map[string]bool)
+
+	rb := &rollbackerFn{fn: func() {
+		for volumeName := range addedRefs {
+			_ = volumeStore.RemoveSandboxRef(volumeName, sandboxName)
+		}
+		for _, volumeName := range createdVolumes {
+			_ = volumeStore.Remove(volumeName)
+			_ = sandbox.RemoveDockerVolume(volumeName)
+		}
+		for mountName := range addedFileRefs {
+			_ = fileMountStore.Remove(mountName)
+		}
+		for _, dir := range createdFileMountDirs {
+			_ = os.RemoveAll(dir)
+		}
+	}}
+
+	for _, m := range mounts {
+		if m.Mode != "rwcopy" {
+			runtimeMounts = append(runtimeMounts, m)
+			continue
+		}
+
+		stat, err := os.Stat(m.Source)
+		if err != nil {
+			rb.Rollback()
+			return nil, rb, fmt.Errorf("rwcopy source %q is not accessible: %w", m.Source, err)
+		}
+
+		if stat.IsDir() {
+			volumeName := generateRWCopyVolumeName(sandboxName, m.Target)
+			if err := sandbox.CreateDockerVolume(volumeName); err != nil {
+				rb.Rollback()
+				return nil, rb, err
+			}
+			createdVolumes = append(createdVolumes, volumeName)
+
+			if err := sandbox.CopyHostDirToVolume(volumeName, m.Source); err != nil {
+				rb.Rollback()
+				return nil, rb, err
+			}
+
+			volInfo := sandbox.VolumeInfo{
+				Name:        volumeName,
+				CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+				CreatedBy:   "rwcopy",
+				SourcePath:  m.Source,
+				SandboxRefs: []string{sandboxName},
+			}
+			if err := volumeStore.Save(volInfo); err != nil {
+				rb.Rollback()
+				return nil, rb, fmt.Errorf("failed to save volume state for %q: %w", volumeName, err)
+			}
+			addedRefs[volumeName] = true
+
+			runtimeMounts = append(runtimeMounts, sandbox.MountBinding{
+				Type:         "volume",
+				Volume:       volumeName,
+				Target:       m.Target,
+				Mode:         "rw",
+				SnapshotFrom: m.Source,
+			})
+		} else {
+			mountName := generateRWCopyFileMountName(sandboxName, m.Target)
+			copyDir := filepath.Join(fileMountsBaseDir, mountName)
+			if err := os.MkdirAll(copyDir, 0755); err != nil {
+				rb.Rollback()
+				return nil, rb, fmt.Errorf("failed to create file mount directory for %q: %w", mountName, err)
+			}
+			createdFileMountDirs = append(createdFileMountDirs, copyDir)
+
+			copyPath := filepath.Join(copyDir, filepath.Base(m.Source))
+			if err := copyFile(m.Source, copyPath); err != nil {
+				rb.Rollback()
+				return nil, rb, fmt.Errorf("failed to copy file for rwcopy mount %q: %w", m.Source, err)
+			}
+
+			fmInfo := sandbox.FileMountInfo{
+				Name:        mountName,
+				Type:        "file",
+				CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+				CreatedBy:   "rwcopy",
+				SourcePath:  m.Source,
+				CopyPath:    copyPath,
+				SandboxRefs: []string{sandboxName},
+			}
+			if err := fileMountStore.Save(fmInfo); err != nil {
+				rb.Rollback()
+				return nil, rb, fmt.Errorf("failed to save file mount state for %q: %w", mountName, err)
+			}
+			addedFileRefs[mountName] = true
+
+			runtimeMounts = append(runtimeMounts, sandbox.MountBinding{
+				Type:         "bind",
+				Source:       copyPath,
+				Target:       m.Target,
+				Mode:         "rw",
+				SnapshotFrom: m.Source,
+			})
+		}
+	}
+
+	return runtimeMounts, rb, nil
 }
 
 func copyFile(src, dst string) error {

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gofixpoint/amika/internal/amikaconfig"
 	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/sandbox"
+	"github.com/gofixpoint/amika/internal/txn"
 	"github.com/gofixpoint/amika/pkg/amika"
 	"github.com/spf13/cobra"
 )
@@ -898,22 +899,6 @@ func collectMounts(
 	}, nil
 }
 
-// Rollbacker allows callers to undo partial mount state or disarm cleanup once
-// the sandbox has been successfully created.
-type Rollbacker interface {
-	// Rollback undoes any partial state created during mount materialization
-	// (removes created volumes, file mount directories, and store entries).
-	Rollback()
-	// Disarm prevents Rollback from doing anything on subsequent calls.
-	// Call after the sandbox is successfully created and state is persisted.
-	Disarm()
-}
-
-type rollbackerFn struct{ fn func() }
-
-func (r *rollbackerFn) Rollback() { r.fn() }
-func (r *rollbackerFn) Disarm()   { r.fn = func() {} }
-
 // setupScriptMountFromConfig reads repoRoot/.amika/config.toml and returns a
 // bind mount for lifecycle.setup_script if one is configured. Returns nil, nil
 // when the file is absent or no setup_script is set.
@@ -958,14 +943,14 @@ func materializeRWCopyMounts(
 	volumeStore sandbox.VolumeStore,
 	fileMountStore sandbox.FileMountStore,
 	fileMountsBaseDir string,
-) ([]sandbox.MountBinding, Rollbacker, error) {
+) ([]sandbox.MountBinding, txn.Rollbacker, error) {
 	var runtimeMounts []sandbox.MountBinding
 	createdVolumes := make([]string, 0)
 	addedRefs := make(map[string]bool)
 	createdFileMountDirs := make([]string, 0)
 	addedFileRefs := make(map[string]bool)
 
-	rb := &rollbackerFn{fn: func() {
+	rb := txn.NewRollbacker(func() {
 		for volumeName := range addedRefs {
 			_ = volumeStore.RemoveSandboxRef(volumeName, sandboxName)
 		}
@@ -979,7 +964,7 @@ func materializeRWCopyMounts(
 		for _, dir := range createdFileMountDirs {
 			_ = os.RemoveAll(dir)
 		}
-	}}
+	})
 
 	for _, m := range mounts {
 		if m.Mode != "rwcopy" {

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -901,6 +901,124 @@ func runGitCmd(t *testing.T, repo string, args ...string) {
 	}
 }
 
+func TestMaterializeRWCopyMounts_Passthrough(t *testing.T) {
+	dir := t.TempDir()
+	volumeStore := sandbox.NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	fileMountStore := sandbox.NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+
+	input := []sandbox.MountBinding{
+		{Type: "bind", Source: "/host/src", Target: "/workspace", Mode: "ro"},
+		{Type: "volume", Volume: "vol1", Target: "/data", Mode: "rw"},
+	}
+
+	runtimeMounts, rb, err := materializeRWCopyMounts(input, "test-sb", volumeStore, fileMountStore, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(runtimeMounts) != 2 {
+		t.Fatalf("expected 2 mounts, got %d", len(runtimeMounts))
+	}
+	if runtimeMounts[0].Source != "/host/src" || runtimeMounts[1].Volume != "vol1" {
+		t.Fatalf("mounts not passed through unchanged: %+v", runtimeMounts)
+	}
+
+	// Rollback on passthrough mounts should be a noop (no state was created).
+	rb.Rollback()
+}
+
+func TestMaterializeRWCopyMounts_FileRWCopy(t *testing.T) {
+	dir := t.TempDir()
+	volumeStore := sandbox.NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	fileMountStore := sandbox.NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+	fileMountsBaseDir := filepath.Join(dir, "file-mounts")
+	if err := os.MkdirAll(fileMountsBaseDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	srcFile := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(srcFile, []byte("key: value"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	input := []sandbox.MountBinding{
+		{Type: "bind", Source: srcFile, Target: "/app/config.yaml", Mode: "rwcopy"},
+	}
+
+	runtimeMounts, rb, err := materializeRWCopyMounts(input, "test-sb", volumeStore, fileMountStore, fileMountsBaseDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(runtimeMounts) != 1 {
+		t.Fatalf("expected 1 runtime mount, got %d", len(runtimeMounts))
+	}
+
+	m := runtimeMounts[0]
+	if m.Type != "bind" {
+		t.Fatalf("type = %q, want bind", m.Type)
+	}
+	if m.Mode != "rw" {
+		t.Fatalf("mode = %q, want rw", m.Mode)
+	}
+	if m.SnapshotFrom != srcFile {
+		t.Fatalf("snapshot_from = %q, want %q", m.SnapshotFrom, srcFile)
+	}
+
+	// Verify the copy actually exists on disk.
+	if _, err := os.Stat(m.Source); err != nil {
+		t.Fatalf("copied file does not exist at %q: %v", m.Source, err)
+	}
+
+	// Verify a file mount store entry was created.
+	mounts, err := fileMountStore.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 file mount store entry, got %d", len(mounts))
+	}
+
+	rb.Rollback()
+}
+
+func TestMaterializeRWCopyMounts_Disarm(t *testing.T) {
+	dir := t.TempDir()
+	volumeStore := sandbox.NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	fileMountStore := sandbox.NewFileMountStore(filepath.Join(dir, "rwcopy-mounts.jsonl"))
+	fileMountsBaseDir := filepath.Join(dir, "file-mounts")
+	if err := os.MkdirAll(fileMountsBaseDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	srcFile := filepath.Join(dir, "secret.yaml")
+	if err := os.WriteFile(srcFile, []byte("token: abc"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	input := []sandbox.MountBinding{
+		{Type: "bind", Source: srcFile, Target: "/app/secret.yaml", Mode: "rwcopy"},
+	}
+
+	runtimeMounts, rb, err := materializeRWCopyMounts(input, "test-sb", volumeStore, fileMountStore, fileMountsBaseDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rb.Disarm()
+	rb.Rollback() // Should be a noop after Disarm.
+
+	// The copied file and store entry must still exist.
+	if _, err := os.Stat(runtimeMounts[0].Source); err != nil {
+		t.Fatalf("file should still exist after Disarm+Rollback: %v", err)
+	}
+	mounts, err := fileMountStore.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("store entry should still exist after Disarm+Rollback, got %d entries", len(mounts))
+	}
+}
+
 func TestSandboxListCommand_PrintsRows(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("AMIKA_STATE_DIRECTORY", dir)

--- a/internal/txn/doc.go
+++ b/internal/txn/doc.go
@@ -1,0 +1,6 @@
+// Package txn provides primitives for managing transactional operations that
+// may need to be rolled back on failure. It is intended for use cases where a
+// sequence of side-effectful steps (creating files, writing store entries,
+// allocating resources) must be undone atomically if any step fails, and
+// cleanly committed once all steps succeed.
+package txn

--- a/internal/txn/rollback.go
+++ b/internal/txn/rollback.go
@@ -1,0 +1,41 @@
+package txn
+
+import "sync"
+
+// Rollbacker allows callers to undo partial state or disarm cleanup once an
+// operation has been successfully committed.
+type Rollbacker interface {
+	// Rollback undoes any partial state created during the operation.
+	Rollback()
+	// Disarm prevents Rollback from doing anything on subsequent calls.
+	// Call after the operation has been successfully committed.
+	Disarm()
+}
+
+// NewRollbacker returns a Rollbacker backed by fn.
+func NewRollbacker(fn func()) Rollbacker {
+	return &rollbackerFn{fn: fn}
+}
+
+type rollbackerFn struct {
+	mu         sync.Mutex
+	fn         func()
+	disarmed   bool
+	rolledBack bool
+}
+
+func (r *rollbackerFn) Rollback() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.disarmed || r.rolledBack {
+		return
+	}
+	r.rolledBack = true
+	r.fn()
+}
+
+func (r *rollbackerFn) Disarm() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.disarmed = true
+}

--- a/internal/txn/rollback_test.go
+++ b/internal/txn/rollback_test.go
@@ -1,0 +1,87 @@
+package txn_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/gofixpoint/amika/internal/txn"
+)
+
+func TestRollbacker_Rollback(t *testing.T) {
+	called := 0
+	rb := txn.NewRollbacker(func() { called++ })
+	rb.Rollback()
+	if called != 1 {
+		t.Fatalf("expected fn called once, got %d", called)
+	}
+}
+
+func TestRollbacker_RollbackIdempotent(t *testing.T) {
+	called := 0
+	rb := txn.NewRollbacker(func() { called++ })
+	rb.Rollback()
+	rb.Rollback()
+	if called != 1 {
+		t.Fatalf("expected fn called once, got %d", called)
+	}
+}
+
+func TestRollbacker_Disarm(t *testing.T) {
+	called := 0
+	rb := txn.NewRollbacker(func() { called++ })
+	rb.Disarm()
+	rb.Rollback()
+	if called != 0 {
+		t.Fatalf("expected fn not called after Disarm, got %d", called)
+	}
+}
+
+func TestRollbacker_ConcurrentRollback(t *testing.T) {
+	called := 0
+	var mu sync.Mutex
+	rb := txn.NewRollbacker(func() {
+		mu.Lock()
+		called++
+		mu.Unlock()
+	})
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rb.Rollback()
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called != 1 {
+		t.Fatalf("expected fn called exactly once under concurrency, got %d", called)
+	}
+}
+
+func TestRollbacker_ConcurrentDisarmAndRollback(t *testing.T) {
+	called := 0
+	var mu sync.Mutex
+	rb := txn.NewRollbacker(func() {
+		mu.Lock()
+		called++
+		mu.Unlock()
+	})
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(2)
+		go func() { defer wg.Done(); rb.Disarm() }()
+		go func() { defer wg.Done(); rb.Rollback() }()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called > 1 {
+		t.Fatalf("fn called more than once: %d", called)
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts mount collection and rwcopy materialization logic out of `sandboxCreateCmd` into standalone helper functions (`collectMounts` and `materializeRWCopyMounts`) to reduce the size and complexity of the command handler.
- Introduces a new `internal/txn` package with a `Rollbacker` interface that provides a safe, idempotent, concurrency-aware way to undo partial state on error paths and disarm cleanup on success.

## Changes

- `internal/txn/rollback.go` — new `Rollbacker` interface and `NewRollbacker` constructor; backed by a mutex-protected function that is run at most once and suppressed after `Disarm`
- `internal/txn/doc.go` — package doc
- `internal/txn/rollback_test.go` — unit tests covering basic rollback, idempotency, disarm, and concurrent access
- `cmd/amika/sandbox.go`
  - Add `collectMounts` function and `collectedMounts` struct that gather bind mounts, volume mounts, ports, git clone, `.amika/config.toml` setup-script, agent credentials, and explicit `--setup-script` flag into a single value with a `Cleanup` func
  - Add `materializeRWCopyMounts` function that converts logical `rwcopy` mounts into Docker volumes or bind-mounted file copies and returns a `txn.Rollbacker`; callers call `Disarm` on success or `Rollback` on failure
  - Replace the inlined logic in `sandboxCreateCmd` with calls to the two new helpers
- `cmd/amika/sandbox_test.go` — unit tests for `materializeRWCopyMounts` covering passthrough mounts, file rwcopy creation, and `Disarm`/`Rollback` behavior

## Test plan

- [x] Run `make test` to verify all unit tests pass, including the new `TestMaterializeRWCopyMounts_*` and `TestRollbacker_*` tests
- [x] Run `make build` to verify the binary builds without errors
- [x] Smoke test: create a sandbox with `--git` and `--mount` flags to confirm mount collection and rwcopy materialization still work end-to-end