### PR TITLE
Add lifecycle hook logging and Docker image tagging

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -113,14 +113,15 @@ esac
 # Build images
 for preset in "${PRESETS[@]}"; do
   image_tag="amika/${preset}:${VERSION}"
+  latest_tag="amika/${preset}:latest"
   dockerfile="$REPO_ROOT/internal/sandbox/presets/${preset}/Dockerfile"
 
   docker_args=(build)
   if [ -n "$PLATFORM" ]; then
     docker_args+=(--platform "$PLATFORM")
-    echo "Building ${image_tag} (platform: ${PLATFORM}) from ${dockerfile}..."
+    echo "Building ${image_tag} and ${latest_tag} (platform: ${PLATFORM}) from ${dockerfile}..."
   else
-    echo "Building ${image_tag} from ${dockerfile}..."
+    echo "Building ${image_tag} and ${latest_tag} from ${dockerfile}..."
   fi
 
   case "$preset" in
@@ -135,7 +136,7 @@ for preset in "${PRESETS[@]}"; do
       ;;
   esac
 
-  docker_args+=(-f "$dockerfile" -t "$image_tag" "$REPO_ROOT/internal/sandbox/presets")
+  docker_args+=(-f "$dockerfile" -t "$image_tag" -t "$latest_tag" "$REPO_ROOT/internal/sandbox/presets")
   docker "${docker_args[@]}"
 
   if [ "$PUSH_DAYTONA" = true ] && [[ "$preset" == daytona-* ]]; then

