### PR TITLE
Move daemon paths to FHS-compliant locations and harden pre-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ claude "Add unit tests for the auth module"
 │  Credentials ────────>   │  /home/amika/workspace/{repo}    │
 │  (auto-discovered) │     │  Agent CLIs ready (claude, codex)│
 │                    │     │  Dev tools (git, node, python)   │
-│  Setup script ───────>   │  /opt/setup.sh runs on start     │
+│  Setup script ───────>   │  setup.sh runs on start     │
 │                    │     │                                  │
 │  Port 8080 <──────────   │  --port 8080:8080                │
 │  (live preview)    │     │                                  │

--- a/cmd/amika/materialize.go
+++ b/cmd/amika/materialize.go
@@ -112,7 +112,7 @@ Examples:
 			mounts = append(mounts, sandbox.MountBinding{
 				Type:   "bind",
 				Source: absSetupScript,
-				Target: "/etc/amikad/setup/setup.sh",
+				Target: "/usr/local/etc/amikad/setup/setup.sh",
 				Mode:   "ro",
 			})
 		}
@@ -310,5 +310,5 @@ func init() {
 	topMaterializeCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
 	topMaterializeCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	topMaterializeCmd.Flags().BoolP("interactive", "i", false, "Run interactively with TTY (for programs like claude)")
-	topMaterializeCmd.Flags().String("setup-script", "", "Mount a local script file to /etc/amikad/setup/setup.sh in the container (read-only)")
+	topMaterializeCmd.Flags().String("setup-script", "", "Mount a local script file to /usr/local/etc/amikad/setup/setup.sh in the container (read-only)")
 }

--- a/cmd/amika/materialize.go
+++ b/cmd/amika/materialize.go
@@ -112,7 +112,7 @@ Examples:
 			mounts = append(mounts, sandbox.MountBinding{
 				Type:   "bind",
 				Source: absSetupScript,
-				Target: "/opt/setup.sh",
+				Target: "/etc/amikad/setup/setup.sh",
 				Mode:   "ro",
 			})
 		}
@@ -310,5 +310,5 @@ func init() {
 	topMaterializeCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
 	topMaterializeCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	topMaterializeCmd.Flags().BoolP("interactive", "i", false, "Run interactively with TTY (for programs like claude)")
-	topMaterializeCmd.Flags().String("setup-script", "", "Mount a local script file to /opt/setup.sh in the container (read-only)")
+	topMaterializeCmd.Flags().String("setup-script", "", "Mount a local script file to /etc/amikad/setup/setup.sh in the container (read-only)")
 }

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1046,12 +1046,12 @@ func setupScriptMountFromConfig(repoRoot string) (*sandbox.MountBinding, error) 
 	return &m, nil
 }
 
-// setupScriptBindMount returns a read-only bind mount for absPath to /etc/amikad/setup/setup.sh.
+// setupScriptBindMount returns a read-only bind mount for absPath to /usr/local/etc/amikad/setup/setup.sh.
 func setupScriptBindMount(absPath string) sandbox.MountBinding {
 	return sandbox.MountBinding{
 		Type:   "bind",
 		Source: absPath,
-		Target: "/etc/amikad/setup/setup.sh",
+		Target: "/usr/local/etc/amikad/setup/setup.sh",
 		Mode:   "ro",
 	}
 }
@@ -1497,7 +1497,7 @@ func init() {
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 	sandboxCreateCmd.Flags().Bool("connect", false, "Connect to the sandbox shell immediately after creation")
-	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /etc/amikad/setup/setup.sh in the container (read-only)")
+	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /usr/local/etc/amikad/setup/setup.sh in the container (read-only)")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1046,12 +1046,12 @@ func setupScriptMountFromConfig(repoRoot string) (*sandbox.MountBinding, error) 
 	return &m, nil
 }
 
-// setupScriptBindMount returns a read-only bind mount for absPath to /opt/setup.sh.
+// setupScriptBindMount returns a read-only bind mount for absPath to /etc/amikad/setup/setup.sh.
 func setupScriptBindMount(absPath string) sandbox.MountBinding {
 	return sandbox.MountBinding{
 		Type:   "bind",
 		Source: absPath,
-		Target: "/opt/setup.sh",
+		Target: "/etc/amikad/setup/setup.sh",
 		Mode:   "ro",
 	}
 }
