### PR TITLE
Add service port binding support from .amika/config.toml

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -291,6 +291,7 @@ var sandboxCreateCmd = &cobra.Command{
 			Mounts:      runtimeMounts,
 			Env:         envStrs,
 			Ports:       publishedPorts,
+			Services:    collected.Services,
 		}
 		if err := store.Save(info); err != nil {
 			return fmt.Errorf("sandbox created but failed to save state: %w", err)
@@ -302,6 +303,18 @@ var sandboxCreateCmd = &cobra.Command{
 			fmt.Println("Published ports:")
 			for _, p := range publishedPorts {
 				fmt.Printf("  %s\n", formatPortBinding(p))
+			}
+		}
+		if len(collected.Services) > 0 {
+			fmt.Println("Services:")
+			for _, svc := range collected.Services {
+				for _, sp := range svc.Ports {
+					url := "-"
+					if sp.URL != "" {
+						url = sp.URL
+					}
+					fmt.Printf("  %s: %s (url: %s)\n", svc.Name, formatPortBinding(sp.PortBinding), url)
+				}
 			}
 		}
 		if connect {
@@ -978,8 +991,9 @@ type collectedMounts struct {
 	Mounts       []sandbox.MountBinding
 	VolumeMounts []sandbox.MountBinding
 	Ports        []sandbox.PortBinding
-	GitInfo      *gitMountInfo // nil if --git was not used
-	Cleanup      func()        // removes git temp dir; noop if no --git
+	Services     []sandbox.ServiceInfo // resolved service port bindings
+	GitInfo      *gitMountInfo         // nil if --git was not used
+	Cleanup      func()                // removes git temp dir; noop if no --git
 }
 
 // collectMounts gathers all mounts from CLI flags, git clone, .amika/config.toml,
@@ -1019,8 +1033,18 @@ func collectMounts(
 		mounts = append(mounts, info.Mount)
 	}
 
-	if gmi != nil && !setupScriptFlagChanged {
-		mount, err := setupScriptMountFromConfig(gmi.RepoRoot)
+	// Load .amika/config.toml once from the repo root for both setup script and services.
+	var repoCfg *amikaconfig.Config
+	if gmi != nil {
+		repoCfg, err = amikaconfig.LoadConfig(gmi.RepoRoot)
+		if err != nil {
+			cleanup()
+			return collectedMounts{}, fmt.Errorf("failed to read .amika/config.toml: %w", err)
+		}
+	}
+
+	if repoCfg != nil && !setupScriptFlagChanged {
+		mount, err := setupScriptMountFromLoadedConfig(repoCfg, gmi.RepoRoot)
 		if err != nil {
 			cleanup()
 			return collectedMounts{}, err
@@ -1028,6 +1052,18 @@ func collectMounts(
 		if mount != nil {
 			mounts = append(mounts, *mount)
 		}
+	}
+
+	// Resolve service ports from config.
+	var serviceInfos []sandbox.ServiceInfo
+	if repoCfg != nil {
+		svcInfos, additionalPorts, err := amika.ResolveServicesFromConfig(repoCfg, publishedPorts, portHostIP)
+		if err != nil {
+			cleanup()
+			return collectedMounts{}, err
+		}
+		serviceInfos = svcInfos
+		publishedPorts = append(publishedPorts, additionalPorts...)
 	}
 
 	if homeDir, err := os.UserHomeDir(); err == nil {
@@ -1052,19 +1088,15 @@ func collectMounts(
 		Mounts:       mounts,
 		VolumeMounts: volumeMounts,
 		Ports:        publishedPorts,
+		Services:     serviceInfos,
 		GitInfo:      gmi,
 		Cleanup:      cleanup,
 	}, nil
 }
 
-// setupScriptMountFromConfig reads repoRoot/.amika/config.toml and returns a
-// bind mount for lifecycle.setup_script if one is configured. Returns nil, nil
-// when the file is absent or no setup_script is set.
-func setupScriptMountFromConfig(repoRoot string) (*sandbox.MountBinding, error) {
-	cfg, err := amikaconfig.LoadConfig(repoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read .amika/config.toml: %w", err)
-	}
+// setupScriptMountFromLoadedConfig uses an already-loaded config to create a
+// bind mount for lifecycle.setup_script if one is configured.
+func setupScriptMountFromLoadedConfig(cfg *amikaconfig.Config, repoRoot string) (*sandbox.MountBinding, error) {
 	if cfg == nil || cfg.Lifecycle.SetupScript == "" {
 		return nil, nil
 	}

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -51,18 +51,19 @@ func sandboxMode(cmd *cobra.Command) string {
 	if remote || remoteTarget != "" {
 		return "remote"
 	}
-	// Default: if logged in, use remote; otherwise local.
-	session, _ := auth.LoadSession()
-	if session == nil {
+	// Default: if logged in with a valid session, include remote; otherwise local.
+	// GetValidSession refreshes expired tokens; if that fails the session is
+	// unusable and we fall back to local-only without blocking the command.
+	if _, err := auth.GetValidSession(defaultWorkOSClientID); err != nil {
 		return "local"
 	}
 	return "both"
 }
 
-// isLoggedIn returns true if a WorkOS session exists on disk.
+// isLoggedIn returns true if a valid (or refreshable) WorkOS session exists.
 func isLoggedIn() bool {
-	session, _ := auth.LoadSession()
-	return session != nil
+	_, err := auth.GetValidSession(defaultWorkOSClientID)
+	return err == nil
 }
 
 // printLocalOnlyNotice prints a notice when the user is not logged in and
@@ -116,6 +117,13 @@ var sandboxCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
+		// Validate flag constraints before any network or auth calls.
+		noClean, _ := cmd.Flags().GetBool("no-clean")
+		gitFlagChanged := cmd.Flags().Changed("git")
+		if err := validateGitFlags(gitFlagChanged, noClean); err != nil {
+			return err
+		}
+
 		target, err := getRemoteTarget(cmd)
 		if err != nil {
 			return err
@@ -134,20 +142,15 @@ var sandboxCreateCmd = &cobra.Command{
 		mountStrs, _ := cmd.Flags().GetStringArray("mount")
 		volumeStrs, _ := cmd.Flags().GetStringArray("volume")
 		gitPath, _ := cmd.Flags().GetString("git")
-		noClean, _ := cmd.Flags().GetBool("no-clean")
 		envStrs, _ := cmd.Flags().GetStringArray("env")
 		portStrs, _ := cmd.Flags().GetStringArray("port")
 		portHostIP, _ := cmd.Flags().GetString("port-host-ip")
 		yes, _ := cmd.Flags().GetBool("yes")
 		connect, _ := cmd.Flags().GetBool("connect")
 		setupScript, _ := cmd.Flags().GetString("setup-script")
-		gitFlagChanged := cmd.Flags().Changed("git")
 
 		if provider != "docker" {
 			return fmt.Errorf("unsupported provider %q: only \"docker\" is supported", provider)
-		}
-		if err := validateGitFlags(gitFlagChanged, noClean); err != nil {
-			return err
 		}
 
 		resolvedImage, err := sandbox.ResolveAndEnsureImage(sandbox.PresetImageOptions{

--- a/cmd/amika/service.go
+++ b/cmd/amika/service.go
@@ -56,7 +56,7 @@ var serviceListCmd = &cobra.Command{
 				}
 				urlStr := "-"
 				if len(urls) > 0 {
-					urlStr = strings.Join(urls, ",")
+					urlStr = strings.Join(urls, " ")
 				}
 				rows = append(rows, serviceRow{
 					service:     svc.Name,

--- a/cmd/amika/service.go
+++ b/cmd/amika/service.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/gofixpoint/amika/internal/config"
+	"github.com/gofixpoint/amika/internal/sandbox"
+	"github.com/spf13/cobra"
+)
+
+var serviceCmd = &cobra.Command{
+	Use:   "service",
+	Short: "Manage sandbox services",
+	Long:  `View and manage declared services and their port bindings across sandboxes.`,
+}
+
+var serviceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List services across sandboxes",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		sandboxName, _ := cmd.Flags().GetString("sandbox-name")
+
+		sandboxesFile, err := config.SandboxesStateFile()
+		if err != nil {
+			return err
+		}
+		store := sandbox.NewStore(sandboxesFile)
+		sandboxes, err := store.List()
+		if err != nil {
+			return err
+		}
+
+		type serviceRow struct {
+			service     string
+			sandboxName string
+			ports       string
+			url         string
+		}
+
+		var rows []serviceRow
+		for _, sb := range sandboxes {
+			if sandboxName != "" && sb.Name != sandboxName {
+				continue
+			}
+			for _, svc := range sb.Services {
+				portStrs := make([]string, 0, len(svc.Ports))
+				var urls []string
+				for _, p := range svc.Ports {
+					portStrs = append(portStrs, formatPortBinding(p.PortBinding))
+					if p.URL != "" {
+						urls = append(urls, p.URL)
+					}
+				}
+				urlStr := "-"
+				if len(urls) > 0 {
+					urlStr = strings.Join(urls, ",")
+				}
+				rows = append(rows, serviceRow{
+					service:     svc.Name,
+					sandboxName: sb.Name,
+					ports:       strings.Join(portStrs, ","),
+					url:         urlStr,
+				})
+			}
+		}
+
+		if len(rows) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No services found.")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "SERVICE\tSANDBOX\tPORTS\tURL")
+		for _, r := range rows {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.service, r.sandboxName, r.ports, r.url)
+		}
+		w.Flush()
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(serviceCmd)
+	serviceCmd.AddCommand(serviceListCmd)
+	serviceListCmd.Flags().String("sandbox-name", "", "Filter services to a specific sandbox")
+}

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -171,7 +171,7 @@ avoid binding to ports in this range.
 | ----------- | -------------------------------- | -------- |
 | 60999       | amikad daemon                    | Reserved |
 | 60998       | OpenCode web UI                  | Active   |
-| 60899–60997 | *(unassigned, reserved for use)* | Reserved |
+| 60899–60997 | _(unassigned, reserved for use)_ | Reserved |
 
 The OpenCode web server starts automatically on port 60998 when OpenCode is
 installed in the container and `AMIKA_OPENCODE_WEB` is not set to `0`. The

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -4,15 +4,20 @@ package amikaconfig
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
 
 // Config is the parsed .amika/config.toml file.
 type Config struct {
-	Lifecycle LifecycleConfig `toml:"lifecycle"`
+	Lifecycle LifecycleConfig          `toml:"lifecycle"`
+	Services  map[string]ServiceConfig `toml:"services"`
 }
 
 // LifecycleConfig holds sandbox lifecycle hooks.
@@ -20,6 +25,26 @@ type LifecycleConfig struct {
 	// SetupScript is the path to an executable to mount at /usr/local/etc/amikad/setup/setup.sh.
 	// Relative paths are resolved from the repo root.
 	SetupScript string `toml:"setup_script"`
+}
+
+// ServiceConfig is the raw TOML representation of a service declaration.
+type ServiceConfig struct {
+	Port      interface{}   `toml:"port"`
+	Ports     []interface{} `toml:"ports"`
+	URLScheme interface{}   `toml:"url_scheme"`
+}
+
+// ServicePortParsed is a normalized port with its resolved URL scheme.
+type ServicePortParsed struct {
+	ContainerPort int
+	Protocol      string // "tcp" or "udp"
+	URLScheme     string // "" (no URL), "http", or "https"
+}
+
+// ServiceParsed is a validated, normalized service definition.
+type ServiceParsed struct {
+	Name  string
+	Ports []ServicePortParsed
 }
 
 // LoadConfig reads $repoRoot/.amika/config.toml.
@@ -38,4 +63,222 @@ func LoadConfig(repoRoot string) (*Config, error) {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 	return &cfg, nil
+}
+
+// ParsedServices validates the service declarations and returns a normalized list.
+// Returns nil, nil when no services are declared.
+func (c *Config) ParsedServices() ([]ServiceParsed, error) {
+	if len(c.Services) == 0 {
+		return nil, nil
+	}
+	if err := ValidateServices(c.Services); err != nil {
+		return nil, err
+	}
+
+	// Sort service names for deterministic output.
+	names := make([]string, 0, len(c.Services))
+	for name := range c.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var result []ServiceParsed
+	for _, name := range names {
+		svc := c.Services[name]
+		parsed, err := parseServiceConfig(name, svc)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, parsed)
+	}
+	return result, nil
+}
+
+// ValidateServices checks all service declarations for correctness.
+func ValidateServices(services map[string]ServiceConfig) error {
+	// Global duplicate check: containerPort/protocol across all services.
+	globalPorts := make(map[string]string) // "port/proto" -> service name
+
+	for name, svc := range services {
+		// Rule 1: exactly one of port or ports.
+		hasPort := svc.Port != nil
+		hasPorts := len(svc.Ports) > 0
+		if hasPort && hasPorts {
+			return fmt.Errorf("service %q: port and ports are mutually exclusive", name)
+		}
+		if !hasPort && !hasPorts {
+			return fmt.Errorf("service %q: one of port or ports is required", name)
+		}
+
+		// Collect and validate port values.
+		var rawPorts []interface{}
+		if hasPort {
+			rawPorts = []interface{}{svc.Port}
+		} else {
+			rawPorts = svc.Ports
+		}
+
+		localPorts := make(map[string]bool)
+		for _, raw := range rawPorts {
+			cp, proto, err := parsePort(raw)
+			if err != nil {
+				return fmt.Errorf("service %q: %w", name, err)
+			}
+			key := fmt.Sprintf("%d/%s", cp, proto)
+			if localPorts[key] {
+				return fmt.Errorf("service %q: duplicate port %s", name, key)
+			}
+			localPorts[key] = true
+			if prev, ok := globalPorts[key]; ok {
+				return fmt.Errorf("duplicate port %s across services %q and %q", key, prev, name)
+			}
+			globalPorts[key] = name
+		}
+
+		// Validate url_scheme.
+		if svc.URLScheme != nil {
+			if err := validateURLScheme(name, svc, localPorts); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// parsePort parses a port value (int64 or "port/proto" string) into container port and protocol.
+func parsePort(v interface{}) (int, string, error) {
+	switch val := v.(type) {
+	case int64:
+		return validatePortNumber(int(val), "tcp")
+	case float64:
+		if val != math.Trunc(val) {
+			return 0, "", fmt.Errorf("invalid port %v: must be an integer", val)
+		}
+		return validatePortNumber(int(val), "tcp")
+	case string:
+		parts := strings.SplitN(val, "/", 2)
+		if len(parts) != 2 {
+			return 0, "", fmt.Errorf("invalid port format %q: expected \"port/protocol\"", val)
+		}
+		port, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return 0, "", fmt.Errorf("invalid port number in %q: %w", val, err)
+		}
+		proto := strings.ToLower(strings.TrimSpace(parts[1]))
+		return validatePortNumber(port, proto)
+	default:
+		return 0, "", fmt.Errorf("invalid port value %v (type %T): must be an integer or \"port/protocol\" string", v, v)
+	}
+}
+
+func validatePortNumber(port int, proto string) (int, string, error) {
+	if port < 1 || port > 65535 {
+		return 0, "", fmt.Errorf("port %d must be between 1 and 65535", port)
+	}
+	if proto != "tcp" && proto != "udp" {
+		return 0, "", fmt.Errorf("invalid protocol %q: must be \"tcp\" or \"udp\"", proto)
+	}
+	if port >= 60899 && port <= 60999 {
+		return 0, "", fmt.Errorf("port %d is in the reserved range 60899-60999", port)
+	}
+	return port, proto, nil
+}
+
+func validateURLScheme(name string, svc ServiceConfig, localPorts map[string]bool) error {
+	hasPort := svc.Port != nil
+
+	if hasPort {
+		// Single-port: url_scheme must be a string.
+		scheme, ok := svc.URLScheme.(string)
+		if !ok {
+			return fmt.Errorf("service %q: url_scheme must be a string when using port (not a list)", name)
+		}
+		if scheme != "http" && scheme != "https" {
+			return fmt.Errorf("service %q: url_scheme %q must be \"http\" or \"https\"", name, scheme)
+		}
+		return nil
+	}
+
+	// Multi-port: url_scheme must be a list of {port, scheme} mappings.
+	list, ok := svc.URLScheme.([]interface{})
+	if !ok {
+		// Could be a string used with ports — that's an error.
+		if _, isStr := svc.URLScheme.(string); isStr {
+			return fmt.Errorf("service %q: url_scheme must be a list of {port, scheme} mappings when using ports (not a string)", name)
+		}
+		return fmt.Errorf("service %q: invalid url_scheme format", name)
+	}
+
+	seen := make(map[string]bool)
+	for _, item := range list {
+		mapping, ok := item.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("service %q: each url_scheme entry must be a {port, scheme} table", name)
+		}
+		portVal, hasP := mapping["port"]
+		schemeVal, hasS := mapping["scheme"]
+		if !hasP || !hasS {
+			return fmt.Errorf("service %q: each url_scheme entry must have port and scheme fields", name)
+		}
+		scheme, ok := schemeVal.(string)
+		if !ok || (scheme != "http" && scheme != "https") {
+			return fmt.Errorf("service %q: url_scheme scheme %q must be \"http\" or \"https\"", name, schemeVal)
+		}
+		cp, proto, err := parsePort(portVal)
+		if err != nil {
+			return fmt.Errorf("service %q: url_scheme port: %w", name, err)
+		}
+		key := fmt.Sprintf("%d/%s", cp, proto)
+		if !localPorts[key] {
+			return fmt.Errorf("service %q: url_scheme references undeclared port %s", name, key)
+		}
+		if seen[key] {
+			return fmt.Errorf("service %q: duplicate port %s in url_scheme", name, key)
+		}
+		seen[key] = true
+	}
+	return nil
+}
+
+// parseServiceConfig converts a validated ServiceConfig into a ServiceParsed.
+func parseServiceConfig(name string, svc ServiceConfig) (ServiceParsed, error) {
+	hasPort := svc.Port != nil
+
+	// Build url_scheme lookup.
+	schemeMap := make(map[string]string) // "port/proto" -> scheme
+	if svc.URLScheme != nil {
+		if hasPort {
+			scheme := svc.URLScheme.(string)
+			cp, proto, _ := parsePort(svc.Port)
+			schemeMap[fmt.Sprintf("%d/%s", cp, proto)] = scheme
+		} else {
+			list := svc.URLScheme.([]interface{})
+			for _, item := range list {
+				mapping := item.(map[string]interface{})
+				cp, proto, _ := parsePort(mapping["port"])
+				schemeMap[fmt.Sprintf("%d/%s", cp, proto)] = mapping["scheme"].(string)
+			}
+		}
+	}
+
+	// Parse ports.
+	var rawPorts []interface{}
+	if hasPort {
+		rawPorts = []interface{}{svc.Port}
+	} else {
+		rawPorts = svc.Ports
+	}
+
+	ports := make([]ServicePortParsed, 0, len(rawPorts))
+	for _, raw := range rawPorts {
+		cp, proto, _ := parsePort(raw)
+		key := fmt.Sprintf("%d/%s", cp, proto)
+		ports = append(ports, ServicePortParsed{
+			ContainerPort: cp,
+			Protocol:      proto,
+			URLScheme:     schemeMap[key],
+		})
+	}
+
+	return ServiceParsed{Name: name, Ports: ports}, nil
 }

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -197,7 +197,7 @@ func validateURLScheme(name string, svc ServiceConfig, localPorts map[string]boo
 			}
 			return nil
 		}
-		// Single port may also use list-form url_scheme — fall through to list validation.
+		// Single port may also use list-form url_scheme, but only as [] or [{port=<same>, scheme=...}].
 	}
 
 	// List-form url_scheme: valid with both port and ports.
@@ -207,6 +207,18 @@ func validateURLScheme(name string, svc ServiceConfig, localPorts map[string]boo
 			return fmt.Errorf("service %q: url_scheme must be a list of {port, scheme} mappings when using ports (not a string)", name)
 		}
 		return fmt.Errorf("service %q: invalid url_scheme format", name)
+	}
+
+	var singlePortKey string
+	if hasPort {
+		cp, proto, err := parsePort(svc.Port)
+		if err != nil {
+			return fmt.Errorf("service %q: %w", name, err)
+		}
+		singlePortKey = fmt.Sprintf("%d/%s", cp, proto)
+		if len(list) > 1 {
+			return fmt.Errorf("service %q: url_scheme list may contain at most one entry when using port", name)
+		}
 	}
 
 	seen := make(map[string]bool)
@@ -231,6 +243,9 @@ func validateURLScheme(name string, svc ServiceConfig, localPorts map[string]boo
 		key := fmt.Sprintf("%d/%s", cp, proto)
 		if !localPorts[key] {
 			return fmt.Errorf("service %q: url_scheme references undeclared port %s", name, key)
+		}
+		if hasPort && key != singlePortKey {
+			return fmt.Errorf("service %q: url_scheme port %s must match declared port %s", name, key, singlePortKey)
 		}
 		if seen[key] {
 			return fmt.Errorf("service %q: duplicate port %s in url_scheme", name, key)

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gofixpoint/amika/internal/constants"
 )
 
 // Config is the parsed .amika/config.toml file.
@@ -100,14 +101,15 @@ func ValidateServices(services map[string]ServiceConfig) error {
 	globalPorts := make(map[string]string) // "port/proto" -> service name
 
 	for name, svc := range services {
-		// Rule 1: exactly one of port or ports.
 		hasPort := svc.Port != nil
 		hasPorts := len(svc.Ports) > 0
 		if hasPort && hasPorts {
 			return fmt.Errorf("service %q: port and ports are mutually exclusive", name)
 		}
+
+		// A service with neither port nor ports is valid (metadata-only).
 		if !hasPort && !hasPorts {
-			return fmt.Errorf("service %q: one of port or ports is required", name)
+			continue
 		}
 
 		// Collect and validate port values.
@@ -178,8 +180,8 @@ func validatePortNumber(port int, proto string) (int, string, error) {
 	if proto != "tcp" && proto != "udp" {
 		return 0, "", fmt.Errorf("invalid protocol %q: must be \"tcp\" or \"udp\"", proto)
 	}
-	if port >= 60899 && port <= 60999 {
-		return 0, "", fmt.Errorf("port %d is in the reserved range 60899-60999", port)
+	if port >= constants.ReservedPortStart && port <= constants.ReservedPortEnd {
+		return 0, "", fmt.Errorf("port %d is in the reserved range %d-%d", port, constants.ReservedPortStart, constants.ReservedPortEnd)
 	}
 	return port, proto, nil
 }
@@ -187,22 +189,20 @@ func validatePortNumber(port int, proto string) (int, string, error) {
 func validateURLScheme(name string, svc ServiceConfig, localPorts map[string]bool) error {
 	hasPort := svc.Port != nil
 
+	// Single-port with a simple string url_scheme.
 	if hasPort {
-		// Single-port: url_scheme must be a string.
-		scheme, ok := svc.URLScheme.(string)
-		if !ok {
-			return fmt.Errorf("service %q: url_scheme must be a string when using port (not a list)", name)
+		if scheme, ok := svc.URLScheme.(string); ok {
+			if scheme != "http" && scheme != "https" {
+				return fmt.Errorf("service %q: url_scheme %q must be \"http\" or \"https\"", name, scheme)
+			}
+			return nil
 		}
-		if scheme != "http" && scheme != "https" {
-			return fmt.Errorf("service %q: url_scheme %q must be \"http\" or \"https\"", name, scheme)
-		}
-		return nil
+		// Single port may also use list-form url_scheme — fall through to list validation.
 	}
 
-	// Multi-port: url_scheme must be a list of {port, scheme} mappings.
+	// List-form url_scheme: valid with both port and ports.
 	list, ok := svc.URLScheme.([]interface{})
 	if !ok {
-		// Could be a string used with ports — that's an error.
 		if _, isStr := svc.URLScheme.(string); isStr {
 			return fmt.Errorf("service %q: url_scheme must be a list of {port, scheme} mappings when using ports (not a string)", name)
 		}
@@ -243,16 +243,22 @@ func validateURLScheme(name string, svc ServiceConfig, localPorts map[string]boo
 // parseServiceConfig converts a validated ServiceConfig into a ServiceParsed.
 func parseServiceConfig(name string, svc ServiceConfig) (ServiceParsed, error) {
 	hasPort := svc.Port != nil
+	hasPorts := len(svc.Ports) > 0
+
+	// No ports declared — return a metadata-only service.
+	if !hasPort && !hasPorts {
+		return ServiceParsed{Name: name}, nil
+	}
 
 	// Build url_scheme lookup.
 	schemeMap := make(map[string]string) // "port/proto" -> scheme
 	if svc.URLScheme != nil {
-		if hasPort {
-			scheme := svc.URLScheme.(string)
+		if scheme, ok := svc.URLScheme.(string); ok {
+			// Simple string form — only valid with single port.
 			cp, proto, _ := parsePort(svc.Port)
 			schemeMap[fmt.Sprintf("%d/%s", cp, proto)] = scheme
-		} else {
-			list := svc.URLScheme.([]interface{})
+		} else if list, ok := svc.URLScheme.([]interface{}); ok {
+			// List form — valid with both port and ports.
 			for _, item := range list {
 				mapping := item.(map[string]interface{})
 				cp, proto, _ := parsePort(mapping["port"])

--- a/internal/amikaconfig/config_test.go
+++ b/internal/amikaconfig/config_test.go
@@ -188,14 +188,23 @@ ports = [3000]
 	}
 }
 
-// Test 5: Neither port nor ports → error
-func TestParsedServices_ErrorNeitherPortNorPorts(t *testing.T) {
+// Test 5: Neither port nor ports → valid metadata-only service
+func TestParsedServices_NeitherPortNorPorts(t *testing.T) {
 	cfg := loadFromTOML(t, `
 [services.api]
 `)
-	_, err := cfg.ParsedServices()
-	if err == nil {
-		t.Fatal("expected error for neither port nor ports, got nil")
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(services))
+	}
+	if services[0].Name != "api" {
+		t.Errorf("expected name %q, got %q", "api", services[0].Name)
+	}
+	if len(services[0].Ports) != 0 {
+		t.Errorf("expected 0 ports, got %d", len(services[0].Ports))
 	}
 }
 
@@ -347,8 +356,8 @@ url_scheme = [
 	}
 }
 
-// Test 16: port used with list-form url_scheme → error
-func TestParsedServices_ErrorPortWithListScheme(t *testing.T) {
+// Test 16: port used with list-form url_scheme → allowed
+func TestParsedServices_PortWithListScheme(t *testing.T) {
 	cfg := loadFromTOML(t, `
 [services.api]
 port = 4838
@@ -356,9 +365,15 @@ url_scheme = [
   { port = 4838, scheme = "http" },
 ]
 `)
-	_, err := cfg.ParsedServices()
-	if err == nil {
-		t.Fatal("expected error for port with list url_scheme, got nil")
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(services))
+	}
+	if services[0].Ports[0].URLScheme != "http" {
+		t.Errorf("expected URLScheme %q, got %q", "http", services[0].Ports[0].URLScheme)
 	}
 }
 

--- a/internal/amikaconfig/config_test.go
+++ b/internal/amikaconfig/config_test.go
@@ -377,6 +377,50 @@ url_scheme = [
 	}
 }
 
+func TestParsedServices_PortWithEmptyListScheme(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+url_scheme = []
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if services[0].Ports[0].URLScheme != "" {
+		t.Errorf("expected empty URLScheme, got %q", services[0].Ports[0].URLScheme)
+	}
+}
+
+func TestParsedServices_ErrorPortWithMismatchedListSchemePort(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+url_scheme = [
+  { port = 9999, scheme = "http" },
+]
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for mismatched single-port url_scheme entry, got nil")
+	}
+}
+
+func TestParsedServices_ErrorPortWithMultipleListSchemes(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+url_scheme = [
+  { port = 4838, scheme = "http" },
+  { port = 4838, scheme = "https" },
+]
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for multiple single-port url_scheme entries, got nil")
+	}
+}
+
 // Test 17: ports used with string url_scheme → error
 func TestParsedServices_ErrorPortsWithStringScheme(t *testing.T) {
 	cfg := loadFromTOML(t, `

--- a/internal/amikaconfig/config_test.go
+++ b/internal/amikaconfig/config_test.go
@@ -83,3 +83,325 @@ func TestLoadConfig_EmptyLifecycleSection(t *testing.T) {
 		t.Errorf("expected empty setup_script, got %q", cfg.Lifecycle.SetupScript)
 	}
 }
+
+// Helper to load a config from TOML content.
+func loadFromTOML(t *testing.T, content string) *amikaconfig.Config {
+	t.Helper()
+	dir := t.TempDir()
+	amikaDir := filepath.Join(dir, ".amika")
+	if err := os.Mkdir(amikaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := amikaconfig.LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	return cfg
+}
+
+// Test 1: Single port = 4838 → 4838/tcp
+func TestParsedServices_SinglePortInt(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(services))
+	}
+	if services[0].Name != "api" {
+		t.Errorf("expected name %q, got %q", "api", services[0].Name)
+	}
+	if len(services[0].Ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(services[0].Ports))
+	}
+	p := services[0].Ports[0]
+	if p.ContainerPort != 4838 || p.Protocol != "tcp" {
+		t.Errorf("expected 4838/tcp, got %d/%s", p.ContainerPort, p.Protocol)
+	}
+}
+
+// Test 2: port = "9090/udp" → 9090/udp
+func TestParsedServices_SinglePortStringUDP(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.metrics]
+port = "9090/udp"
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p := services[0].Ports[0]
+	if p.ContainerPort != 9090 || p.Protocol != "udp" {
+		t.Errorf("expected 9090/udp, got %d/%s", p.ContainerPort, p.Protocol)
+	}
+}
+
+// Test 3: ports = [3000, "3001/tcp", "9090/udp"] → three ports
+func TestParsedServices_MultiplePorts(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.web]
+ports = [3000, "3001/tcp", "9090/udp"]
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ports := services[0].Ports
+	if len(ports) != 3 {
+		t.Fatalf("expected 3 ports, got %d", len(ports))
+	}
+	expected := []struct {
+		port  int
+		proto string
+	}{
+		{3000, "tcp"},
+		{3001, "tcp"},
+		{9090, "udp"},
+	}
+	for i, e := range expected {
+		if ports[i].ContainerPort != e.port || ports[i].Protocol != e.proto {
+			t.Errorf("port %d: expected %d/%s, got %d/%s", i, e.port, e.proto, ports[i].ContainerPort, ports[i].Protocol)
+		}
+	}
+}
+
+// Test 4: Both port and ports set → error
+func TestParsedServices_ErrorBothPortAndPorts(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+ports = [3000]
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for both port and ports, got nil")
+	}
+}
+
+// Test 5: Neither port nor ports → error
+func TestParsedServices_ErrorNeitherPortNorPorts(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for neither port nor ports, got nil")
+	}
+}
+
+// Test 6: Port outside 1-65535 → error
+func TestParsedServices_ErrorPortOutOfRange(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 70000
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for port out of range, got nil")
+	}
+}
+
+// Test 7: Invalid protocol → error
+func TestParsedServices_ErrorInvalidProtocol(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = "4838/sctp"
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for invalid protocol, got nil")
+	}
+}
+
+// Test 8: Reserved port in range 60899-60999 → error
+func TestParsedServices_ErrorReservedPort(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 60900
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for reserved port, got nil")
+	}
+}
+
+// Test 9: Duplicate container port/protocol across services → error
+func TestParsedServices_ErrorDuplicateAcrossServices(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+
+[services.other]
+port = 4838
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for duplicate port across services, got nil")
+	}
+}
+
+// Test 10: No services sections → nil services, no error
+func TestParsedServices_NoServices(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[lifecycle]
+setup_script = "setup.sh"
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if services != nil {
+		t.Fatalf("expected nil services, got %v", services)
+	}
+}
+
+// Test 11: Single-port with url_scheme = "http"
+func TestParsedServices_URLSchemeHTTP(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+url_scheme = "http"
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if services[0].Ports[0].URLScheme != "http" {
+		t.Errorf("expected URLScheme %q, got %q", "http", services[0].Ports[0].URLScheme)
+	}
+}
+
+// Test 12: Single-port with url_scheme = "https"
+func TestParsedServices_URLSchemeHTTPS(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+url_scheme = "https"
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if services[0].Ports[0].URLScheme != "https" {
+		t.Errorf("expected URLScheme %q, got %q", "https", services[0].Ports[0].URLScheme)
+	}
+}
+
+// Test 13: No url_scheme → empty URLScheme on all ports
+func TestParsedServices_NoURLScheme(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if services[0].Ports[0].URLScheme != "" {
+		t.Errorf("expected empty URLScheme, got %q", services[0].Ports[0].URLScheme)
+	}
+}
+
+// Test 14: Invalid scheme value → error
+func TestParsedServices_ErrorInvalidScheme(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+url_scheme = "ftp"
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for invalid scheme, got nil")
+	}
+}
+
+// Test 15: Multi-port with url_scheme list — only mapped port gets scheme
+func TestParsedServices_MultiPortURLScheme(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.web]
+ports = [3000, "3001/tcp"]
+url_scheme = [
+  { port = 3000, scheme = "http" },
+]
+`)
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ports := services[0].Ports
+	if ports[0].URLScheme != "http" {
+		t.Errorf("port 3000: expected URLScheme %q, got %q", "http", ports[0].URLScheme)
+	}
+	if ports[1].URLScheme != "" {
+		t.Errorf("port 3001: expected empty URLScheme, got %q", ports[1].URLScheme)
+	}
+}
+
+// Test 16: port used with list-form url_scheme → error
+func TestParsedServices_ErrorPortWithListScheme(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+port = 4838
+url_scheme = [
+  { port = 4838, scheme = "http" },
+]
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for port with list url_scheme, got nil")
+	}
+}
+
+// Test 17: ports used with string url_scheme → error
+func TestParsedServices_ErrorPortsWithStringScheme(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.api]
+ports = [4838]
+url_scheme = "http"
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for ports with string url_scheme, got nil")
+	}
+}
+
+// Test 18: url_scheme references undeclared port → error
+func TestParsedServices_ErrorSchemeUndeclaredPort(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.web]
+ports = [3000]
+url_scheme = [
+  { port = 9999, scheme = "http" },
+]
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for url_scheme referencing undeclared port, got nil")
+	}
+}
+
+// Test 19: Duplicate port in url_scheme list → error
+func TestParsedServices_ErrorDuplicateSchemePort(t *testing.T) {
+	cfg := loadFromTOML(t, `
+[services.web]
+ports = [3000, 3001]
+url_scheme = [
+  { port = 3000, scheme = "http" },
+  { port = 3000, scheme = "https" },
+]
+`)
+	_, err := cfg.ParsedServices()
+	if err == nil {
+		t.Fatal("expected error for duplicate port in url_scheme, got nil")
+	}
+}

--- a/internal/app/service_impl.go
+++ b/internal/app/service_impl.go
@@ -257,6 +257,28 @@ func (s *Service) DeleteVolume(_ context.Context, req amika.DeleteVolumeRequest)
 	return amika.DeleteVolumeResult{Deleted: deleted}, nil
 }
 
+// ListServices lists services across sandboxes with optional filtering.
+func (s *Service) ListServices(_ context.Context, req amika.ListServicesRequest) (amika.ListServicesResult, error) {
+	recs, err := s.deps.Sandboxes.List()
+	if err != nil {
+		return amika.ListServicesResult{}, fmt.Errorf("%w: list sandboxes: %v", amika.ErrInternal, err)
+	}
+	var items []amika.ServiceListItem
+	for _, rec := range recs {
+		if req.SandboxName != "" && rec.Name != req.SandboxName {
+			continue
+		}
+		for _, svc := range rec.Services {
+			items = append(items, amika.ServiceListItem{
+				Service:     svc.Name,
+				SandboxName: rec.Name,
+				Ports:       toPublicServicePortInfos(svc.Ports),
+			})
+		}
+	}
+	return amika.ListServicesResult{Items: items}, nil
+}
+
 // ExtractAuth extracts auth env assignment lines.
 func (s *Service) ExtractAuth(_ context.Context, req amika.AuthExtractRequest) (amika.AuthExtractResult, error) {
 	result, err := auth.Discover(auth.Options{HomeDir: req.HomeDir, IncludeOAuth: !req.NoOAuth})
@@ -310,6 +332,22 @@ func toPortBindings(bindings []amika.PortBinding) []ports.PortBinding {
 			HostPort:      p.HostPort,
 			ContainerPort: p.ContainerPort,
 			Protocol:      p.Protocol,
+		})
+	}
+	return out
+}
+
+func toPublicServicePortInfos(in []ports.ServicePortRecord) []amika.ServicePortInfo {
+	out := make([]amika.ServicePortInfo, 0, len(in))
+	for _, p := range in {
+		out = append(out, amika.ServicePortInfo{
+			PortBinding: amika.PortBinding{
+				HostIP:        p.HostIP,
+				HostPort:      p.HostPort,
+				ContainerPort: p.ContainerPort,
+				Protocol:      p.Protocol,
+			},
+			URL: p.URL,
 		})
 	}
 	return out

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -8,4 +8,12 @@ const (
 
 	// ProviderLocalDocker is the provider value for local Docker sandboxes.
 	ProviderLocalDocker = "local-docker"
+
+	// ReservedPortStart is the beginning of the port range reserved for Amika
+	// internal services inside sandbox containers (inclusive).
+	ReservedPortStart = 60899
+
+	// ReservedPortEnd is the end of the port range reserved for Amika
+	// internal services inside sandbox containers (inclusive).
+	ReservedPortEnd = 60999
 )

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -28,6 +28,7 @@ func NewHandler(service amika.Service) http.Handler {
 	registerDeleteVolume(api, service)
 	registerAuthExtract(api, service)
 	registerMaterialize(api, service)
+	registerListServices(api, service)
 	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.OpenAPI())
@@ -140,6 +141,23 @@ func registerMaterialize(api huma.API, service amika.Service) {
 			return nil, toHTTPError(err)
 		}
 		return &materializeOutput{Body: result}, nil
+	})
+}
+
+type listServicesInput struct {
+	SandboxName string `query:"sandbox_name"`
+}
+type listServicesOutput struct{ Body amika.ListServicesResult }
+
+func registerListServices(api huma.API, service amika.Service) {
+	huma.Get(api, "/v1/services", func(ctx context.Context, input *listServicesInput) (*listServicesOutput, error) {
+		result, err := service.ListServices(ctx, amika.ListServicesRequest{
+			SandboxName: input.SandboxName,
+		})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &listServicesOutput{Body: result}, nil
 	})
 }
 

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -37,6 +37,9 @@ func (stubService) DeleteVolume(context.Context, amika.DeleteVolumeRequest) (ami
 func (stubService) ExtractAuth(context.Context, amika.AuthExtractRequest) (amika.AuthExtractResult, error) {
 	return amika.AuthExtractResult{Lines: []string{"A='1'"}}, nil
 }
+func (stubService) ListServices(context.Context, amika.ListServicesRequest) (amika.ListServicesResult, error) {
+	return amika.ListServicesResult{}, nil
+}
 
 type captureCreateSandboxService struct {
 	stubService

--- a/internal/ports/store.go
+++ b/internal/ports/store.go
@@ -1,5 +1,17 @@
 package ports
 
+// ServiceRecord describes a named service and its resolved port bindings.
+type ServiceRecord struct {
+	Name  string
+	Ports []ServicePortRecord
+}
+
+// ServicePortRecord is a resolved port binding with an optional generated URL.
+type ServicePortRecord struct {
+	PortBinding
+	URL string
+}
+
 // SandboxRecord stores sandbox metadata.
 type SandboxRecord struct {
 	Name        string
@@ -11,6 +23,7 @@ type SandboxRecord struct {
 	Mounts      []Mount
 	Env         []string
 	Ports       []PortBinding
+	Services    []ServiceRecord
 }
 
 // VolumeRecord stores tracked volume metadata.

--- a/internal/sandbox/store.go
+++ b/internal/sandbox/store.go
@@ -26,6 +26,18 @@ type PortBinding struct {
 	Protocol      string `json:"protocol,omitempty"`
 }
 
+// ServiceInfo describes a named service and its resolved port bindings.
+type ServiceInfo struct {
+	Name  string            `json:"name"`
+	Ports []ServicePortInfo `json:"ports"`
+}
+
+// ServicePortInfo is a resolved port binding with an optional generated URL.
+type ServicePortInfo struct {
+	PortBinding
+	URL string `json:"url,omitempty"`
+}
+
 // Info represents a tracked sandbox.
 type Info struct {
 	Name        string         `json:"name"`
@@ -37,6 +49,7 @@ type Info struct {
 	Mounts      []MountBinding `json:"mounts,omitempty"`
 	Env         []string       `json:"env,omitempty"`
 	Ports       []PortBinding  `json:"ports,omitempty"`
+	Services    []ServiceInfo  `json:"services,omitempty"`
 }
 
 // Store manages sandbox state persistence.

--- a/internal/sandbox/store.go
+++ b/internal/sandbox/store.go
@@ -19,8 +19,11 @@ type MountBinding struct {
 }
 
 // PortBinding represents a published container port.
+// For local sandboxes, HostIP is "127.0.0.1" and HostDomain is "localhost".
+// For remote sandboxes, HostIP is empty and HostDomain holds the remote hostname.
 type PortBinding struct {
 	HostIP        string `json:"hostIp,omitempty"`
+	HostDomain    string `json:"hostDomain,omitempty"`
 	HostPort      int    `json:"hostPort"`
 	ContainerPort int    `json:"containerPort"`
 	Protocol      string `json:"protocol,omitempty"`

--- a/pkg/amika/requests.go
+++ b/pkg/amika/requests.go
@@ -80,3 +80,8 @@ type AuthExtractRequest struct {
 	HomeDir    string
 	NoOAuth    bool
 }
+
+// ListServicesRequest describes service listing input.
+type ListServicesRequest struct {
+	SandboxName string // optional filter
+}

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -12,6 +12,31 @@ type Sandbox struct {
 	Mounts      []Mount
 	Env         []string
 	Ports       []PortBinding
+	Services    []ServiceInfo
+}
+
+// ServiceInfo describes a named service running in a sandbox.
+type ServiceInfo struct {
+	Name  string            `json:"Name"`
+	Ports []ServicePortInfo `json:"Ports"`
+}
+
+// ServicePortInfo is a resolved port binding with an optional generated URL.
+type ServicePortInfo struct {
+	PortBinding
+	URL string `json:"URL,omitempty"`
+}
+
+// ListServicesResult reports listed services.
+type ListServicesResult struct {
+	Items []ServiceListItem
+}
+
+// ServiceListItem is a service with its owning sandbox name.
+type ServiceListItem struct {
+	Service     string
+	SandboxName string
+	Ports       []ServicePortInfo
 }
 
 // DeleteSandboxResult reports sandbox deletion details.

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -29,6 +29,7 @@ type Service interface {
 	ListVolumes(ctx context.Context, req ListVolumesRequest) (ListVolumesResult, error)
 	DeleteVolume(ctx context.Context, req DeleteVolumeRequest) (DeleteVolumeResult, error)
 	ExtractAuth(ctx context.Context, req AuthExtractRequest) (AuthExtractResult, error)
+	ListServices(ctx context.Context, req ListServicesRequest) (ListServicesResult, error)
 }
 
 // Options controls construction of a public Amika service.
@@ -218,6 +219,7 @@ func (s *serviceImpl) ListSandboxes(context.Context, ListSandboxesRequest) (List
 			Mounts:      toMounts(it.Mounts),
 			Env:         it.Env,
 			Ports:       toPortBindings(it.Ports),
+			Services:    toPublicServiceInfos(it.Services),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
@@ -310,6 +312,27 @@ func (s *serviceImpl) ExtractAuth(_ context.Context, req AuthExtractRequest) (Au
 		return AuthExtractResult{}, fmt.Errorf("%w: %v", ErrDependency, err)
 	}
 	return AuthExtractResult{Lines: auth.BuildEnvMap(result).Lines(req.WithExport)}, nil
+}
+
+func (s *serviceImpl) ListServices(_ context.Context, req ListServicesRequest) (ListServicesResult, error) {
+	items, err := s.sandboxes.List()
+	if err != nil {
+		return ListServicesResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+	}
+	var result []ServiceListItem
+	for _, sb := range items {
+		if req.SandboxName != "" && sb.Name != req.SandboxName {
+			continue
+		}
+		for _, svc := range sb.Services {
+			result = append(result, ServiceListItem{
+				Service:     svc.Name,
+				SandboxName: sb.Name,
+				Ports:       toPublicServicePortInfos(svc.Ports),
+			})
+		}
+	}
+	return ListServicesResult{Items: result}, nil
 }
 
 func toSandboxMountBindings(mounts []Mount, volumes []Mount) []sandbox.MountBinding {
@@ -590,6 +613,9 @@ func (s *initErrorService) DeleteVolume(context.Context, DeleteVolumeRequest) (D
 func (s *initErrorService) ExtractAuth(context.Context, AuthExtractRequest) (AuthExtractResult, error) {
 	return AuthExtractResult{}, s.err
 }
+func (s *initErrorService) ListServices(context.Context, ListServicesRequest) (ListServicesResult, error) {
+	return ListServicesResult{}, s.err
+}
 
 func toMounts(in []sandbox.MountBinding) []Mount {
 	out := make([]Mount, 0, len(in))
@@ -607,4 +633,64 @@ func hasEnvKey(env []string, key string) bool {
 		}
 	}
 	return false
+}
+
+func toPublicServiceInfos(in []sandbox.ServiceInfo) []ServiceInfo {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ServiceInfo, 0, len(in))
+	for _, s := range in {
+		out = append(out, ServiceInfo{
+			Name:  s.Name,
+			Ports: toPublicServicePortInfos(s.Ports),
+		})
+	}
+	return out
+}
+
+func toPublicServicePortInfos(in []sandbox.ServicePortInfo) []ServicePortInfo {
+	out := make([]ServicePortInfo, 0, len(in))
+	for _, p := range in {
+		out = append(out, ServicePortInfo{
+			PortBinding: PortBinding{
+				HostIP:        p.HostIP,
+				HostPort:      p.HostPort,
+				ContainerPort: p.ContainerPort,
+				Protocol:      p.Protocol,
+			},
+			URL: p.URL,
+		})
+	}
+	return out
+}
+
+func toSandboxServiceInfos(in []ServiceInfo) []sandbox.ServiceInfo {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]sandbox.ServiceInfo, 0, len(in))
+	for _, s := range in {
+		out = append(out, sandbox.ServiceInfo{
+			Name:  s.Name,
+			Ports: toSandboxServicePortInfos(s.Ports),
+		})
+	}
+	return out
+}
+
+func toSandboxServicePortInfos(in []ServicePortInfo) []sandbox.ServicePortInfo {
+	out := make([]sandbox.ServicePortInfo, 0, len(in))
+	for _, p := range in {
+		out = append(out, sandbox.ServicePortInfo{
+			PortBinding: sandbox.PortBinding{
+				HostIP:        p.HostIP,
+				HostPort:      p.HostPort,
+				ContainerPort: p.ContainerPort,
+				Protocol:      p.Protocol,
+			},
+			URL: p.URL,
+		})
+	}
+	return out
 }

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofixpoint/amika/internal/amikaconfig"
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/constants"
@@ -111,22 +112,39 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		cleanupSetupScript = cleanup
 	}
 	cleanupGitRepo := func() {}
+	var repoCfg *amikaconfig.Config
 	if req.GitRepo != "" {
-		gitMount, gitCleanup, err := s.resolveGitRepoMount(name, req.GitRepo)
+		gitResult, gitCleanup, err := s.resolveGitRepoMount(name, req.GitRepo)
 		if err != nil {
 			cleanupSetupScript()
 			return Sandbox{}, err
 		}
-		mounts = append(mounts, gitMount)
+		mounts = append(mounts, gitResult.Mount)
+		repoCfg = gitResult.Config
 		cleanupGitRepo = gitCleanup
 		if !hasEnvKey(req.Env, "AMIKA_AGENT_CWD") {
-			req.Env = append(req.Env, "AMIKA_AGENT_CWD="+gitMount.Target)
+			req.Env = append(req.Env, "AMIKA_AGENT_CWD="+gitResult.Mount.Target)
 		}
 	}
+
+	// Resolve service ports from config and merge with --port bindings.
+	sandboxPorts := toSandboxPortBindings(ports)
+	var serviceInfos []sandbox.ServiceInfo
+	if repoCfg != nil {
+		svcInfos, additionalPorts, err := ResolveServicesFromConfig(repoCfg, sandboxPorts, "127.0.0.1")
+		if err != nil {
+			cleanupSetupScript()
+			cleanupGitRepo()
+			return Sandbox{}, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
+		}
+		serviceInfos = svcInfos
+		sandboxPorts = append(sandboxPorts, additionalPorts...)
+	}
+
 	if !hasEnvKey(req.Env, constants.EnvSandboxProvider) {
 		req.Env = append(req.Env, constants.EnvSandboxProvider+"="+constants.ProviderLocalDocker)
 	}
-	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env, toSandboxPortBindings(ports))
+	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env, sandboxPorts)
 	if err != nil {
 		cleanupSetupScript()
 		cleanupGitRepo()
@@ -141,7 +159,8 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		Preset:      req.Preset,
 		Mounts:      mounts,
 		Env:         req.Env,
-		Ports:       toSandboxPortBindings(ports),
+		Ports:       sandboxPorts,
+		Services:    serviceInfos,
 	}
 	if err := s.sandboxes.Save(info); err != nil {
 		return Sandbox{}, fmt.Errorf("%w: %v", ErrInternal, err)
@@ -156,6 +175,7 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		Mounts:      toMounts(info.Mounts),
 		Env:         info.Env,
 		Ports:       toPortBindings(info.Ports),
+		Services:    toPublicServiceInfos(info.Services),
 	}, nil
 }
 func (s *serviceImpl) DeleteSandbox(_ context.Context, req DeleteSandboxRequest) (DeleteSandboxResult, error) {
@@ -465,19 +485,25 @@ func isScpStyleURL(s string) bool {
 	return colon > 0 && colon < len(s)-1
 }
 
+// gitRepoResult holds the results of resolving a git repo mount.
+type gitRepoResult struct {
+	Mount  sandbox.MountBinding
+	Config *amikaconfig.Config // nil if no .amika/config.toml
+}
+
 // resolveGitRepoMount clones gitRepo to a temp directory, copies it into a
 // Docker volume, and returns a volume MountBinding targeting the sandbox
 // workspace. The returned cleanup func removes the volume on error; call it
-// only on failure paths.
-func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (sandbox.MountBinding, func(), error) {
+// only on failure paths. It also reads .amika/config.toml from the cloned repo.
+func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (gitRepoResult, func(), error) {
 	repoName, err := parseGitRepoURL(gitRepo)
 	if err != nil {
-		return sandbox.MountBinding{}, func() {}, err
+		return gitRepoResult{}, func() {}, err
 	}
 
 	tmpDir, err := os.MkdirTemp("", "amika-git-clone-*")
 	if err != nil {
-		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: create temp dir for git clone: %v", ErrInternal, err)
+		return gitRepoResult{}, func() {}, fmt.Errorf("%w: create temp dir for git clone: %v", ErrInternal, err)
 	}
 	cloneDst := filepath.Join(tmpDir, repoName)
 
@@ -489,18 +515,25 @@ func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (sandbox.
 	cmd := exec.Command("git", "clone", cloneURL, cloneDst)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: git clone %q failed: %s", ErrDependency, gitRepo, strings.TrimSpace(string(out)))
+		return gitRepoResult{}, func() {}, fmt.Errorf("%w: git clone %q failed: %s", ErrDependency, gitRepo, strings.TrimSpace(string(out)))
+	}
+
+	// Read .amika/config.toml before the temp dir is cleaned up.
+	repoCfg, err := amikaconfig.LoadConfig(cloneDst)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return gitRepoResult{}, func() {}, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
 	}
 
 	volumeName := fmt.Sprintf("amika-git-%s-%s-%d", sandboxName, repoName, time.Now().UnixNano())
 	if err := sandbox.CreateDockerVolume(volumeName); err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: create git volume: %v", ErrDependency, err)
+		return gitRepoResult{}, func() {}, fmt.Errorf("%w: create git volume: %v", ErrDependency, err)
 	}
 	if err := sandbox.CopyHostDirToVolume(volumeName, cloneDst); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		_ = sandbox.RemoveDockerVolume(volumeName)
-		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: copy git repo to volume: %v", ErrInternal, err)
+		return gitRepoResult{}, func() {}, fmt.Errorf("%w: copy git repo to volume: %v", ErrInternal, err)
 	}
 	_ = os.RemoveAll(tmpDir) // volume is the source of truth from here
 
@@ -513,7 +546,7 @@ func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (sandbox.
 	}
 	if err := s.volumes.Save(volInfo); err != nil {
 		_ = sandbox.RemoveDockerVolume(volumeName)
-		return sandbox.MountBinding{}, func() {}, fmt.Errorf("%w: save git volume state: %v", ErrInternal, err)
+		return gitRepoResult{}, func() {}, fmt.Errorf("%w: save git volume state: %v", ErrInternal, err)
 	}
 
 	cleanup := func() {
@@ -527,7 +560,7 @@ func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (sandbox.
 		Mode:         "rw",
 		SnapshotFrom: gitRepo,
 	}
-	return mount, cleanup, nil
+	return gitRepoResult{Mount: mount, Config: repoCfg}, cleanup, nil
 }
 
 func resolveSetupScriptMount(name, setupScriptPath, setupScriptText string) (*sandbox.MountBinding, func(), error) {

--- a/pkg/amika/services.go
+++ b/pkg/amika/services.go
@@ -137,4 +137,3 @@ func ResolveServicesFromConfig(
 	}
 	return resolveServicePorts(services, existingPorts, hostIP)
 }
-

--- a/pkg/amika/services.go
+++ b/pkg/amika/services.go
@@ -1,0 +1,140 @@
+package amika
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/gofixpoint/amika/internal/amikaconfig"
+	"github.com/gofixpoint/amika/internal/sandbox"
+)
+
+// resolveServicePorts resolves parsed service declarations into concrete port bindings.
+// It returns sandbox ServiceInfo records (for storage) and additional PortBindings to publish.
+// existingPorts are the --port flag bindings; conflicts produce an error.
+func resolveServicePorts(
+	services []amikaconfig.ServiceParsed,
+	existingPorts []sandbox.PortBinding,
+	hostIP string,
+) ([]sandbox.ServiceInfo, []sandbox.PortBinding, error) {
+	if len(services) == 0 {
+		return nil, nil, nil
+	}
+
+	// Build set of existing container port claims (from --port flags).
+	existingContainerPorts := make(map[string]bool)
+	claimedHostPorts := make(map[string]bool)
+	for _, p := range existingPorts {
+		cKey := fmt.Sprintf("%d/%s", p.ContainerPort, p.Protocol)
+		existingContainerPorts[cKey] = true
+		hKey := fmt.Sprintf("%d/%s", p.HostPort, p.Protocol)
+		claimedHostPorts[hKey] = true
+	}
+
+	var serviceInfos []sandbox.ServiceInfo
+	var additionalPorts []sandbox.PortBinding
+
+	for _, svc := range services {
+		svcInfo := sandbox.ServiceInfo{Name: svc.Name}
+
+		for _, sp := range svc.Ports {
+			cKey := fmt.Sprintf("%d/%s", sp.ContainerPort, sp.Protocol)
+			if existingContainerPorts[cKey] {
+				return nil, nil, fmt.Errorf("service %q port %s conflicts with --port flag", svc.Name, cKey)
+			}
+
+			hostPort, err := resolveHostPort(sp.ContainerPort, sp.Protocol, claimedHostPorts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("service %q port %s: %w", svc.Name, cKey, err)
+			}
+			hKey := fmt.Sprintf("%d/%s", hostPort, sp.Protocol)
+			claimedHostPorts[hKey] = true
+
+			pb := sandbox.PortBinding{
+				HostIP:        hostIP,
+				HostPort:      hostPort,
+				ContainerPort: sp.ContainerPort,
+				Protocol:      sp.Protocol,
+			}
+			additionalPorts = append(additionalPorts, pb)
+
+			url := ""
+			if sp.URLScheme != "" {
+				url = fmt.Sprintf("%s://%s:%d", sp.URLScheme, hostIP, hostPort)
+			}
+
+			svcInfo.Ports = append(svcInfo.Ports, sandbox.ServicePortInfo{
+				PortBinding: pb,
+				URL:         url,
+			})
+		}
+
+		serviceInfos = append(serviceInfos, svcInfo)
+	}
+
+	return serviceInfos, additionalPorts, nil
+}
+
+// resolveHostPort tries to assign a host port for the given container port.
+// First attempts direct mirror (hostPort = containerPort), then falls back to random.
+func resolveHostPort(containerPort int, protocol string, claimed map[string]bool) (int, error) {
+	key := fmt.Sprintf("%d/%s", containerPort, protocol)
+	if !claimed[key] {
+		return containerPort, nil
+	}
+	// Fall back to random port assignment.
+	network := "tcp"
+	if protocol == "udp" {
+		network = "udp"
+	}
+	addr, err := net.ResolveUDPAddr(network, "127.0.0.1:0")
+	if err != nil {
+		// For TCP, use a different approach.
+		if network == "tcp" {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				return 0, fmt.Errorf("failed to allocate random host port: %w", err)
+			}
+			port := listener.Addr().(*net.TCPAddr).Port
+			listener.Close()
+			return port, nil
+		}
+		return 0, fmt.Errorf("failed to allocate random host port: %w", err)
+	}
+	if network == "udp" {
+		conn, err := net.ListenPacket("udp", addr.String())
+		if err != nil {
+			return 0, fmt.Errorf("failed to allocate random host port: %w", err)
+		}
+		port := conn.LocalAddr().(*net.UDPAddr).Port
+		conn.Close()
+		return port, nil
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("failed to allocate random host port: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+	return port, nil
+}
+
+// ResolveServicesFromConfig parses services from a loaded config
+// and resolves port bindings. Returns nil results when no services are configured.
+func ResolveServicesFromConfig(
+	cfg *amikaconfig.Config,
+	existingPorts []sandbox.PortBinding,
+	hostIP string,
+) ([]sandbox.ServiceInfo, []sandbox.PortBinding, error) {
+	if cfg == nil {
+		return nil, nil, nil
+	}
+	services, err := cfg.ParsedServices()
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid service declarations: %w", err)
+	}
+	if len(services) == 0 {
+		return nil, nil, nil
+	}
+	return resolveServicePorts(services, existingPorts, hostIP)
+}
+

--- a/pkg/amika/services.go
+++ b/pkg/amika/services.go
@@ -1,8 +1,11 @@
 package amika
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 
 	"github.com/gofixpoint/amika/internal/amikaconfig"
 	"github.com/gofixpoint/amika/internal/sandbox"
@@ -42,7 +45,7 @@ func resolveServicePorts(
 				return nil, nil, fmt.Errorf("service %q port %s conflicts with --port flag", svc.Name, cKey)
 			}
 
-			hostPort, err := resolveHostPort(sp.ContainerPort, sp.Protocol, claimedHostPorts)
+			hostPort, err := resolveHostPort(hostIP, sp.ContainerPort, sp.Protocol, claimedHostPorts)
 			if err != nil {
 				return nil, nil, fmt.Errorf("service %q port %s: %w", svc.Name, cKey, err)
 			}
@@ -81,38 +84,102 @@ func resolveServicePorts(
 // container. This is the common case when no other binding has claimed that port.
 //
 // Step 2: If the direct mirror port is already claimed, fall back to an
-// OS-assigned ephemeral port. Binding to "127.0.0.1:0" tells the OS to pick
+// OS-assigned ephemeral port. Binding to the configured host IP with port 0
+// tells the OS to pick
 // any available port; we immediately close the listener/connection and return
 // the assigned port number.
 //
 // TCP and UDP use different listener APIs (net.Listen vs net.ListenPacket)
 // because Go's net package exposes them as distinct types.
-func resolveHostPort(containerPort int, protocol string, claimed map[string]bool) (int, error) {
+func resolveHostPort(hostIP string, containerPort int, protocol string, claimed map[string]bool) (int, error) {
 	// Step 1: try direct mirror (host port = container port).
 	key := fmt.Sprintf("%d/%s", containerPort, protocol)
 	if !claimed[key] {
-		return containerPort, nil
+		available, err := isHostPortAvailable(hostIP, containerPort, protocol)
+		if err != nil {
+			return 0, err
+		}
+		if available {
+			return containerPort, nil
+		}
 	}
 
 	// Step 2: fall back to OS-assigned ephemeral port by binding to :0.
+	port, err := allocateRandomHostPort(hostIP, protocol)
+	if err != nil {
+		return 0, err
+	}
+	return port, nil
+}
+
+func isHostPortAvailable(hostIP string, port int, protocol string) (bool, error) {
+	addr := net.JoinHostPort(hostIPForBinding(hostIP), strconv.Itoa(port))
 	if protocol == "udp" {
-		conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+		conn, err := net.ListenPacket("udp", addr)
+		if err != nil {
+			if isAddressInUse(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to probe mirrored host port: %w", err)
+		}
+		if closeErr := conn.Close(); closeErr != nil {
+			return false, fmt.Errorf("failed to release probed mirrored host port: %w", closeErr)
+		}
+		return true, nil
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		if isAddressInUse(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to probe mirrored host port: %w", err)
+	}
+	if closeErr := listener.Close(); closeErr != nil {
+		return false, fmt.Errorf("failed to release probed mirrored host port: %w", closeErr)
+	}
+	return true, nil
+}
+
+func allocateRandomHostPort(hostIP string, protocol string) (int, error) {
+	addr := net.JoinHostPort(hostIPForBinding(hostIP), "0")
+	if protocol == "udp" {
+		conn, err := net.ListenPacket("udp", addr)
 		if err != nil {
 			return 0, fmt.Errorf("failed to allocate random host port: %w", err)
 		}
 		port := conn.LocalAddr().(*net.UDPAddr).Port
-		conn.Close()
+		if closeErr := conn.Close(); closeErr != nil {
+			return 0, fmt.Errorf("failed to release allocated random host port: %w", closeErr)
+		}
 		return port, nil
 	}
 
 	// TCP (default)
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return 0, fmt.Errorf("failed to allocate random host port: %w", err)
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close()
+	if closeErr := listener.Close(); closeErr != nil {
+		return 0, fmt.Errorf("failed to release allocated random host port: %w", closeErr)
+	}
 	return port, nil
+}
+
+func hostIPForBinding(hostIP string) string {
+	if hostIP == "" {
+		return "127.0.0.1"
+	}
+	return hostIP
+}
+
+func isAddressInUse(err error) bool {
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) {
+		return false
+	}
+	return opErr.Err != nil && strings.Contains(opErr.Err.Error(), "address already in use")
 }
 
 // ResolveServicesFromConfig parses services from a loaded config

--- a/pkg/amika/services.go
+++ b/pkg/amika/services.go
@@ -51,6 +51,7 @@ func resolveServicePorts(
 
 			pb := sandbox.PortBinding{
 				HostIP:        hostIP,
+				HostDomain:    "localhost",
 				HostPort:      hostPort,
 				ContainerPort: sp.ContainerPort,
 				Protocol:      sp.Protocol,
@@ -59,7 +60,7 @@ func resolveServicePorts(
 
 			url := ""
 			if sp.URLScheme != "" {
-				url = fmt.Sprintf("%s://%s:%d", sp.URLScheme, hostIP, hostPort)
+				url = fmt.Sprintf("%s://%s:%d", sp.URLScheme, pb.HostDomain, hostPort)
 			}
 
 			svcInfo.Ports = append(svcInfo.Ports, sandbox.ServicePortInfo{
@@ -74,34 +75,28 @@ func resolveServicePorts(
 	return serviceInfos, additionalPorts, nil
 }
 
-// resolveHostPort tries to assign a host port for the given container port.
-// First attempts direct mirror (hostPort = containerPort), then falls back to random.
+// resolveHostPort assigns a host port for the given container port and protocol.
+//
+// Step 1: Try direct mirror — use the same port number on the host as in the
+// container. This is the common case when no other binding has claimed that port.
+//
+// Step 2: If the direct mirror port is already claimed, fall back to an
+// OS-assigned ephemeral port. Binding to "127.0.0.1:0" tells the OS to pick
+// any available port; we immediately close the listener/connection and return
+// the assigned port number.
+//
+// TCP and UDP use different listener APIs (net.Listen vs net.ListenPacket)
+// because Go's net package exposes them as distinct types.
 func resolveHostPort(containerPort int, protocol string, claimed map[string]bool) (int, error) {
+	// Step 1: try direct mirror (host port = container port).
 	key := fmt.Sprintf("%d/%s", containerPort, protocol)
 	if !claimed[key] {
 		return containerPort, nil
 	}
-	// Fall back to random port assignment.
-	network := "tcp"
+
+	// Step 2: fall back to OS-assigned ephemeral port by binding to :0.
 	if protocol == "udp" {
-		network = "udp"
-	}
-	addr, err := net.ResolveUDPAddr(network, "127.0.0.1:0")
-	if err != nil {
-		// For TCP, use a different approach.
-		if network == "tcp" {
-			listener, err := net.Listen("tcp", "127.0.0.1:0")
-			if err != nil {
-				return 0, fmt.Errorf("failed to allocate random host port: %w", err)
-			}
-			port := listener.Addr().(*net.TCPAddr).Port
-			listener.Close()
-			return port, nil
-		}
-		return 0, fmt.Errorf("failed to allocate random host port: %w", err)
-	}
-	if network == "udp" {
-		conn, err := net.ListenPacket("udp", addr.String())
+		conn, err := net.ListenPacket("udp", "127.0.0.1:0")
 		if err != nil {
 			return 0, fmt.Errorf("failed to allocate random host port: %w", err)
 		}
@@ -109,6 +104,8 @@ func resolveHostPort(containerPort int, protocol string, claimed map[string]bool
 		conn.Close()
 		return port, nil
 	}
+
+	// TCP (default)
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, fmt.Errorf("failed to allocate random host port: %w", err)

--- a/pkg/amika/services.go
+++ b/pkg/amika/services.go
@@ -52,9 +52,10 @@ func resolveServicePorts(
 			hKey := fmt.Sprintf("%d/%s", hostPort, sp.Protocol)
 			claimedHostPorts[hKey] = true
 
+			hostDomain := hostDomainForService(hostIP)
 			pb := sandbox.PortBinding{
 				HostIP:        hostIP,
-				HostDomain:    "localhost",
+				HostDomain:    hostDomain,
 				HostPort:      hostPort,
 				ContainerPort: sp.ContainerPort,
 				Protocol:      sp.Protocol,
@@ -63,7 +64,7 @@ func resolveServicePorts(
 
 			url := ""
 			if sp.URLScheme != "" {
-				url = fmt.Sprintf("%s://%s:%d", sp.URLScheme, pb.HostDomain, hostPort)
+				url = fmt.Sprintf("%s://%s", sp.URLScheme, net.JoinHostPort(pb.HostDomain, strconv.Itoa(hostPort)))
 			}
 
 			svcInfo.Ports = append(svcInfo.Ports, sandbox.ServicePortInfo{
@@ -172,6 +173,15 @@ func hostIPForBinding(hostIP string) string {
 		return "127.0.0.1"
 	}
 	return hostIP
+}
+
+func hostDomainForService(hostIP string) string {
+	switch hostIP {
+	case "", "127.0.0.1", "::1":
+		return "localhost"
+	default:
+		return hostIP
+	}
 }
 
 func isAddressInUse(err error) bool {

--- a/pkg/amika/services_test.go
+++ b/pkg/amika/services_test.go
@@ -1,0 +1,135 @@
+package amika
+
+import (
+	"testing"
+
+	"github.com/gofixpoint/amika/internal/amikaconfig"
+	"github.com/gofixpoint/amika/internal/sandbox"
+)
+
+func TestResolveServicePorts_DirectMirror(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 4838, Protocol: "tcp"},
+		}},
+	}
+	infos, ports, err := resolveServicePorts(services, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Name != "api" {
+		t.Fatalf("expected 1 service 'api', got %+v", infos)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(ports))
+	}
+	if ports[0].HostPort != 4838 || ports[0].ContainerPort != 4838 {
+		t.Errorf("expected direct mirror 4838->4838, got %d->%d", ports[0].HostPort, ports[0].ContainerPort)
+	}
+}
+
+func TestResolveServicePorts_FallbackRandomWhenTaken(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 4838, Protocol: "tcp"},
+		}},
+	}
+	existing := []sandbox.PortBinding{
+		{HostIP: "127.0.0.1", HostPort: 4838, ContainerPort: 4838, Protocol: "tcp"},
+	}
+	_, _, err := resolveServicePorts(services, existing, "127.0.0.1")
+	// This should error because the same container port conflicts with --port flag
+	if err == nil {
+		t.Fatal("expected error for conflicting container port, got nil")
+	}
+}
+
+func TestResolveServicePorts_ConflictWithPortFlag(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 4838, Protocol: "tcp"},
+		}},
+	}
+	existing := []sandbox.PortBinding{
+		{HostIP: "127.0.0.1", HostPort: 9999, ContainerPort: 4838, Protocol: "tcp"},
+	}
+	_, _, err := resolveServicePorts(services, existing, "127.0.0.1")
+	if err == nil {
+		t.Fatal("expected error for conflicting container port, got nil")
+	}
+}
+
+func TestResolveServicePorts_MultipleServices(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 4838, Protocol: "tcp"},
+		}},
+		{Name: "metrics", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 9090, Protocol: "tcp"},
+		}},
+	}
+	infos, ports, err := resolveServicePorts(services, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(infos))
+	}
+	if len(ports) != 2 {
+		t.Fatalf("expected 2 ports, got %d", len(ports))
+	}
+}
+
+func TestResolveServicePorts_URLGeneration(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 4838, Protocol: "tcp", URLScheme: "http"},
+		}},
+	}
+	infos, _, err := resolveServicePorts(services, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if infos[0].Ports[0].URL != "http://127.0.0.1:4838" {
+		t.Errorf("expected URL %q, got %q", "http://127.0.0.1:4838", infos[0].Ports[0].URL)
+	}
+}
+
+func TestResolveServicePorts_MultiPortURLGeneration(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "web", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 3000, Protocol: "tcp", URLScheme: "https"},
+			{ContainerPort: 3001, Protocol: "tcp", URLScheme: ""},
+			{ContainerPort: 9090, Protocol: "udp", URLScheme: ""},
+		}},
+	}
+	infos, _, err := resolveServicePorts(services, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ports := infos[0].Ports
+	if ports[0].URL != "https://127.0.0.1:3000" {
+		t.Errorf("port 3000: expected URL %q, got %q", "https://127.0.0.1:3000", ports[0].URL)
+	}
+	if ports[1].URL != "" {
+		t.Errorf("port 3001: expected empty URL, got %q", ports[1].URL)
+	}
+	if ports[2].URL != "" {
+		t.Errorf("port 9090: expected empty URL, got %q", ports[2].URL)
+	}
+}
+
+func TestResolveServicePorts_NoURLScheme(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 4838, Protocol: "tcp", URLScheme: ""},
+		}},
+	}
+	infos, _, err := resolveServicePorts(services, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if infos[0].Ports[0].URL != "" {
+		t.Errorf("expected empty URL, got %q", infos[0].Ports[0].URL)
+	}
+}