--- a/internal/sandbox/build_docker_images_script_test.go
+++ b/internal/sandbox/build_docker_images_script_test.go
@@ -31,15 +31,18 @@ func TestBuildDockerImagesScript_AllBuildsFullGraphAndPushesOnlyDaytona(t *testi
 	}
 
 	wantOrder := []string{
-		"-t amika/base:abc123",
-		"-t amika/coder:abc123",
-		"-t amika/claude:abc123",
-		"-t amika/daytona-coder:abc123",
-		"-t amika/daytona-claude:abc123",
+		"amika/base",
+		"amika/coder",
+		"amika/claude",
+		"amika/daytona-coder",
+		"amika/daytona-claude",
 	}
 	for i, want := range wantOrder {
-		if !strings.Contains(dockerLines[i], want) {
-			t.Fatalf("docker line %d = %q, want substring %q", i, dockerLines[i], want)
+		if !strings.Contains(dockerLines[i], "-t "+want+":abc123") {
+			t.Fatalf("docker line %d = %q, want hash tag for %q", i, dockerLines[i], want)
+		}
+		if !strings.Contains(dockerLines[i], "-t "+want+":latest") {
+			t.Fatalf("docker line %d = %q, want latest tag for %q", i, dockerLines[i], want)
 		}
 	}
 	if !strings.Contains(dockerLines[1], "--build-arg BASE_IMAGE=amika/base:abc123") {
@@ -96,13 +99,13 @@ func TestBuildDockerImagesScript_DaytonaTargetBuildsPrereqs(t *testing.T) {
 	if len(dockerLines) != 3 {
 		t.Fatalf("docker build count = %d, want 3\nlines=%q", len(dockerLines), dockerLines)
 	}
-	if !strings.Contains(dockerLines[0], "-t amika/base:abc123") {
+	if !strings.Contains(dockerLines[0], "-t amika/base:abc123") || !strings.Contains(dockerLines[0], "-t amika/base:latest") {
 		t.Fatalf("first build should be base, got %q", dockerLines[0])
 	}
-	if !strings.Contains(dockerLines[1], "-t amika/coder:abc123") {
+	if !strings.Contains(dockerLines[1], "-t amika/coder:abc123") || !strings.Contains(dockerLines[1], "-t amika/coder:latest") {
 		t.Fatalf("second build should be coder, got %q", dockerLines[1])
 	}
-	if !strings.Contains(dockerLines[2], "-t amika/daytona-coder:abc123") {
+	if !strings.Contains(dockerLines[2], "-t amika/daytona-coder:abc123") || !strings.Contains(dockerLines[2], "-t amika/daytona-coder:latest") {
 		t.Fatalf("third build should be daytona-coder, got %q", dockerLines[2])
 	}
 }

--- a/internal/sandbox/pre_setup_test.go
+++ b/internal/sandbox/pre_setup_test.go
@@ -97,3 +97,40 @@ func TestPresetPreSetup_OpenCodeGatingContract(t *testing.T) {
 		t.Fatal("pre-setup.sh should require OPENCODE_SERVER_PASSWORD when opencode web startup is enabled")
 	}
 }
+
+func TestPresetRunHook_LogsToAmikadHookSpecificFiles(t *testing.T) {
+	data, err := presetFS.ReadFile("presets/run-hook.sh")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		`log_dir="/var/log/amikad"`,
+		`log_file="$log_dir/${script_name%.sh}.log"`,
+		`exec >>"$log_file" 2>&1`,
+		`export BASH_ENV="/usr/lib/amikad/bash-error-prelude.sh"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("run-hook.sh missing %q", want)
+		}
+	}
+}
+
+func TestPresetBashErrorPrelude_LogsErrTrapDetails(t *testing.T) {
+	data, err := presetFS.ReadFile("presets/bash-error-prelude.sh")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		`trap 'status=$?; if [[ $status -ne 0 ]]; then`,
+		`ERROR ${AMIKA_HOOK_SCRIPT_NAME:-hook} exit=$status`,
+		`command=${BASH_COMMAND@Q}`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("bash-error-prelude.sh missing %q", want)
+		}
+	}
+}

--- a/internal/sandbox/pre_setup_test.go
+++ b/internal/sandbox/pre_setup_test.go
@@ -98,7 +98,7 @@ func TestPresetPreSetup_OpenCodeGatingContract(t *testing.T) {
 	}
 }
 
-func TestPresetRunHook_LogsToAmikadHookSpecificFiles(t *testing.T) {
+func TestPresetRunHook_UsesAmikaOnlyForSetupAndMirrorsItToAmikad(t *testing.T) {
 	data, err := presetFS.ReadFile("presets/run-hook.sh")
 	if err != nil {
 		t.Fatalf("ReadFile failed: %v", err)
@@ -106,9 +106,13 @@ func TestPresetRunHook_LogsToAmikadHookSpecificFiles(t *testing.T) {
 
 	content := string(data)
 	for _, want := range []string{
-		`log_dir="/var/log/amikad"`,
-		`log_file="$log_dir/${script_name%.sh}.log"`,
+		`daemon_log_dir="/var/log/amikad"`,
+		`daemon_log_file="$daemon_log_dir/${script_name%.sh}.log"`,
+		`if [[ "$script_name" == "setup.sh" ]]; then`,
+		`log_file="/var/log/amika/setup.log"`,
+		`mirror_to_daemon=1`,
 		`exec >>"$log_file" 2>&1`,
+		`sudo cp "$log_file" "$daemon_log_file"`,
 		`export BASH_ENV="/usr/lib/amikad/bash-error-prelude.sh"`,
 	} {
 		if !strings.Contains(content, want) {

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir -p \
 # setup.sh is user-supplied and runs second.
 # post-setup.sh runs last as root to restore expected ownership after setup.
 # run-hook.sh wraps each hook so stdout, stderr, and Bash ERR trap output land
-# in /var/log/amikad/<hook>.log.
+# in /var/log/amika/<hook>.log and are mirrored to /var/log/amikad/<hook>.log.
 RUN printf '#!/bin/bash\n# post-setup.sh runs after setup.sh as root.\n# It restores /home/amika ownership in case the user hook wrote files as root.\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
     && chmod +x /usr/lib/amikad/post-setup.sh
 COPY pre-setup.sh opencode-setup.sh run-hook.sh bash-error-prelude.sh /usr/lib/amikad/

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -65,5 +65,6 @@ USER amika
 ENV HOME=/home/amika
 RUN mkdir -p /home/amika
 WORKDIR /home/amika
+RUN mkdir -p /home/amika/workspace
 
 COPY --chown=amika:amika .zshrc /home/amika/.zshrc

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -22,9 +22,13 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Default no-op setup script; users can shadow it via --setup-script.
-# We put setup.sh inside a setup/ directory so we can mount an entire setup
-# volume there. We use /usr/local/etc instead of /etc because some sandbox
-# providers ban mounting to /etc.
+# This is the user-facing middle hook in the lifecycle:
+# 1. /usr/lib/amikad/pre-setup.sh
+# 2. /usr/local/etc/amikad/setup/setup.sh
+# 3. /usr/lib/amikad/post-setup.sh
+# We put setup.sh inside a setup/ directory so a whole setup volume can be
+# mounted there, and we use /usr/local/etc instead of /etc because some
+# sandbox providers ban mounting to /etc.
 RUN mkdir -p /usr/local/etc/amikad/setup \
     && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/setup.sh \
     && chmod +x /usr/local/etc/amikad/setup/setup.sh
@@ -38,13 +42,16 @@ RUN mkdir -p \
     /var/lib/amikad /var/lib/amika \
     /tmp/amikad /tmp/amika
 
-# Amika hook scripts that run before/after the user setup script.
-# pre-setup.sh: clones repo, optionally starts opencode web when enabled.
-# post-setup.sh: chowns /home/amika to the amika user.
-RUN printf '#!/bin/bash\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
+# Amika lifecycle hooks:
+# pre-setup.sh runs first as root for Amika-managed initialization.
+# setup.sh is user-supplied and runs second.
+# post-setup.sh runs last as root to restore expected ownership after setup.
+# run-hook.sh wraps each hook so stdout, stderr, and Bash ERR trap output land
+# in /var/log/amikad/<hook>.log.
+RUN printf '#!/bin/bash\n# post-setup.sh runs after setup.sh as root.\n# It restores /home/amika ownership in case the user hook wrote files as root.\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
     && chmod +x /usr/lib/amikad/post-setup.sh
-COPY pre-setup.sh opencode-setup.sh /usr/lib/amikad/
-RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/opencode-setup.sh
+COPY pre-setup.sh opencode-setup.sh run-hook.sh bash-error-prelude.sh /usr/lib/amikad/
+RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/opencode-setup.sh /usr/lib/amikad/run-hook.sh
 
 # Create user with home directory.
 RUN useradd -m -s /usr/bin/zsh amika

--- a/internal/sandbox/presets/bash-error-prelude.sh
+++ b/internal/sandbox/presets/bash-error-prelude.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This file is sourced by Bash via BASH_ENV before each lifecycle hook runs.
+# It installs an ERR trap that records the failing command, exit status, and
+# best-effort line information into the hook log opened by run-hook.sh.
+
+set -E
+
+trap 'status=$?; if [[ $status -ne 0 ]]; then line="$(caller 0 2>/dev/null || true)"; echo "[$(date -Is)] ERROR ${AMIKA_HOOK_SCRIPT_NAME:-hook} exit=$status line=${line:-unknown} command=${BASH_COMMAND@Q}" >&2; fi' ERR

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -14,6 +14,6 @@ USER amika
 # pre-setup and post-setup run as root because they manage container-owned
 # state. setup.sh runs as the amika user because it is the user-facing hook.
 # Each hook is invoked through run-hook.sh so its stdout, stderr, and ERR trap
-# output are written to /var/log/amikad/pre-setup.log, setup.log, and
-# post-setup.log.
+# output are written to /var/log/amika/*.log and mirrored to
+# /var/log/amikad/*.log.
 ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/run-hook.sh /usr/lib/amikad/pre-setup.sh && /usr/lib/amikad/run-hook.sh /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/run-hook.sh /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -10,7 +10,10 @@ RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code
 
 USER amika
 
-# We run the pre-setup and post-setup as root. setup runs as the amika user.
-# Pre and post-setup are not intended to be user-facing configuration. They are
-# for the amika system.
-ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/pre-setup.sh && /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]
+# Lifecycle order is pre-setup -> setup -> post-setup.
+# pre-setup and post-setup run as root because they manage container-owned
+# state. setup.sh runs as the amika user because it is the user-facing hook.
+# Each hook is invoked through run-hook.sh so its stdout, stderr, and ERR trap
+# output are written to /var/log/amikad/pre-setup.log, setup.log, and
+# post-setup.log.
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/run-hook.sh /usr/lib/amikad/pre-setup.sh && /usr/lib/amikad/run-hook.sh /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/run-hook.sh /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -14,6 +14,6 @@ USER amika
 # pre-setup and post-setup run as root because they manage container-owned
 # state. setup.sh runs as the amika user because it is the user-facing hook.
 # Each hook is invoked through run-hook.sh so its stdout, stderr, and ERR trap
-# output are written to /var/log/amikad/pre-setup.log, setup.log, and
-# post-setup.log.
+# output are written to /var/log/amika/*.log and mirrored to
+# /var/log/amikad/*.log.
 ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/run-hook.sh /usr/lib/amikad/pre-setup.sh && /usr/lib/amikad/run-hook.sh /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/run-hook.sh /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -10,7 +10,10 @@ RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex o
 
 USER amika
 
-# We run the pre-setup and post-setup as root. setup runs as the amika user.
-# Pre and post-setup are not intended to be user-facing configuration. They are
-# for the amika system.
-ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/pre-setup.sh && /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]
+# Lifecycle order is pre-setup -> setup -> post-setup.
+# pre-setup and post-setup run as root because they manage container-owned
+# state. setup.sh runs as the amika user because it is the user-facing hook.
+# Each hook is invoked through run-hook.sh so its stdout, stderr, and ERR trap
+# output are written to /var/log/amikad/pre-setup.log, setup.log, and
+# post-setup.log.
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/run-hook.sh /usr/lib/amikad/pre-setup.sh && /usr/lib/amikad/run-hook.sh /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/run-hook.sh /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# pre-setup.sh runs first as root for Amika-managed container initialization.
+# It creates fixed amikad/amika directories, remembers the agent working
+# directory, switches into that directory, and optionally starts opencode web
+# before the user-facing setup.sh hook runs.
+
 set -euo pipefail
 
 OPENCODE_WEB_PORT=65535
@@ -37,7 +42,8 @@ echo "$amika_agent_cwd" > "$AMIKA_CWD_FILE"
 cd "$amika_agent_cwd"
 
 # Start opencode web server in the background by default when opencode is
-# installed, unless Amika explicitly disables it.
+# installed, unless Amika explicitly disables it. Output is redirected to
+# /var/log/amikad/opencode-web.log because the server outlives this hook.
 if command -v opencode &> /dev/null && [[ "${AMIKA_OPENCODE_WEB:-1}" != "0" ]]; then
   if [[ -z "${OPENCODE_SERVER_PASSWORD:-}" ]]; then
     echo "ERROR: OPENCODE_SERVER_PASSWORD must be set when opencode is installed" >&2

--- a/internal/sandbox/presets/run-hook.sh
+++ b/internal/sandbox/presets/run-hook.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # run-hook.sh is the stable entrypoint for all setup lifecycle hooks.
-# It executes one hook script, routes stdout/stderr into
-# /var/log/amikad/<hook>.log, and injects a Bash ERR trap via BASH_ENV so
-# command failures are also written to the same log.
+# It executes one hook script and injects a Bash ERR trap via BASH_ENV so
+# command failures are written to the same log. setup.sh logs to
+# /var/log/amika/setup.log so the amika user can write it, then mirrors the
+# finished file to /var/log/amikad/setup.log. Root-owned hooks log directly to
+# /var/log/amikad.
 
 set -Eeuo pipefail
 
@@ -14,10 +16,17 @@ fi
 
 script_path="$1"
 script_name="$(basename "$script_path")"
-log_dir="/var/log/amikad"
-log_file="$log_dir/${script_name%.sh}.log"
+daemon_log_dir="/var/log/amikad"
+daemon_log_file="$daemon_log_dir/${script_name%.sh}.log"
+log_file="$daemon_log_file"
+mirror_to_daemon=0
 
-mkdir -p "$log_dir"
+if [[ "$script_name" == "setup.sh" ]]; then
+  log_file="/var/log/amika/setup.log"
+  mirror_to_daemon=1
+fi
+
+mkdir -p "$(dirname "$log_file")"
 touch "$log_file"
 
 export AMIKA_HOOK_SCRIPT_NAME="$script_name"
@@ -33,4 +42,17 @@ status=$?
 set -e
 
 echo "[$(date -Is)] finished $script_name exit=$status"
+
+if [[ $mirror_to_daemon -eq 1 ]]; then
+  set +e
+  sudo mkdir -p "$daemon_log_dir"
+  sudo cp "$log_file" "$daemon_log_file"
+  copy_status=$?
+  set -e
+
+  if [[ $copy_status -ne 0 ]]; then
+    echo "[$(date -Is)] failed to mirror $script_name log to $daemon_log_file" >&2
+  fi
+fi
+
 exit "$status"

--- a/internal/sandbox/presets/run-hook.sh
+++ b/internal/sandbox/presets/run-hook.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# run-hook.sh is the stable entrypoint for all setup lifecycle hooks.
+# It executes one hook script, routes stdout/stderr into
+# /var/log/amikad/<hook>.log, and injects a Bash ERR trap via BASH_ENV so
+# command failures are also written to the same log.
+
+set -Eeuo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <script>" >&2
+  exit 64
+fi
+
+script_path="$1"
+script_name="$(basename "$script_path")"
+log_dir="/var/log/amikad"
+log_file="$log_dir/${script_name%.sh}.log"
+
+mkdir -p "$log_dir"
+touch "$log_file"
+
+export AMIKA_HOOK_SCRIPT_NAME="$script_name"
+export BASH_ENV="/usr/lib/amikad/bash-error-prelude.sh"
+
+exec >>"$log_file" 2>&1
+
+echo "[$(date -Is)] starting $script_name"
+
+set +e
+"$script_path"
+status=$?
+set -e
+
+echo "[$(date -Is)] finished $script_name exit=$status"
+exit "$status"

--- a/internal/sandbox/presets_test.go
+++ b/internal/sandbox/presets_test.go
@@ -26,7 +26,7 @@ func TestGetPresetDockerfile_PreservesAgentCWDForPreSetup(t *testing.T) {
 			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
 		}
 		content := string(data)
-		if !strings.Contains(content, `sudo AMIKA_AGENT_CWD=`) || !strings.Contains(content, `/usr/lib/amikad/pre-setup.sh`) {
+		if !strings.Contains(content, `sudo AMIKA_AGENT_CWD=`) || !strings.Contains(content, `/usr/lib/amikad/run-hook.sh /usr/lib/amikad/pre-setup.sh`) {
 			t.Fatalf("%s Dockerfile does not preserve AMIKA_AGENT_CWD for pre-setup", preset)
 		}
 	}
@@ -44,6 +44,25 @@ func TestGetPresetDockerfile_PreservesOpenCodeEnvForPreSetup(t *testing.T) {
 		}
 		if !strings.Contains(content, `OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\"`) {
 			t.Fatalf("%s Dockerfile does not preserve OPENCODE_SERVER_PASSWORD for pre-setup", preset)
+		}
+	}
+}
+
+func TestGetPresetDockerfile_RunsAllHooksThroughLogger(t *testing.T) {
+	for _, preset := range []string{"coder", "claude"} {
+		data, err := GetPresetDockerfile(preset)
+		if err != nil {
+			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
+		}
+		content := string(data)
+		for _, want := range []string{
+			`/usr/lib/amikad/run-hook.sh /usr/lib/amikad/pre-setup.sh`,
+			`/usr/lib/amikad/run-hook.sh /usr/local/etc/amikad/setup/setup.sh`,
+			`/usr/lib/amikad/run-hook.sh /usr/lib/amikad/post-setup.sh`,
+		} {
+			if !strings.Contains(content, want) {
+				t.Fatalf("%s Dockerfile missing hook logger invocation %q", preset, want)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `run-hook.sh` script that wraps lifecycle hook execution with structured logging to `/var/log/amikad/`
- Add `bash-error-prelude.sh` for consistent error handling in shell scripts
- Route setup hook execution through amika's logging before mirroring output
- Tag Docker images with `latest` in addition to versioned tags in `build-docker-images`
- Ensure `/home/amika/workspace` directory exists in the base Dockerfile

## Test plan
- [x] Build preset images and verify hook logging works during container startup
- [x] Verify `run-hook.sh` captures stdout/stderr to log files
- [x] Verify `build-docker-images` script tags images with `latest`
- [x] Run `make ci` to confirm tests pass

## Stack
1. `dylan/setup-daytona-tweaks` #60
2. `dylan/daytona-specific-images` #63
3. `dylan/docker-amika-amikad` #64
4. `dylan/docker-fixes` `#THIS` ← you are here