@@ -1497,7 +1497,7 @@ func init() {
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 	sandboxCreateCmd.Flags().Bool("connect", false, "Connect to the sandbox shell immediately after creation")
-	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /opt/setup.sh in the container (read-only)")
+	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /etc/amikad/setup/setup.sh in the container (read-only)")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,22 +56,22 @@ amika sandbox create --name dev-sandbox --port 3000:3000 --port-host-ip 0.0.0.0
 
 #### Flags
 
-| Flag                    | Default              | Description                                                                                                          |
-| ----------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `--name <name>`         | auto-generated       | Name for the sandbox. If omitted, a random `{color}-{city}` name is generated (e.g. `teal-tokyo`)                    |
-| `--provider <name>`     | `docker`             | Sandbox provider (only `docker` is currently supported)                                                              |
-| `--image <image>`       | `amika/coder:latest` | Docker image to use (mutually exclusive with `--preset`)                                                             |
-| `--preset <name>`       |                      | Use a preset environment, e.g. `coder` or `claude` (mutually exclusive with `--image`). See [presets.md](presets.md) |
-| `--mount <spec>`        |                      | Mount a host path (`source:target[:mode]`, mode defaults to `rwcopy`). Repeatable                                    |
-| `--volume <spec>`       |                      | Mount an existing named volume (`name:target[:mode]`, mode defaults to `rw`). Repeatable                             |
-| `--git [path]`          |                      | Mount the git repo root (or repo containing `path`) to `/home/amika/workspace/{repo}`. Uses a clean clone by default |
-| `--no-clean`            | `false`              | With `--git`, include untracked/uncommitted files instead of a clean clone                                           |
-| `--env <KEY=VALUE>`     |                      | Set environment variable. Repeatable                                                                                 |
-| `--port <spec>`         |                      | Publish a container port (`hostPort:containerPort[/protocol]`, protocol defaults to `tcp`). Repeatable               |
-| `--port-host-ip <ip>`   | `127.0.0.1`          | Host IP address to bind all published ports to. Use `0.0.0.0` to bind to all interfaces                             |
-| `--yes`                 | `false`              | Skip mount confirmation prompt                                                                                       |
-| `--connect`             | `false`              | Connect to the sandbox shell immediately after creation                                                              |
-| `--setup-script <path>` |                      | Mount a local script to `/etc/amikad/setup/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md)        |
+| Flag                    | Default              | Description                                                                                                                          |
+| ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `--name <name>`         | auto-generated       | Name for the sandbox. If omitted, a random `{color}-{city}` name is generated (e.g. `teal-tokyo`)                                    |
+| `--provider <name>`     | `docker`             | Sandbox provider (only `docker` is currently supported)                                                                              |
+| `--image <image>`       | `amika/coder:latest` | Docker image to use (mutually exclusive with `--preset`)                                                                             |
+| `--preset <name>`       |                      | Use a preset environment, e.g. `coder` or `claude` (mutually exclusive with `--image`). See [presets.md](presets.md)                 |
+| `--mount <spec>`        |                      | Mount a host path (`source:target[:mode]`, mode defaults to `rwcopy`). Repeatable                                                    |
+| `--volume <spec>`       |                      | Mount an existing named volume (`name:target[:mode]`, mode defaults to `rw`). Repeatable                                             |
+| `--git [path]`          |                      | Mount the git repo root (or repo containing `path`) to `/home/amika/workspace/{repo}`. Uses a clean clone by default                 |
+| `--no-clean`            | `false`              | With `--git`, include untracked/uncommitted files instead of a clean clone                                                           |
+| `--env <KEY=VALUE>`     |                      | Set environment variable. Repeatable                                                                                                 |
+| `--port <spec>`         |                      | Publish a container port (`hostPort:containerPort[/protocol]`, protocol defaults to `tcp`). Repeatable                               |
+| `--port-host-ip <ip>`   | `127.0.0.1`          | Host IP address to bind all published ports to. Use `0.0.0.0` to bind to all interfaces                                              |
+| `--yes`                 | `false`              | Skip mount confirmation prompt                                                                                                       |
+| `--connect`             | `false`              | Connect to the sandbox shell immediately after creation                                                                              |
+| `--setup-script <path>` |                      | Mount a local script to `/usr/local/etc/amikad/setup/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md) |
 
 #### Mount modes
 
@@ -228,18 +228,18 @@ amika materialize --setup-script ./install-deps.sh --cmd "echo done" --destdir /
 
 ### Flags
 
