### PR TITLE
Add GitRepo field to HTTP API and document git cloning

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -68,7 +68,7 @@ amika sandbox create --name dev-sandbox --port 3000:3000 --port-host-ip 0.0.0.0
 | `--no-clean`            | `false`              | With `--git`, include untracked/uncommitted files instead of a clean clone                                           |
 | `--env <KEY=VALUE>`     |                      | Set environment variable. Repeatable                                                                                 |
 | `--port <spec>`         |                      | Publish a container port (`hostPort:containerPort[/protocol]`, protocol defaults to `tcp`). Repeatable               |
-| `--port-host-ip <ip>`   | `127.0.0.1`          | Host IP address to bind published ports to                                                                           |
+| `--port-host-ip <ip>`   | `127.0.0.1`          | Host IP address to bind all published ports to. Use `0.0.0.0` to bind to all interfaces                             |
 | `--yes`                 | `false`              | Skip mount confirmation prompt                                                                                       |
 | `--connect`             | `false`              | Connect to the sandbox shell immediately after creation                                                              |
 | `--setup-script <path>` |                      | Mount a local script to `/opt/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md)        |
@@ -283,6 +283,28 @@ The server provides OpenAPI documentation at `/openapi.json` and `/docs`.
 | `DELETE` | `/v1/volumes/{name}`   | Delete a volume             |
 | `POST`   | `/v1/auth/extract`     | Extract credentials         |
 | `POST`   | `/v1/materialize`      | Run a materialize operation |
+
+### `POST /v1/sandboxes` — Port Publishing
+
+The `Ports` field accepts an array of port binding objects. It is the HTTP API equivalent of the `--port` and `--port-host-ip` CLI flags.
+
+```json
+{
+  "Ports": [
+    {"HostIP": "127.0.0.1", "HostPort": 8080, "ContainerPort": 80, "Protocol": "tcp"},
+    {"HostPort": 5432, "ContainerPort": 5432, "Protocol": "tcp"}
+  ]
+}
+```
+
+| Field           | Required | Default     | Description                                                         |
+| --------------- | -------- | ----------- | ------------------------------------------------------------------- |
+| `HostPort`      | yes      |             | Port on the host (1–65535)                                          |
+| `ContainerPort` | yes      |             | Port inside the container (1–65535)                                 |
+| `Protocol`      | no       | `"tcp"`     | `"tcp"` or `"udp"`                                                  |
+| `HostIP`        | no       | `127.0.0.1` | Host IP to bind the port. Use `"0.0.0.0"` to bind all interfaces   |
+
+Duplicate bindings (same `HostIP:HostPort/Protocol`) are rejected with a 400 error.
 
 ### API-Only Fields
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -289,6 +289,7 @@ The server provides OpenAPI documentation at `/openapi.json` and `/docs`.
 The HTTP API accepts some fields that are not available as CLI flags:
 
 - **`SetupScriptText`** (on `POST /v1/sandboxes`): Inline setup script content as a string. Amika writes it to a temporary file and mounts it as `/opt/setup.sh`. Mutually exclusive with `SetupScript` (file path).
+- **`GitRepo`** (on `POST /v1/sandboxes`): URL of a git repository to clone into the sandbox. The repo is cloned on the host, copied into a Docker volume, and mounted at `/home/amika/workspace/<repo-name>`. Supported schemes: `https://`, `http://`, `ssh://`, `file:///` (absolute paths only), and SCP-style (`git@host:path`). See [sandbox-configuration.md](sandbox-configuration.md) for details.
 
 ---
 

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -46,6 +46,51 @@ When you pass `--setup-script`, your script is bind-mounted over the no-op, so t
 - If the script exits with a non-zero status, the container's main command will not run.
 - Preset images are cached locally. If you have an existing preset image from before the setup script feature was added, you need to rebuild your images by removing the old image first: `docker rmi amika/coder:latest`.
 
