### PR TITLE
fix: local service URL scheme and OpenCode web UI port binding

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -182,6 +182,18 @@ var sandboxCreateCmd = &cobra.Command{
 		if !hasEnvKey(envStrs, constants.EnvSandboxProvider) {
 			envStrs = append(envStrs, constants.EnvSandboxProvider+"="+constants.ProviderLocalDocker)
 		}
+
+		// Resolve provisioned (Amika-managed) services such as the OpenCode web
+		// UI. These run on reserved ports inside the container and need explicit
+		// Docker port bindings. Must run after appendPresetRuntimeEnv so
+		// OPENCODE_SERVER_PASSWORD is present in envStrs.
+		provSvcInfos, provPorts, err := amika.ResolveProvisionedServices(envStrs, publishedPorts, portHostIP)
+		if err != nil {
+			return err
+		}
+		collected.Services = append(collected.Services, provSvcInfos...)
+		publishedPorts = append(publishedPorts, provPorts...)
+
 		if err := validateMountTargets(mounts, volumeMounts); err != nil {
 			return err
 		}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -16,4 +16,7 @@ const (
 	// ReservedPortEnd is the end of the port range reserved for Amika
 	// internal services inside sandbox containers (inclusive).
 	ReservedPortEnd = 60999
+
+	// OpenCodeWebPort is the container port reserved for the OpenCode web UI.
+	OpenCodeWebPort = 60998
 )

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -144,6 +144,17 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	if !hasEnvKey(req.Env, constants.EnvSandboxProvider) {
 		req.Env = append(req.Env, constants.EnvSandboxProvider+"="+constants.ProviderLocalDocker)
 	}
+
+	// Resolve provisioned (Amika-managed) services like OpenCode web UI.
+	provSvcInfos, provPorts, err := ResolveProvisionedServices(req.Env, sandboxPorts, "127.0.0.1")
+	if err != nil {
+		cleanupSetupScript()
+		cleanupGitRepo()
+		return Sandbox{}, fmt.Errorf("%w: %v", ErrDependency, err)
+	}
+	serviceInfos = append(serviceInfos, provSvcInfos...)
+	sandboxPorts = append(sandboxPorts, provPorts...)
+
 	containerID, err := sandbox.CreateDockerSandbox(name, req.Image, mounts, req.Env, sandboxPorts)
 	if err != nil {
 		cleanupSetupScript()

--- a/pkg/amika/services.go
+++ b/pkg/amika/services.go
@@ -64,7 +64,8 @@ func resolveServicePorts(
 
 			url := ""
 			if sp.URLScheme != "" {
-				url = fmt.Sprintf("%s://%s", sp.URLScheme, net.JoinHostPort(pb.HostDomain, strconv.Itoa(hostPort)))
+				scheme := localServiceScheme(sp.URLScheme, hostIP)
+				url = fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(pb.HostDomain, strconv.Itoa(hostPort)))
 			}
 
 			svcInfo.Ports = append(svcInfo.Ports, sandbox.ServicePortInfo{
@@ -181,6 +182,21 @@ func hostDomainForService(hostIP string) string {
 		return "localhost"
 	default:
 		return hostIP
+	}
+}
+
+// localServiceScheme downgrades "https" to "http" when the host IP is a
+// local address. Local Docker sandboxes do not have TLS certificates, so
+// advertising an https URL would be misleading.
+func localServiceScheme(scheme, hostIP string) string {
+	if scheme != "https" {
+		return scheme
+	}
+	switch hostIP {
+	case "", "127.0.0.1", "::1":
+		return "http"
+	default:
+		return scheme
 	}
 }
 

--- a/pkg/amika/services.go
+++ b/pkg/amika/services.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gofixpoint/amika/internal/amikaconfig"
+	"github.com/gofixpoint/amika/internal/constants"
 	"github.com/gofixpoint/amika/internal/sandbox"
 )
 
@@ -198,6 +199,70 @@ func localServiceScheme(scheme, hostIP string) string {
 	default:
 		return scheme
 	}
+}
+
+// ResolveProvisionedServices returns port bindings and service info for
+// Amika-managed internal services (e.g. OpenCode web UI) that run inside
+// sandbox containers on reserved ports. The env slice is the set of
+// environment variables that will be passed to the container.
+func ResolveProvisionedServices(
+	env []string,
+	existingPorts []sandbox.PortBinding,
+	hostIP string,
+) ([]sandbox.ServiceInfo, []sandbox.PortBinding, error) {
+	if !isOpenCodeWebEnabled(env) {
+		return nil, nil, nil
+	}
+
+	const opencodeProtocol = "tcp"
+
+	claimedHostPorts := make(map[string]bool)
+	for _, p := range existingPorts {
+		hKey := fmt.Sprintf("%d/%s", p.HostPort, p.Protocol)
+		claimedHostPorts[hKey] = true
+	}
+
+	hostPort, err := resolveHostPort(hostIP, constants.OpenCodeWebPort, opencodeProtocol, claimedHostPorts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opencode web port: %w", err)
+	}
+
+	hostDomain := hostDomainForService(hostIP)
+	pb := sandbox.PortBinding{
+		HostIP:        hostIP,
+		HostDomain:    hostDomain,
+		HostPort:      hostPort,
+		ContainerPort: constants.OpenCodeWebPort,
+		Protocol:      opencodeProtocol,
+	}
+
+	url := fmt.Sprintf("http://%s", net.JoinHostPort(hostDomain, strconv.Itoa(hostPort)))
+
+	svcInfo := sandbox.ServiceInfo{
+		Name: "opencode",
+		Ports: []sandbox.ServicePortInfo{
+			{PortBinding: pb, URL: url},
+		},
+	}
+
+	return []sandbox.ServiceInfo{svcInfo}, []sandbox.PortBinding{pb}, nil
+}
+
+// isOpenCodeWebEnabled reports whether the environment variables indicate that
+// the OpenCode web UI will be started inside the container. This requires
+// OPENCODE_SERVER_PASSWORD to be set and AMIKA_OPENCODE_WEB to not be "0".
+func isOpenCodeWebEnabled(env []string) bool {
+	hasPassword := false
+	disabled := false
+	for _, e := range env {
+		if strings.HasPrefix(e, "OPENCODE_SERVER_PASSWORD=") {
+			hasPassword = true
+		}
+		if e == "AMIKA_OPENCODE_WEB=0" {
+			disabled = true
+		}
+	}
+	return hasPassword && !disabled
 }
 
 func isAddressInUse(err error) bool {

--- a/pkg/amika/services_test.go
+++ b/pkg/amika/services_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gofixpoint/amika/internal/amikaconfig"
+	"github.com/gofixpoint/amika/internal/constants"
 	"github.com/gofixpoint/amika/internal/sandbox"
 )
 
@@ -259,5 +260,55 @@ func TestResolveServicePorts_HTTPSPreservedForNonLocalHost(t *testing.T) {
 	url := infos[0].Ports[0].URL
 	if !strings.HasPrefix(url, "https://") {
 		t.Errorf("expected https preserved for non-local host, got %q", url)
+	}
+}
+
+func TestResolveProvisionedServices_OpenCodeEnabled(t *testing.T) {
+	env := []string{
+		"OPENCODE_SERVER_PASSWORD=secret",
+	}
+	infos, ports, err := ResolveProvisionedServices(env, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(infos))
+	}
+	if infos[0].Name != "opencode" {
+		t.Errorf("expected service name %q, got %q", "opencode", infos[0].Name)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(ports))
+	}
+	if ports[0].ContainerPort != constants.OpenCodeWebPort {
+		t.Errorf("expected container port %d, got %d", constants.OpenCodeWebPort, ports[0].ContainerPort)
+	}
+	if infos[0].Ports[0].URL == "" {
+		t.Error("expected non-empty URL for opencode service")
+	}
+}
+
+func TestResolveProvisionedServices_DisabledWithoutPassword(t *testing.T) {
+	env := []string{"SOME_OTHER_VAR=value"}
+	infos, ports, err := ResolveProvisionedServices(env, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 0 || len(ports) != 0 {
+		t.Errorf("expected no provisioned services without OPENCODE_SERVER_PASSWORD")
+	}
+}
+
+func TestResolveProvisionedServices_DisabledExplicitly(t *testing.T) {
+	env := []string{
+		"OPENCODE_SERVER_PASSWORD=secret",
+		"AMIKA_OPENCODE_WEB=0",
+	}
+	infos, ports, err := ResolveProvisionedServices(env, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(infos) != 0 || len(ports) != 0 {
+		t.Errorf("expected no provisioned services when AMIKA_OPENCODE_WEB=0")
 	}
 }

--- a/pkg/amika/services_test.go
+++ b/pkg/amika/services_test.go
@@ -3,6 +3,7 @@ package amika
 import (
 	"net"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gofixpoint/amika/internal/amikaconfig"
@@ -202,8 +203,8 @@ func TestResolveServicePorts_MultiPortURLGeneration(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	ports := infos[0].Ports
-	if ports[0].URL != "https://localhost:3000" {
-		t.Errorf("port 3000: expected URL %q, got %q", "https://localhost:3000", ports[0].URL)
+	if ports[0].URL != "http://localhost:3000" {
+		t.Errorf("port 3000: expected URL %q, got %q (https downgraded to http for local host)", "http://localhost:3000", ports[0].URL)
 	}
 	if ports[1].URL != "" {
 		t.Errorf("port 3001: expected empty URL, got %q", ports[1].URL)
@@ -225,5 +226,38 @@ func TestResolveServicePorts_NoURLScheme(t *testing.T) {
 	}
 	if infos[0].Ports[0].URL != "" {
 		t.Errorf("expected empty URL, got %q", infos[0].Ports[0].URL)
+	}
+}
+
+func TestResolveServicePorts_HTTPSDowngradedToHTTPForLocalHost(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "web", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 3000, Protocol: "tcp", URLScheme: "https"},
+		}},
+	}
+	// 127.0.0.1 is local — https must become http.
+	infos, _, err := resolveServicePorts(services, nil, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if infos[0].Ports[0].URL != "http://localhost:3000" {
+		t.Errorf("expected https downgraded to http, got %q", infos[0].Ports[0].URL)
+	}
+}
+
+func TestResolveServicePorts_HTTPSPreservedForNonLocalHost(t *testing.T) {
+	services := []amikaconfig.ServiceParsed{
+		{Name: "web", Ports: []amikaconfig.ServicePortParsed{
+			{ContainerPort: 3000, Protocol: "tcp", URLScheme: "https"},
+		}},
+	}
+	// 0.0.0.0 is not a local loopback — https is preserved.
+	infos, _, err := resolveServicePorts(services, nil, "0.0.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	url := infos[0].Ports[0].URL
+	if !strings.HasPrefix(url, "https://") {
+		t.Errorf("expected https preserved for non-local host, got %q", url)
 	}
 }


### PR DESCRIPTION
## Summary
- Downgrade `https` to `http` for service URLs when the host is a local address (127.0.0.1/::1), since local Docker sandboxes don't have TLS certificates
- Expose the OpenCode web UI port (60998) via `ResolveProvisionedServices`, which creates the Docker port binding and service info when `OPENCODE_SERVER_PASSWORD` is set