### PR TITLE
Add CLI authentication via WorkOS Device Authorization Flow

### DIFF
--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/spf13/cobra"
 )
+
+const defaultWorkOSClientID = "client_01KHA495MJS1KT6QBRTYJ239DY"
 
 var authCmd = &cobra.Command{
 	Use:   "auth",
@@ -46,11 +49,79 @@ Examples:
 	},
 }
 
+var authLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Log in to Amika via WorkOS",
+	Long: `Authenticate with Amika using the WorkOS Device Authorization Flow.
+Opens a browser for you to authorize the CLI.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
+		clientID := os.Getenv("AMIKA_WORKOS_CLIENT_ID")
+		if clientID == "" {
+			clientID = defaultWorkOSClientID
+		}
+
+		session, err := auth.DeviceLogin(clientID)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Logged in as %s\n", session.Email)
+		return nil
+	},
+}
+
+var authLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Log out of Amika",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
+		if err := auth.DeleteSession(); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "Logged out")
+		return nil
+	},
+}
+
+var authStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show current authentication status",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
+		session, err := auth.LoadSession()
+		if err != nil {
+			return err
+		}
+		if session == nil {
+			fmt.Fprintln(cmd.OutOrStdout(), "Not logged in")
+			return nil
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Logged in as %s", session.Email)
+		if session.OrgID != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), " (org: %s)", session.OrgID)
+		}
+		fmt.Fprintln(cmd.OutOrStdout())
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(authCmd)
 	authCmd.AddCommand(authExtractCmd)
+	authCmd.AddCommand(authLoginCmd)
+	authCmd.AddCommand(authLogoutCmd)
+	authCmd.AddCommand(authStatusCmd)
 
 	authExtractCmd.Flags().Bool("export", false, "Prefix each line with export")
 	authExtractCmd.Flags().String("homedir", "", "Override home directory used for credential discovery")
 	authExtractCmd.Flags().Bool("no-oauth", false, "Skip OAuth credential sources")
+
 }

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -1,0 +1,184 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const workosDeviceAuthorizeURL = "https://api.workos.com/user_management/authorize/device"
+
+type deviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// DeviceLogin performs the OAuth 2.0 Device Authorization Flow via WorkOS.
+func DeviceLogin(clientID string) (*WorkOSSession, error) {
+	// Step 1: Request device code.
+	dc, err := requestDeviceCode(clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 2: Display instructions and open browser.
+	fmt.Printf("\nYour authorization code is: %s\n\n", dc.UserCode)
+	fmt.Printf("Opening browser to: %s\n", dc.VerificationURIComplete)
+	fmt.Printf("Or visit %s and enter the code manually.\n\n", dc.VerificationURI)
+	openBrowser(dc.VerificationURIComplete)
+
+	// Step 3: Poll for token.
+	return pollForToken(clientID, dc)
+}
+
+func requestDeviceCode(clientID string) (*deviceCodeResponse, error) {
+	body := url.Values{
+		"client_id": {clientID},
+	}
+
+	resp, err := http.Post(workosDeviceAuthorizeURL, "application/x-www-form-urlencoded", strings.NewReader(body.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("device authorize request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading device authorize response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("device authorize failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var dc deviceCodeResponse
+	if err := json.Unmarshal(respBody, &dc); err != nil {
+		return nil, fmt.Errorf("parsing device authorize response: %w", err)
+	}
+
+	if dc.Interval == 0 {
+		dc.Interval = 5
+	}
+	return &dc, nil
+}
+
+func pollForToken(clientID string, dc *deviceCodeResponse) (*WorkOSSession, error) {
+	interval := time.Duration(dc.Interval) * time.Second
+	deadline := time.Now().Add(time.Duration(dc.ExpiresIn) * time.Second)
+
+	body := url.Values{
+		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+		"device_code": {dc.DeviceCode},
+		"client_id":   {clientID},
+	}
+
+	fmt.Print("Waiting for authorization...")
+
+	for {
+		if time.Now().After(deadline) {
+			fmt.Println()
+			return nil, fmt.Errorf("authorization expired, please try again")
+		}
+
+		time.Sleep(interval)
+		fmt.Print(".")
+
+		resp, err := http.Post(workosAuthenticateURL, "application/x-www-form-urlencoded", strings.NewReader(body.Encode()))
+		if err != nil {
+			continue
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			fmt.Println()
+			return parseTokenResponse(respBody)
+		}
+
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(respBody, &errResp); err != nil {
+			continue
+		}
+
+		switch errResp.Error {
+		case "authorization_pending":
+			// Keep polling.
+		case "slow_down":
+			interval += time.Second
+		case "access_denied":
+			fmt.Println()
+			return nil, fmt.Errorf("authorization denied")
+		case "expired_token":
+			fmt.Println()
+			return nil, fmt.Errorf("authorization expired, please try again")
+		default:
+			fmt.Println()
+			return nil, fmt.Errorf("unexpected error: %s", errResp.Error)
+		}
+	}
+}
+
+func parseTokenResponse(respBody []byte) (*WorkOSSession, error) {
+	var result struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		User         struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"user"`
+		OrganizationID string `json:"organization_id"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parsing token response: %w", err)
+	}
+
+	expiresAt, err := ParseJWTExpiry(result.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("parsing token expiry: %w", err)
+	}
+
+	session := &WorkOSSession{
+		AccessToken:  result.AccessToken,
+		RefreshToken: result.RefreshToken,
+		UserID:       result.User.ID,
+		Email:        result.User.Email,
+		OrgID:        result.OrganizationID,
+		ExpiresAt:    expiresAt,
+	}
+
+	if err := SaveSession(*session); err != nil {
+		return nil, fmt.Errorf("saving session: %w", err)
+	}
+	return session, nil
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		return
+	}
+	_ = cmd.Start()
+}

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const workosAuthenticateURL = "https://api.workos.com/user_management/authenticate"
+
+// RefreshAccessToken exchanges a refresh token for a new access token via WorkOS.
+func RefreshAccessToken(clientID, refreshToken string) (*WorkOSSession, error) {
+	body := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {clientID},
+	}
+
+	resp, err := http.Post(workosAuthenticateURL, "application/x-www-form-urlencoded", strings.NewReader(body.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("refresh request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading refresh response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("refresh failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		User         struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"user"`
+		OrganizationID string `json:"organization_id"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parsing refresh response: %w", err)
+	}
+
+	expiresAt, err := ParseJWTExpiry(result.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("parsing token expiry: %w", err)
+	}
+
+	session := &WorkOSSession{
+		AccessToken:  result.AccessToken,
+		RefreshToken: result.RefreshToken,
+		UserID:       result.User.ID,
+		Email:        result.User.Email,
+		OrgID:        result.OrganizationID,
+		ExpiresAt:    expiresAt,
+	}
+
+	if err := SaveSession(*session); err != nil {
+		return nil, fmt.Errorf("saving refreshed session: %w", err)
+	}
+	return session, nil
+}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+)
+
+// GetValidSession loads the current session and refreshes it if expired.
+// Returns an error if no session exists (user needs to run "amika auth login").
+func GetValidSession(clientID string) (*WorkOSSession, error) {
+	session, err := LoadSession()
+	if err != nil {
+		return nil, fmt.Errorf("loading session: %w", err)
+	}
+	if session == nil {
+		return nil, fmt.Errorf("not logged in, run: amika auth login")
+	}
+
+	// Refresh if token expires within 60 seconds.
+	if time.Until(session.ExpiresAt) < 60*time.Second {
+		session, err = RefreshAccessToken(clientID, session.RefreshToken)
+		if err != nil {
+			return nil, fmt.Errorf("session expired and refresh failed: %w", err)
+		}
+	}
+	return session, nil
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gofixpoint/amika/internal/config"
+)
+
+const sessionFileName = "workos-session.json"
+
+// WorkOSSession holds the persisted WorkOS authentication state.
+type WorkOSSession struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	UserID       string    `json:"user_id"`
+	Email        string    `json:"email"`
+	OrgID        string    `json:"organization_id"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+func sessionPath() (string, error) {
+	dir, err := config.StateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, sessionFileName), nil
+}
+
+// SaveSession writes the session to disk with restricted permissions.
+func SaveSession(session WorkOSSession) error {
+	path, err := sessionPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// LoadSession reads the persisted session. Returns nil, nil if no session file exists.
+func LoadSession() (*WorkOSSession, error) {
+	path, err := sessionPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var session WorkOSSession
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("corrupt session file: %w", err)
+	}
+	return &session, nil
+}
+
+// DeleteSession removes the persisted session file.
+func DeleteSession() error {
+	path, err := sessionPath()
+	if err != nil {
+		return err
+	}
+	err = os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// ParseJWTExpiry decodes the JWT payload (without verification) to extract the exp claim.
+func ParseJWTExpiry(accessToken string) (time.Time, error) {
+	parts := strings.Split(accessToken, ".")
+	if len(parts) != 3 {
+		return time.Time{}, fmt.Errorf("invalid JWT: expected 3 parts, got %d", len(parts))
+	}
+	payload := parts[1]
+	// Add padding if needed.
+	switch len(payload) % 4 {
+	case 2:
+		payload += "=="
+	case 3:
+		payload += "="
+	}
+	data, err := base64.URLEncoding.DecodeString(payload)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid JWT payload: %w", err)
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(data, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("invalid JWT claims: %w", err)
+	}
+	if claims.Exp == 0 {
+		return time.Time{}, fmt.Errorf("JWT missing exp claim")
+	}
+	return time.Unix(claims.Exp, 0), nil
+}


### PR DESCRIPTION
Implement `amika auth login`, `amika auth logout`, and `amika auth status` commands using the OAuth 2.0 Device Authorization Flow (RFC 8628).

- login: opens browser for device authorization, polls for token, persists session to ~/.local/state/amika/workos-session.json
- logout: deletes the persisted session file
- status: displays current user email and org, or "Not logged in"
- Auto-refreshes expired access tokens using the stored refresh token