### PR TITLE
Split preset images into base and Daytona variants

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -5,10 +5,12 @@ set -euo pipefail
 #/
 #/ Build preset Docker images and tag them with the current git commit.
 #/ By default, builds for the host architecture. With --push-daytona,
-#/ builds for linux/amd64 (Daytona's architecture).
+#/ builds for linux/amd64 (Daytona's architecture) and only pushes the
+#/ Daytona variant images.
 #/
 #/ Arguments:
-#/   <image>              One of: amika/coder, amika/claude, all
+#/   <image>              One of: amika/base, amika/coder, amika/claude,
+#/                        amika/daytona-coder, amika/daytona-claude, all
 #/
 #/ Options:
 #/   --platform <plat>    Override build platform (linux/amd64 or linux/arm64)
@@ -58,8 +60,8 @@ fi
 
 # Validate image argument
 case "$IMAGE" in
-  amika/coder|amika/claude|all) ;;
-  *) echo "Error: <image> must be one of: amika/coder, amika/claude, all" >&2; exit 1 ;;
+  amika/base|amika/coder|amika/claude|amika/daytona-coder|amika/daytona-claude|all) ;;
+  *) echo "Error: <image> must be one of: amika/base, amika/coder, amika/claude, amika/daytona-coder, amika/daytona-claude, all" >&2; exit 1 ;;
 esac
 
 # Validate --platform value
@@ -97,12 +99,15 @@ fi
 # Determine git version tag
 VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
-# Determine which presets to build
+# Determine which presets to build in dependency order.
 PRESETS=()
 case "$IMAGE" in
-  amika/coder)  PRESETS=(coder) ;;
-  amika/claude) PRESETS=(claude) ;;
-  all)          PRESETS=(coder claude) ;;
+  amika/base)            PRESETS=(base) ;;
+  amika/coder)           PRESETS=(base coder) ;;
+  amika/claude)          PRESETS=(base claude) ;;
+  amika/daytona-coder)   PRESETS=(base coder daytona-coder) ;;
+  amika/daytona-claude)  PRESETS=(base claude daytona-claude) ;;
+  all)                   PRESETS=(base coder claude daytona-coder daytona-claude) ;;
 esac
 
 # Build images
@@ -110,16 +115,30 @@ for preset in "${PRESETS[@]}"; do
   image_tag="amika/${preset}:${VERSION}"
   dockerfile="$REPO_ROOT/internal/sandbox/presets/${preset}/Dockerfile"
 
-  platform_args=()
+  docker_args=(build)
   if [ -n "$PLATFORM" ]; then
-    platform_args=(--platform "$PLATFORM")
+    docker_args+=(--platform "$PLATFORM")
     echo "Building ${image_tag} (platform: ${PLATFORM}) from ${dockerfile}..."
   else
     echo "Building ${image_tag} from ${dockerfile}..."
   fi
-  docker build "${platform_args[@]}" -f "$dockerfile" -t "$image_tag" "$REPO_ROOT/internal/sandbox/presets"
 
-  if [ "$PUSH_DAYTONA" = true ]; then
+  case "$preset" in
+    coder|claude)
+      docker_args+=(--build-arg "BASE_IMAGE=amika/base:${VERSION}")
+      ;;
+    daytona-coder)
+      docker_args+=(--build-arg "CODER_IMAGE=amika/coder:${VERSION}")
+      ;;
+    daytona-claude)
+      docker_args+=(--build-arg "CLAUDE_IMAGE=amika/claude:${VERSION}")
+      ;;
+  esac
+
+  docker_args+=(-f "$dockerfile" -t "$image_tag" "$REPO_ROOT/internal/sandbox/presets")
+  docker "${docker_args[@]}"
+
+  if [ "$PUSH_DAYTONA" = true ] && [[ "$preset" == daytona-* ]]; then
     echo "Pushing ${image_tag} to Daytona..."
     daytona snapshot push "$image_tag" --name "$image_tag"
   fi

--- a/cmd/amika/materialize.go
+++ b/cmd/amika/materialize.go
@@ -88,6 +88,8 @@ Examples:
 			return fmt.Errorf("--destdir is required")
 		}
 
+		envStrs = appendPresetRuntimeEnv(envStrs)
+
 		mounts, err := parseMountFlags(mountStrs)
 		if err != nil {
 			return err

--- a/cmd/amika/materialize_test.go
+++ b/cmd/amika/materialize_test.go
@@ -183,16 +183,19 @@ func TestTopMaterialize_PresetAgentsAvailableOnPath(t *testing.T) {
 		name   string
 		preset string
 		cmdStr string
+		env    []string
 	}{
 		{
 			name:   "coder includes claude codex opencode",
 			preset: "coder",
 			cmdStr: "command -v claude && command -v codex && command -v opencode && echo ok > ready.txt",
+			env:    []string{"AMIKA_OPENCODE_WEB=0"},
 		},
 		{
 			name:   "claude includes only claude",
 			preset: "claude",
 			cmdStr: "command -v claude && ! command -v codex && ! command -v opencode && echo ok > ready.txt",
+			env:    []string{"AMIKA_OPENCODE_WEB=0"},
 		},
 	}
 
@@ -205,13 +208,15 @@ func TestTopMaterialize_PresetAgentsAvailableOnPath(t *testing.T) {
 			})
 
 			destdir := t.TempDir()
