### PR TITLE
Add remote sandbox support with local/remote mode routing

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -334,17 +334,27 @@ var sandboxDeleteCmd = &cobra.Command{
 
 		var errs []string
 		for _, name := range args {
-			info, localErr := store.Get(name)
-			if localErr != nil && (mode == "remote" || mode == "both") {
-				// Not found locally, try remote.
+			// Remote-only mode: skip local entirely.
+			if mode == "remote" {
 				if remoteClient != nil {
 					if remoteErr := remoteClient.DeleteSandbox(name); remoteErr != nil {
 						errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
-						continue
+					} else {
+						fmt.Printf("Sandbox %q deleted (remote)\n", name)
 					}
-					fmt.Printf("Sandbox %q deleted (remote)\n", name)
-					continue
 				}
+				continue
+			}
+
+			info, localErr := store.Get(name)
+			if localErr != nil && mode == "both" && remoteClient != nil {
+				// Not found locally, try remote.
+				if remoteErr := remoteClient.DeleteSandbox(name); remoteErr != nil {
+					errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
+				} else {
+					fmt.Printf("Sandbox %q deleted (remote)\n", name)
+				}
+				continue
 			}
 			if localErr != nil {
 				errs = append(errs, fmt.Sprintf("sandbox %q not found", name))
@@ -1397,18 +1407,19 @@ func hasEnvKey(env []string, key string) bool {
 		}
 	}
 	return false
+}
+
 func createRemoteSandbox(cmd *cobra.Command) error {
 	name, _ := cmd.Flags().GetString("name")
-	githubURL, _ := cmd.Flags().GetString("github-url")
-	gitPath, _ := cmd.Flags().GetString("git")
+	gitValue, _ := cmd.Flags().GetString("git")
 
-	// If --github-url not provided, try to derive from --git repo's remote.
-	if githubURL == "" && cmd.Flags().Changed("git") {
-		derived, err := deriveGitHubURL(gitPath)
+	var gitURL string
+	if cmd.Flags().Changed("git") {
+		resolved, err := resolveGitURL(gitValue)
 		if err != nil {
-			return fmt.Errorf("could not derive GitHub URL from git repo: %w\nUse --github-url to specify it explicitly", err)
+			return err
 		}
-		githubURL = derived
+		gitURL = resolved
 	}
 
 	client, err := getRemoteClient()
@@ -1419,7 +1430,7 @@ func createRemoteSandbox(cmd *cobra.Command) error {
 	req := apiclient.CreateSandboxRequest{
 		Name:      name,
 		Provider:  "daytona",
-		GitHubURL: githubURL,
+		GitHubURL: gitURL,
 	}
 
 	sb, err := client.CreateSandbox(req)
@@ -1431,12 +1442,20 @@ func createRemoteSandbox(cmd *cobra.Command) error {
 	return nil
 }
 
-// deriveGitHubURL resolves the git repo at startPath and returns the origin remote URL
-// if it looks like a GitHub URL.
-func deriveGitHubURL(startPath string) (string, error) {
-	repoRoot, err := resolveGitRoot(startPath)
+// resolveGitURL takes the --git flag value and returns a git URL suitable for
+// remote sandbox creation. If the value is already an HTTP(S) or SSH URL, it is
+// returned directly. Otherwise it is treated as a local path and the origin
+// remote URL is extracted.
+func resolveGitURL(value string) (string, error) {
+	// Already a URL — use as-is.
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "git@") {
+		return value, nil
+	}
+
+	// Treat as local path — derive from origin remote.
+	repoRoot, err := resolveGitRoot(value)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("could not find git repo at %q: %w", value, err)
 	}
 	remotes, err := listGitRemotes(repoRoot)
 	if err != nil {
@@ -1444,15 +1463,10 @@ func deriveGitHubURL(startPath string) (string, error) {
 	}
 	origin, ok := remotes["origin"]
 	if !ok {
-		return "", fmt.Errorf("no origin remote found")
+		return "", fmt.Errorf("no origin remote found in %q; specify a git HTTP(S) or SSH URL directly with --git <url>", repoRoot)
 	}
-	// Normalize SSH URL to HTTPS.
-	if strings.HasPrefix(origin, "git@github.com:") {
-		origin = "https://github.com/" + strings.TrimPrefix(origin, "git@github.com:")
-	}
-	origin = strings.TrimSuffix(origin, ".git")
-	if !strings.Contains(origin, "github.com") {
-		return "", fmt.Errorf("origin remote %q is not a GitHub URL", origin)
+	if !isNetworkRemoteURL(origin) {
+		return "", fmt.Errorf("origin remote %q is a local path; specify a git HTTP(S) or SSH URL directly with --git <url>", origin)
 	}
 	return origin, nil
 }
@@ -1484,7 +1498,6 @@ func init() {
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 	sandboxCreateCmd.Flags().Bool("connect", false, "Connect to the sandbox shell immediately after creation")
 	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /opt/setup.sh in the container (read-only)")
-	sandboxCreateCmd.Flags().String("github-url", "", "GitHub repository URL for remote sandbox creation")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/gofixpoint/amika/internal/agentconfig"
 	"github.com/gofixpoint/amika/internal/amikaconfig"
+	"github.com/gofixpoint/amika/internal/apiclient"
+	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/sandbox"
 	"github.com/gofixpoint/amika/internal/txn"
@@ -30,6 +32,58 @@ var sandboxCmd = &cobra.Command{
 }
 
 const sandboxConnectWorkdir = "/home/amika"
+
+const envAPIURL = "AMIKA_API_URL"
+
+// TODO: Parse env variables from an environment file (e.g. .amika/.env or ~/.config/amika/env)
+// so users don't need to export AMIKA_API_URL, AMIKA_WORKOS_CLIENT_ID, etc. in their shell profile.
+
+// sandboxMode determines whether a command operates locally, remotely, or both.
+// Returns "local", "remote", or "both".
+func sandboxMode(cmd *cobra.Command) string {
+	local, _ := cmd.Flags().GetBool("local")
+	remote, _ := cmd.Flags().GetBool("remote")
+	if local {
+		return "local"
+	}
+	if remote {
+		return "remote"
+	}
+	// Default: if logged in, use remote; otherwise local.
+	session, _ := auth.LoadSession()
+	if session == nil {
+		return "local"
+	}
+	return "both"
+}
+
+// isLoggedIn returns true if a WorkOS session exists on disk.
+func isLoggedIn() bool {
+	session, _ := auth.LoadSession()
+	return session != nil
+}
+
+// printLocalOnlyNotice prints a notice when the user is not logged in and
+// no explicit --local flag was set.
+func printLocalOnlyNotice(cmd *cobra.Command) {
+	local, _ := cmd.Flags().GetBool("local")
+	if !local && !isLoggedIn() {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Note: showing local resources only. Run \"amika auth login\" to access remote sandboxes.")
+	}
+}
+
+// getRemoteClient returns an API client authenticated with the current session.
+func getRemoteClient() (*apiclient.Client, error) {
+	session, err := auth.GetValidSession(defaultWorkOSClientID)
+	if err != nil {
+		return nil, err
+	}
+	baseURL := os.Getenv(envAPIURL)
+	if baseURL == "" {
+		baseURL = apiclient.DefaultAPIURL
+	}
+	return apiclient.NewClient(baseURL, session.AccessToken), nil
+}
 
 var runSandboxConnect = func(name, shell string, stdin io.Reader, stdout, stderr io.Writer) error {
 	dockerArgs := buildSandboxConnectArgs(name, shell)
@@ -47,6 +101,12 @@ var sandboxCreateCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
+
+		mode := sandboxMode(cmd)
+		if mode == "remote" || mode == "both" {
+			return createRemoteSandbox(cmd)
+		}
+		printLocalOnlyNotice(cmd)
 
 		provider, _ := cmd.Flags().GetString("provider")
 		name, _ := cmd.Flags().GetString("name")
@@ -237,6 +297,8 @@ var sandboxDeleteCmd = &cobra.Command{
 	Long:    `Delete one or more sandboxes and remove their backing containers.`,
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		mode := sandboxMode(cmd)
+
 		deleteVolumes, _ := cmd.Flags().GetBool("delete-volumes")
 		keepVolumes, _ := cmd.Flags().GetBool("keep-volumes")
 		deleteVolumesSet := cmd.Flags().Changed("delete-volumes")
@@ -261,10 +323,30 @@ var sandboxDeleteCmd = &cobra.Command{
 		}
 		fileMountStore := sandbox.NewFileMountStore(fileMountsFile)
 
+		// Build a remote client if we may need it.
+		var remoteClient *apiclient.Client
+		if mode == "remote" || mode == "both" {
+			remoteClient, err = getRemoteClient()
+			if err != nil {
+				return err
+			}
+		}
+
 		var errs []string
 		for _, name := range args {
-			info, err := store.Get(name)
-			if err != nil {
+			info, localErr := store.Get(name)
+			if localErr != nil && (mode == "remote" || mode == "both") {
+				// Not found locally, try remote.
+				if remoteClient != nil {
+					if remoteErr := remoteClient.DeleteSandbox(name); remoteErr != nil {
+						errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
+						continue
+					}
+					fmt.Printf("Sandbox %q deleted (remote)\n", name)
+					continue
+				}
+			}
+			if localErr != nil {
 				errs = append(errs, fmt.Sprintf("sandbox %q not found", name))
 				continue
 			}
@@ -323,20 +405,50 @@ var sandboxListCmd = &cobra.Command{
 	Short: "List all sandboxes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		result, err := amika.NewService(amika.Options{}).ListSandboxes(cmd.Context(), amika.ListSandboxesRequest{})
-		if err != nil {
-			return err
+		mode := sandboxMode(cmd)
+		printLocalOnlyNotice(cmd)
+
+		var allItems []amika.Sandbox
+
+		if mode == "local" || mode == "both" {
+			result, err := amika.NewService(amika.Options{}).ListSandboxes(cmd.Context(), amika.ListSandboxesRequest{})
+			if err != nil {
+				return err
+			}
+			for i := range result.Items {
+				result.Items[i].Location = "local"
+			}
+			allItems = append(allItems, result.Items...)
 		}
 
-		if len(result.Items) == 0 {
+		if mode == "remote" || mode == "both" {
+			client, err := getRemoteClient()
+			if err != nil {
+				return err
+			}
+			remoteSandboxes, err := client.ListSandboxes()
+			if err != nil {
+				return err
+			}
+			for _, rs := range remoteSandboxes {
+				allItems = append(allItems, amika.Sandbox{
+					Name:      rs.Name,
+					Provider:  rs.Provider,
+					CreatedAt: rs.CreatedAt,
+					Location:  "remote",
+				})
+			}
+		}
+
+		if len(allItems) == 0 {
 			fmt.Println("No sandboxes found.")
 			return nil
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tPROVIDER\tIMAGE\tPORTS\tCREATED")
-		for _, sb := range result.Items {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.Provider, sb.Image, formatPortBindings(sb.Ports), sb.CreatedAt)
+		fmt.Fprintln(w, "NAME\tLOCATION\tPROVIDER\tIMAGE\tPORTS\tCREATED")
+		for _, sb := range allItems {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.Location, sb.Provider, sb.Image, formatPortBindings(sb.Ports), sb.CreatedAt)
 		}
 		w.Flush()
 		return nil
@@ -1285,6 +1397,64 @@ func hasEnvKey(env []string, key string) bool {
 		}
 	}
 	return false
+func createRemoteSandbox(cmd *cobra.Command) error {
+	name, _ := cmd.Flags().GetString("name")
+	githubURL, _ := cmd.Flags().GetString("github-url")
+	gitPath, _ := cmd.Flags().GetString("git")
+
+	// If --github-url not provided, try to derive from --git repo's remote.
+	if githubURL == "" && cmd.Flags().Changed("git") {
+		derived, err := deriveGitHubURL(gitPath)
+		if err != nil {
+			return fmt.Errorf("could not derive GitHub URL from git repo: %w\nUse --github-url to specify it explicitly", err)
+		}
+		githubURL = derived
+	}
+
+	client, err := getRemoteClient()
+	if err != nil {
+		return err
+	}
+
+	req := apiclient.CreateSandboxRequest{
+		Name:      name,
+		Provider:  "daytona",
+		GitHubURL: githubURL,
+	}
+
+	sb, err := client.CreateSandbox(req)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Sandbox %q created (remote)\n", sb.Name)
+	return nil
+}
+
+// deriveGitHubURL resolves the git repo at startPath and returns the origin remote URL
+// if it looks like a GitHub URL.
+func deriveGitHubURL(startPath string) (string, error) {
+	repoRoot, err := resolveGitRoot(startPath)
+	if err != nil {
+		return "", err
+	}
+	remotes, err := listGitRemotes(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	origin, ok := remotes["origin"]
+	if !ok {
+		return "", fmt.Errorf("no origin remote found")
+	}
+	// Normalize SSH URL to HTTPS.
+	if strings.HasPrefix(origin, "git@github.com:") {
+		origin = "https://github.com/" + strings.TrimPrefix(origin, "git@github.com:")
+	}
+	origin = strings.TrimSuffix(origin, ".git")
+	if !strings.Contains(origin, "github.com") {
+		return "", fmt.Errorf("origin remote %q is not a GitHub URL", origin)
+	}
+	return origin, nil
 }
 
 func init() {
@@ -1293,6 +1463,10 @@ func init() {
 	sandboxCmd.AddCommand(sandboxDeleteCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxConnectCmd)
+
+	// Persistent flags for local/remote mode
+	sandboxCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
+	sandboxCmd.PersistentFlags().Bool("remote", false, "Only operate on remote sandboxes")
 
 	// Create flags
 	sandboxCreateCmd.Flags().String("provider", "docker", "Sandbox provider")
@@ -1310,8 +1484,8 @@ func init() {
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 	sandboxCreateCmd.Flags().Bool("connect", false, "Connect to the sandbox shell immediately after creation")
 	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /opt/setup.sh in the container (read-only)")
+	sandboxCreateCmd.Flags().String("github-url", "", "GitHub repository URL for remote sandbox creation")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")
-
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -1,0 +1,118 @@
+// Package apiclient provides an HTTP client for the remote Amika API.
+package apiclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultAPIURL is the default remote API base URL.
+const DefaultAPIURL = "https://api.amika.dev"
+
+// Client calls the remote Amika API with a bearer token.
+type Client struct {
+	BaseURL     string
+	AccessToken string
+	HTTP        *http.Client
+}
+
+// NewClient creates a Client for the given base URL and access token.
+func NewClient(baseURL, accessToken string) *Client {
+	return &Client{
+		BaseURL:     strings.TrimRight(baseURL, "/"),
+		AccessToken: accessToken,
+		HTTP:        &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// CreateSandboxRequest is the request body for POST /api/sandboxes.
+type CreateSandboxRequest struct {
+	Name               string `json:"name,omitempty"`
+	Provider           string `json:"provider,omitempty"`
+	GitHubURL          string `json:"github_url,omitempty"`
+	AutoStopInterval   *int   `json:"auto_stop_interval,omitempty"`
+	AutoDeleteInterval *int   `json:"auto_delete_interval,omitempty"`
+}
+
+// RemoteSandbox represents a sandbox returned by the remote API.
+type RemoteSandbox struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+	GitHubURL string `json:"github_url"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+}
+
+// ListSandboxes fetches sandboxes from the remote API.
+func (c *Client) ListSandboxes() ([]RemoteSandbox, error) {
+	var result []RemoteSandbox
+	if err := c.doJSON("GET", "/api/sandboxes", nil, &result); err != nil {
+		return nil, fmt.Errorf("remote list sandboxes: %w", err)
+	}
+	return result, nil
+}
+
+// CreateSandbox creates a sandbox on the remote API.
+func (c *Client) CreateSandbox(req CreateSandboxRequest) (*RemoteSandbox, error) {
+	var result RemoteSandbox
+	if err := c.doJSON("POST", "/api/sandboxes", req, &result); err != nil {
+		return nil, fmt.Errorf("remote create sandbox: %w", err)
+	}
+	return &result, nil
+}
+
+// DeleteSandbox deletes a sandbox on the remote API.
+func (c *Client) DeleteSandbox(name string) error {
+	if err := c.doJSON("DELETE", "/api/sandboxes/"+name, nil, nil); err != nil {
+		return fmt.Errorf("remote delete sandbox: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) doJSON(method, path string, body interface{}, out interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshalling request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, c.BaseURL+path, bodyReader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -8,6 +8,7 @@ type Sandbox struct {
 	Image       string
 	CreatedAt   string
 	Preset      string
+	Location    string // "local" or "remote"
 	Mounts      []Mount
 	Env         []string
 	Ports       []PortBinding


### PR DESCRIPTION
- Add API client (internal/apiclient) for the remote Amika API (POST/GET/DELETE /api/sandboxes) with bearer token auth
- Add --local and --remote persistent flags to sandbox commands
- When logged in, sandbox list merges local and remote results; sandbox create/delete route to remote by default
- When not logged in, commands operate locally with a notice
- Add Location column to sandbox list output (local/remote)
- Add --github-url flag for remote sandbox creation; auto-derives GitHub URL from git origin when --git is used with remote mode
- Remote API URL defaults to https://api.amika.dev, overridable via AMIKA_API_URL env var