### PR TITLE
Little improvements to Docker build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ build-server: goenv
 clean:
 	rm -rf dist .gocache .gotmp .gomodcache
 
+clean-docker:
+	docker image rm amika/coder:latest amika/base:latest
+
 test: goenv
 	go test ./...
 

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -20,6 +20,9 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Determine git version tag
+VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+
 usage() {
   grep '^#/' "$0" | cut -c4-
 }
@@ -95,9 +98,6 @@ if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
     echo "Warning: there are unstaged/uncommitted changes, continuing anyway." >&2
   fi
 fi
-
-# Determine git version tag
-VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
 # Determine which presets to build in dependency order.
 PRESETS=()


### PR DESCRIPTION
In `build-docker-images`, hoist the part of the code that grabs the git
ref, so that it's at the top of the script. This way, we can start build
and then make unrelated git changes while it's building.

Add "clean-docker" make target, which cleans local docker images so that
the `amika` binary can automatically rebuild them.