+## Git Repository Cloning
+
+The `--git` CLI flag and the `GitRepo` HTTP API field clone a remote or local git repository into a Docker volume that is mounted at `/home/amika/workspace/<repo-name>` inside the sandbox.
+
+### CLI (`--git`)
+
+`--git` clones the local repository containing the current working directory (or a given path). It always sources from a local git repo on the host.
+
+```bash
+# Clone the current repo (clean clone)
+amika sandbox create --git
+
+# Include untracked/uncommitted files
+amika sandbox create --git --no-clean
+
+# Clone the repo containing a specific path
+amika sandbox create --git ./src
+```
+
+### HTTP API (`GitRepo`)
+
+The `GitRepo` field on `POST /v1/sandboxes` accepts a URL pointing to any remote or local git repository. Supported URL schemes:
+
+| Scheme     | Example                                               |
+| ---------- | ----------------------------------------------------- |
+| `https://` | `https://github.com/octocat/Hello-World.git`          |
+| `http://`  | `http://git.example.com/repo.git`                     |
+| `ssh://`   | `ssh://git@github.com/org/proj.git`                   |
+| `file:///` | `file:///home/user/local-repo.git` (must be absolute) |
+| SCP-style  | `git@github.com:org/proj.git`                         |
+
+```bash
+curl -X POST http://localhost:8080/v1/sandboxes \
+  -H 'Content-Type: application/json' \
+  -d '{"GitRepo": "https://github.com/octocat/Hello-World.git"}'
+```
+
+The repository is cloned on the host, copied into a named Docker volume, and mounted read-write at `/home/amika/workspace/<repo-name>`. The volume is tracked by `amika volume list`. If the clone fails, no sandbox is created.
+
+### Notes
+
+- `file://` URLs must use three slashes (`file:///absolute/path`). Relative paths are rejected.
+- The volume name is derived from the sandbox name and repo name, e.g. `amika-git-teal-tokyo-Hello-World-<timestamp>`.
+- Deleting the sandbox does not automatically delete the git volume; use `amika volume delete` when you no longer need it.
+
 ## Per-repo configuration: `.amika/config.toml`
 
 When you use `--git`, Amika looks for a `.amika/config.toml` file at the root of the repository and applies it automatically. This lets you commit sandbox configuration alongside your code so every collaborator gets the same environment without passing extra flags.

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -112,7 +112,7 @@ func TestCreateSandboxBodyIncludesSetupScriptFields(t *testing.T) {
 		Preset:          "",
 		Mounts:          []amika.Mount{},
 		Volumes:         []amika.Mount{},
-		GitPath:         "",
+		GitRepo:         "",
 		NoClean:         false,
 		Env:             []string{},
 		Ports:           []amika.PortBinding{{HostIP: "127.0.0.1", HostPort: 8080, ContainerPort: 80, Protocol: "tcp"}},
@@ -168,6 +168,9 @@ func TestOpenAPICreateSandboxUsesPascalCaseSetupScriptFields(t *testing.T) {
 	}
 	if _, ok := props["Ports"]; !ok {
 		t.Fatalf("missing Ports property")
+	}
+	if _, ok := props["GitRepo"]; !ok {
+		t.Fatalf("missing GitRepo property")
 	}
 
 	required, hasRequired := createReq["required"]

--- a/pkg/amika/requests.go
+++ b/pkg/amika/requests.go
@@ -26,7 +26,7 @@ type CreateSandboxRequest struct {
 	Preset          string
 	Mounts          []Mount
 	Volumes         []Mount
-	GitPath         string
+	GitRepo         string `json:"GitRepo,omitempty"`
 	NoClean         bool
 	Env             []string
 	Ports           []PortBinding `json:"Ports,omitempty"`

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -3,8 +3,10 @@ package amika
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -106,9 +108,20 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		mounts = append(mounts, *setupScriptMount)
 		cleanupSetupScript = cleanup
 	}
+	cleanupGitRepo := func() {}
+	if req.GitRepo != "" {
+		gitMount, gitCleanup, err := s.resolveGitRepoMount(name, req.GitRepo)
+		if err != nil {
+			cleanupSetupScript()
+			return Sandbox{}, err
+		}
+		mounts = append(mounts, gitMount)
+		cleanupGitRepo = gitCleanup
+	}
 	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env, toSandboxPortBindings(ports))
 	if err != nil {
 		cleanupSetupScript()
+		cleanupGitRepo()
 		return Sandbox{}, fmt.Errorf("%w: %v", ErrDependency, err)
 	}
 	info := sandbox.Info{
@@ -363,6 +376,128 @@ func toPortBindings(in []sandbox.PortBinding) []PortBinding {
 		})
 	}
 	return out
