### PR TITLE
Add component release workflows and version metadata

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,83 @@
+name: Create Release Tag
+
+# Manually cuts a component-scoped annotated release tag from the current main
+# branch tip. This is the entry point for stable and prerelease publishing:
+# the created tag triggers release.yml, which performs the cross-platform build
+# and GitHub Release publication.
+#
+# Supported tag shapes:
+#   amika/v1.2.3
+#   amika/v1.2.3-rc.1
+#   amika-server/v1.2.3
+#   amika-server/v1.2.3-beta.1
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: Component to release
+        required: true
+        type: choice
+        options:
+          - amika
+          - amika-server
+      version:
+        description: Semver version with v prefix, optionally including a prerelease suffix
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "This workflow can only be run from the main branch." >&2
+            exit 1
+          fi
+
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'; then
+            echo "Version must be semver with a v prefix, optionally with a prerelease suffix." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Verify tag does not already exist
+        env:
+          COMPONENT: ${{ inputs.component }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          tag="${COMPONENT}/${VERSION}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists." >&2
+            exit 1
+          fi
+
+      - name: Verify repository is healthy enough to tag
+        run: |
+          make fmtcheck
+          make vet
+          make test-unit
+
+      - name: Create and push annotated tag
+        env:
+          COMPONENT: ${{ inputs.component }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          tag="${COMPONENT}/${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "Release $tag"
+          git push origin "$tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,187 @@
+name: Release
+
+# Publishes a GitHub Release for a component-scoped tag created by
+# release-tag.yml. The workflow:
+# 1. Parses the component and semver from tags like amika/v1.2.3-rc.1
+# 2. Builds only that component for linux/darwin on amd64 and arm64
+# 3. Injects version, full commit SHA, and build date into the binary metadata
+# 4. Uploads platform tarballs plus a shared checksums.txt file
+# 5. Marks the GitHub Release as a prerelease when the tag contains a semver
+#    prerelease suffix
+#
+# This workflow intentionally uses component-prefixed tags so amika and
+# amika-server can be versioned independently.
+
+on:
+  push:
+    tags:
+      - "amika/v*"
+      - "amika-server/v*"
+
+permissions:
+  contents: write
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      component: ${{ steps.parse.outputs.component }}
+      version: ${{ steps.parse.outputs.version }}
+      release_name: ${{ steps.parse.outputs.release_name }}
+      prerelease: ${{ steps.parse.outputs.prerelease }}
+      commit: ${{ steps.parse.outputs.commit }}
+      build_date: ${{ steps.parse.outputs.build_date }}
+      binary_name: ${{ steps.parse.outputs.binary_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: parse
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          case "$TAG" in
+            amika/*)
+              component="amika"
+              binary_name="amika"
+              ;;
+            amika-server/*)
+              component="amika-server"
+              binary_name="amika-server"
+              ;;
+            *)
+              echo "Unsupported tag format: $TAG" >&2
+              exit 1
+              ;;
+          esac
+
+          version="${TAG#*/}"
+          if ! printf '%s' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'; then
+            echo "Tag version is not valid semver: $version" >&2
+            exit 1
+          fi
+
+          commit="$(git rev-list -n 1 "$TAG")"
+          build_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          prerelease=false
+          if printf '%s' "$version" | grep -q -- '-'; then
+            prerelease=true
+          fi
+
+          {
+            echo "component=$component"
+            echo "version=$version"
+            echo "release_name=$component $version"
+            echo "prerelease=$prerelease"
+            echo "commit=$commit"
+            echo "build_date=$build_date"
+            echo "binary_name=$binary_name"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: metadata
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+
+      - name: Build archive
+        env:
+          COMPONENT: ${{ needs.metadata.outputs.component }}
+          VERSION: ${{ needs.metadata.outputs.version }}
+          COMMIT: ${{ needs.metadata.outputs.commit }}
+          BUILD_DATE: ${{ needs.metadata.outputs.build_date }}
+          BINARY_NAME: ${{ needs.metadata.outputs.binary_name }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          mkdir -p dist
+          case "$COMPONENT" in
+            amika)
+              package_path="./cmd/amika"
+              ld_version="github.com/gofixpoint/amika/internal/buildmeta.AmikaVersion=$VERSION"
+              ;;
+            amika-server)
+              package_path="./cmd/amika-server"
+              ld_version="github.com/gofixpoint/amika/internal/buildmeta.AmikaServerVersion=$VERSION"
+              ;;
+            *)
+              echo "Unsupported component: $COMPONENT" >&2
+              exit 1
+              ;;
+          esac
+
+          archive_base="${COMPONENT}_${VERSION#v}_${GOOS}_${GOARCH}"
+          staging_dir="dist/${archive_base}"
+          binary_path="${staging_dir}/${BINARY_NAME}"
+
+          mkdir -p "$staging_dir"
+
+          env CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+            go build \
+              -trimpath \
+              -ldflags="-s -w -X ${ld_version} -X github.com/gofixpoint/amika/internal/buildmeta.Commit=${COMMIT} -X github.com/gofixpoint/amika/internal/buildmeta.Date=${BUILD_DATE}" \
+              -o "$binary_path" \
+              "$package_path"
+
+          tar -C "dist" -czf "dist/${archive_base}.tar.gz" "${archive_base}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.metadata.outputs.component }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    needs:
+      - metadata
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release-upload
+          find release-artifacts -type f -name '*.tar.gz' -exec cp {} release-upload/ \;
+          cd release-upload
+          sha256sum *.tar.gz > checksums.txt
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          RELEASE_NAME: ${{ needs.metadata.outputs.release_name }}
+          PRERELEASE: ${{ needs.metadata.outputs.prerelease }}
+        run: |
+          prerelease_flag=""
+          if [ "$PRERELEASE" = "true" ]; then
+            prerelease_flag="--prerelease"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" release-upload/* --clobber
+          else
+            gh release create "$TAG" release-upload/* \
+              --title "$RELEASE_NAME" \
+              --generate-notes \
+              $prerelease_flag
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,11 @@ jobs:
           case "$COMPONENT" in
             amika)
               package_path="./cmd/amika"
-              ld_version="github.com/gofixpoint/amika/internal/buildmeta.AmikaVersion=$VERSION"
+              ld_version="github.com/gofixpoint/amika/internal/buildmeta.amikaVersionValue=$VERSION"
               ;;
             amika-server)
               package_path="./cmd/amika-server"
-              ld_version="github.com/gofixpoint/amika/internal/buildmeta.AmikaServerVersion=$VERSION"
+              ld_version="github.com/gofixpoint/amika/internal/buildmeta.amikaServerVersionValue=$VERSION"
               ;;
             *)
               echo "Unsupported component: $COMPONENT" >&2

--- a/cmd/amika-server/main.go
+++ b/cmd/amika-server/main.go
@@ -5,26 +5,51 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
 	"strings"
 
+	"github.com/gofixpoint/amika/internal/buildmeta"
 	"github.com/gofixpoint/amika/internal/httpapi"
 	"github.com/gofixpoint/amika/pkg/amika"
 )
 
 func main() {
-	addr, err := resolveListenAddr(flag.CommandLine, os.Args[1:], os.LookupEnv)
+	if err := run(os.Args[1:], os.Stdout, os.LookupEnv, http.ListenAndServe); err != nil {
+		panic(err)
+	}
+}
+
+func run(
+	args []string,
+	stdout io.Writer,
+	lookupEnv func(string) (string, bool),
+	listenAndServe func(string, http.Handler) error,
+) error {
+	fs := flag.NewFlagSet("amika-server", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	addr, addrFlagSet, showVersion, err := parseServerFlags(fs, args)
 	if err != nil {
-		panic(fmt.Errorf("invalid listen address configuration: %w", err))
+		return fmt.Errorf("invalid listen address configuration: %w", err)
+	}
+	if showVersion {
+		fmt.Fprintln(stdout, buildmeta.New("amika-server", buildmeta.AmikaServerVersion).String())
+		return nil
+	}
+	addr, err = applyListenAddrEnv(addr, addrFlagSet, lookupEnv)
+	if err != nil {
+		return fmt.Errorf("invalid listen address configuration: %w", err)
 	}
 
 	handler := httpapi.NewHandler(amika.NewService(amika.Options{}))
 	log.Printf("amika-server listening on %s", addr)
-	if err := http.ListenAndServe(addr, handler); err != nil {
-		panic(fmt.Errorf("server failed: %w", err))
+	if err := listenAndServe(addr, handler); err != nil {
+		return fmt.Errorf("server failed: %w", err)
 	}
+	return nil
 }
 
 func resolveListenAddr(
@@ -32,10 +57,21 @@ func resolveListenAddr(
 	args []string,
 	lookupEnv func(string) (string, bool),
 ) (string, error) {
+	addr, addrFlagSet, _, err := parseServerFlags(fs, args)
+	if err != nil {
+		return "", err
+	}
+	return applyListenAddrEnv(addr, addrFlagSet, lookupEnv)
+}
+
+func parseServerFlags(fs *flag.FlagSet, args []string) (string, bool, bool, error) {
 	const defaultAddr = ":8080"
 
 	addr := defaultAddr
 	addrFlagSet := false
+	showVersion := false
+
+	fs.BoolVar(&showVersion, "version", false, "Print version information and exit")
 	fs.Func("addr", "HTTP listen address", func(value string) error {
 		addr = value
 		addrFlagSet = true
@@ -43,9 +79,12 @@ func resolveListenAddr(
 	})
 
 	if err := fs.Parse(args); err != nil {
-		return "", err
+		return "", false, false, err
 	}
+	return addr, addrFlagSet, showVersion, nil
+}
 
+func applyListenAddrEnv(addr string, addrFlagSet bool, lookupEnv func(string) (string, bool)) (string, error) {
 	port, portSet := lookupEnv("PORT")
 	if !portSet || port == "" {
 		return addr, nil

--- a/cmd/amika-server/main_test.go
+++ b/cmd/amika-server/main_test.go
@@ -59,7 +59,7 @@ func TestRunVersion(t *testing.T) {
 	t.Cleanup(func() {
 		buildmeta.AmikaServerVersion = originalVersion
 	})
-	buildmeta.AmikaServerVersion = "v1.2.3-rc.1"
+	buildmeta.AmikaServerVersion = buildmeta.MustParseSemVer("v1.2.3-rc.1")
 
 	buf := &strings.Builder{}
 	called := false

--- a/cmd/amika-server/main_test.go
+++ b/cmd/amika-server/main_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"flag"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/gofixpoint/amika/internal/buildmeta"
 )
 
 func TestResolveListenAddr_Default(t *testing.T) {
@@ -48,6 +51,48 @@ func TestResolveListenAddr_AddrAndPortMutuallyExclusive(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("resolveListenAddr() error = %q, want mutually exclusive error", err.Error())
+	}
+}
+
+func TestRunVersion(t *testing.T) {
+	originalVersion := buildmeta.AmikaServerVersion
+	t.Cleanup(func() {
+		buildmeta.AmikaServerVersion = originalVersion
+	})
+	buildmeta.AmikaServerVersion = "v1.2.3-rc.1"
+
+	buf := &strings.Builder{}
+	called := false
+	err := run([]string{"--version"}, buf, mapEnv(nil), func(_ string, _ http.Handler) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if called {
+		t.Fatal("run() started server for --version")
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "amika-server version v1.2.3-rc.1") {
+		t.Fatalf("run() output = %q, want version line", got)
+	}
+	if !strings.Contains(got, "commit: ") {
+		t.Fatalf("run() output = %q, want commit line", got)
+	}
+}
+
+func TestRunVersionIgnoresAddrConflicts(t *testing.T) {
+	buf := &strings.Builder{}
+	err := run([]string{"--version", "-addr", ":7070"}, buf, mapEnv(map[string]string{
+		"PORT": "9090",
+	}), func(_ string, _ http.Handler) error {
+		t.Fatal("run() started server for --version")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v, want nil for --version", err)
 	}
 }
 

--- a/cmd/amika/main.go
+++ b/cmd/amika/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gofixpoint/amika/internal/buildmeta"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,15 @@ var rootCmd = &cobra.Command{
 	Short:             "Amika - filesystem mounting and script execution",
 	Long:              `Amika provides filesystem mounting and script execution with output materialization.`,
 	CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
+}
+
+func init() {
+	rootCmd.Version = versionString()
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+}
+
+func versionString() string {
+	return buildmeta.New("amika", buildmeta.AmikaVersion).String()
 }
 
 func main() {

--- a/cmd/amika/main_test.go
+++ b/cmd/amika/main_test.go
@@ -14,7 +14,7 @@ func TestRootVersionFlag(t *testing.T) {
 		rootCmd.Version = versionString()
 	})
 
-	buildmeta.AmikaVersion = "v2.0.0-beta.1"
+	buildmeta.AmikaVersion = buildmeta.MustParseSemVer("v2.0.0-beta.1")
 	rootCmd.Version = versionString()
 
 	output, err := runRootCommand("--version")

--- a/cmd/amika/main_test.go
+++ b/cmd/amika/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/amika/internal/buildmeta"
+)
+
+func TestRootVersionFlag(t *testing.T) {
+	originalVersion := buildmeta.AmikaVersion
+	t.Cleanup(func() {
+		buildmeta.AmikaVersion = originalVersion
+		rootCmd.Version = versionString()
+	})
+
+	buildmeta.AmikaVersion = "v2.0.0-beta.1"
+	rootCmd.Version = versionString()
+
+	output, err := runRootCommand("--version")
+	if err != nil {
+		t.Fatalf("runRootCommand() error = %v", err)
+	}
+	if !strings.Contains(output, "amika version v2.0.0-beta.1") {
+		t.Fatalf("runRootCommand() output = %q, want version line", output)
+	}
+	if !strings.Contains(output, "commit: ") {
+		t.Fatalf("runRootCommand() output = %q, want commit line", output)
+	}
+}

--- a/internal/buildmeta/buildmeta.go
+++ b/internal/buildmeta/buildmeta.go
@@ -1,32 +1,111 @@
 // Package buildmeta exposes build-time metadata for Amika binaries.
 package buildmeta
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 var (
-	// AmikaVersion is the version string for the amika CLI.
-	AmikaVersion = "dev"
-	// AmikaServerVersion is the version string for the amika-server binary.
-	AmikaServerVersion = "dev"
+	amikaVersionValue       = "dev"
+	amikaServerVersionValue = "dev"
+
+	// AmikaVersion is the parsed semantic version for the amika CLI.
+	AmikaVersion = MustParseSemVer(amikaVersionValue)
+	// AmikaServerVersion is the parsed semantic version for the amika-server binary.
+	AmikaServerVersion = MustParseSemVer(amikaServerVersionValue)
 	// Commit is the full git SHA for the build.
 	Commit = "unknown"
 	// Date is the UTC build timestamp.
 	Date = "unknown"
 )
 
+// SemVer describes an Amika semantic version or the local dev build.
+type SemVer struct {
+	Major      int
+	Minor      int
+	Patch      int
+	PreRelease string
+	Dev        bool
+}
+
+// String renders the semantic version in canonical CLI output format.
+func (v SemVer) String() string {
+	if v.Dev {
+		return "dev"
+	}
+	if v.PreRelease != "" {
+		return fmt.Sprintf("v%d.%d.%d-%s", v.Major, v.Minor, v.Patch, v.PreRelease)
+	}
+	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// ParseSemVer parses a canonical Amika version string.
+func ParseSemVer(value string) (SemVer, error) {
+	if value == "" || value == "dev" {
+		return SemVer{Dev: true}, nil
+	}
+	if !strings.HasPrefix(value, "v") {
+		return SemVer{}, fmt.Errorf("version %q must start with v", value)
+	}
+
+	version := strings.TrimPrefix(value, "v")
+	core := version
+	preRelease := ""
+	if idx := strings.Index(version, "-"); idx >= 0 {
+		core = version[:idx]
+		preRelease = version[idx+1:]
+		if preRelease == "" {
+			return SemVer{}, fmt.Errorf("version %q has empty prerelease", value)
+		}
+	}
+
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return SemVer{}, fmt.Errorf("version %q must have major, minor, and patch", value)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return SemVer{}, fmt.Errorf("invalid major version in %q: %w", value, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return SemVer{}, fmt.Errorf("invalid minor version in %q: %w", value, err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return SemVer{}, fmt.Errorf("invalid patch version in %q: %w", value, err)
+	}
+
+	return SemVer{
+		Major:      major,
+		Minor:      minor,
+		Patch:      patch,
+		PreRelease: preRelease,
+	}, nil
+}
+
+// MustParseSemVer parses a canonical Amika version string and panics on failure.
+func MustParseSemVer(value string) SemVer {
+	version, err := ParseSemVer(value)
+	if err != nil {
+		panic(err)
+	}
+	return version
+}
+
 // Info describes the build metadata emitted by a binary.
 type Info struct {
 	Component string
-	Version   string
+	Version   SemVer
 	Commit    string
 	Date      string
 }
 
 // New returns normalized build metadata for a component.
-func New(component, version string) Info {
-	if version == "" {
-		version = "dev"
-	}
+func New(component string, version SemVer) Info {
 	commit := Commit
 	if commit == "" {
 		commit = "unknown"

--- a/internal/buildmeta/buildmeta.go
+++ b/internal/buildmeta/buildmeta.go
@@ -1,0 +1,49 @@
+// Package buildmeta exposes build-time metadata for Amika binaries.
+package buildmeta
+
+import "fmt"
+
+var (
+	// AmikaVersion is the version string for the amika CLI.
+	AmikaVersion = "dev"
+	// AmikaServerVersion is the version string for the amika-server binary.
+	AmikaServerVersion = "dev"
+	// Commit is the full git SHA for the build.
+	Commit = "unknown"
+	// Date is the UTC build timestamp.
+	Date = "unknown"
+)
+
+// Info describes the build metadata emitted by a binary.
+type Info struct {
+	Component string
+	Version   string
+	Commit    string
+	Date      string
+}
+
+// New returns normalized build metadata for a component.
+func New(component, version string) Info {
+	if version == "" {
+		version = "dev"
+	}
+	commit := Commit
+	if commit == "" {
+		commit = "unknown"
+	}
+	date := Date
+	if date == "" {
+		date = "unknown"
+	}
+	return Info{
+		Component: component,
+		Version:   version,
+		Commit:    commit,
+		Date:      date,
+	}
+}
+
+// String renders the build metadata for human-readable CLI output.
+func (i Info) String() string {
+	return fmt.Sprintf("%s version %s\ncommit: %s\ndate: %s", i.Component, i.Version, i.Commit, i.Date)
+}

--- a/internal/buildmeta/buildmeta_test.go
+++ b/internal/buildmeta/buildmeta_test.go
@@ -13,9 +13,9 @@ func TestNewDefaults(t *testing.T) {
 	Commit = ""
 	Date = ""
 
-	info := New("amika", "")
-	if info.Version != "dev" {
-		t.Fatalf("info.Version = %q, want %q", info.Version, "dev")
+	info := New("amika", SemVer{Dev: true})
+	if got := info.Version.String(); got != "dev" {
+		t.Fatalf("info.Version.String() = %q, want %q", got, "dev")
 	}
 	if info.Commit != "unknown" {
 		t.Fatalf("info.Commit = %q, want %q", info.Commit, "unknown")
@@ -28,7 +28,7 @@ func TestNewDefaults(t *testing.T) {
 func TestInfoString(t *testing.T) {
 	info := Info{
 		Component: "amika-server",
-		Version:   "v1.2.3-rc.1",
+		Version:   SemVer{Major: 1, Minor: 2, Patch: 3, PreRelease: "rc.1"},
 		Commit:    "abcdef123456",
 		Date:      "2026-03-17T12:00:00Z",
 	}
@@ -37,5 +37,69 @@ func TestInfoString(t *testing.T) {
 	want := "amika-server version v1.2.3-rc.1\ncommit: abcdef123456\ndate: 2026-03-17T12:00:00Z"
 	if got != want {
 		t.Fatalf("info.String() = %q, want %q", got, want)
+	}
+}
+
+func TestParseSemVer(t *testing.T) {
+	tests := []struct {
+		input string
+		want  SemVer
+	}{
+		{
+			input: "dev",
+			want:  SemVer{Dev: true},
+		},
+		{
+			input: "v1.2.3",
+			want:  SemVer{Major: 1, Minor: 2, Patch: 3},
+		},
+		{
+			input: "v1.2.3-beta.1",
+			want:  SemVer{Major: 1, Minor: 2, Patch: 3, PreRelease: "beta.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseSemVer(tt.input)
+			if err != nil {
+				t.Fatalf("ParseSemVer() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseSemVer() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSemVerString(t *testing.T) {
+	tests := []struct {
+		name    string
+		version SemVer
+		want    string
+	}{
+		{
+			name:    "dev",
+			version: SemVer{Dev: true},
+			want:    "dev",
+		},
+		{
+			name:    "stable",
+			version: SemVer{Major: 1, Minor: 2, Patch: 3},
+			want:    "v1.2.3",
+		},
+		{
+			name:    "prerelease",
+			version: SemVer{Major: 1, Minor: 2, Patch: 3, PreRelease: "rc.1"},
+			want:    "v1.2.3-rc.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.version.String(); got != tt.want {
+				t.Fatalf("SemVer.String() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/buildmeta/buildmeta_test.go
+++ b/internal/buildmeta/buildmeta_test.go
@@ -1,0 +1,41 @@
+package buildmeta
+
+import "testing"
+
+func TestNewDefaults(t *testing.T) {
+	originalCommit := Commit
+	originalDate := Date
+	t.Cleanup(func() {
+		Commit = originalCommit
+		Date = originalDate
+	})
+
+	Commit = ""
+	Date = ""
+
+	info := New("amika", "")
+	if info.Version != "dev" {
+		t.Fatalf("info.Version = %q, want %q", info.Version, "dev")
+	}
+	if info.Commit != "unknown" {
+		t.Fatalf("info.Commit = %q, want %q", info.Commit, "unknown")
+	}
+	if info.Date != "unknown" {
+		t.Fatalf("info.Date = %q, want %q", info.Date, "unknown")
+	}
+}
+
+func TestInfoString(t *testing.T) {
+	info := Info{
+		Component: "amika-server",
+		Version:   "v1.2.3-rc.1",
+		Commit:    "abcdef123456",
+		Date:      "2026-03-17T12:00:00Z",
+	}
+
+	got := info.String()
+	want := "amika-server version v1.2.3-rc.1\ncommit: abcdef123456\ndate: 2026-03-17T12:00:00Z"
+	if got != want {
+		t.Fatalf("info.String() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/buildmeta` package with semver parsing and build-time version/commit/date injection via `-ldflags`
- Add `--version` flag to both `amika` and `amika-server` binaries
- Add `release-tag.yml` workflow for manually cutting component-scoped annotated tags (`amika/v1.2.3`, `amika-server/v1.2.3-rc.1`)
- Add `release.yml` workflow that builds cross-platform tarballs (linux/darwin, amd64/arm64) and publishes GitHub Releases on tag push