--- a/pkg/amika/services_test.go
+++ b/pkg/amika/services_test.go
@@ -28,7 +28,7 @@ func TestResolveServicePorts_DirectMirror(t *testing.T) {
 	}
 }
 
-func TestResolveServicePorts_FallbackRandomWhenTaken(t *testing.T) {
+func TestResolveServicePorts_ConflictSameContainerPort(t *testing.T) {
 	services := []amikaconfig.ServiceParsed{
 		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
 			{ContainerPort: 4838, Protocol: "tcp"},
@@ -38,9 +38,42 @@ func TestResolveServicePorts_FallbackRandomWhenTaken(t *testing.T) {
 		{HostIP: "127.0.0.1", HostPort: 4838, ContainerPort: 4838, Protocol: "tcp"},
 	}
 	_, _, err := resolveServicePorts(services, existing, "127.0.0.1")
-	// This should error because the same container port conflicts with --port flag
+	// This should error because the same container port conflicts with --port flag.
 	if err == nil {
 		t.Fatal("expected error for conflicting container port, got nil")
+	}
+}
+
+func TestResolveServicePorts_FallbackRandomWhenHostPortTaken(t *testing.T) {
+	// Service wants container port 5000, but host port 5000 is already
+	// claimed by a different container port mapping. The service should
+	// fall back to an OS-assigned random host port.
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 5000, Protocol: "tcp"},
+		}},
+	}
+	existing := []sandbox.PortBinding{
+		{HostIP: "127.0.0.1", HostPort: 5000, ContainerPort: 9999, Protocol: "tcp"},
+	}
+	infos, ports, err := resolveServicePorts(services, existing, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(ports))
+	}
+	if ports[0].HostPort == 5000 {
+		t.Errorf("expected random fallback port, got direct mirror 5000")
+	}
+	if ports[0].HostPort == 0 {
+		t.Errorf("expected non-zero host port")
+	}
+	if ports[0].ContainerPort != 5000 {
+		t.Errorf("expected container port 5000, got %d", ports[0].ContainerPort)
+	}
+	if len(infos) != 1 || infos[0].Ports[0].HostPort != ports[0].HostPort {
+		t.Errorf("service info host port should match allocated port")
 	}
 }
 