+}
+
+// parseGitRepoURL validates gitRepo and returns the repository name derived
+// from the last path component of the URL (with any .git suffix removed).
+func parseGitRepoURL(gitRepo string) (string, error) {
+	if gitRepo == "" {
+		return "", fmt.Errorf("GitRepo must not be empty")
+	}
+	switch {
+	case strings.HasPrefix(gitRepo, "https://"),
+		strings.HasPrefix(gitRepo, "http://"),
+		strings.HasPrefix(gitRepo, "ssh://"):
+		u, err := url.Parse(gitRepo)
+		if err != nil || u.Host == "" {
+			return "", fmt.Errorf("%w: invalid GitRepo URL %q", ErrInvalidArgument, gitRepo)
+		}
+		return repoNameFromPath(u.Path), nil
+	case strings.HasPrefix(gitRepo, "file:///"):
+		p := strings.TrimPrefix(gitRepo, "file://")
+		if !filepath.IsAbs(p) {
+			return "", fmt.Errorf("%w: file:// GitRepo must use an absolute path: %q", ErrInvalidArgument, gitRepo)
+		}
+		return repoNameFromPath(p), nil
+	case strings.HasPrefix(gitRepo, "file://"):
+		// file:// with non-absolute path (e.g. file://relative) is rejected
+		return "", fmt.Errorf("%w: file:// GitRepo must use an absolute path (use file:///...): %q", ErrInvalidArgument, gitRepo)
+	}
+	// SCP-style: [user@]host:path
+	if isScpStyleURL(gitRepo) {
+		colon := strings.Index(gitRepo, ":")
+		return repoNameFromPath(gitRepo[colon+1:]), nil
+	}
+	return "", fmt.Errorf("%w: unsupported GitRepo URL scheme %q", ErrInvalidArgument, gitRepo)
+}
+
+// repoNameFromPath returns the last path component with any .git suffix removed.
+func repoNameFromPath(p string) string {
+	name := path.Base(p)
+	return strings.TrimSuffix(name, ".git")
+}
+
+// isScpStyleURL reports whether s looks like SCP-style SSH syntax: [user@]host:path.
+// Strings containing "://" are URL schemes and are not SCP-style.
+func isScpStyleURL(s string) bool {
+	if strings.Contains(s, "://") {
+		return false
+	}
+	at := strings.Index(s, "@")
+	colon := strings.Index(s, ":")
+	if colon < 0 {
+		return false
+	}
+	if at >= 0 {
+		return colon > at+1
+	}
+	// no @: host:path — colon must not be at position 0 and path must follow
+	return colon > 0 && colon < len(s)-1
+}
+
+// resolveGitRepoMount clones gitRepo to a temp directory, copies it into a
+// Docker volume, and returns a volume MountBinding targeting the sandbox
+// workspace. The returned cleanup func removes the volume on error; call it
+// only on failure paths.
+func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (sandbox.MountBinding, func(), error) {
+	repoName, err := parseGitRepoURL(gitRepo)
+	if err != nil {
+		return sandbox.MountBinding{}, func() {}, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "amika-git-clone-*")
+	if err != nil {
+		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: create temp dir for git clone: %v", ErrInternal, err)
+	}
+	cloneDst := filepath.Join(tmpDir, repoName)
+
+	cloneURL := gitRepo
+	if strings.HasPrefix(gitRepo, "file:///") {
+		cloneURL = strings.TrimPrefix(gitRepo, "file://")
+	}
+
+	cmd := exec.Command("git", "clone", cloneURL, cloneDst)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: git clone %q failed: %s", ErrDependency, gitRepo, strings.TrimSpace(string(out)))
+	}
+
+	volumeName := fmt.Sprintf("amika-git-%s-%s-%d", sandboxName, repoName, time.Now().UnixNano())
+	if err := sandbox.CreateDockerVolume(volumeName); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: create git volume: %v", ErrDependency, err)
+	}
+	if err := sandbox.CopyHostDirToVolume(volumeName, cloneDst); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		_ = sandbox.RemoveDockerVolume(volumeName)
+		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: copy git repo to volume: %v", ErrInternal, err)
+	}
+	_ = os.RemoveAll(tmpDir) // volume is the source of truth from here
+
+	volInfo := sandbox.VolumeInfo{
+		Name:        volumeName,
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		CreatedBy:   "git-repo",
+		SourcePath:  gitRepo,
+		SandboxRefs: []string{sandboxName},
+	}
+	if err := s.volumes.Save(volInfo); err != nil {
+		_ = sandbox.RemoveDockerVolume(volumeName)
+		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: save git volume state: %v", ErrInternal, err)
+	}
+
+	cleanup := func() {
+		_ = s.volumes.Remove(volumeName)
+		_ = sandbox.RemoveDockerVolume(volumeName)
+	}
+	mount := sandbox.MountBinding{
+		Type:         "volume",
+		Volume:       volumeName,
+		Target:       path.Join(sandbox.SandboxWorkdir, repoName),
+		Mode:         "rw",
+		SnapshotFrom: gitRepo,
+	}
+	return mount, cleanup, nil
 }
 
 func resolveSetupScriptMount(name, setupScriptPath, setupScriptText string) (*sandbox.MountBinding, func(), error) {

--- a/pkg/amika/service_test.go
+++ b/pkg/amika/service_test.go
@@ -153,6 +153,44 @@ func TestMaterialize_RequiresDestdir(t *testing.T) {
 	}
 }
 