-			cmd := exec.Command(
-				bin, "materialize",
+			args := []string{
+				"materialize",
 				"--preset", tt.preset,
 				"--cmd", tt.cmdStr,
 				"--destdir", destdir,
-			)
-			cmd.Env = append(os.Environ(), "AMIKA_PRESET_IMAGE_PREFIX="+prefix)
+			}
+			cmd := exec.Command(bin, args...)
+			cmd.Env = withEnv(os.Environ(), "AMIKA_PRESET_IMAGE_PREFIX="+prefix)
+			cmd.Env = withEnv(cmd.Env, tt.env...)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("amika materialize failed: %v\n%s", err, out)
@@ -236,6 +241,27 @@ func requireExpensiveDockerTests(t *testing.T) {
 	if os.Getenv(runExpensiveTestsEnv) != "1" {
 		t.Skipf("set %s=1 to run expensive Docker rebuild tests", runExpensiveTestsEnv)
 	}
+}
+
+func withEnv(base []string, kvs ...string) []string {
+	env := append([]string(nil), base...)
+	for _, kv := range kvs {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			env = append(env, kv)
+			continue
+		}
+
+		prefix := key + "="
+		filtered := env[:0]
+		for _, existing := range env {
+			if !strings.HasPrefix(existing, prefix) {
+				filtered = append(filtered, existing)
+			}
+		}
+		env = append(filtered, kv)
+	}
+	return env
 }
 
 func requireDockerIntegration(t *testing.T) {

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -156,6 +156,7 @@ var sandboxCreateCmd = &cobra.Command{
 		if gitMountInfo != nil && !hasEnvKey(envStrs, "AMIKA_AGENT_CWD") {
 			envStrs = append(envStrs, "AMIKA_AGENT_CWD="+gitMountInfo.Mount.Target)
 		}
+		envStrs = appendPresetRuntimeEnv(envStrs)
 		if err := validateMountTargets(mounts, volumeMounts); err != nil {
 			return err
 		}
@@ -1534,6 +1535,18 @@ Examples:
 		sshCmd.Stderr = os.Stderr
 		return sshCmd.Run()
 	},
+}
+
+func appendPresetRuntimeEnv(env []string) []string {
+	for _, key := range []string{"OPENCODE_SERVER_PASSWORD", "AMIKA_OPENCODE_WEB"} {
+		if hasEnvKey(env, key) {
+			continue
+		}
+		if value, ok := os.LookupEnv(key); ok {
+			env = append(env, key+"="+value)
+		}
+	}
+	return env
 }
 
 func init() {

--- a/internal/sandbox/build_docker_images_script_test.go
+++ b/internal/sandbox/build_docker_images_script_test.go
@@ -1,0 +1,193 @@
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildDockerImagesScript_AllBuildsFullGraphAndPushesOnlyDaytona(t *testing.T) {
+	repoRoot := repoRootForScriptTest(t)
+	logDir := t.TempDir()
+	binDir := writeFakeCLIs(t, logDir)
+
+	cmd := exec.Command(filepath.Join(repoRoot, "bin", "build-docker-images"), "all", "--ignore-unstaged", "--push-daytona")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_LOG_DIR="+logDir,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, out)
+	}
+
+	dockerLines := readLogLines(t, filepath.Join(logDir, "docker.log"))
+	if len(dockerLines) != 5 {
+		t.Fatalf("docker build count = %d, want 5\nlines=%q", len(dockerLines), dockerLines)
+	}
+
+	wantOrder := []string{
+		"-t amika/base:abc123",
+		"-t amika/coder:abc123",
+		"-t amika/claude:abc123",
+		"-t amika/daytona-coder:abc123",
+		"-t amika/daytona-claude:abc123",
+	}
+	for i, want := range wantOrder {
+		if !strings.Contains(dockerLines[i], want) {
+			t.Fatalf("docker line %d = %q, want substring %q", i, dockerLines[i], want)
+		}
+	}
+	if !strings.Contains(dockerLines[1], "--build-arg BASE_IMAGE=amika/base:abc123") {
+		t.Fatalf("coder build args missing base image: %q", dockerLines[1])
+	}
+	if !strings.Contains(dockerLines[2], "--build-arg BASE_IMAGE=amika/base:abc123") {
+		t.Fatalf("claude build args missing base image: %q", dockerLines[2])
+	}
+	if !strings.Contains(dockerLines[3], "--build-arg CODER_IMAGE=amika/coder:abc123") {
+		t.Fatalf("daytona-coder build args missing coder image: %q", dockerLines[3])
+	}
+	if !strings.Contains(dockerLines[4], "--build-arg CLAUDE_IMAGE=amika/claude:abc123") {
+		t.Fatalf("daytona-claude build args missing claude image: %q", dockerLines[4])
+	}
+	for _, line := range dockerLines {
+		if !strings.Contains(line, "--platform linux/amd64") {
+			t.Fatalf("docker line missing linux/amd64 platform: %q", line)
+		}
+	}
+
+	daytonaLines := readLogLines(t, filepath.Join(logDir, "daytona.log"))
+	wantPushes := []string{
+		"snapshot push amika/daytona-coder:abc123 --name amika/daytona-coder:abc123",
+		"snapshot push amika/daytona-claude:abc123 --name amika/daytona-claude:abc123",
+	}
+	if len(daytonaLines) != len(wantPushes) {
+		t.Fatalf("daytona push count = %d, want %d\nlines=%q", len(daytonaLines), len(wantPushes), daytonaLines)
+	}
+	for i, want := range wantPushes {
+		if daytonaLines[i] != want {
+			t.Fatalf("daytona line %d = %q, want %q", i, daytonaLines[i], want)
+		}
+	}
+}
+
+func TestBuildDockerImagesScript_DaytonaTargetBuildsPrereqs(t *testing.T) {
+	repoRoot := repoRootForScriptTest(t)
+	logDir := t.TempDir()
+	binDir := writeFakeCLIs(t, logDir)
+
+	cmd := exec.Command(filepath.Join(repoRoot, "bin", "build-docker-images"), "amika/daytona-coder", "--ignore-unstaged")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_LOG_DIR="+logDir,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, out)
+	}
+
+	dockerLines := readLogLines(t, filepath.Join(logDir, "docker.log"))
+	if len(dockerLines) != 3 {
+		t.Fatalf("docker build count = %d, want 3\nlines=%q", len(dockerLines), dockerLines)
+	}
+	if !strings.Contains(dockerLines[0], "-t amika/base:abc123") {
+		t.Fatalf("first build should be base, got %q", dockerLines[0])
+	}
+	if !strings.Contains(dockerLines[1], "-t amika/coder:abc123") {
+		t.Fatalf("second build should be coder, got %q", dockerLines[1])
+	}
+	if !strings.Contains(dockerLines[2], "-t amika/daytona-coder:abc123") {
+		t.Fatalf("third build should be daytona-coder, got %q", dockerLines[2])
+	}
+}
+
+func TestBuildDockerImagesScript_RejectsArm64PushDaytona(t *testing.T) {
+	repoRoot := repoRootForScriptTest(t)
+	logDir := t.TempDir()
+	binDir := writeFakeCLIs(t, logDir)
+
+	cmd := exec.Command(filepath.Join(repoRoot, "bin", "build-docker-images"), "all", "--platform", "linux/arm64", "--push-daytona")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_LOG_DIR="+logDir,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected script to fail")
+	}
+	if !strings.Contains(string(out), "--push-daytona requires linux/amd64") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func repoRootForScriptTest(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(cwd, "..", ".."))
+}
+
+func writeFakeCLIs(t *testing.T, _ string) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	for name, body := range map[string]string{
+		"git": `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "status" ]; then
+    printf '%s' "${FAKE_GIT_STATUS:-}"
+    exit 0
+  fi
+  if [ "$arg" = "rev-parse" ]; then
+    echo "abc123"
+    exit 0
+  fi
+done
+exit 0
+`,
+		"docker": `#!/bin/sh
+echo "$*" >> "$FAKE_LOG_DIR/docker.log"
+exit 0
+`,
+		"daytona": `#!/bin/sh
+echo "$*" >> "$FAKE_LOG_DIR/daytona.log"
+exit 0
+`,
+	} {
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte(body), 0755); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	return binDir
+}
+
+func readLogLines(t *testing.T, path string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return nil
+	}
+	return strings.Split(text, "\n")
+}

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -30,8 +31,23 @@ func DockerImageExists(name string) bool {
 // BuildDockerImage builds a Docker image from a Dockerfile within the given
 // build context directory.
 func BuildDockerImage(name string, contextDir string, dockerfileRelPath string) error {
+	return buildDockerImageWithArgs(name, contextDir, dockerfileRelPath, nil)
+}
+
+func buildDockerImageWithArgs(name string, contextDir string, dockerfileRelPath string, buildArgs map[string]string) error {
 	dockerfilePath := filepath.Join(contextDir, dockerfileRelPath)
-	cmd := exec.Command("docker", "build", "-t", name, "-f", dockerfilePath, contextDir)
+	args := []string{"build", "-t", name, "-f", dockerfilePath}
+	keys := make([]string, 0, len(buildArgs))
+	for key := range buildArgs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		args = append(args, "--build-arg", key+"="+buildArgs[key])
+	}
+	args = append(args, contextDir)
+
+	cmd := exec.Command("docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/sandbox/image_resolution.go
+++ b/internal/sandbox/image_resolution.go
@@ -28,7 +28,6 @@ type PresetImageResult struct {
 
 var (
 	dockerImageExistsFn                 = DockerImageExists
-	buildDockerImageFn                  = BuildDockerImage
 	writePresetBuildContextFn           = WritePresetBuildContext
 	buildMessageWriter        io.Writer = os.Stdout
 )
@@ -60,9 +59,8 @@ func ResolveAndEnsureImage(opts PresetImageOptions) (PresetImageResult, error) {
 		}
 		defer cleanup()
 
-		dockerfileRelPath := result.BuildPreset + "/Dockerfile"
 		fmt.Fprintf(buildMessageWriter, "Building %q preset image (this may take a few minutes)...\n", result.BuildPreset)
-		if err := buildDockerImageFn(result.Image, contextDir, dockerfileRelPath); err != nil {
+		if err := buildPresetImageFn(result.BuildPreset, contextDir); err != nil {
 			return PresetImageResult{}, err
 		}
 	}

--- a/internal/sandbox/image_resolution_test.go
+++ b/internal/sandbox/image_resolution_test.go
@@ -11,7 +11,7 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherImageWins(t *testing.T) {
 
 	buildCalled := false
 	dockerImageExistsFn = func(_ string) bool { return true }
-	buildDockerImageFn = func(_ string, _ string, _ string) error {
+	buildPresetImageFn = func(_ string, _ string) error {
 		buildCalled = true
 		return nil
 	}
@@ -46,8 +46,8 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherNoAutoBuild(t *testing.T) {
 		t.Fatal("writePresetBuildContextFn should not be called")
 		return "", nil, nil
 	}
-	buildDockerImageFn = func(_ string, _ string, _ string) error {
-		t.Fatal("buildDockerImageFn should not be called")
+	buildPresetImageFn = func(_ string, _ string) error {
+		t.Fatal("buildPresetImageFn should not be called")
 		return nil
 	}
 
@@ -73,17 +73,15 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherNoAutoBuild(t *testing.T) {
 func TestResolveAndEnsureImage_ExplicitClaudePresetBuildsWhenMissing(t *testing.T) {
 	resetImageResolutionStubs(t)
 
-	var builtImage string
+	var builtPreset string
 	var builtContextDir string
-	var builtDockerfileRelPath string
 	dockerImageExistsFn = func(_ string) bool { return false }
 	writePresetBuildContextFn = func(_ string) (string, func(), error) {
 		return "/fake/context", func() {}, nil
 	}
-	buildDockerImageFn = func(name string, contextDir string, dockerfileRelPath string) error {
-		builtImage = name
+	buildPresetImageFn = func(preset string, contextDir string) error {
+		builtPreset = preset
 		builtContextDir = contextDir
-		builtDockerfileRelPath = dockerfileRelPath
 		return nil
 	}
 
@@ -104,27 +102,24 @@ func TestResolveAndEnsureImage_ExplicitClaudePresetBuildsWhenMissing(t *testing.
 	if res.BuildPreset != "claude" {
 		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "claude")
 	}
-	if builtImage != "amika/claude:latest" {
-		t.Fatalf("built image = %q, want %q", builtImage, "amika/claude:latest")
+	if builtPreset != "claude" {
+		t.Fatalf("built preset = %q, want %q", builtPreset, "claude")
 	}
 	if builtContextDir != "/fake/context" {
 		t.Fatalf("context dir = %q, want %q", builtContextDir, "/fake/context")
-	}
-	if builtDockerfileRelPath != "claude/Dockerfile" {
-		t.Fatalf("dockerfile rel path = %q, want %q", builtDockerfileRelPath, "claude/Dockerfile")
 	}
 }
 
 func TestResolveAndEnsureImage_ExplicitCoderPresetBuildsWhenMissing(t *testing.T) {
 	resetImageResolutionStubs(t)
 
-	var builtImage string
+	var builtPreset string
 	dockerImageExistsFn = func(_ string) bool { return false }
 	writePresetBuildContextFn = func(_ string) (string, func(), error) {
 		return "/fake/context", func() {}, nil
 	}
-	buildDockerImageFn = func(name string, _ string, _ string) error {
-		builtImage = name
+	buildPresetImageFn = func(preset string, _ string) error {
+		builtPreset = preset
 		return nil
 	}
 
@@ -145,8 +140,8 @@ func TestResolveAndEnsureImage_ExplicitCoderPresetBuildsWhenMissing(t *testing.T
 	if res.BuildPreset != "coder" {
 		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder")
 	}
-	if builtImage != DefaultCoderImage {
-		t.Fatalf("built image = %q, want %q", builtImage, DefaultCoderImage)
+	if builtPreset != "coder" {
+		t.Fatalf("built preset = %q, want %q", builtPreset, "coder")
 	}
 }
 
@@ -158,7 +153,7 @@ func TestResolveAndEnsureImage_DefaultBuildPresetWhenImageNotChanged(t *testing.
 	writePresetBuildContextFn = func(_ string) (string, func(), error) {
 		return "/fake/context", func() {}, nil
 	}
-	buildDockerImageFn = func(_ string, _ string, _ string) error {
+	buildPresetImageFn = func(_ string, _ string) error {
 		built = true
 		return nil
 	}
@@ -190,7 +185,7 @@ func TestResolveAndEnsureImage_NoDefaultBuildWhenImageChanged(t *testing.T) {
 	writePresetBuildContextFn = func(_ string) (string, func(), error) {
 		return "/fake/context", func() {}, nil
 	}
-	buildDockerImageFn = func(_ string, _ string, _ string) error {
+	buildPresetImageFn = func(_ string, _ string) error {
 		buildCalled = true
 		return nil
 	}
@@ -219,8 +214,8 @@ func TestResolveAndEnsureImage_CustomImageNoPresetSkipsPresetBuildAndNormalizati
 		t.Fatal("writePresetBuildContextFn should not be called")
 		return "", nil, nil
 	}
-	buildDockerImageFn = func(_ string, _ string, _ string) error {
-		t.Fatal("buildDockerImageFn should not be called")
+	buildPresetImageFn = func(_ string, _ string) error {
+		t.Fatal("buildPresetImageFn should not be called")
 		return nil
 	}
 
@@ -265,7 +260,7 @@ func TestResolveAndEnsureImage_SkipsBuildWhenImageExists(t *testing.T) {
 
 	buildCalled := false
 	dockerImageExistsFn = func(_ string) bool { return true }
-	buildDockerImageFn = func(_ string, _ string, _ string) error {
+	buildPresetImageFn = func(_ string, _ string) error {
 		buildCalled = true
 		return nil
 	}
@@ -324,14 +319,14 @@ func resetImageResolutionStubs(t *testing.T) {
 	t.Helper()
 
 	oldExists := dockerImageExistsFn
-	oldBuild := buildDockerImageFn
+	oldBuildPreset := buildPresetImageFn
 	oldWriteContext := writePresetBuildContextFn
 	oldWriter := buildMessageWriter
 	buildMessageWriter = &bytes.Buffer{}
 
 	t.Cleanup(func() {
 		dockerImageExistsFn = oldExists
-		buildDockerImageFn = oldBuild
+		buildPresetImageFn = oldBuildPreset
 		writePresetBuildContextFn = oldWriteContext
 		buildMessageWriter = oldWriter
 	})

--- a/internal/sandbox/pre_setup_test.go
+++ b/internal/sandbox/pre_setup_test.go
@@ -1,0 +1,48 @@
+package sandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPresetPreSetup_UsesFixedAmikaInternalPaths(t *testing.T) {
+	data, err := presetFS.ReadFile("presets/pre-setup.sh")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		`AMIKA_STATE_DIR="/var/lib/amikad"`,
+		`AMIKA_LOG_DIR="/var/log/amikad"`,
+		`AMIKA_RUN_DIR="/run/amikad"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("pre-setup.sh missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		`${AMIKA_STATE_DIR:-/var/lib/amikad}`,
+		`${AMIKA_LOG_DIR:-/var/log/amikad}`,
+		`${AMIKA_RUN_DIR:-/run/amikad}`,
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("pre-setup.sh should not allow overriding %q", forbidden)
+		}
+	}
+}
+
+func TestPresetPreSetup_OpenCodeGatingContract(t *testing.T) {
+	data, err := presetFS.ReadFile("presets/pre-setup.sh")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, `[[ "${AMIKA_OPENCODE_WEB:-1}" != "0" ]]`) {
+		t.Fatal("pre-setup.sh should allow opting out of opencode web startup via AMIKA_OPENCODE_WEB=0")
+	}
+	if !strings.Contains(content, `OPENCODE_SERVER_PASSWORD must be set`) {
+		t.Fatal("pre-setup.sh should require OPENCODE_SERVER_PASSWORD when opencode web startup is enabled")
+	}
+}

--- a/internal/sandbox/preset_build.go
+++ b/internal/sandbox/preset_build.go
@@ -1,0 +1,58 @@
+package sandbox
+
+import "fmt"
+
+var buildPresetImageFn = BuildPresetImage
+
+var buildDockerImageWithArgsFn = buildDockerImageWithArgs
+
+// BuildPresetImage builds a preset image and any prerequisite preset images
+// needed by its Dockerfile.
+func BuildPresetImage(preset string, contextDir string) error {
+	buildOrder, err := presetBuildOrder(preset)
+	if err != nil {
+		return err
+	}
+
+	for _, buildPreset := range buildOrder {
+		imageName := presetImageName(buildPreset)
+		if dockerImageExistsFn(imageName) {
+			continue
+		}
+		if err := buildDockerImageWithArgsFn(imageName, contextDir, buildPreset+"/Dockerfile", presetBuildArgs(buildPreset)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func presetBuildOrder(preset string) ([]string, error) {
+	switch preset {
+	case "base":
+		return []string{"base"}, nil
+	case "coder":
+		return []string{"base", "coder"}, nil
+	case "claude":
+		return []string{"base", "claude"}, nil
+	case "daytona-coder":
+		return []string{"base", "coder", "daytona-coder"}, nil
+	case "daytona-claude":
+		return []string{"base", "claude", "daytona-claude"}, nil
+	default:
+		return nil, fmt.Errorf("unknown preset %q", preset)
+	}
+}
+
+func presetBuildArgs(preset string) map[string]string {
+	switch preset {
+	case "coder", "claude":
+		return map[string]string{"BASE_IMAGE": presetImageName("base")}
+	case "daytona-coder":
+		return map[string]string{"CODER_IMAGE": presetImageName("coder")}
+	case "daytona-claude":
+		return map[string]string{"CLAUDE_IMAGE": presetImageName("claude")}
+	default:
+		return nil
+	}
+}

--- a/internal/sandbox/preset_build_test.go
+++ b/internal/sandbox/preset_build_test.go
@@ -1,0 +1,115 @@
+package sandbox
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestBuildPresetImage_BuildsDependenciesInOrder(t *testing.T) {
+	resetPresetBuildStubs(t)
+
+	var built []string
+	dockerImageExistsFn = func(_ string) bool { return false }
+	buildDockerImageWithArgsFn = func(name string, contextDir string, dockerfileRelPath string, buildArgs map[string]string) error {
+		built = append(built, fmt.Sprintf("%s|%s|%s|%v", name, contextDir, dockerfileRelPath, buildArgs))
+		return nil
+	}
+
+	if err := BuildPresetImage("daytona-coder", "/tmp/context"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{
+		"amika/base:latest|/tmp/context|base/Dockerfile|map[]",
+		"amika/coder:latest|/tmp/context|coder/Dockerfile|map[BASE_IMAGE:amika/base:latest]",
+		"amika/daytona-coder:latest|/tmp/context|daytona-coder/Dockerfile|map[CODER_IMAGE:amika/coder:latest]",
+	}
+	if !reflect.DeepEqual(built, want) {
+		t.Fatalf("built sequence = %#v, want %#v", built, want)
+	}
+}
+
+func TestBuildPresetImage_SkipsExistingDependencies(t *testing.T) {
+	resetPresetBuildStubs(t)
+
+	var built []string
+	dockerImageExistsFn = func(name string) bool { return name == "amika/base:latest" }
+	buildDockerImageWithArgsFn = func(name string, _ string, _ string, _ map[string]string) error {
+		built = append(built, name)
+		return nil
+	}
+
+	if err := BuildPresetImage("claude", "/tmp/context"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"amika/claude:latest"}
+	if !reflect.DeepEqual(built, want) {
+		t.Fatalf("built sequence = %#v, want %#v", built, want)
+	}
+}
+
+func TestBuildPresetImage_UsesPresetImagePrefixForDependencies(t *testing.T) {
+	resetPresetBuildStubs(t)
+	t.Setenv(presetImagePrefixEnv, "amika-test-789")
+
+	var built []string
+	dockerImageExistsFn = func(_ string) bool { return false }
+	buildDockerImageWithArgsFn = func(name string, _ string, _ string, buildArgs map[string]string) error {
+		built = append(built, fmt.Sprintf("%s|%v", name, buildArgs))
+		return nil
+	}
+
+	if err := BuildPresetImage("daytona-claude", "/tmp/context"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{
+		"amika-test-789-base:latest|map[]",
+		"amika-test-789-claude:latest|map[BASE_IMAGE:amika-test-789-base:latest]",
+		"amika-test-789-daytona-claude:latest|map[CLAUDE_IMAGE:amika-test-789-claude:latest]",
+	}
+	if !reflect.DeepEqual(built, want) {
+		t.Fatalf("built sequence = %#v, want %#v", built, want)
+	}
+}
+
+func TestBuildPresetImage_UnknownPreset(t *testing.T) {
+	resetPresetBuildStubs(t)
+
+	if err := BuildPresetImage("missing", "/tmp/context"); err == nil {
+		t.Fatal("expected error for unknown preset")
+	}
+}
+
+func resetPresetBuildStubs(t *testing.T) {
+	t.Helper()
+
+	oldExists := dockerImageExistsFn
+	oldBuild := buildDockerImageWithArgsFn
+
+	t.Cleanup(func() {
+		dockerImageExistsFn = oldExists
+		buildDockerImageWithArgsFn = oldBuild
+	})
+}
+
+func TestPresetBuildOrder(t *testing.T) {
+	t.Run("known preset", func(t *testing.T) {
+		order, err := presetBuildOrder("daytona-coder")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"base", "coder", "daytona-coder"}
+		if !reflect.DeepEqual(order, want) {
+			t.Fatalf("order = %#v, want %#v", order, want)
+		}
+	})
+
+	t.Run("unknown preset", func(t *testing.T) {
+		if _, err := presetBuildOrder("missing"); err == nil {
+			t.Fatal("expected error for unknown preset")
+		}
+	})
+}

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -1,0 +1,56 @@
+# Locally, this image is called "amika/base"
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    sudo \
+    zsh \
+    build-essential \
+    python3 \
+    python3-pip \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 22.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Default no-op setup script; users can shadow it via --setup-script.
+# We put setup.sh inside a setup/ directory so we can mount an entire setup
+# volume there. We use /usr/local/etc instead of /etc because some sandbox
+# providers ban mounting to /etc.
+RUN mkdir -p /usr/local/etc/amikad/setup \
+    && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/setup.sh \
+    && chmod +x /usr/local/etc/amikad/setup/setup.sh
+
+# amikad is for the daemon.
+RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /usr/local/etc/amikad /var/lib/amikad
+
+# Amika hook scripts that run before/after the user setup script.
+# pre-setup.sh: clones repo, optionally starts opencode web.
+# post-setup.sh: chowns /home/amika to the amika user.
+RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
+    && chmod +x /usr/lib/amikad/post-setup.sh
+COPY pre-setup.sh opencode-setup.sh /usr/lib/amikad/
+RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/opencode-setup.sh
+
+# Create user with home directory.
+RUN useradd -m -s /usr/bin/zsh amika
+RUN usermod -aG sudo amika
+# Let amika user run sudo without a password.
+RUN echo "amika ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Everything after this point runs as the amika user.
+USER amika
+
+ENV HOME=/home/amika
+RUN mkdir -p /home/amika
+WORKDIR /home/amika
+
+COPY --chown=amika:amika .zshrc /home/amika/.zshrc

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /usr/local/etc/amikad/setup \
 RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /usr/local/etc/amikad /var/lib/amikad
 
 # Amika hook scripts that run before/after the user setup script.
-# pre-setup.sh: clones repo, optionally starts opencode web.
+# pre-setup.sh: clones repo, optionally starts opencode web when enabled.
 # post-setup.sh: chowns /home/amika to the amika user.
 RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
     && chmod +x /usr/lib/amikad/post-setup.sh

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -1,64 +1,14 @@
 # Locally, this image is called "amika/claude"
 
-FROM ubuntu:24.04
+ARG BASE_IMAGE=amika/base:latest
+FROM ${BASE_IMAGE}
 
-ENV DEBIAN_FRONTEND=noninteractive
+USER root
 
-RUN apt-get update && apt-get install -y \
-    git \
-    curl \
-    sudo \
-    zsh \
-    build-essential \
-    python3 \
-    python3-pip \
-    ca-certificates \
-    gnupg \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Node.js 22
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install pnpm, TypeScript, and Claude Code CLI
+# Install pnpm, TypeScript, and Claude Code CLI.
 RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code
 
-# Default no-op setup script; users can shadow it via --setup-script.
-# The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
-# don't need to include `exec "$@"` themselves.
-# We put setup.sh inside a setup/ directory so we can mount an entire setup
-# volume there. We use /usr/local/etc instead of /etc because some sandbox
-# providers ban mounting to /etc.
-RUN mkdir -p /usr/local/etc/amikad/setup \
-    && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/setup.sh \
-    && chmod +x /usr/local/etc/amikad/setup/setup.sh
-
-# amikad is for the daemon
-RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /usr/local/etc/amikad /var/lib/amikad
-
-# Amika hook scripts that run before/after the user setup script.
-# pre-setup.sh: clones repo, optionally starts opencode web.
-# post-setup.sh: chowns /home/amika to the amika user.
-RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
-    && chmod +x /usr/lib/amikad/post-setup.sh
-COPY pre-setup.sh opencode-setup.sh /usr/lib/amikad/
-RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/opencode-setup.sh
-
-# Create user with home directory
-RUN useradd -m -s /usr/bin/zsh amika
-RUN usermod -aG sudo amika
-# Let amika user run sudo without a password
-RUN echo "amika ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-# Everything after this point runs as the amika user
 USER amika
-
-ENV HOME=/home/amika
-RUN mkdir -p /home/amika
-WORKDIR /home/amika
-
-COPY --chown=amika:amika .zshrc /home/amika/.zshrc
 
 # We run the pre-setup and post-setup as root. setup runs as the amika user.
 # Pre and post-setup are not intended to be user-facing configuration. They are

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -13,4 +13,4 @@ USER amika
 # We run the pre-setup and post-setup as root. setup runs as the amika user.
 # Pre and post-setup are not intended to be user-facing configuration. They are
 # for the amika system.
-ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /usr/lib/amikad/pre-setup.sh && /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/pre-setup.sh && /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -13,4 +13,4 @@ USER amika
 # We run the pre-setup and post-setup as root. setup runs as the amika user.
 # Pre and post-setup are not intended to be user-facing configuration. They are
 # for the amika system.
-ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" /usr/lib/amikad/pre-setup.sh && /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/pre-setup.sh && /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -1,64 +1,14 @@
 # Locally, this image is called "amika/coder"
 
-FROM ubuntu:24.04
+ARG BASE_IMAGE=amika/base:latest
+FROM ${BASE_IMAGE}
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y \
-    git \
-    curl \
-    sudo \
-    zsh \
-    build-essential \
-    python3 \
-    python3-pip \
-    ca-certificates \
-    gnupg \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Node.js 22
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/*
+USER root
 
 # Install coding agent CLIs.
 RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai
 
-# Default no-op setup script; users can shadow it via --setup-script.
-# The ENTRYPOINT runs the setup script then execs into CMD, so user scripts
-# don't need to include `exec "$@"` themselves.
-# We put setup.sh inside a setup/ directory so we can mount an entire setup
-# volume there. We use /usr/local/etc instead of /etc because some sandbox
-# providers ban mounting to /etc.
-RUN mkdir -p /usr/local/etc/amikad/setup \
-    && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/setup.sh \
-    && chmod +x /usr/local/etc/amikad/setup/setup.sh
-
-# amikad is for the daemon
-RUN mkdir -p /var/log/amikad /usr/lib/amikad /run/amikad /usr/local/etc/amikad /var/lib/amikad
-
-# Amika hook scripts that run before/after the user setup script.
-# pre-setup.sh: clones repo, optionally starts opencode web.
-# post-setup.sh: chowns /home/amika to the amika user.
-RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
-    && chmod +x /usr/lib/amikad/post-setup.sh
-COPY pre-setup.sh opencode-setup.sh /usr/lib/amikad/
-RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/opencode-setup.sh
-
-# Create user with home directory
-RUN useradd -m -s /usr/bin/zsh amika
-RUN usermod -aG sudo amika
-# Let amika user run sudo without a password
-RUN echo "amika ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-# Everything after this point runs as the amika user
 USER amika
-
-ENV HOME=/home/amika
-RUN mkdir -p /home/amika
-WORKDIR /home/amika
-
-COPY --chown=amika:amika .zshrc /home/amika/.zshrc
 
 # We run the pre-setup and post-setup as root. setup runs as the amika user.
 # Pre and post-setup are not intended to be user-facing configuration. They are

--- a/internal/sandbox/presets/daytona-claude/Dockerfile
+++ b/internal/sandbox/presets/daytona-claude/Dockerfile
@@ -1,0 +1,9 @@
+# Locally, this image is called "amika/daytona-claude"
+
+ARG CLAUDE_IMAGE=amika/claude:latest
+FROM ${CLAUDE_IMAGE}
+
+# In Daytona we do not manage container/sandbox lifecycle via Docker ENTRYPOINT.
+# That lifecycle is orchestrated by our external control plane, so the image
+# must not run Amika setup hooks from the Docker entrypoint.
+ENTRYPOINT []

--- a/internal/sandbox/presets/daytona-coder/Dockerfile
+++ b/internal/sandbox/presets/daytona-coder/Dockerfile
@@ -1,0 +1,9 @@
+# Locally, this image is called "amika/daytona-coder"
+
+ARG CODER_IMAGE=amika/coder:latest
+FROM ${CODER_IMAGE}
+
+# In Daytona we do not manage container/sandbox lifecycle via Docker ENTRYPOINT.
+# That lifecycle is orchestrated by our external control plane, so the image
+# must not run Amika setup hooks from the Docker entrypoint.
+ENTRYPOINT []

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 OPENCODE_WEB_PORT=65535
 
 AMIKA_STATE_DIR="/var/lib/amikad"
+AMIKA_LOG_DIR="/var/log/amikad"
+AMIKA_RUN_DIR="/run/amikad"
 AMIKA_CWD_FILE="$AMIKA_STATE_DIR/agent-cwd"
 
 if [[ -n "${AMIKA_AGENT_CWD:-}" ]]; then
@@ -20,20 +22,21 @@ echo "$amika_agent_cwd" > "$AMIKA_CWD_FILE"
 
 cd "$amika_agent_cwd"
 
-# Start opencode web server in the background, if opencode is installed.
-if command -v opencode &> /dev/null; then
+# Start opencode web server in the background by default when opencode is
+# installed, unless Amika explicitly disables it.
+if command -v opencode &> /dev/null && [[ "${AMIKA_OPENCODE_WEB:-1}" != "0" ]]; then
   if [[ -z "${OPENCODE_SERVER_PASSWORD:-}" ]]; then
     echo "ERROR: OPENCODE_SERVER_PASSWORD must be set when opencode is installed" >&2
     exit 1
   fi
 
-  mkdir -p /var/log/amikad
+  mkdir -p "$AMIKA_LOG_DIR" "$AMIKA_RUN_DIR"
 
   sudo -H -u amika \
     nohup env OPENCODE_SERVER_PASSWORD="$OPENCODE_SERVER_PASSWORD" \
     /usr/lib/amikad/opencode-setup.sh "$amika_agent_cwd" "$OPENCODE_WEB_PORT" \
-    > /var/log/amikad/opencode-web.log 2>&1 &
+    > "$AMIKA_LOG_DIR/opencode-web.log" 2>&1 &
 
-  echo "$!" > /run/amikad/opencode-web.pid
-  echo "$OPENCODE_WEB_PORT" > /run/amikad/opencode-web.port
+  echo "$!" > "$AMIKA_RUN_DIR/opencode-web.pid"
+  echo "$OPENCODE_WEB_PORT" > "$AMIKA_RUN_DIR/opencode-web.port"
 fi

--- a/internal/sandbox/presets_test.go
+++ b/internal/sandbox/presets_test.go
@@ -32,6 +32,22 @@ func TestGetPresetDockerfile_PreservesAgentCWDForPreSetup(t *testing.T) {
 	}
 }
 
+func TestGetPresetDockerfile_PreservesOpenCodeEnvForPreSetup(t *testing.T) {
+	for _, preset := range []string{"coder", "claude"} {
+		data, err := GetPresetDockerfile(preset)
+		if err != nil {
+			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
+		}
+		content := string(data)
+		if !strings.Contains(content, `AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\"`) {
+			t.Fatalf("%s Dockerfile does not preserve AMIKA_OPENCODE_WEB for pre-setup", preset)
+		}
+		if !strings.Contains(content, `OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\"`) {
+			t.Fatalf("%s Dockerfile does not preserve OPENCODE_SERVER_PASSWORD for pre-setup", preset)
+		}
+	}
+}
+
 func TestGetPresetDockerfile_DaytonaVariantsClearEntrypoint(t *testing.T) {
 	for _, preset := range []string{"daytona-coder", "daytona-claude"} {
 		data, err := GetPresetDockerfile(preset)

--- a/internal/sandbox/presets_test.go
+++ b/internal/sandbox/presets_test.go
@@ -7,37 +7,15 @@ import (
 	"testing"
 )
 
-func TestGetPresetDockerfile_CoderReturnsDockerfile(t *testing.T) {
-	data, err := GetPresetDockerfile("coder")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(data) == 0 {
-		t.Fatal("expected non-empty Dockerfile")
-	}
-}
-
-func TestGetPresetDockerfile_ClaudeReturnsDockerfile(t *testing.T) {
-	data, err := GetPresetDockerfile("claude")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(data) == 0 {
-		t.Fatal("expected non-empty Dockerfile")
-	}
-}
-
-func TestGetPresetDockerfile_CoderAndClaudeDiffer(t *testing.T) {
-	coderData, err := GetPresetDockerfile("coder")
-	if err != nil {
-		t.Fatalf("unexpected error loading coder preset: %v", err)
-	}
-	claudeData, err := GetPresetDockerfile("claude")
-	if err != nil {
-		t.Fatalf("unexpected error loading claude preset: %v", err)
-	}
-	if string(coderData) == string(claudeData) {
-		t.Fatal("expected coder and claude Dockerfiles to differ")
+func TestGetPresetDockerfile_ReturnsDockerfilesForKnownPresets(t *testing.T) {
+	for _, preset := range []string{"base", "coder", "claude", "daytona-coder", "daytona-claude"} {
+		data, err := GetPresetDockerfile(preset)
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %v", preset, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("expected non-empty Dockerfile for %s", preset)
+		}
 	}
 }
 
@@ -50,6 +28,22 @@ func TestGetPresetDockerfile_PreservesAgentCWDForPreSetup(t *testing.T) {
 		content := string(data)
 		if !strings.Contains(content, `sudo AMIKA_AGENT_CWD=`) || !strings.Contains(content, `/usr/lib/amikad/pre-setup.sh`) {
 			t.Fatalf("%s Dockerfile does not preserve AMIKA_AGENT_CWD for pre-setup", preset)
+		}
+	}
+}
+
+func TestGetPresetDockerfile_DaytonaVariantsClearEntrypoint(t *testing.T) {
+	for _, preset := range []string{"daytona-coder", "daytona-claude"} {
+		data, err := GetPresetDockerfile(preset)
+		if err != nil {
+			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
+		}
+		content := string(data)
+		if !strings.Contains(content, "ENTRYPOINT []") {
+			t.Fatalf("%s Dockerfile does not clear the inherited entrypoint", preset)
+		}
+		if strings.Contains(content, "/usr/local/etc/amikad/setup/setup.sh") || strings.Contains(content, "/usr/lib/amikad/pre-setup.sh") {
+			t.Fatalf("%s Dockerfile should not invoke Amika setup hooks", preset)
 		}
 	}
 }
@@ -81,14 +75,20 @@ func TestWritePresetBuildContext_ExtractsZshrc(t *testing.T) {
 		t.Fatal("expected non-empty .zshrc")
 	}
 
-	// Verify the preset Dockerfile exists.
-	dockerfilePath := filepath.Join(contextDir, "coder", "Dockerfile")
-	data, err = os.ReadFile(dockerfilePath)
-	if err != nil {
-		t.Fatalf("failed to read coder/Dockerfile from context dir: %v", err)
-	}
-	if len(data) == 0 {
-		t.Fatal("expected non-empty coder/Dockerfile")
+	for _, relPath := range []string{
+		filepath.Join("base", "Dockerfile"),
+		filepath.Join("coder", "Dockerfile"),
+		filepath.Join("claude", "Dockerfile"),
+		filepath.Join("daytona-coder", "Dockerfile"),
+		filepath.Join("daytona-claude", "Dockerfile"),
+	} {
+		data, err = os.ReadFile(filepath.Join(contextDir, relPath))
+		if err != nil {
+			t.Fatalf("failed to read %s from context dir: %v", relPath, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("expected non-empty %s", relPath)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extract shared Dockerfile logic into a new `base` preset image, reducing duplication between `claude` and `coder` presets
- Add `daytona-claude` and `daytona-coder` preset variants that extend the base images for Daytona sandbox environments
- Add `preset_build.go` with build orchestration for multi-stage preset images and update image resolution logic
- Preserve opencode startup environment variables in preset entrypoints
- Add tests for preset build scripts, pre-setup behavior, and image resolution

## Test plan
- [x] Build all preset images (base, claude, coder, daytona-claude, daytona-coder) successfully
- [x] Verify Daytona-specific images work in Daytona sandbox environments
- [x] Run `make ci` to confirm tests pass

## Stack
1. `dylan/setup-daytona-tweaks` #60
2. `dylan/daytona-specific-images` `#THIS` ← you are here
3. `dylan/docker-amika-amikad` #64
4. `dylan/docker-fixes` #65