### PR TITLE
feat: reserve ports 60899-60999 for internal sandbox services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Amika is a Go module that lets people control sandboxed AI agents, focused on us
 - Linting uses [revive](https://github.com/mgechev/revive) — config in `revive.toml`
 - All exported symbols must have doc comments (enforced by the `exported` rule)
 - No external dependencies need to be installed for linting; `make lint` uses `go run`
+- Ports 60899–60999 are reserved inside sandbox containers for Amika services. See `docs/sandbox-configuration.md` for the allocation table.
 
 ## Testing Notes
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -91,6 +91,13 @@ Use `amikad` paths for Amika-managed daemon and system files. Use `amika` paths 
 
 The user-supplied setup hook remains at `/usr/local/etc/amikad/setup/setup.sh`.
 
+## Reserved Ports
+
+Preset images reserve container ports 60899–60999 for Amika internal services
+(e.g. OpenCode web on 60998, amikad daemon on 60999). See
+[sandbox-configuration.md](sandbox-configuration.md#reserved-ports) for the
+full allocation table.
+
 ## Image Name Prefix
 
 Set the `AMIKA_PRESET_IMAGE_PREFIX` environment variable to override the default image name prefix. For example:

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -160,3 +160,19 @@ The container receives copies of the files — the originals on the host are nev
 Only files that exist on the host are mounted. Inside the container, they appear at the same relative paths under `/home/amika/`.
 
 This behavior is automatic and requires no flags. See [presets.md](presets.md) for more details on preset images.
+
+## Reserved Ports
+
+Amika reserves container ports **60899–60999** (101 ports) for internal
+services that run inside sandboxes. User workloads and setup scripts should
+avoid binding to ports in this range.
+
+| Port        | Service                          | Status   |
+| ----------- | -------------------------------- | -------- |
+| 60999       | amikad daemon                    | Reserved |
+| 60998       | OpenCode web UI                  | Active   |
+| 60899–60997 | *(unassigned, reserved for use)* | Reserved |
+
+The OpenCode web server starts automatically on port 60998 when OpenCode is
+installed in the container and `AMIKA_OPENCODE_WEB` is not set to `0`. The
+port number is written to `/run/amikad/opencode-web.port` at startup.

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -7,7 +7,12 @@
 
 set -euo pipefail
 
-OPENCODE_WEB_PORT=65535
+# Amika reserves container ports 60899-60999 for internal sandbox services.
+# See docs/sandbox-configuration.md for the full port allocation table.
+#   60999 — amikad daemon
+#   60998 — OpenCode web UI
+#   60899-60997 — unassigned (reserved for future use)
+OPENCODE_WEB_PORT=60998
 
 AMIKA_STATE_DIR="/var/lib/amikad"
 AMIKA_USER_STATE_DIR="/var/lib/amika"


### PR DESCRIPTION
Change the OpenCode web port from 65535 to 60998 and document the reserved port range (60899-60999) for Amika internal sandbox services.