-| Flag                    | Default              | Description                                                                                                          |
-| ----------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `--script <path>`       |                      | Path to the script to execute (mutually exclusive with `--cmd`)                                                      |
-| `--cmd <string>`        |                      | Bash command string to execute (mutually exclusive with `--script`)                                                  |
-| `--outdir <path>`       | workdir              | Container directory to copy from. Absolute paths are used as-is; relative paths resolve from workdir                 |
-| `--destdir <path>`      | **(required)**       | Host directory where output files are copied                                                                         |
-| `--image <image>`       | `amika/coder:latest` | Docker image to use (mutually exclusive with `--preset`)                                                             |
-| `--preset <name>`       |                      | Use a preset environment, e.g. `coder` or `claude` (mutually exclusive with `--image`). See [presets.md](presets.md) |
-| `--mount <spec>`        |                      | Mount a host directory (`source:target[:mode]`, mode defaults to `rw`). Repeatable                                   |
-| `--env <KEY=VALUE>`     |                      | Set environment variable in the container. Repeatable                                                                |
-| `-i`, `--interactive`   | `false`              | Run interactively with TTY (for programs like `claude`)                                                              |
-| `--setup-script <path>` |                      | Mount a local script to `/etc/amikad/setup/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md)        |
+| Flag                    | Default              | Description                                                                                                                          |
+| ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `--script <path>`       |                      | Path to the script to execute (mutually exclusive with `--cmd`)                                                                      |
+| `--cmd <string>`        |                      | Bash command string to execute (mutually exclusive with `--script`)                                                                  |
+| `--outdir <path>`       | workdir              | Container directory to copy from. Absolute paths are used as-is; relative paths resolve from workdir                                 |
+| `--destdir <path>`      | **(required)**       | Host directory where output files are copied                                                                                         |
+| `--image <image>`       | `amika/coder:latest` | Docker image to use (mutually exclusive with `--preset`)                                                                             |
+| `--preset <name>`       |                      | Use a preset environment, e.g. `coder` or `claude` (mutually exclusive with `--image`). See [presets.md](presets.md)                 |
+| `--mount <spec>`        |                      | Mount a host directory (`source:target[:mode]`, mode defaults to `rw`). Repeatable                                                   |
+| `--env <KEY=VALUE>`     |                      | Set environment variable in the container. Repeatable                                                                                |
+| `-i`, `--interactive`   | `false`              | Run interactively with TTY (for programs like `claude`)                                                                              |
+| `--setup-script <path>` |                      | Mount a local script to `/usr/local/etc/amikad/setup/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md) |
 
 Script arguments can be passed after `--`:
 
@@ -291,18 +291,23 @@ The `Ports` field accepts an array of port binding objects. It is the HTTP API e
 ```json
 {
   "Ports": [
-    {"HostIP": "127.0.0.1", "HostPort": 8080, "ContainerPort": 80, "Protocol": "tcp"},
-    {"HostPort": 5432, "ContainerPort": 5432, "Protocol": "tcp"}
+    {
+      "HostIP": "127.0.0.1",
+      "HostPort": 8080,
+      "ContainerPort": 80,
+      "Protocol": "tcp"
+    },
+    { "HostPort": 5432, "ContainerPort": 5432, "Protocol": "tcp" }
   ]
 }
 ```
 
-| Field           | Required | Default     | Description                                                         |
-| --------------- | -------- | ----------- | ------------------------------------------------------------------- |
-| `HostPort`      | yes      |             | Port on the host (1–65535)                                          |
-| `ContainerPort` | yes      |             | Port inside the container (1–65535)                                 |
-| `Protocol`      | no       | `"tcp"`     | `"tcp"` or `"udp"`                                                  |
-| `HostIP`        | no       | `127.0.0.1` | Host IP to bind the port. Use `"0.0.0.0"` to bind all interfaces   |
+| Field           | Required | Default     | Description                                                      |
+| --------------- | -------- | ----------- | ---------------------------------------------------------------- |
+| `HostPort`      | yes      |             | Port on the host (1–65535)                                       |
+| `ContainerPort` | yes      |             | Port inside the container (1–65535)                              |
+| `Protocol`      | no       | `"tcp"`     | `"tcp"` or `"udp"`                                               |
+| `HostIP`        | no       | `127.0.0.1` | Host IP to bind the port. Use `"0.0.0.0"` to bind all interfaces |
 
 Duplicate bindings (same `HostIP:HostPort/Protocol`) are rejected with a 400 error.
 
@@ -310,7 +315,7 @@ Duplicate bindings (same `HostIP:HostPort/Protocol`) are rejected with a 400 err
 
 The HTTP API accepts some fields that are not available as CLI flags:
 
-- **`SetupScriptText`** (on `POST /v1/sandboxes`): Inline setup script content as a string. Amika writes it to a temporary file and mounts it as `/etc/amikad/setup/setup.sh`. Mutually exclusive with `SetupScript` (file path).
+- **`SetupScriptText`** (on `POST /v1/sandboxes`): Inline setup script content as a string. Amika writes it to a temporary file and mounts it as `/usr/local/etc/amikad/setup/setup.sh`. Mutually exclusive with `SetupScript` (file path).
 - **`GitRepo`** (on `POST /v1/sandboxes`): URL of a git repository to clone into the sandbox. The repo is cloned on the host, copied into a Docker volume, and mounted at `/home/amika/workspace/<repo-name>`. Supported schemes: `https://`, `http://`, `ssh://`, `file:///` (absolute paths only), and SCP-style (`git@host:path`). See [sandbox-configuration.md](sandbox-configuration.md) for details.
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -71,7 +71,7 @@ amika sandbox create --name dev-sandbox --port 3000:3000 --port-host-ip 0.0.0.0
 | `--port-host-ip <ip>`   | `127.0.0.1`          | Host IP address to bind all published ports to. Use `0.0.0.0` to bind to all interfaces                             |
 | `--yes`                 | `false`              | Skip mount confirmation prompt                                                                                       |
 | `--connect`             | `false`              | Connect to the sandbox shell immediately after creation                                                              |
