### PR TITLE
Add Docker image build script and non-root amika user

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-#/ Usage: bin/build-docker-images <image> [--ignore-unstaged] [--push-daytona]
+#/ Usage: bin/build-docker-images <image> [--platform <platform>] [--ignore-unstaged] [--push-daytona]
 #/
 #/ Build preset Docker images and tag them with the current git commit.
+#/ By default, builds for both linux/amd64 and linux/arm64.
 #/
 #/ Arguments:
 #/   <image>              One of: amika/coder, amika/claude, all
 #/
 #/ Options:
+#/   --platform <plat>    Build for a single platform (linux/amd64 or linux/arm64)
 #/   --ignore-unstaged    Continue even if there are unstaged changes
-#/   --push-daytona       Push built images to Daytona after building
+#/   --push-daytona       Push built images to Daytona after building (requires linux/amd64)
 #/   --help               Show this help message
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -21,22 +23,28 @@ usage() {
 
 # Parse arguments
 IMAGE=""
+PLATFORM=""
 IGNORE_UNSTAGED=false
 PUSH_DAYTONA=false
 
-for arg in "$@"; do
-  case "$arg" in
-    --ignore-unstaged) IGNORE_UNSTAGED=true ;;
-    --push-daytona)    PUSH_DAYTONA=true ;;
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --platform)
+      if [ $# -lt 2 ]; then
+        echo "Error: --platform requires a value" >&2; exit 1
+      fi
+      PLATFORM="$2"; shift 2 ;;
+    --ignore-unstaged) IGNORE_UNSTAGED=true; shift ;;
+    --push-daytona)    PUSH_DAYTONA=true; shift ;;
     --help)            usage; exit 0 ;;
-    -*)                echo "Unknown option: $arg" >&2; usage >&2; exit 1 ;;
+    -*)                echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
     *)
       if [ -z "$IMAGE" ]; then
-        IMAGE="$arg"
+        IMAGE="$1"
       else
-        echo "Unexpected argument: $arg" >&2; usage >&2; exit 1
+        echo "Unexpected argument: $1" >&2; usage >&2; exit 1
       fi
-      ;;
+      shift ;;
   esac
 done
 
@@ -52,6 +60,25 @@ case "$IMAGE" in
   amika/coder|amika/claude|all) ;;
   *) echo "Error: <image> must be one of: amika/coder, amika/claude, all" >&2; exit 1 ;;
 esac
+
+# Validate --platform value
+if [ -n "$PLATFORM" ]; then
+  case "$PLATFORM" in
+    linux/amd64|linux/arm64) ;;
+    *) echo "Error: --platform must be one of: linux/amd64, linux/arm64" >&2; exit 1 ;;
+  esac
+fi
+
+# Validate --push-daytona + --platform combination
+if [ "$PUSH_DAYTONA" = true ] && [ "$PLATFORM" = "linux/arm64" ]; then
+  echo "Error: --push-daytona requires linux/amd64; cannot use --platform linux/arm64." >&2
+  exit 1
+fi
+
+# Default platform: build for both architectures
+if [ -z "$PLATFORM" ]; then
+  PLATFORM="linux/amd64,linux/arm64"
+fi
 
 # Check for unstaged changes
 if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
@@ -79,8 +106,8 @@ for preset in "${PRESETS[@]}"; do
   image_tag="amika/${preset}:${VERSION}"
   dockerfile="$REPO_ROOT/internal/sandbox/presets/${preset}/Dockerfile"
 
-  echo "Building ${image_tag} from ${dockerfile}..."
-  docker build -f "$dockerfile" -t "$image_tag" "$REPO_ROOT"
+  echo "Building ${image_tag} (platform: ${PLATFORM}) from ${dockerfile}..."
+  docker build --platform "$PLATFORM" -f "$dockerfile" -t "$image_tag" "$REPO_ROOT"
 
   if [ "$PUSH_DAYTONA" = true ]; then
     echo "Pushing ${image_tag} to Daytona..."

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -4,13 +4,14 @@ set -euo pipefail
 #/ Usage: bin/build-docker-images <image> [--platform <platform>] [--ignore-unstaged] [--push-daytona]
 #/
 #/ Build preset Docker images and tag them with the current git commit.
