### PR TITLE
fix: extract post-setup.sh and fix /home/amika ownership

### DIFF
--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -48,10 +48,8 @@ RUN mkdir -p \
 # post-setup.sh runs last as root to restore expected ownership after setup.
 # run-hook.sh wraps each hook so stdout, stderr, and Bash ERR trap output land
 # in /var/log/amika/<hook>.log and are mirrored to /var/log/amikad/<hook>.log.
-RUN printf '#!/bin/bash\n# post-setup.sh runs after setup.sh as root.\n# It restores /home/amika ownership in case the user hook wrote files as root.\nsudo chown -R amika:amika /home/amika\n' > /usr/lib/amikad/post-setup.sh \
-    && chmod +x /usr/lib/amikad/post-setup.sh
-COPY pre-setup.sh opencode-setup.sh run-hook.sh bash-error-prelude.sh /usr/lib/amikad/
-RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/opencode-setup.sh /usr/lib/amikad/run-hook.sh
+COPY pre-setup.sh post-setup.sh opencode-setup.sh run-hook.sh bash-error-prelude.sh /usr/lib/amikad/
+RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/post-setup.sh /usr/lib/amikad/opencode-setup.sh /usr/lib/amikad/run-hook.sh
 
 # Create user with home directory.
 RUN useradd -m -s /usr/bin/zsh amika

--- a/internal/sandbox/presets/post-setup.sh
+++ b/internal/sandbox/presets/post-setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# post-setup.sh runs after setup.sh as root.
+# It restores /home/amika ownership in case the user hook wrote files as root.
+
+set -euo pipefail
+
+sudo chown -R amika:amika /home/amika

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -63,3 +63,5 @@ if command -v opencode &> /dev/null && [[ "${AMIKA_OPENCODE_WEB:-1}" != "0" ]]; 
   echo "$!" > "$AMIKA_RUN_DIR/opencode-web.pid"
   echo "$OPENCODE_WEB_PORT" > "$AMIKA_RUN_DIR/opencode-web.port"
 fi
+
+sudo chown -R amika:amika /home/amika


### PR DESCRIPTION
## Summary
- Extract inline `post-setup.sh` from Dockerfile `printf` into a proper script file
- Add `chown -R amika:amika /home/amika` to `pre-setup.sh` so the amika user owns its home directory before setup hooks run