-| `--setup-script <path>` |                      | Mount a local script to `/opt/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md)        |
+| `--setup-script <path>` |                      | Mount a local script to `/etc/amikad/setup/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md)        |
 
 #### Mount modes
 
@@ -239,7 +239,7 @@ amika materialize --setup-script ./install-deps.sh --cmd "echo done" --destdir /
 | `--mount <spec>`        |                      | Mount a host directory (`source:target[:mode]`, mode defaults to `rw`). Repeatable                                   |
 | `--env <KEY=VALUE>`     |                      | Set environment variable in the container. Repeatable                                                                |
 | `-i`, `--interactive`   | `false`              | Run interactively with TTY (for programs like `claude`)                                                              |
-| `--setup-script <path>` |                      | Mount a local script to `/opt/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md)        |
+| `--setup-script <path>` |                      | Mount a local script to `/etc/amikad/setup/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md)        |
 
 Script arguments can be passed after `--`:
 
@@ -310,7 +310,7 @@ Duplicate bindings (same `HostIP:HostPort/Protocol`) are rejected with a 400 err
 
 The HTTP API accepts some fields that are not available as CLI flags:
 
-- **`SetupScriptText`** (on `POST /v1/sandboxes`): Inline setup script content as a string. Amika writes it to a temporary file and mounts it as `/opt/setup.sh`. Mutually exclusive with `SetupScript` (file path).
+- **`SetupScriptText`** (on `POST /v1/sandboxes`): Inline setup script content as a string. Amika writes it to a temporary file and mounts it as `/etc/amikad/setup/setup.sh`. Mutually exclusive with `SetupScript` (file path).
 - **`GitRepo`** (on `POST /v1/sandboxes`): URL of a git repository to clone into the sandbox. The repo is cloned on the host, copied into a Docker volume, and mounted at `/home/amika/workspace/<repo-name>`. Supported schemes: `https://`, `http://`, `ssh://`, `file:///` (absolute paths only), and SCP-style (`git@host:path`). See [sandbox-configuration.md](sandbox-configuration.md) for details.
 
 ---

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -68,7 +68,7 @@ The next command that uses the preset will rebuild it.
 
 ## Setup Scripts
 
-Both presets include an ENTRYPOINT that runs `/etc/amikad/setup/setup.sh` before the main command. By default this is a no-op script. When creating a sandbox, use `--setup-script` to inject your own setup logic:
+Both presets include an ENTRYPOINT that runs `/usr/local/etc/amikad/setup/setup.sh` before the main command. By default this is a no-op script. When creating a sandbox, use `--setup-script` to inject your own setup logic:
 
 ```bash
 amika sandbox create --setup-script ./install-deps.sh

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -68,7 +68,7 @@ The next command that uses the preset will rebuild it.
 
 ## Setup Scripts
 
-Both presets include an ENTRYPOINT that runs `/opt/setup.sh` before the main command. By default this is a no-op script. When creating a sandbox, use `--setup-script` to inject your own setup logic:
+Both presets include an ENTRYPOINT that runs `/etc/amikad/setup/setup.sh` before the main command. By default this is a no-op script. When creating a sandbox, use `--setup-script` to inject your own setup logic:
 
 ```bash
 amika sandbox create --setup-script ./install-deps.sh

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -2,7 +2,7 @@
 
 ## Setup Scripts
 
-The `--setup-script` flag lets you mount a local script into the container at `/opt/setup.sh`. The script runs automatically when the container starts, before the main command (CMD).
+The `--setup-script` flag lets you mount a local script into the container at `/etc/amikad/setup/setup.sh`. The script runs automatically when the container starts, before the main command (CMD).
 
 ### Usage
 
@@ -30,12 +30,13 @@ The script is mounted read-only, so it cannot be modified from inside the contai
 
 ### How it works
 