@@ -90,8 +123,8 @@ func TestResolveServicePorts_URLGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if infos[0].Ports[0].URL != "http://127.0.0.1:4838" {
-		t.Errorf("expected URL %q, got %q", "http://127.0.0.1:4838", infos[0].Ports[0].URL)
+	if infos[0].Ports[0].URL != "http://localhost:4838" {
+		t.Errorf("expected URL %q, got %q", "http://localhost:4838", infos[0].Ports[0].URL)
 	}
 }
 
@@ -108,8 +141,8 @@ func TestResolveServicePorts_MultiPortURLGeneration(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	ports := infos[0].Ports
-	if ports[0].URL != "https://127.0.0.1:3000" {
-		t.Errorf("port 3000: expected URL %q, got %q", "https://127.0.0.1:3000", ports[0].URL)
+	if ports[0].URL != "https://localhost:3000" {
+		t.Errorf("port 3000: expected URL %q, got %q", "https://localhost:3000", ports[0].URL)
 	}
 	if ports[1].URL != "" {
 		t.Errorf("port 3001: expected empty URL, got %q", ports[1].URL)

--- a/pkg/amika/services_test.go
+++ b/pkg/amika/services_test.go
@@ -1,6 +1,8 @@
 package amika
 
 import (
+	"net"
+	"strconv"
 	"testing"
 
 	"github.com/gofixpoint/amika/internal/amikaconfig"
@@ -75,6 +77,47 @@ func TestResolveServicePorts_FallbackRandomWhenHostPortTaken(t *testing.T) {
 	if len(infos) != 1 || infos[0].Ports[0].HostPort != ports[0].HostPort {
 		t.Errorf("service info host port should match allocated port")
 	}
+}
+
+func TestResolveServicePorts_FallbackRandomWhenMirroredHostPortInUse(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve test host port: %v", err)
+	}
+	defer listener.Close()
+
+	reservedPort := listener.Addr().(*net.TCPAddr).Port
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: reservedPort, Protocol: "tcp"},
+		}},
+	}
+
+	infos, ports, err := resolveServicePorts(services, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(ports))
+	}
+	if ports[0].HostPort == reservedPort {
+		t.Fatalf("expected fallback away from occupied host port %d", reservedPort)
+	}
+	if ports[0].HostPort == 0 {
+		t.Fatal("expected non-zero fallback host port")
+	}
+	if ports[0].ContainerPort != reservedPort {
+		t.Fatalf("expected container port %d, got %d", reservedPort, ports[0].ContainerPort)
+	}
+	if infos[0].Ports[0].HostPort != ports[0].HostPort {
+		t.Fatalf("expected service info host port %d, got %d", ports[0].HostPort, infos[0].Ports[0].HostPort)
+	}
+
+	probeListener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(ports[0].HostPort)))
+	if err != nil {
+		t.Fatalf("expected fallback host port %d to be free after allocation, got %v", ports[0].HostPort, err)
+	}
+	probeListener.Close()
 }
 
 func TestResolveServicePorts_ConflictWithPortFlag(t *testing.T) {

--- a/pkg/amika/services_test.go
+++ b/pkg/amika/services_test.go
@@ -171,6 +171,24 @@ func TestResolveServicePorts_URLGeneration(t *testing.T) {
 	}
 }
 
