### PR TITLE
Fix preset image auto-build and fix ImageFlagChanged 

### DIFF
--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -85,6 +85,17 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		return Sandbox{}, err
 	}
 
+	resolvedImage, err := sandbox.ResolveAndEnsureImage(sandbox.PresetImageOptions{
+		Image:              req.Image,
+		Preset:             req.Preset,
+		ImageFlagChanged:   req.Image != "",
+		DefaultBuildPreset: "coder",
+	})
+	if err != nil {
+		return Sandbox{}, fmt.Errorf("%w: %v", ErrDependency, err)
+	}
+	req.Image = resolvedImage.Image
+
 	mounts := toSandboxMountBindings(req.Mounts, req.Volumes)
 	cleanupSetupScript := func() {}
 	setupScriptMount, cleanup, err := resolveSetupScriptMount(name, req.SetupScript, req.SetupScriptText)

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -88,7 +88,7 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	resolvedImage, err := sandbox.ResolveAndEnsureImage(sandbox.PresetImageOptions{
 		Image:              req.Image,
 		Preset:             req.Preset,
-		ImageFlagChanged:   req.Image != "" && req.Preset == "",
+		ImageFlagChanged:   req.Image != "",
 		DefaultBuildPreset: "coder",
 	})
 	if err != nil {

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -88,7 +88,7 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	resolvedImage, err := sandbox.ResolveAndEnsureImage(sandbox.PresetImageOptions{
 		Image:              req.Image,
 		Preset:             req.Preset,
-		ImageFlagChanged:   req.Image != "",
+		ImageFlagChanged:   req.Image != "" && req.Preset == "",
 		DefaultBuildPreset: "coder",
 	})
 	if err != nil {


### PR DESCRIPTION
Fix preset image auto-build for amika-server sandbox creation

The public service's CreateSandbox (pkg/amika) passed the image name
directly to Docker without calling ResolveAndEnsureImage, so preset
images (e.g. amika/coder) were never auto-built when using amika-server.
This caused a 503 "Unable to find image" error. The CLI already handled
this correctly; this brings the server path in line.

Fix ImageFlagChanged to not override preset when image is also set

When both Image and Preset are provided in CreateSandboxRequest,
ImageFlagChanged was incorrectly set to true, causing the preset
to be ignored. Now ImageFlagChanged is only true when an explicit
image is given without a preset.