-Preset images (coder, claude) bake a no-op `/opt/setup.sh` into the image and declare an ENTRYPOINT that runs it before execing into CMD:
+Preset images (coder, claude) bake a no-op `/etc/amikad/setup/setup.sh` into the image and declare an ENTRYPOINT that runs it before execing into CMD:
 
 ```dockerfile
-RUN printf '#!/bin/bash\nexit 0\n' > /opt/setup.sh \
-    && chmod +x /opt/setup.sh
-ENTRYPOINT ["/bin/bash", "-c", "/opt/setup.sh && exec \"$@\"", "--"]
+RUN mkdir -p /etc/amikad/setup \
+    && printf '#!/bin/bash\nexit 0\n' > /etc/amikad/setup/setup.sh \
+    && chmod +x /etc/amikad/setup/setup.sh
+ENTRYPOINT ["/bin/bash", "-c", "/etc/amikad/setup/setup.sh && exec \"$@\"", "--"]
 ```
 
 When you pass `--setup-script`, your script is bind-mounted over the no-op, so the ENTRYPOINT runs your script instead.
@@ -107,14 +108,14 @@ When you use `--git`, Amika looks for a `.amika/config.toml` file at the root of
 
 ```toml
 [lifecycle]
-# Path to an executable that is mounted into the container at /opt/setup.sh.
+# Path to an executable that is mounted into the container at /etc/amikad/setup/setup.sh.
 # Relative paths are resolved from the repository root.
 setup_script = "scripts/setup.sh"
 ```
 
 #### `[lifecycle].setup_script`
 
-Works exactly like `--setup-script`: the script is bind-mounted read-only at `/opt/setup.sh` and the container's ENTRYPOINT runs it before the main command.
+Works exactly like `--setup-script`: the script is bind-mounted read-only at `/etc/amikad/setup/setup.sh` and the container's ENTRYPOINT runs it before the main command.
 
 **Path resolution:** if the value is a relative path it is resolved from the repository root (the directory containing `.git`). Absolute paths are used as-is.
 
@@ -140,7 +141,7 @@ my-project/
     setup.sh          # must be executable (chmod +x)
 ```
 
-Running `amika sandbox create --git` from anywhere inside `my-project` will automatically mount `scripts/setup.sh` to `/opt/setup.sh` in the container.
+Running `amika sandbox create --git` from anywhere inside `my-project` will automatically mount `scripts/setup.sh` to `/etc/amikad/setup/setup.sh` in the container.
 
 ## Agent Credential Auto-Mounting
 

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -2,7 +2,7 @@
 
 ## Setup Scripts
 
-The `--setup-script` flag lets you mount a local script into the container at `/etc/amikad/setup/setup.sh`. The script runs automatically when the container starts, before the main command (CMD).
+The `--setup-script` flag lets you mount a local script into the container at `/usr/local/etc/amikad/setup/setup.sh`. The script runs automatically when the container starts, before the main command (CMD).
 
 ### Usage
 
@@ -30,13 +30,13 @@ The script is mounted read-only, so it cannot be modified from inside the contai
 
 ### How it works
 
-Preset images (coder, claude) bake a no-op `/etc/amikad/setup/setup.sh` into the image and declare an ENTRYPOINT that runs it before execing into CMD:
+Preset images (coder, claude) bake a no-op `/usr/local/etc/amikad/setup/setup.sh` into the image and declare an ENTRYPOINT that runs it before execing into CMD:
 
 ```dockerfile
-RUN mkdir -p /etc/amikad/setup \
-    && printf '#!/bin/bash\nexit 0\n' > /etc/amikad/setup/setup.sh \
-    && chmod +x /etc/amikad/setup/setup.sh
-ENTRYPOINT ["/bin/bash", "-c", "/etc/amikad/setup/setup.sh && exec \"$@\"", "--"]
+RUN mkdir -p /usr/local/etc/amikad/setup \
+    && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/setup.sh \
+    && chmod +x /usr/local/etc/amikad/setup/setup.sh
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/etc/amikad/setup/setup.sh && exec \"$@\"", "--"]
 ```
 
 When you pass `--setup-script`, your script is bind-mounted over the no-op, so the ENTRYPOINT runs your script instead.
@@ -108,14 +108,14 @@ When you use `--git`, Amika looks for a `.amika/config.toml` file at the root of
 
 ```toml
 [lifecycle]
-# Path to an executable that is mounted into the container at /etc/amikad/setup/setup.sh.
+# Path to an executable that is mounted into the container at /usr/local/etc/amikad/setup/setup.sh.
 # Relative paths are resolved from the repository root.
 setup_script = "scripts/setup.sh"
 ```
 
 #### `[lifecycle].setup_script`
 
-Works exactly like `--setup-script`: the script is bind-mounted read-only at `/etc/amikad/setup/setup.sh` and the container's ENTRYPOINT runs it before the main command.
+Works exactly like `--setup-script`: the script is bind-mounted read-only at `/usr/local/etc/amikad/setup/setup.sh` and the container's ENTRYPOINT runs it before the main command.
 
 **Path resolution:** if the value is a relative path it is resolved from the repository root (the directory containing `.git`). Absolute paths are used as-is.
 
@@ -141,7 +141,7 @@ my-project/
     setup.sh          # must be executable (chmod +x)
 ```
 