+func TestResolveServicePorts_URLGenerationUsesConfiguredBindAddress(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "api", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 4838, Protocol: "tcp", URLScheme: "http"},
+		}},
+	}
+	infos, ports, err := resolveServicePorts(services, nil, "0.0.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ports[0].HostDomain != "0.0.0.0" {
+		t.Fatalf("expected HostDomain %q, got %q", "0.0.0.0", ports[0].HostDomain)
+	}
+	if infos[0].Ports[0].URL != "http://0.0.0.0:4838" {
+		t.Errorf("expected URL %q, got %q", "http://0.0.0.0:4838", infos[0].Ports[0].URL)
+	}
+}
+
 func TestResolveServicePorts_MultiPortURLGeneration(t *testing.T) {
 	services := []amikaconfig.ServiceParsed{
 		{Name: "web", Ports: []amikaconfig.ServicePortParsed{

--- a/specs/005-services.md
+++ b/specs/005-services.md
@@ -61,18 +61,29 @@ url_scheme = [
 - Valid protocols: `tcp`, `udp`.
 - Port numbers must be in the range 1–65535.
 - Ports in the reserved range 60899–60999 are rejected (see `docs/sandbox-configuration.md`).
-- At least one of `port` or `ports` must be specified per service.
+- A service may omit both `port` and `ports`, in which case it is treated as metadata-only and has no resolved ports.
 
 ### `url_scheme` format
 
 The shape of `url_scheme` depends on whether the service uses `port` or `ports`:
 
-**With `port` (single port):** `url_scheme` is a plain string — `"http"` or `"https"`. The scheme applies to the single declared port.
+**With `port` (single port):** `url_scheme` may be either a plain string or a list of inline tables.
+
+- String form: `"http"` or `"https"`. The scheme applies to the single declared port.
+- List form: either `[]` or a single `{port, scheme}` inline table whose `port` exactly matches the declared `port`.
 
 ```toml
 [services.api]
 port = 4838
 url_scheme = "http"
+```
+
+```toml
+[services.api]
+port = 4838
+url_scheme = [
+  { port = 4838, scheme = "http" },
+]
 ```
 
 **With `ports` (multiple ports):** `url_scheme` is a list of `{port, scheme}` inline tables. Each entry specifies which port gets a URL and with what scheme. Ports not listed do not get URLs — this is intentional so that URLs are only generated for ports the user explicitly opts in to.
@@ -90,11 +101,12 @@ url_scheme = [
 **Validation rules for `url_scheme`:**
 
 - Optional. When omitted, no URLs are generated for the service.
-- When `port` is used, `url_scheme` must be a string. A list value is a validation error.
+- When `port` is used, `url_scheme` may be a string, an empty list, or a one-entry list whose `port` matches the declared `port`.
 - When `ports` is used, `url_scheme` must be a list of `{port, scheme}` tables. A string value is a validation error.
 - Each `scheme` value must be `"http"` or `"https"`.
-- Each `port` in a `url_scheme` mapping must reference a port declared in the service's `ports` list (matched by container port and protocol). An unrecognized port is a validation error.
+- Each `port` in a `url_scheme` mapping must reference a port declared in the service. For single-port services using list form, the mapping must match the declared `port` exactly.
 - Duplicate port entries within `url_scheme` are a validation error.
+- For single-port services using list form, more than one entry is a validation error.
 
 ### Port format
 
@@ -106,15 +118,17 @@ This matches the container-port side of the existing `--port` CLI flag syntax.
 
 ### URL generation
 
-For each port that has an associated scheme (either from the string `url_scheme` with `port`, or from a matching entry in the `url_scheme` list with `ports`), Amika generates a URL using the format:
+For each port that has an associated scheme, Amika generates a URL using the format:
 
 ```
-<scheme>://<hostIP>:<hostPort>
+<scheme>://<host-or-bind-address>:<hostPort>
 ```
 
-For example, a service with `port = 4838` and `url_scheme = "http"` that resolves to `127.0.0.1:4838` produces the URL `http://127.0.0.1:4838`.
+For loopback bindings (`127.0.0.1`, `::1`, or empty/default), Amika uses `localhost` in the generated URL. For other bind addresses, it uses the configured bind address directly.
 
-For a multi-port service, only ports with `url_scheme` mappings get URLs. A service with `ports = [3000, 3001, 9090]` and `url_scheme = [{port = 3000, scheme = "https"}]` generates one URL (`https://127.0.0.1:3000`); ports 3001 and 9090 get no URLs.
+For example, a service with `port = 4838` and `url_scheme = "http"` that resolves to loopback on port 4838 produces `http://localhost:4838`. A service bound to `0.0.0.0` on port 4838 produces `http://0.0.0.0:4838`.
+
+For a multi-port service, only ports with `url_scheme` mappings get URLs. A service with `ports = [3000, 3001, 9090]` and `url_scheme = [{port = 3000, scheme = "https"}]` generates one URL (`https://localhost:3000` for loopback binding); ports 3001 and 9090 get no URLs.
 
 URLs are computed at sandbox creation time (after port resolution) and stored in the service metadata. They appear in `amika service list` output and API responses.
 
@@ -153,10 +167,10 @@ type Config struct {
 type ServiceConfig struct {
     Port      interface{}   `toml:"port"`       // int or string
     Ports     []interface{} `toml:"ports"`      // list of int or string
-    URLScheme interface{}   `toml:"url_scheme"` // string (with port) or []URLSchemeMapping (with ports)
+    URLScheme interface{}   `toml:"url_scheme"` // string, []URLSchemeMapping, or empty list depending on port/ports
 }
 
-// URLSchemeMapping maps a port to a URL scheme in multi-port services.
+// URLSchemeMapping maps a port to a URL scheme.
 type URLSchemeMapping struct {
     Port   interface{} `toml:"port"`   // int or "port/protocol" string
     Scheme string      `toml:"scheme"` // "http" or "https"
@@ -167,15 +181,16 @@ type URLSchemeMapping struct {
 
 Add `ValidateServices(services map[string]ServiceConfig) error` that checks:
 
-1. Each service has exactly one of `port` or `ports` (not both, not neither).
+1. Each service has at most one of `port` or `ports`. A service may omit both and remain metadata-only.
 2. Every port value parses to a valid container port (1–65535) and protocol (`tcp` or `udp`).
 3. No port falls in the reserved range 60899–60999.
 4. No duplicate container port/protocol pair across all services in the file.
 5. If `url_scheme` is set:
-   - With `port`: must be a string, either `"http"` or `"https"`. A list is a validation error.
+   - With `port`: may be a string (`"http"` or `"https"`), an empty list, or a one-entry list whose `port` matches the declared port.
    - With `ports`: must be a list of `{port, scheme}` mappings. A string is a validation error.
    - Each `scheme` must be `"http"` or `"https"`.
-   - Each `port` in a mapping must match a declared port in the service's `ports` list.
+   - Each `port` in a mapping must match a declared port in the service.
+   - With `port` and list form, the list may contain at most one entry.
    - No duplicate ports within the `url_scheme` list.
 
 ### Parsed representation
@@ -195,7 +210,7 @@ type ServiceParsed struct {
 }
 ```
 
-Each `ServicePortParsed` carries its own `URLScheme`. For a single-port service with `url_scheme = "http"`, the port's `URLScheme` is `"http"`. For a multi-port service, only ports that appear in the `url_scheme` list get a non-empty `URLScheme`; the rest have `""`.
+Each `ServicePortParsed` carries its own `URLScheme`. For a single-port service with `url_scheme = "http"`, the port's `URLScheme` is `"http"`. For a single-port service using the list form, the port gets the mapped scheme when the list contains a matching entry, or `""` when the list is empty. For a multi-port service, only ports that appear in the `url_scheme` list get a non-empty `URLScheme`; the rest have `""`.
 
 Add a method `Config.ParsedServices() ([]ServiceParsed, error)` that validates and returns the normalized list.
 
@@ -207,7 +222,7 @@ When `--git` is used and the cloned repo contains `.amika/config.toml` with serv
 
 For each service port (`containerPort/protocol`):
 
-1. **Try direct mirror**: attempt `hostPort = containerPort`. If the host port is available (not already claimed by another binding in this sandbox creation), use it.
+1. **Try direct mirror**: attempt `hostPort = containerPort`. If the host port is not already claimed by another binding in this sandbox creation and is available on the configured bind address, use it.
 2. **Fallback**: pick a random available host port by binding to port 0 and reading the assigned port (same mechanism as Docker's random port assignment).
 
 The host IP defaults to `127.0.0.1`, consistent with the `--port-host-ip` default.
@@ -239,11 +254,11 @@ type ServiceInfo struct {
 // ServicePortInfo is a resolved port binding with an optional generated URL.
 type ServicePortInfo struct {
     PortBinding          // embedded: HostIP, HostPort, ContainerPort, Protocol
-    URL         string   `json:"url,omitempty"` // e.g. "http://127.0.0.1:4838", or ""
+    URL         string   `json:"url,omitempty"` // e.g. "http://localhost:4838", or ""
 }
 ```
 
-`URL` is computed at creation time for ports that have an associated `url_scheme`. For example, a port with scheme `"http"` resolved to `127.0.0.1:4838` gets `URL: "http://127.0.0.1:4838"`. Ports without a scheme have an empty `URL` (omitted from JSON).
+`URL` is computed at creation time for ports that have an associated `url_scheme`. For example, a port with scheme `"http"` resolved to loopback on port 4838 gets `URL: "http://localhost:4838"`. Ports without a scheme have an empty `URL` (omitted from JSON).
 
 ### Extended `Info` struct
 
@@ -286,10 +301,10 @@ Tab-separated columns:
 
 ```
 SERVICE    SANDBOX          PORTS                                                URL
-api        teal-tokyo       127.0.0.1:4838->4838/tcp                            http://127.0.0.1:4838
+api        teal-tokyo       127.0.0.1:4838->4838/tcp                            http://localhost:4838
 metrics    teal-tokyo       127.0.0.1:9090->9090/tcp                            -
-frontend   teal-tokyo       127.0.0.1:3000->3000/tcp,127.0.0.1:3001->3001/tcp   https://127.0.0.1:3000
-api        blue-paris       127.0.0.1:4838->4838/tcp                            http://127.0.0.1:4838
+frontend   teal-tokyo       127.0.0.1:3000->3000/tcp,127.0.0.1:3001->3001/tcp   https://localhost:3000
+api        blue-paris       127.0.0.1:4838->4838/tcp                            http://localhost:4838
 ```
 
 Port formatting uses the same `hostIP:hostPort->containerPort/protocol` format as existing `sandbox list` output.
@@ -324,7 +339,7 @@ type ServiceInfo struct {
 // ServicePortInfo is a resolved port binding with an optional generated URL.
 type ServicePortInfo struct {
     PortBinding          // embedded: HostIP, HostPort, ContainerPort, Protocol
-    URL         string   `json:"URL,omitempty"` // e.g. "http://127.0.0.1:4838", or ""
+    URL         string   `json:"URL,omitempty"` // e.g. "http://localhost:4838", or ""
 }
 ```
 
@@ -422,7 +437,7 @@ func registerListServices(api huma.API, service amika.Service) {
 
 ### `internal/amikaconfig` unit tests
 
-1. Parse config with a single `[service.api]` using `port = 4838` — returns one service with port 4838/tcp.
+1. Parse config with a single `[services.api]` using `port = 4838` — returns one service with port 4838/tcp.
 2. Parse config with `port = "9090/udp"` — returns port 9090/udp.
 3. Parse config with `ports = [3000, "3001/tcp", "9090/udp"]` — returns three ports with correct protocols.
 4. Validation error when both `port` and `ports` are set on the same service.
@@ -437,10 +452,13 @@ func registerListServices(api huma.API, service amika.Service) {
 13. Parse config with no `url_scheme` — all parsed ports have `URLScheme: ""`.
 14. Validation error for invalid scheme value (e.g. `"ftp"`, `"ws"`).
 15. Parse multi-port service with `url_scheme = [{port = 3000, scheme = "http"}]` — only port 3000 has `URLScheme: "http"`, others have `""`.
-16. Validation error when `port` is used with a list-form `url_scheme`.
+16. Parse single-port service with `url_scheme = [{port = 4838, scheme = "http"}]` — parsed port has `URLScheme: "http"`.
 17. Validation error when `ports` is used with a string-form `url_scheme`.
-18. Validation error when a `url_scheme` mapping references a port not in the service's `ports` list.
-19. Validation error for duplicate port in `url_scheme` list.
+18. Parse single-port service with `url_scheme = []` — parsed port has `URLScheme: ""`.
+19. Validation error when a single-port `url_scheme` list references a port other than the declared `port`.
+20. Validation error when a single-port `url_scheme` list contains more than one entry.
+21. Validation error when a `url_scheme` mapping references a port not in the service's `ports` list.
+22. Validation error for duplicate port in `url_scheme` list.
 
 ### Port resolution and URL generation unit tests
 
@@ -448,9 +466,10 @@ func registerListServices(api huma.API, service amika.Service) {
 2. Service ports fall back to random host port when direct mirror is taken by a `--port` flag.
 3. Error when a service container port conflicts with a `--port` flag container port.
 4. Multiple services with non-overlapping ports all resolve correctly.
-5. Single-port service with `url_scheme = "http"` resolved to `127.0.0.1:4838` — port has `URL: "http://127.0.0.1:4838"`.
-6. Multi-port service with `url_scheme` mapping for one port — only that port has a URL, others have `URL: ""`.
-7. Service without `url_scheme` — all ports have `URL: ""`.
+5. Single-port service with `url_scheme = "http"` resolved to loopback on port 4838 — port has `URL: "http://localhost:4838"`.
+6. Single-port service with non-loopback bind address uses that bind address in the generated URL.
+7. Multi-port service with `url_scheme` mapping for one port — only that port has a URL, others have `URL: ""`.
+8. Service without `url_scheme` — all ports have `URL: ""`.
 
 ### `sandbox.Info` storage tests
 
@@ -490,9 +509,10 @@ func registerListServices(api huma.API, service amika.Service) {
 9. `--port` flags and service ports merge cleanly; duplicates produce a clear error.
 10. Reserved ports (60899–60999) are rejected in service declarations.
 11. Single-port services with `url_scheme` string have auto-generated URLs in stored metadata, CLI output, and API responses.
-12. Multi-port services with `url_scheme` list generate URLs only for the mapped ports.
-13. Services without `url_scheme` have no URLs in output.
-14. Using a string `url_scheme` with `ports` is a validation error, and vice versa.
+12. Single-port services may also use `url_scheme = []` or a one-entry list whose port matches the declared `port`.
+13. Multi-port services with `url_scheme` list generate URLs only for the mapped ports.
+14. Services without `url_scheme` have no URLs in output.
+15. Using a string `url_scheme` with `ports` is a validation error.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
This PR adds support for declaring and automatically binding service ports through `.amika/config.toml`. Services can now be defined with port configurations, and the system will automatically resolve port bindings, generate URLs, and expose them through the API and CLI.

## Key Changes

### Configuration & Parsing
- Added `ServiceConfig` struct to parse service declarations from TOML with support for:
  - Single port via `port` field (integer or "port/protocol" string)
  - Multiple ports via `ports` array
  - URL scheme mapping via `url_scheme` (string for single-port, list of {port, scheme} for multi-port)
- Implemented comprehensive validation in `ValidateServices()` with checks for:
  - Mutual exclusivity of `port` and `ports`
  - Port range validation (1-65535)
  - Protocol validation (tcp/udp only)
  - Reserved port range blocking (60899-60999)
  - Duplicate port detection across services
  - URL scheme format and port reference validation
- Added `ParsedServices()` method to `Config` for normalized service resolution

### Port Resolution
- Created `resolveServicePorts()` to map declared container ports to host ports
- Implements direct mirroring when host port is available, falls back to random allocation
- Detects conflicts between service ports and `--port` flag bindings
- Generates service URLs when URL scheme is specified
- Returns both `ServiceInfo` records (for storage) and `PortBinding` objects (for Docker)

### Storage & API
- Extended `SandboxRecord` and related types to store `ServiceInfo` with resolved port bindings and URLs
- Added `ListServices()` method to service interface for querying services across sandboxes
- Implemented HTTP endpoint `/services` with optional `sandbox_name` query filter
- Added `service list` CLI command with tabular output showing service names, ports, and URLs

### Integration
- Modified `CreateSandbox()` to load `.amika/config.toml` from git repos and resolve service ports
- Service ports are automatically added to sandbox port bindings
- Service information is persisted and returned in sandbox responses
- CLI displays resolved services and their URLs after sandbox creation

### Testing
- Added 19 comprehensive test cases covering:
  - Single and multiple port parsing
  - Protocol handling (tcp/udp)
  - URL scheme validation and application
  - Error cases (out-of-range ports, invalid protocols, reserved ports, duplicates, conflicts)
  - Multi-port URL scheme mapping
- Added integration tests for port resolution with conflict detection and URL generation

## Notable Implementation Details
- Services are sorted deterministically by name for consistent output
- Port binding uses "port/protocol" keys to track uniqueness across services
- URL generation only occurs when `URLScheme` is explicitly set (empty string means no URL)
- Host port allocation prefers direct mirroring but gracefully falls back to OS-assigned random ports
- Service configuration is loaded once per sandbox creation and reused for both setup scripts and service resolution

https://claude.ai/code/session_01QFg476vyvEYttJD52qBiPo