### PR TITLE
Support numeric epoch-millisecond format for Claude OAuth expiry

### DIFF
--- a/internal/auth/discovery.go
+++ b/internal/auth/discovery.go
@@ -165,24 +165,74 @@ func parseClaudeOAuth(homeDir string, includeOAuth bool, now time.Time, _ basedi
 			continue
 		}
 
-		expiresAt, hasExpiry, err := getStringPath(obj, "claudeAiOauth.expiresAt")
+		expiresTime, hasExpiry, err := parseClaudeOAuthExpiry(obj)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse credentials file %q: %w", path, err)
 		}
-		if hasExpiry {
-			expiresTime, err := time.Parse(time.RFC3339, expiresAt)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse credentials file %q: invalid claudeAiOauth.expiresAt: %w", path, err)
-			}
-			if !expiresTime.After(now) {
-				continue
-			}
+		if hasExpiry && !expiresTime.After(now) {
+			continue
 		}
 
 		return map[string]string{"anthropic": token}, nil
 	}
 
 	return nil, nil
+}
+
+// parseClaudeOAuthExpiry extracts claudeAiOauth.expiresAt from the parsed
+// credentials object, handling both RFC 3339 strings (legacy) and numeric
+// epoch-millisecond values (current).
+func parseClaudeOAuthExpiry(obj map[string]any) (time.Time, bool, error) {
+	raw, found := getValuePath(obj, "claudeAiOauth.expiresAt")
+	if !found || raw == nil {
+		return time.Time{}, false, nil
+	}
+
+	switch v := raw.(type) {
+	case string:
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return time.Time{}, false, nil
+		}
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return time.Time{}, false, fmt.Errorf("invalid claudeAiOauth.expiresAt: %w", err)
+		}
+		return t, true, nil
+	default:
+		ms, err := parseEpochMillis(raw)
+		if err != nil {
+			return time.Time{}, false, fmt.Errorf("invalid claudeAiOauth.expiresAt: %w", err)
+		}
+		return time.UnixMilli(ms), true, nil
+	}
+}
+
+// getValuePath navigates a dot-separated path into a nested JSON object and
+// returns the raw value at the leaf. It returns (nil, false) when any
+// intermediate key is missing.
+func getValuePath(obj map[string]any, path string) (any, bool) {
+	parts := strings.Split(path, ".")
+	var current any = obj
+
+	for i, part := range parts {
+		if current == nil {
+			return nil, false
+		}
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		raw, exists := m[part]
+		if !exists {
+			return nil, false
+		}
+		if i == len(parts)-1 {
+			return raw, true
+		}
+		current = raw
+	}
+	return nil, false
 }
 
 func parseCodex(homeDir string, includeOAuth bool, _ time.Time, _ basedir.Paths) (map[string]string, error) {

--- a/internal/auth/discovery_test.go
+++ b/internal/auth/discovery_test.go
@@ -58,6 +58,40 @@ func TestDiscover_ClaudeOAuthExpiryAndNoOAuth(t *testing.T) {
 	}
 }
 
+func TestDiscover_ClaudeOAuthNumericExpiry(t *testing.T) {
+	t.Run("future_epoch_millis", func(t *testing.T) {
+		home := t.TempDir()
+		setXDGForHome(t, home)
+		future := time.Now().Add(2 * time.Hour).UnixMilli()
+		writeDiscoveryFixture(t, filepath.Join(home, ".claude-oauth-credentials.json"),
+			`{"claudeAiOauth":{"accessToken":"oauth-num","expiresAt":`+itoa(future)+`}}`)
+
+		result, err := Discover(Options{HomeDir: home, IncludeOAuth: true})
+		if err != nil {
+			t.Fatalf("Discover() unexpected error: %v", err)
+		}
+		if result.Anthropic != "oauth-num" {
+			t.Fatalf("Anthropic = %q, want %q", result.Anthropic, "oauth-num")
+		}
+	})
+
+	t.Run("expired_epoch_millis", func(t *testing.T) {
+		home := t.TempDir()
+		setXDGForHome(t, home)
+		past := time.Now().Add(-2 * time.Hour).UnixMilli()
+		writeDiscoveryFixture(t, filepath.Join(home, ".claude-oauth-credentials.json"),
+			`{"claudeAiOauth":{"accessToken":"oauth-expired","expiresAt":`+itoa(past)+`}}`)
+
+		result, err := Discover(Options{HomeDir: home, IncludeOAuth: true})
+		if err != nil {
+			t.Fatalf("Discover() unexpected error: %v", err)
+		}
+		if result.Anthropic != "" {
+			t.Fatalf("Anthropic = %q, want empty", result.Anthropic)
+		}
+	})
+}
+
 func TestDiscover_CodexPrefersAPIOverOAuth(t *testing.T) {
 	home := t.TempDir()
 	setXDGForHome(t, home)


### PR DESCRIPTION
## Summary
Refactored Claude OAuth expiry parsing to support both RFC 3339 string format (legacy) and numeric epoch-millisecond values (current format). This improves compatibility with different credential file formats.

## Key Changes
- Extracted expiry parsing logic into a new `parseClaudeOAuthExpiry()` function that handles both string and numeric timestamp formats
- Added `getValuePath()` helper function to safely navigate nested JSON objects using dot-separated paths
- Simplified the expiry validation logic in `parseClaudeOAuth()` by delegating format-specific parsing to the new helper
- Added comprehensive test coverage for numeric epoch-millisecond expiry values (both future and expired cases)

## Implementation Details
- `parseClaudeOAuthExpiry()` uses type assertion to distinguish between string (RFC 3339) and numeric (epoch-millisecond) formats
- Numeric values are parsed using `parseEpochMillis()` and converted to `time.Time` via `time.UnixMilli()`
- String values continue to use RFC 3339 parsing with proper error handling
- Both formats return consistent `(time.Time, bool, error)` tuple for seamless integration
- The refactoring maintains backward compatibility while enabling support for the newer numeric format

https://claude.ai/code/session_01AHDUK7B1fcEhPCsXVVuT1G