-Running `amika sandbox create --git` from anywhere inside `my-project` will automatically mount `scripts/setup.sh` to `/etc/amikad/setup/setup.sh` in the container.
+Running `amika sandbox create --git` from anywhere inside `my-project` will automatically mount `scripts/setup.sh` to `/usr/local/etc/amikad/setup/setup.sh` in the container.
 
 ## Agent Credential Auto-Mounting
 

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -17,7 +17,7 @@ type Config struct {
 
 // LifecycleConfig holds sandbox lifecycle hooks.
 type LifecycleConfig struct {
-	// SetupScript is the path to an executable to mount at /opt/setup.sh.
+	// SetupScript is the path to an executable to mount at /etc/amikad/setup/setup.sh.
 	// Relative paths are resolved from the repo root.
 	SetupScript string `toml:"setup_script"`
 }

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -17,7 +17,7 @@ type Config struct {
 
 // LifecycleConfig holds sandbox lifecycle hooks.
 type LifecycleConfig struct {
-	// SetupScript is the path to an executable to mount at /etc/amikad/setup/setup.sh.
+	// SetupScript is the path to an executable to mount at /usr/local/etc/amikad/setup/setup.sh.
 	// Relative paths are resolved from the repo root.
 	SetupScript string `toml:"setup_script"`
 }

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -27,19 +27,22 @@ RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code
 # Default no-op setup script; users can shadow it via --setup-script.
 # The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
 # don't need to include `exec "$@"` themselves.
-RUN printf '#!/bin/bash\nexit 0\n' > /opt/setup.sh \
-    && chmod +x /opt/setup.sh
+# We put setup.sh inside a setup/ directory so we can mount an entire setup
+# volume there.
+RUN mkdir -p /etc/amikad/setup \
+    && printf '#!/bin/bash\nexit 0\n' > /etc/amikad/setup/setup.sh \
+    && chmod +x /etc/amikad/setup/setup.sh
 
 # amikad is for the daemon
-RUN mkdir -p /var/log/amika /opt/amika /run/amika /etc/amikad
+RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /etc/amikad /var/lib/amikad
 
 # Amika hook scripts that run before/after the user setup script.
 # pre-setup.sh: clones repo, optionally starts opencode web.
 # post-setup.sh: chowns /home/amika to the amika user.
-RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /opt/amika/post-setup.sh \
-    && chmod +x /opt/amika/post-setup.sh
-COPY pre-setup.sh opencode-setup.sh /opt/amika/
-RUN chmod +x /opt/amika/pre-setup.sh /opt/amika/opencode-setup.sh
+RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
+    && chmod +x /usr/lib/amikad/post-setup.sh
+COPY pre-setup.sh opencode-setup.sh /usr/lib/amikad/
+RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/opencode-setup.sh
 
 # Create user with home directory
 RUN useradd -m -s /usr/bin/zsh amika
@@ -59,4 +62,4 @@ COPY --chown=amika:amika .zshrc /home/amika/.zshrc
 # We run the pre-setup and post-setup as root. setup runs as the amika user.
 # Pre and post-setup are not intended to be user-facing configuration. They are
 # for the amika system.
-ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /opt/amika/pre-setup.sh && /opt/setup.sh && sudo /opt/amika/post-setup.sh && exec \"$@\"", "--"]
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /usr/lib/amikad/pre-setup.sh && /etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -28,13 +28,14 @@ RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code
 # The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
 # don't need to include `exec "$@"` themselves.
 # We put setup.sh inside a setup/ directory so we can mount an entire setup
-# volume there.
-RUN mkdir -p /etc/amikad/setup \
-    && printf '#!/bin/bash\nexit 0\n' > /etc/amikad/setup/setup.sh \
-    && chmod +x /etc/amikad/setup/setup.sh
+# volume there. We use /usr/local/etc instead of /etc because some sandbox
+# providers ban mounting to /etc.
+RUN mkdir -p /usr/local/etc/amikad/setup \
+    && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/setup.sh \
+    && chmod +x /usr/local/etc/amikad/setup/setup.sh
 
 # amikad is for the daemon
-RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /etc/amikad /var/lib/amikad
+RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /usr/local/etc/amikad /var/lib/amikad
 
 # Amika hook scripts that run before/after the user setup script.
 # pre-setup.sh: clones repo, optionally starts opencode web.
@@ -62,4 +63,4 @@ COPY --chown=amika:amika .zshrc /home/amika/.zshrc
 # We run the pre-setup and post-setup as root. setup runs as the amika user.
 # Pre and post-setup are not intended to be user-facing configuration. They are
 # for the amika system.
-ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /usr/lib/amikad/pre-setup.sh && /etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /usr/lib/amikad/pre-setup.sh && /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -28,13 +28,14 @@ RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex o
 # The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
 # don't need to include `exec "$@"` themselves.
 # We put setup.sh inside a setup/ directory so we can mount an entire setup
-# volume there.
-RUN mkdir -p /etc/amikad/setup \
-    && printf '#!/bin/bash\nexit 0\n' > /etc/amikad/setup/setup.sh \
-    && chmod +x /etc/amikad/setup/setup.sh
+# volume there. We use /usr/local/etc instead of /etc because some sandbox
+# providers ban mounting to /etc.
+RUN mkdir -p /usr/local/etc/amikad/setup \
+    && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/setup.sh \
+    && chmod +x /usr/local/etc/amikad/setup/setup.sh
 
 # amikad is for the daemon
-RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /etc/amikad /var/lib/amikad
+RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /usr/local/etc/amikad /var/lib/amikad
 
 # Amika hook scripts that run before/after the user setup script.
 # pre-setup.sh: clones repo, optionally starts opencode web.
@@ -62,4 +63,4 @@ COPY --chown=amika:amika .zshrc /home/amika/.zshrc
 # We run the pre-setup and post-setup as root. setup runs as the amika user.
 # Pre and post-setup are not intended to be user-facing configuration. They are
 # for the amika system.
-ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /usr/lib/amikad/pre-setup.sh && /etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /usr/lib/amikad/pre-setup.sh && /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -27,19 +27,22 @@ RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex o
 # Default no-op setup script; users can shadow it via --setup-script.
 # The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
 # don't need to include `exec "$@"` themselves.
-RUN printf '#!/bin/bash\nexit 0\n' > /opt/setup.sh \
-    && chmod +x /opt/setup.sh
+# We put setup.sh inside a setup/ directory so we can mount an entire setup
+# volume there.
+RUN mkdir -p /etc/amikad/setup \
+    && printf '#!/bin/bash\nexit 0\n' > /etc/amikad/setup/setup.sh \
+    && chmod +x /etc/amikad/setup/setup.sh
 
 # amikad is for the daemon
-RUN mkdir -p /var/log/amika /opt/amika /run/amika /etc/amikad
+RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /etc/amikad /var/lib/amikad
 
 # Amika hook scripts that run before/after the user setup script.
 # pre-setup.sh: clones repo, optionally starts opencode web.
 # post-setup.sh: chowns /home/amika to the amika user.
-RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /opt/amika/post-setup.sh \
-    && chmod +x /opt/amika/post-setup.sh
-COPY pre-setup.sh opencode-setup.sh /opt/amika/
-RUN chmod +x /opt/amika/pre-setup.sh /opt/amika/opencode-setup.sh
+RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
+    && chmod +x /usr/lib/amikad/post-setup.sh
+COPY pre-setup.sh opencode-setup.sh /usr/lib/amikad/
+RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/opencode-setup.sh
 
 # Create user with home directory
 RUN useradd -m -s /usr/bin/zsh amika
@@ -59,4 +62,4 @@ COPY --chown=amika:amika .zshrc /home/amika/.zshrc
 # We run the pre-setup and post-setup as root. setup runs as the amika user.
 # Pre and post-setup are not intended to be user-facing configuration. They are
 # for the amika system.
-ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /opt/amika/pre-setup.sh && /opt/setup.sh && sudo /opt/amika/post-setup.sh && exec \"$@\"", "--"]
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /usr/lib/amikad/pre-setup.sh && /etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 OPENCODE_WEB_PORT=65535
 