+func TestParseGitRepoURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantName string
+		wantErr  bool
+	}{
+		{name: "https with .git", input: "https://github.com/octocat/Hello-World.git", wantName: "Hello-World"},
+		{name: "https without .git", input: "https://github.com/octocat/Hello-World", wantName: "Hello-World"},
+		{name: "http", input: "http://example.com/repo.git", wantName: "repo"},
+		{name: "ssh scheme", input: "ssh://git@github.com/org/proj.git", wantName: "proj"},
+		{name: "file absolute", input: "file:///home/user/myrepo.git", wantName: "myrepo"},
+		{name: "file relative rejected", input: "file://relative/path", wantErr: true},
+		{name: "scp style with user", input: "git@github.com:org/proj.git", wantName: "proj"},
+		{name: "scp style no user", input: "github.com:proj.git", wantName: "proj"},
+		{name: "unknown scheme", input: "ftp://example.com/repo.git", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+		{name: "bare path no colon", input: "/local/path/repo", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseGitRepoURL(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got name=%q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantName {
+				t.Fatalf("got %q, want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
 func TestDeleteVolume_NotFound(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	svc := NewService(Options{})


### PR DESCRIPTION
## Stack

1. `dylan/git-api-server-mounting` `#THIS` ← you are here
2. `dylan/docker-build-daytona` #57
3. `dylan/build-and-opencode-fixes` #58

## Summary

- Renames `GitPath` to `GitRepo` on `CreateSandboxRequest` with a JSON tag, and implements host-side git cloning via `POST /v1/sandboxes`
- Supports `https://`, `http://`, `ssh://`, `file:///`, and SCP-style URLs; validates and extracts repo name from the URL
- Documents the `--git` CLI flag and `GitRepo` HTTP API field in `sandbox-configuration.md` and `cli-reference.md`, including supported URL schemes, volume lifecycle, and the `--port-host-ip` clarification

## Test plan

- [x] `go test ./pkg/amika/...` passes (includes `TestParseGitRepoURL` covering all URL schemes and error cases)
- [x] `go test ./internal/httpapi/...` passes (OpenAPI schema includes `GitRepo` field)
- [x] `amika sandbox create --git` clones current repo and mounts it at `/home/amika/workspace/<repo>`
- [ ] `POST /v1/sandboxes` with `"GitRepo": "https://github.com/..."` creates sandbox with cloned repo mounted
- [x] Verify `amika volume list` shows the git volume after sandbox creation
- [x] Verify volume persists after `amika sandbox delete` (requires explicit `amika volume delete`)