### PR TITLE
WIP Add sandbox name validation with DNS label compliance

### DIFF
--- a/internal/sandbox/names.go
+++ b/internal/sandbox/names.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 )
 
 var colors = []string{
@@ -17,6 +18,29 @@ var cities = []string{
 	"lima", "rome", "seoul", "delhi", "cairo",
 	"lagos", "dublin", "milan", "zurich", "vienna",
 	"prague", "lisbon", "havana", "bogota", "nairobi",
+}
+
+// MaxNameLength is the maximum allowed length for a sandbox name (DNS label limit).
+const MaxNameLength = 63
+
+// namePattern matches lowercase alphanumeric strings with optional hyphens
+// between segments. Leading/trailing/consecutive hyphens are not allowed.
+var namePattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// ValidateName checks that name contains only lowercase letters, numbers, and
+// hyphens, with no leading/trailing/consecutive hyphens, and is at most 63
+// characters long (DNS label compatible).
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("sandbox name must not be empty")
+	}
+	if len(name) > MaxNameLength {
+		return fmt.Errorf("sandbox name %q exceeds maximum length of %d characters", name, MaxNameLength)
+	}
+	if !namePattern.MatchString(name) {
+		return fmt.Errorf("sandbox name %q is invalid: must contain only lowercase letters, numbers, and hyphens (no leading, trailing, or consecutive hyphens)", name)
+	}
+	return nil
 }
 
 // GenerateName returns a random name in the format "{color}-{city}".

--- a/internal/sandbox/names_test.go
+++ b/internal/sandbox/names_test.go
@@ -1,0 +1,51 @@
+package sandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateName(t *testing.T) {
+	valid := []string{
+		"foo",
+		"a",
+		"red-tokyo",
+		"my-sandbox-1",
+		"abc123",
+		"a-b-c",
+	}
+	for _, name := range valid {
+		if err := ValidateName(name); err != nil {
+			t.Errorf("ValidateName(%q) = %v; want nil", name, err)
+		}
+	}
+
+	invalid := []struct {
+		name string
+		desc string
+	}{
+		{"", "empty"},
+		{"My-Sandbox", "uppercase"},
+		{"foo_bar", "underscore"},
+		{"-foo", "leading hyphen"},
+		{"foo-", "trailing hyphen"},
+		{"foo--bar", "consecutive hyphens"},
+		{"foo.bar", "dot"},
+		{"hello world", "space"},
+		{strings.Repeat("a", 64), "too long"},
+	}
+	for _, tc := range invalid {
+		if err := ValidateName(tc.name); err == nil {
+			t.Errorf("ValidateName(%q) [%s] = nil; want error", tc.name, tc.desc)
+		}
+	}
+}
+
+func TestGenerateNameIsValid(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		name := GenerateName()
+		if err := ValidateName(name); err != nil {
+			t.Fatalf("GenerateName() = %q; ValidateName returned %v", name, err)
+		}
+	}
+}

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -79,6 +79,8 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 				break
 			}
 		}
+	} else if err := sandbox.ValidateName(name); err != nil {
+		return Sandbox{}, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
 	} else if _, err := s.sandboxes.Get(name); err == nil {
 		return Sandbox{}, fmt.Errorf("%w: sandbox %q already exists", ErrInvalidArgument, name)
 	}


### PR DESCRIPTION
## Summary
This PR adds comprehensive validation for sandbox names to ensure they comply with DNS label requirements and maintain consistency across the system.

## Key Changes
- **Added `ValidateName()` function** in `internal/sandbox/names.go` that validates sandbox names against the following rules:
  - Must not be empty
  - Must be at most 63 characters (DNS label limit)
  - Must contain only lowercase letters, numbers, and hyphens
  - Cannot have leading, trailing, or consecutive hyphens
  
- **Added regex pattern validation** using `namePattern` to enforce the allowed character set and hyphen placement rules

- **Added `MaxNameLength` constant** set to 63 to match DNS label specifications

- **Integrated validation into `CreateSandbox()`** in `pkg/amika/service.go` to validate user-provided sandbox names before creation

- **Added comprehensive test coverage** in `internal/sandbox/names_test.go`:
  - `TestValidateName()` validates both valid and invalid name formats
  - `TestGenerateNameIsValid()` ensures auto-generated names always pass validation

## Implementation Details
- The validation uses a regex pattern `^[a-z0-9]+(-[a-z0-9]+)*$` to ensure hyphens only appear between alphanumeric segments
- Validation is applied to user-provided names in the service layer, returning `ErrInvalidArgument` on failure
- Auto-generated names (color-city format) are guaranteed to be valid by design

https://claude.ai/code/session_01TND4LDP6AZGUbi92edwe14