### PR TITLE
Add --remote-target flag to sandbox commands

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1528,7 +1528,12 @@ Examples:
 			}
 		}
 
-		client, err := getRemoteClient()
+		target, err := getRemoteTarget(cmd)
+		if err != nil {
+			return err
+		}
+
+		client, err := getRemoteClient(target)
 		if err != nil {
 			return err
 		}

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -75,15 +75,11 @@ func printLocalOnlyNotice(cmd *cobra.Command) {
 }
 
 // getRemoteTarget validates that --remote-target is not combined with --local or --remote, and returns the target string.
+// The flag is currently hidden and disabled; it will be enabled once named-remote config is implemented.
 func getRemoteTarget(cmd *cobra.Command) (string, error) {
 	target, _ := cmd.Flags().GetString("remote-target")
-	local, _ := cmd.Flags().GetBool("local")
-	remote, _ := cmd.Flags().GetBool("remote")
-	if target != "" && local {
-		return "", fmt.Errorf("--remote-target and --local are contradictory")
-	}
-	if target != "" && remote {
-		return "", fmt.Errorf("--remote-target and --remote are mutually exclusive")
+	if target != "" {
+		return "", fmt.Errorf("--remote-target is not yet supported")
 	}
 	return target, nil
 }
@@ -1597,6 +1593,7 @@ func init() {
 	sandboxCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
 	sandboxCmd.PersistentFlags().Bool("remote", false, "Only operate on remote sandboxes")
 	sandboxCmd.PersistentFlags().String("remote-target", "", "Operate on a specific named remote target")
+	sandboxCmd.PersistentFlags().MarkHidden("remote-target")
 
 	// Create flags
 	sandboxCreateCmd.Flags().String("provider", "docker", "Sandbox provider")

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -44,10 +44,11 @@ const envAPIURL = "AMIKA_API_URL"
 func sandboxMode(cmd *cobra.Command) string {
 	local, _ := cmd.Flags().GetBool("local")
 	remote, _ := cmd.Flags().GetBool("remote")
+	remoteTarget, _ := cmd.Flags().GetString("remote-target")
 	if local {
 		return "local"
 	}
-	if remote {
+	if remote || remoteTarget != "" {
 		return "remote"
 	}
 	// Default: if logged in, use remote; otherwise local.
@@ -73,8 +74,24 @@ func printLocalOnlyNotice(cmd *cobra.Command) {
 	}
 }
 
+// getRemoteTarget validates that --remote-target is not combined with --local or --remote, and returns the target string.
+func getRemoteTarget(cmd *cobra.Command) (string, error) {
+	target, _ := cmd.Flags().GetString("remote-target")
+	local, _ := cmd.Flags().GetBool("local")
+	remote, _ := cmd.Flags().GetBool("remote")
+	if target != "" && local {
+		return "", fmt.Errorf("--remote-target and --local are contradictory")
+	}
+	if target != "" && remote {
+		return "", fmt.Errorf("--remote-target and --remote are mutually exclusive")
+	}
+	return target, nil
+}
+
 // getRemoteClient returns an API client authenticated with the current session.
-func getRemoteClient() (*apiclient.Client, error) {
+func getRemoteClient(target string) (*apiclient.Client, error) {
+	// TODO: when named-remote config is added, look up target here.
+	_ = target
 	session, err := auth.GetValidSession(defaultWorkOSClientID)
 	if err != nil {
 		return nil, err
@@ -103,9 +120,14 @@ var sandboxCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
+		target, err := getRemoteTarget(cmd)
+		if err != nil {
+			return err
+		}
+
 		mode := sandboxMode(cmd)
 		if mode == "remote" || mode == "both" {
-			return createRemoteSandbox(cmd)
+			return createRemoteSandbox(cmd, target)
 		}
 		printLocalOnlyNotice(cmd)
 
@@ -302,6 +324,11 @@ var sandboxDeleteCmd = &cobra.Command{
 	Long:    `Delete one or more sandboxes and remove their backing containers.`,
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		target, err := getRemoteTarget(cmd)
+		if err != nil {
+			return err
+		}
+
 		mode := sandboxMode(cmd)
 
 		deleteVolumes, _ := cmd.Flags().GetBool("delete-volumes")
@@ -331,7 +358,7 @@ var sandboxDeleteCmd = &cobra.Command{
 		// Build a remote client if we may need it.
 		var remoteClient *apiclient.Client
 		if mode == "remote" || mode == "both" {
-			remoteClient, err = getRemoteClient()
+			remoteClient, err = getRemoteClient(target)
 			if err != nil {
 				return err
 			}
@@ -420,6 +447,11 @@ var sandboxListCmd = &cobra.Command{
 	Short: "List all sandboxes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		target, err := getRemoteTarget(cmd)
+		if err != nil {
+			return err
+		}
+
 		mode := sandboxMode(cmd)
 		printLocalOnlyNotice(cmd)
 
@@ -437,7 +469,7 @@ var sandboxListCmd = &cobra.Command{
 		}
 
 		if mode == "remote" || mode == "both" {
-			client, err := getRemoteClient()
+			client, err := getRemoteClient(target)
 			if err != nil {
 				return err
 			}
@@ -1414,7 +1446,7 @@ func hasEnvKey(env []string, key string) bool {
 	return false
 }
 
-func createRemoteSandbox(cmd *cobra.Command) error {
+func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	name, _ := cmd.Flags().GetString("name")
 	gitValue, _ := cmd.Flags().GetString("git")
 
@@ -1427,7 +1459,7 @@ func createRemoteSandbox(cmd *cobra.Command) error {
 		gitURL = resolved
 	}
 
-	client, err := getRemoteClient()
+	client, err := getRemoteClient(target)
 	if err != nil {
 		return err
 	}
@@ -1564,6 +1596,7 @@ func init() {
 	// Persistent flags for local/remote mode
 	sandboxCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
 	sandboxCmd.PersistentFlags().Bool("remote", false, "Only operate on remote sandboxes")
+	sandboxCmd.PersistentFlags().String("remote-target", "", "Operate on a specific named remote target")
 
 	// Create flags
 	sandboxCreateCmd.Flags().String("provider", "docker", "Sandbox provider")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,15 +10,14 @@ Manage Docker-backed persistent sandboxes with bind mounts and named volumes.
 
 These persistent flags apply to all `sandbox` subcommands (`create`, `list`, `delete`, `connect`):
 
-| Flag                     | Default | Description                                                     |
-| ------------------------ | ------- | --------------------------------------------------------------- |
-| `--local`                | `false` | Only operate on local sandboxes                                 |
-| `--remote`               | `false` | Only operate on remote sandboxes                                |
-| `--remote-target <name>` |         | Operate on a specific named remote target (implies remote mode) |
+| Flag       | Default | Description                      |
+| ---------- | ------- | -------------------------------- |
+| `--local`  | `false` | Only operate on local sandboxes  |
+| `--remote` | `false` | Only operate on remote sandboxes |
 
 When none of these flags are set, the default behavior depends on login state: if you are logged in, both local and remote sandboxes are shown; otherwise only local.
 
-`--local`, `--remote`, and `--remote-target` are mutually exclusive.
+`--local` and `--remote` are mutually exclusive.
 
 ### `amika sandbox create`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,6 +6,20 @@ Complete reference for all `amika` commands, flags, and environment variables.
 
 Manage Docker-backed persistent sandboxes with bind mounts and named volumes.
 
+### Global sandbox flags
+
+These persistent flags apply to all `sandbox` subcommands (`create`, `list`, `delete`, `connect`):
+
+| Flag                     | Default | Description                                                     |
+| ------------------------ | ------- | --------------------------------------------------------------- |
+| `--local`                | `false` | Only operate on local sandboxes                                 |
+| `--remote`               | `false` | Only operate on remote sandboxes                                |
+| `--remote-target <name>` |         | Operate on a specific named remote target (implies remote mode) |
+
+When none of these flags are set, the default behavior depends on login state: if you are logged in, both local and remote sandboxes are shown; otherwise only local.
+
+`--local`, `--remote`, and `--remote-target` are mutually exclusive.
+
 ### `amika sandbox create`
 
 Create a new sandbox.
@@ -89,7 +103,7 @@ List all tracked sandboxes.
 amika sandbox list
 ```
 
-Output columns: `NAME`, `PROVIDER`, `IMAGE`, `PORTS`, `CREATED`.
+Output columns: `NAME`, `LOCATION`, `PROVIDER`, `IMAGE`, `PORTS`, `CREATED`.
 
 ### `amika sandbox connect`
 


### PR DESCRIPTION
Introduce a `--remote-target <name>` persistent flag on the sandbox command to allow specifying a named remote target. This implies remote mode and errors if combined with `--local`. The target string is threaded through `getRemoteClient()` with a TODO for future named-remote config lookup.

For now, it is hidden from user-facing docs and help messages.