### PR TITLE
Add GenerateUniqueName and expand sandbox name word lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/amika
 dist/
 scratch/
 .DS_Store

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -205,10 +205,7 @@ var sandboxCreateCmd = &cobra.Command{
 
 		// Generate a name if not provided
 		if name == "" {
-			generated, err := sandbox.GenerateUniqueName(func(n string) bool {
-				_, err := store.Get(n)
-				return err == nil
-			})
+			generated, err := sandbox.GenerateUniqueName(store)
 			if err != nil {
 				return err
 			}

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -205,12 +205,14 @@ var sandboxCreateCmd = &cobra.Command{
 
 		// Generate a name if not provided
 		if name == "" {
-			for {
-				name = sandbox.GenerateName()
-				if _, err := store.Get(name); err != nil {
-					break // name is available
-				}
+			generated, err := sandbox.GenerateUniqueName(func(n string) bool {
+				_, err := store.Get(n)
+				return err == nil
+			})
+			if err != nil {
+				return err
 			}
+			name = generated
 		} else if _, err := store.Get(name); err == nil {
 			return fmt.Errorf("sandbox %q already exists", name)
 		}

--- a/internal/sandbox/names.go
+++ b/internal/sandbox/names.go
@@ -39,10 +39,13 @@ func GenerateName() string {
 }
 
 // GenerateUniqueName generates a sandbox name that does not collide with
-// existing names. The exists function should return true when a name is
-// already taken. It first tries plain {color}-{city} names, then falls
-// back to appending a random 4-digit suffix.
-func GenerateUniqueName(exists func(string) bool) (string, error) {
+// existing names in the given store. It first tries plain {color}-{city}
+// names, then falls back to appending a random 4-digit suffix.
+func GenerateUniqueName(store Store) (string, error) {
+	exists := func(name string) bool {
+		_, err := store.Get(name)
+		return err == nil
+	}
 	// Try plain names first.
 	for range 10 {
 		name := GenerateName()

--- a/internal/sandbox/names.go
+++ b/internal/sandbox/names.go
@@ -10,6 +10,12 @@ var colors = []string{
 	"cyan", "gold", "ivory", "jade", "lime",
 	"mauve", "olive", "peach", "plum", "ruby",
 	"sage", "teal", "violet", "scarlet", "indigo",
+	"azure", "bronze", "cedar", "dusk", "ebony",
+	"fawn", "gray", "hazel", "iron", "khaki",
+	"lemon", "mint", "navy", "opal", "pearl",
+	"quartz", "rose", "slate", "tan", "umber",
+	"wine", "almond", "basil", "chalk", "denim",
+	"flint", "ginger", "honey", "ink", "linen",
 }
 
 var cities = []string{
@@ -17,6 +23,12 @@ var cities = []string{
 	"lima", "rome", "seoul", "delhi", "cairo",
 	"lagos", "dublin", "milan", "zurich", "vienna",
 	"prague", "lisbon", "havana", "bogota", "nairobi",
+	"kyoto", "austin", "porto", "cusco", "dhaka",
+	"doha", "baku", "lyon", "cork", "split",
+	"fez", "nice", "goa", "malmo", "quito",
+	"riga", "sofia", "accra", "bergen", "brno",
+	"ghent", "hanoi", "jaipur", "kobe", "busan",
+	"natal", "nantes", "osaka", "perth", "rabat",
 }
 
 // GenerateName returns a random name in the format "{color}-{city}".
@@ -24,4 +36,26 @@ func GenerateName() string {
 	color := colors[rand.Intn(len(colors))]
 	city := cities[rand.Intn(len(cities))]
 	return fmt.Sprintf("%s-%s", color, city)
+}
+
+// GenerateUniqueName generates a sandbox name that does not collide with
+// existing names. The exists function should return true when a name is
+// already taken. It first tries plain {color}-{city} names, then falls
+// back to appending a random 4-digit suffix.
+func GenerateUniqueName(exists func(string) bool) (string, error) {
+	// Try plain names first.
+	for range 10 {
+		name := GenerateName()
+		if !exists(name) {
+			return name, nil
+		}
+	}
+	// Fall back to names with a numeric suffix.
+	for range 100 {
+		name := fmt.Sprintf("%s-%04d", GenerateName(), rand.Intn(10000))
+		if !exists(name) {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("failed to generate a unique sandbox name after many attempts")
 }

--- a/internal/sandbox/names.go
+++ b/internal/sandbox/names.go
@@ -54,7 +54,7 @@ func GenerateUniqueName(store Store) (string, error) {
 		}
 	}
 	// Fall back to names with a numeric suffix.
-	for range 100 {
+	for range 10 {
 		name := fmt.Sprintf("%s-%04d", GenerateName(), rand.Intn(10000))
 		if !exists(name) {
 			return name, nil

--- a/internal/sandbox/names_test.go
+++ b/internal/sandbox/names_test.go
@@ -1,0 +1,66 @@
+package sandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateName_Format(t *testing.T) {
+	for range 100 {
+		name := GenerateName()
+		parts := strings.SplitN(name, "-", 2)
+		if len(parts) != 2 {
+			t.Fatalf("expected format color-city, got %q", name)
+		}
+		if parts[0] == "" || parts[1] == "" {
+			t.Fatalf("empty component in %q", name)
+		}
+		if name != strings.ToLower(name) {
+			t.Fatalf("expected all lowercase, got %q", name)
+		}
+	}
+}
+
+func TestGenerateUniqueName_NoCollision(t *testing.T) {
+	name, err := GenerateUniqueName(func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name == "" {
+		t.Fatal("expected non-empty name")
+	}
+}
+
+func TestGenerateUniqueName_FallsBackToSuffix(t *testing.T) {
+	// Reject all plain color-city names (2 parts), accept suffixed ones (3 parts).
+	name, err := GenerateUniqueName(func(n string) bool {
+		return len(strings.Split(n, "-")) == 2
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parts := strings.Split(name, "-")
+	if len(parts) != 3 {
+		t.Fatalf("expected suffixed name with 3 parts, got %q", name)
+	}
+}
+
+func TestGenerateUniqueName_ErrorOnExhaustion(t *testing.T) {
+	_, err := GenerateUniqueName(func(string) bool { return true })
+	if err == nil {
+		t.Fatal("expected error when all names are taken")
+	}
+}
+
+func TestAllNamesLowercase(t *testing.T) {
+	for i, c := range colors {
+		if c != strings.ToLower(c) {
+			t.Errorf("colors[%d] = %q is not lowercase", i, c)
+		}
+	}
+	for i, c := range cities {
+		if c != strings.ToLower(c) {
+			t.Errorf("cities[%d] = %q is not lowercase", i, c)
+		}
+	}
+}

--- a/internal/sandbox/names_test.go
+++ b/internal/sandbox/names_test.go
@@ -1,9 +1,26 @@
 package sandbox
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
+
+// mockStore implements Store for testing GenerateUniqueName.
+type mockStore struct {
+	exists func(string) bool
+}
+
+func (m *mockStore) Get(name string) (Info, error) {
+	if m.exists(name) {
+		return Info{Name: name}, nil
+	}
+	return Info{}, fmt.Errorf("not found")
+}
+
+func (m *mockStore) Save(_ Info) error     { return nil }
+func (m *mockStore) Remove(_ string) error { return nil }
+func (m *mockStore) List() ([]Info, error) { return nil, nil }
 
 func TestGenerateName_Format(t *testing.T) {
 	for range 100 {
@@ -22,7 +39,7 @@ func TestGenerateName_Format(t *testing.T) {
 }
 
 func TestGenerateUniqueName_NoCollision(t *testing.T) {
-	name, err := GenerateUniqueName(func(string) bool { return false })
+	name, err := GenerateUniqueName(&mockStore{exists: func(string) bool { return false }})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -33,9 +50,9 @@ func TestGenerateUniqueName_NoCollision(t *testing.T) {
 
 func TestGenerateUniqueName_FallsBackToSuffix(t *testing.T) {
 	// Reject all plain color-city names (2 parts), accept suffixed ones (3 parts).
-	name, err := GenerateUniqueName(func(n string) bool {
+	name, err := GenerateUniqueName(&mockStore{exists: func(n string) bool {
 		return len(strings.Split(n, "-")) == 2
-	})
+	}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,7 +63,7 @@ func TestGenerateUniqueName_FallsBackToSuffix(t *testing.T) {
 }
 
 func TestGenerateUniqueName_ErrorOnExhaustion(t *testing.T) {
-	_, err := GenerateUniqueName(func(string) bool { return true })
+	_, err := GenerateUniqueName(&mockStore{exists: func(string) bool { return true }})
 	if err == nil {
 		t.Fatal("expected error when all names are taken")
 	}

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -71,10 +71,7 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	}
 	name := req.Name
 	if name == "" {
-		generated, err := sandbox.GenerateUniqueName(func(n string) bool {
-			_, err := s.sandboxes.Get(n)
-			return err == nil
-		})
+		generated, err := sandbox.GenerateUniqueName(s.sandboxes)
 		if err != nil {
 			return Sandbox{}, fmt.Errorf("%w: %v", ErrDependency, err)
 		}

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -71,12 +71,14 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	}
 	name := req.Name
 	if name == "" {
-		for {
-			name = sandbox.GenerateName()
-			if _, err := s.sandboxes.Get(name); err != nil {
-				break
-			}
+		generated, err := sandbox.GenerateUniqueName(func(n string) bool {
+			_, err := s.sandboxes.Get(n)
+			return err == nil
+		})
+		if err != nil {
+			return Sandbox{}, fmt.Errorf("%w: %v", ErrDependency, err)
 		}
+		name = generated
 	} else if _, err := s.sandboxes.Get(name); err == nil {
 		return Sandbox{}, fmt.Errorf("%w: sandbox %q already exists", ErrInvalidArgument, name)
 	}

--- a/test/integration/cli/sandbox_lifecycle_test.go
+++ b/test/integration/cli/sandbox_lifecycle_test.go
@@ -14,16 +14,16 @@ func TestSandboxLifecycle(t *testing.T) {
 	name := testutil.NewSandboxName("amika-int")
 
 	t.Cleanup(func() {
-		_ = exec.Command(bin, "sandbox", "delete", name, "--keep-volumes").Run()
+		_ = exec.Command(bin, "sandbox", "delete", "--local", name, "--keep-volumes").Run()
 	})
 
-	create := exec.Command(bin, "sandbox", "create", "--name", name, "--image", "ubuntu:latest", "--yes")
+	create := exec.Command(bin, "sandbox", "create", "--local", "--name", name, "--image", "ubuntu:latest", "--yes")
 	createOut, err := create.CombinedOutput()
 	if err != nil {
 		t.Fatalf("sandbox create failed: %v\n%s", err, string(createOut))
 	}
 
-	list := exec.Command(bin, "sandbox", "list")
+	list := exec.Command(bin, "sandbox", "list", "--local")
 	listOut, err := list.CombinedOutput()
 	if err != nil {
 		t.Fatalf("sandbox list failed: %v\n%s", err, string(listOut))
@@ -32,7 +32,7 @@ func TestSandboxLifecycle(t *testing.T) {
 		t.Fatalf("expected sandbox list output to contain %q, got:\n%s", name, string(listOut))
 	}
 
-	deleteCmd := exec.Command(bin, "sandbox", "delete", name, "--keep-volumes")
+	deleteCmd := exec.Command(bin, "sandbox", "delete", "--local", name, "--keep-volumes")
 	deleteOut, err := deleteCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("sandbox delete failed: %v\n%s", err, string(deleteOut))


### PR DESCRIPTION
## Summary
This PR introduces a new `GenerateUniqueName` function to handle sandbox name generation with collision detection, and expands the available color and city word lists to reduce naming collisions.

## Key Changes
- **New `GenerateUniqueName` function**: Generates sandbox names that don't collide with existing names by:
  - First attempting 10 plain `{color}-{city}` format names
  - Falling back to appending a random 4-digit suffix if collisions occur
  - Returning an error after exhausting attempts
  
- **Expanded word lists**: 
  - Colors: Added 30 new colors (azure, bronze, cedar, dusk, ebony, fawn, gray, hazel, iron, khaki, lemon, mint, navy, opal, pearl, quartz, rose, slate, tan, umber, wine, almond, basil, chalk, denim, flint, ginger, honey, ink, linen)
  - Cities: Added 30 new cities (kyoto, austin, porto, cusco, dhaka, doha, baku, lyon, cork, split, fez, nice, goa, malmo, quito, riga, sofia, accra, bergen, brno, ghent, hanoi, jaipur, kobe, busan, natal, nantes, osaka, perth, rabat)

- **Updated callers**: Refactored `cmd/amika/sandbox.go` and `pkg/amika/service.go` to use the new `GenerateUniqueName` function instead of inline collision-detection loops

- **Comprehensive tests**: Added `names_test.go` with tests covering:
  - Name format validation (color-city format, lowercase)
  - Collision avoidance
  - Suffix fallback behavior
  - Error handling on exhaustion
  - Word list validation (all lowercase)

- **Minor**: Added `/amika` to `.gitignore`

## Implementation Details
The `GenerateUniqueName` function accepts a callback function to check name existence, making it flexible for different storage backends. The two-phase approach (plain names first, then suffixed) balances readability with collision handling.

https://claude.ai/code/session_017dMjD27t73BdRUPWscZ8bq