-AMIKA_STATE_DIR="/var/lib/amika"
+AMIKA_STATE_DIR="/var/lib/amikad"
 AMIKA_CWD_FILE="$AMIKA_STATE_DIR/agent-cwd"
 
 if [[ -n "${AMIKA_AGENT_CWD:-}" ]]; then
@@ -27,13 +27,13 @@ if command -v opencode &> /dev/null; then
     exit 1
   fi
 
-  mkdir -p /var/log/amika
+  mkdir -p /var/log/amikad
 
   sudo -H -u amika \
     nohup env OPENCODE_SERVER_PASSWORD="$OPENCODE_SERVER_PASSWORD" \
-    /opt/amika/opencode-setup.sh "$amika_agent_cwd" "$OPENCODE_WEB_PORT" \
-    > /var/log/amika/opencode-web.log 2>&1 &
+    /usr/lib/amikad/opencode-setup.sh "$amika_agent_cwd" "$OPENCODE_WEB_PORT" \
+    > /var/log/amikad/opencode-web.log 2>&1 &
 
-  echo "$!" > /run/amika/opencode-web.pid
-  echo "$OPENCODE_WEB_PORT" > /run/amika/opencode-web.port
+  echo "$!" > /run/amikad/opencode-web.pid
+  echo "$OPENCODE_WEB_PORT" > /run/amikad/opencode-web.port
 fi

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -4,19 +4,33 @@ set -euo pipefail
 
 OPENCODE_WEB_PORT=65535
 
