### PR TITLE
Add sandbox ssh command for remote SSH access

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1471,12 +1471,85 @@ func resolveGitURL(value string) (string, error) {
 	return origin, nil
 }
 
+var sandboxSSHCmd = &cobra.Command{
+	Use:   "ssh [name]",
+	Short: "SSH into a remote sandbox",
+	Long: `Connect to a remote sandbox via SSH, or revoke SSH access.
+
+Examples:
+  amika sandbox ssh my-sandbox
+  amika sandbox ssh --name my-sandbox
+  amika sandbox ssh my-sandbox --revoke`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
+		name, _ := cmd.Flags().GetString("name")
+		if len(args) > 0 {
+			name = args[0]
+		}
+		if name == "" {
+			return fmt.Errorf("sandbox name is required")
+		}
+
+		// Check if this is a local sandbox.
+		sandboxesFile, err := config.SandboxesStateFile()
+		if err == nil {
+			store := sandbox.NewStore(sandboxesFile)
+			if _, err := store.Get(name); err == nil {
+				return fmt.Errorf("SSH access currently only works for remote sandboxes; %q is a local sandbox", name)
+			}
+		}
+
+		client, err := getRemoteClient()
+		if err != nil {
+			return err
+		}
+
+		revoke, _ := cmd.Flags().GetBool("revoke")
+		if revoke {
+			// Get the current SSH token, then revoke it.
+			info, err := client.GetSSH(name)
+			if err != nil {
+				return err
+			}
+			if info.Token == "" {
+				return fmt.Errorf("no SSH token to revoke for sandbox %q", name)
+			}
+			if err := client.RevokeSSH(name, info.Token); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "SSH access revoked for sandbox %q\n", name)
+			return nil
+		}
+
+		info, err := client.GetSSH(name)
+		if err != nil {
+			return err
+		}
+
+		if info.SSHDestination == "" {
+			return fmt.Errorf("server returned empty SSH destination")
+		}
+
+		// Parse destination and exec ssh.
+		sshArgs := strings.Fields(info.SSHDestination)
+		sshCmd := exec.Command("ssh", sshArgs...)
+		sshCmd.Stdin = os.Stdin
+		sshCmd.Stdout = os.Stdout
+		sshCmd.Stderr = os.Stderr
+		return sshCmd.Run()
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(sandboxCmd)
 	sandboxCmd.AddCommand(sandboxCreateCmd)
 	sandboxCmd.AddCommand(sandboxDeleteCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxConnectCmd)
+	sandboxCmd.AddCommand(sandboxSSHCmd)
 
 	// Persistent flags for local/remote mode
 	sandboxCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
@@ -1501,4 +1574,6 @@ func init() {
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")
+	sandboxSSHCmd.Flags().String("name", "", "Name of the sandbox to SSH into")
+	sandboxSSHCmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
 }

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1472,26 +1472,19 @@ func resolveGitURL(value string) (string, error) {
 }
 
 var sandboxSSHCmd = &cobra.Command{
-	Use:   "ssh [name]",
+	Use:   "ssh <name>",
 	Short: "SSH into a remote sandbox",
 	Long: `Connect to a remote sandbox via SSH, or revoke SSH access.
 
 Examples:
   amika sandbox ssh my-sandbox
-  amika sandbox ssh --name my-sandbox
   amika sandbox ssh my-sandbox --revoke`,
-	Args: cobra.MaximumNArgs(1),
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 
-		name, _ := cmd.Flags().GetString("name")
-		if len(args) > 0 {
-			name = args[0]
-		}
-		if name == "" {
-			return fmt.Errorf("sandbox name is required")
-		}
+		name := args[0]
 
 		// Check if this is a local sandbox.
 		sandboxesFile, err := config.SandboxesStateFile()
@@ -1574,6 +1567,5 @@ func init() {
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")
-	sandboxSSHCmd.Flags().String("name", "", "Name of the sandbox to SSH into")
 	sandboxSSHCmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -67,6 +67,36 @@ func (c *Client) CreateSandbox(req CreateSandboxRequest) (*RemoteSandbox, error)
 	return &result, nil
 }
 
+// SSHInfo contains SSH connection details for a remote sandbox.
+type SSHInfo struct {
+	SSHDestination string `json:"ssh_destination"`
+	Token          string `json:"token"`
+	ExpiresAt      string `json:"expires_at"`
+}
+
+// GetSSH retrieves SSH connection details for a remote sandbox.
+func (c *Client) GetSSH(name string) (*SSHInfo, error) {
+	var result SSHInfo
+	if err := c.doJSON("POST", "/api/sandboxes/"+name+"/ssh", nil, &result); err != nil {
+		return nil, fmt.Errorf("remote ssh: %w", err)
+	}
+	return &result, nil
+}
+
+// RevokeSSHRequest is the request body for DELETE /api/sandboxes/{name}/ssh.
+type RevokeSSHRequest struct {
+	Token string `json:"token"`
+}
+
+// RevokeSSH revokes an SSH token for a remote sandbox.
+func (c *Client) RevokeSSH(name, token string) error {
+	req := RevokeSSHRequest{Token: token}
+	if err := c.doJSON("DELETE", "/api/sandboxes/"+name+"/ssh", req, nil); err != nil {
+		return fmt.Errorf("remote revoke ssh: %w", err)
+	}
+	return nil
+}
+
 // DeleteSandbox deletes a sandbox on the remote API.
 func (c *Client) DeleteSandbox(name string) error {
 	if err := c.doJSON("DELETE", "/api/sandboxes/"+name, nil, nil); err != nil {


### PR DESCRIPTION
- Add `amika sandbox ssh <name>` to connect to remote sandboxes via SSH
- Fetches SSH destination from POST /api/sandboxes/{name}/ssh and execs into an interactive ssh session
- Add --revoke flag to revoke SSH access (DELETE /api/sandboxes/{name}/ssh)
- Local sandboxes get a clear error: "SSH access currently only works for remote sandboxes"
- Add GetSSH and RevokeSSH methods to the API client