-#/ By default, builds for both linux/amd64 and linux/arm64.
+#/ By default, builds for the host architecture. With --push-daytona,
+#/ builds for linux/amd64 (Daytona's architecture).
 #/
 #/ Arguments:
 #/   <image>              One of: amika/coder, amika/claude, all
 #/
 #/ Options:
-#/   --platform <plat>    Build for a single platform (linux/amd64 or linux/arm64)
+#/   --platform <plat>    Override build platform (linux/amd64 or linux/arm64)
 #/   --ignore-unstaged    Continue even if there are unstaged changes
 #/   --push-daytona       Push built images to Daytona after building (requires linux/amd64)
 #/   --help               Show this help message
@@ -75,9 +76,12 @@ if [ "$PUSH_DAYTONA" = true ] && [ "$PLATFORM" = "linux/arm64" ]; then
   exit 1
 fi
 
-# Default platform: build for both architectures
+# Default platform: host architecture, or linux/amd64 when pushing to Daytona
 if [ -z "$PLATFORM" ]; then
-  PLATFORM="linux/amd64,linux/arm64"
+  if [ "$PUSH_DAYTONA" = true ]; then
+    PLATFORM="linux/amd64"
+  fi
+  # Otherwise, no --platform flag is passed to docker build (uses host arch)
 fi
 
 # Check for unstaged changes
@@ -106,8 +110,14 @@ for preset in "${PRESETS[@]}"; do
   image_tag="amika/${preset}:${VERSION}"
   dockerfile="$REPO_ROOT/internal/sandbox/presets/${preset}/Dockerfile"
 
-  echo "Building ${image_tag} (platform: ${PLATFORM}) from ${dockerfile}..."
-  docker build --platform "$PLATFORM" -f "$dockerfile" -t "$image_tag" "$REPO_ROOT"
+  platform_args=()
+  if [ -n "$PLATFORM" ]; then
+    platform_args=(--platform "$PLATFORM")
+    echo "Building ${image_tag} (platform: ${PLATFORM}) from ${dockerfile}..."
+  else
+    echo "Building ${image_tag} from ${dockerfile}..."
+  fi
+  docker build "${platform_args[@]}" -f "$dockerfile" -t "$image_tag" "$REPO_ROOT"
 
   if [ "$PUSH_DAYTONA" = true ]; then
     echo "Pushing ${image_tag} to Daytona..."

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#/ Usage: bin/build-docker-images <image> [--ignore-unstaged] [--push-daytona]
+#/
+#/ Build preset Docker images and tag them with the current git commit.
+#/
+#/ Arguments:
+#/   <image>              One of: amika/coder, amika/claude, all
+#/
+#/ Options:
+#/   --ignore-unstaged    Continue even if there are unstaged changes
+#/   --push-daytona       Push built images to Daytona after building
+#/   --help               Show this help message
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+usage() {
+  grep '^#/' "$0" | cut -c4-
+}
+
+# Parse arguments
+IMAGE=""
+IGNORE_UNSTAGED=false
+PUSH_DAYTONA=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --ignore-unstaged) IGNORE_UNSTAGED=true ;;
+    --push-daytona)    PUSH_DAYTONA=true ;;
+    --help)            usage; exit 0 ;;
+    -*)                echo "Unknown option: $arg" >&2; usage >&2; exit 1 ;;
+    *)
+      if [ -z "$IMAGE" ]; then
+        IMAGE="$arg"
+      else
+        echo "Unexpected argument: $arg" >&2; usage >&2; exit 1
+      fi
+      ;;
+  esac
+done
+
+if [ -z "$IMAGE" ]; then
+  echo "Error: <image> argument is required." >&2
+  echo "" >&2
+  usage >&2
+  exit 1
+fi
+
+# Validate image argument
+case "$IMAGE" in
+  amika/coder|amika/claude|all) ;;
+  *) echo "Error: <image> must be one of: amika/coder, amika/claude, all" >&2; exit 1 ;;
+esac
+
+# Check for unstaged changes
+if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
+  if [ "$IGNORE_UNSTAGED" = false ]; then
+    echo "Error: there are unstaged/uncommitted changes. Use --ignore-unstaged to continue anyway." >&2
+    exit 1
+  else
+    echo "Warning: there are unstaged/uncommitted changes, continuing anyway." >&2
+  fi
+fi
+
+# Determine git version tag
+VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+
+# Determine which presets to build
+PRESETS=()
+case "$IMAGE" in
+  amika/coder)  PRESETS=(coder) ;;
+  amika/claude) PRESETS=(claude) ;;
+  all)          PRESETS=(coder claude) ;;
+esac
+
+# Build images
+for preset in "${PRESETS[@]}"; do
+  image_tag="amika/${preset}:${VERSION}"
+  dockerfile="$REPO_ROOT/internal/sandbox/presets/${preset}/Dockerfile"
+
+  echo "Building ${image_tag} from ${dockerfile}..."
+  docker build -f "$dockerfile" -t "$image_tag" "$REPO_ROOT"
+
+  if [ "$PUSH_DAYTONA" = true ]; then
+    echo "Pushing ${image_tag} to Daytona..."
+    daytona snapshot push "$image_tag" --name "$image_tag"
+  fi
+done
+
+echo "Done."

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -3,11 +3,11 @@
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV HOME=/home/amika
 
 RUN apt-get update && apt-get install -y \
     git \
     curl \
