### PR TITLE
feat: install GitHub CLI in base sandbox image

### DIFF
--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -21,6 +21,17 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Install GitHub CLI (https://github.com/cli/cli/blob/trunk/docs/install_linux.md).
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
 # Default no-op setup script; users can shadow it via --setup-script.
 # This is the user-facing middle hook in the lifecycle:
 # 1. /usr/lib/amikad/pre-setup.sh


### PR DESCRIPTION
Install `gh` via the official apt repository so it's available in all preset containers that inherit from amika/base.