### PR TITLE
feat: only require OPENCODE_SERVER_PASSWORD for local-docker provider

### DIFF
--- a/cmd/amika/materialize.go
+++ b/cmd/amika/materialize.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gofixpoint/amika/internal/agentconfig"
+	"github.com/gofixpoint/amika/internal/constants"
 	"github.com/gofixpoint/amika/internal/sandbox"
 	"github.com/spf13/cobra"
 )
@@ -89,6 +90,9 @@ Examples:
 		}
 
 		envStrs = appendPresetRuntimeEnv(envStrs)
+		if !hasEnvKey(envStrs, constants.EnvSandboxProvider) {
+			envStrs = append(envStrs, constants.EnvSandboxProvider+"="+constants.ProviderLocalDocker)
+		}
 
 		mounts, err := parseMountFlags(mountStrs)
 		if err != nil {

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gofixpoint/amika/internal/apiclient"
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/gofixpoint/amika/internal/config"
+	"github.com/gofixpoint/amika/internal/constants"
 	"github.com/gofixpoint/amika/internal/sandbox"
 	"github.com/gofixpoint/amika/internal/txn"
 	"github.com/gofixpoint/amika/pkg/amika"
@@ -157,6 +158,9 @@ var sandboxCreateCmd = &cobra.Command{
 			envStrs = append(envStrs, "AMIKA_AGENT_CWD="+gitMountInfo.Mount.Target)
 		}
 		envStrs = appendPresetRuntimeEnv(envStrs)
+		if !hasEnvKey(envStrs, constants.EnvSandboxProvider) {
+			envStrs = append(envStrs, constants.EnvSandboxProvider+"="+constants.ProviderLocalDocker)
+		}
 		if err := validateMountTargets(mounts, volumeMounts); err != nil {
 			return err
 		}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,11 @@
+// Package constants defines shared constant values used across the amika codebase.
+package constants
+
+const (
+	// EnvSandboxProvider is the environment variable name that identifies the
+	// sandbox provider inside a running container.
+	EnvSandboxProvider = "AMIKA_SANDBOX_PROVIDER"
+
+	// ProviderLocalDocker is the provider value for local Docker sandboxes.
+	ProviderLocalDocker = "local-docker"
+)

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -45,7 +45,7 @@ cd "$amika_agent_cwd"
 # installed, unless Amika explicitly disables it. Output is redirected to
 # /var/log/amikad/opencode-web.log because the server outlives this hook.
 if command -v opencode &> /dev/null && [[ "${AMIKA_OPENCODE_WEB:-1}" != "0" ]]; then
-  if [[ -z "${OPENCODE_SERVER_PASSWORD:-}" ]]; then
+  if [[ "${AMIKA_SANDBOX_PROVIDER:-}" == "local-docker" ]] && [[ -z "${OPENCODE_SERVER_PASSWORD:-}" ]]; then
     echo "ERROR: OPENCODE_SERVER_PASSWORD must be set when opencode is installed" >&2
     exit 1
   fi

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/gofixpoint/amika/internal/config"
+	"github.com/gofixpoint/amika/internal/constants"
 	"github.com/gofixpoint/amika/internal/materialize"
 	"github.com/gofixpoint/amika/internal/sandbox"
 )
@@ -120,6 +121,9 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		if !hasEnvKey(req.Env, "AMIKA_AGENT_CWD") {
 			req.Env = append(req.Env, "AMIKA_AGENT_CWD="+gitMount.Target)
 		}
+	}
+	if !hasEnvKey(req.Env, constants.EnvSandboxProvider) {
+		req.Env = append(req.Env, constants.EnvSandboxProvider+"="+constants.ProviderLocalDocker)
 	}
 	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env, toSandboxPortBindings(ports))
 	if err != nil {


### PR DESCRIPTION
Non-local providers (e.g. remote/cloud) may not have the password available, so the pre-setup.sh check is now conditional on AMIKA_SANDBOX_PROVIDER=local-docker. Local sandbox and materialize codepaths inject this env var automatically.