+    sudo \
     zsh \
     build-essential \
     python3 \
@@ -24,12 +24,23 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # Install pnpm, TypeScript, and Claude Code CLI
 RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code
 
-RUN mkdir -p /home/amika
-WORKDIR /home/amika
-
 # Default no-op setup script; users can shadow it via --setup-script.
 # The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
 # don't need to include `exec "$@"` themselves.
 RUN printf '#!/bin/bash\nexit 0\n' > /opt/setup.sh \
     && chmod +x /opt/setup.sh
+
+# Create user with home directory
+RUN useradd -m -s /usr/bin/zsh amika
+RUN usermod -aG sudo amika
+# Let amika user run sudo without a password
+RUN echo "amika ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Everything after this point runs as the amika user
+USER amika
+
+ENV HOME=/home/amika
+RUN mkdir -p /home/amika
+WORKDIR /home/amika
+
 ENTRYPOINT ["/bin/bash", "-c", "/opt/setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -1,3 +1,5 @@
+# Locally, this image is called "amika/claude"
+
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -1,3 +1,5 @@
+# Locally, this image is called "amika/coder"
+
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -3,11 +3,11 @@
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV HOME=/home/amika
 
 RUN apt-get update && apt-get install -y \
     git \
     curl \
+    sudo \
     zsh \
     build-essential \
     python3 \
@@ -24,12 +24,23 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # Install coding agent CLIs.
 RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai
 
-RUN mkdir -p /home/amika
-WORKDIR /home/amika
-
 # Default no-op setup script; users can shadow it via --setup-script.
 # The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
 # don't need to include `exec "$@"` themselves.
 RUN printf '#!/bin/bash\nexit 0\n' > /opt/setup.sh \
     && chmod +x /opt/setup.sh
+
+# Create user with home directory
+RUN useradd -m -s /usr/bin/zsh amika
+RUN usermod -aG sudo amika
+# Let amika user run sudo without a password
+RUN echo "amika ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Everything after this point runs as the amika user
+USER amika
+
+ENV HOME=/home/amika
+RUN mkdir -p /home/amika
+WORKDIR /home/amika
+
 ENTRYPOINT ["/bin/bash", "-c", "/opt/setup.sh && exec \"$@\"", "--"]


### PR DESCRIPTION
## Stack

1. `dylan/git-api-server-mounting` #54
2. `dylan/docker-build-daytona` `#THIS` ← you are here
3. `dylan/build-and-opencode-fixes` #58

## Summary

- Add `bin/build-docker-images` script for explicitly building and tagging preset Docker images with the current git SHA, with `--push-daytona` support
- Add `--platform` flag defaulting to host architecture; `--push-daytona` forces linux/amd64 (Daytona's requirement)
- Install sudo, create a non-root `amika` user with passwordless sudo in both claude and coder preset Dockerfiles