+AMIKA_STATE_DIR="/var/lib/amika"
+AMIKA_CWD_FILE="$AMIKA_STATE_DIR/agent-cwd"
+
 if [[ -n "${AMIKA_AGENT_CWD:-}" ]]; then
   amika_agent_cwd="$AMIKA_AGENT_CWD"
+elif [[ -f "$AMIKA_CWD_FILE" ]]; then
+  amika_agent_cwd="$(cat "$AMIKA_CWD_FILE")"
 else
   amika_agent_cwd="/home/amika/workspace"
 fi
+
+mkdir -p "$AMIKA_STATE_DIR"
+echo "$amika_agent_cwd" > "$AMIKA_CWD_FILE"
+
 cd "$amika_agent_cwd"
 
 # Start opencode web server in the background, if opencode is installed.
 if command -v opencode &> /dev/null; then
+  if [[ -z "${OPENCODE_SERVER_PASSWORD:-}" ]]; then
+    echo "ERROR: OPENCODE_SERVER_PASSWORD must be set when opencode is installed" >&2
+    exit 1
+  fi
+
   mkdir -p /var/log/amika
 
   sudo -H -u amika \
-    nohup env OPENCODE_SERVER_PASSWORD='fill-me-in' \
+    nohup env OPENCODE_SERVER_PASSWORD="$OPENCODE_SERVER_PASSWORD" \
     /opt/amika/opencode-setup.sh "$amika_agent_cwd" "$OPENCODE_WEB_PORT" \
     > /var/log/amika/opencode-web.log 2>&1 &
 

--- a/internal/sandbox/presets_test.go
+++ b/internal/sandbox/presets_test.go
@@ -48,7 +48,7 @@ func TestGetPresetDockerfile_PreservesAgentCWDForPreSetup(t *testing.T) {
 			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
 		}
 		content := string(data)
-		if !strings.Contains(content, `sudo AMIKA_AGENT_CWD=`) || !strings.Contains(content, `/opt/amika/pre-setup.sh`) {
+		if !strings.Contains(content, `sudo AMIKA_AGENT_CWD=`) || !strings.Contains(content, `/usr/lib/amikad/pre-setup.sh`) {
 			t.Fatalf("%s Dockerfile does not preserve AMIKA_AGENT_CWD for pre-setup", preset)
 		}
 	}

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -504,7 +504,7 @@ func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (sandbox.
 }
 
 func resolveSetupScriptMount(name, setupScriptPath, setupScriptText string) (*sandbox.MountBinding, func(), error) {
-	const setupScriptTarget = "/opt/setup.sh"
+	const setupScriptTarget = "/etc/amikad/setup/setup.sh"
 
 	if setupScriptPath != "" {
 		absSetupScript, err := filepath.Abs(setupScriptPath)

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -504,7 +504,7 @@ func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (sandbox.
 }
 
 func resolveSetupScriptMount(name, setupScriptPath, setupScriptText string) (*sandbox.MountBinding, func(), error) {
-	const setupScriptTarget = "/etc/amikad/setup/setup.sh"
+	const setupScriptTarget = "/usr/local/etc/amikad/setup/setup.sh"
 
 	if setupScriptPath != "" {
 		absSetupScript, err := filepath.Abs(setupScriptPath)


### PR DESCRIPTION
## Summary
- Move setup scripts from `/opt/setup.sh` to `/usr/local/etc/amikad/setup/setup.sh` — some sandbox providers (e.g. Daytona) ban mounting to `/etc`, so we use `/usr/local/etc` instead
- Move internal daemon scripts (`pre-setup.sh`, `post-setup.sh`, `opencode-setup.sh`) from `/opt/amika/` to `/usr/lib/amikad/`
- Rename runtime directories to use `amikad` suffix (`/var/log/amikad`, `/run/amikad`, `/var/lib/amikad`)
- Persist the resolved `AMIKA_AGENT_CWD` to `/var/lib/amikad/agent-cwd` so subsequent container runs remember the working directory
- Require `OPENCODE_SERVER_PASSWORD` to be set via env var instead of hardcoding a placeholder

## Test plan
- [x] Build both presets (`coder`, `claude`) and verify containers start correctly
- [x] Verify `--setup-script` still works with the new mount target
- [x] Verify `AMIKA_AGENT_CWD` persistence across container restarts
- [x] Verify opencode startup fails with a clear error when `OPENCODE_SERVER_PASSWORD` is unset
- [x] Run `make ci` to confirm tests pass

## Stack
1. `dylan/setup-daytona-tweaks` `#THIS` ← you are here
2. `dylan/daytona-specific-images` #63
3. `dylan/docker-amika-amikad` #64
4. `dylan/docker-fixes` #65