### PR TITLE
ci: fix release tag format and use GitHub App token to trigger release

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -73,10 +73,17 @@ jobs:
             fi
           fi
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Assemble version string
         id: version

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -6,10 +6,10 @@ name: Create Release Tag
 # and GitHub Release publication.
 #
 # Supported tag shapes:
-#   amika/v1.2.3
-#   amika/v1.2.3-rc.1
-#   amika-server/v1.2.3
-#   amika-server/v1.2.3-beta.1
+#   amika@v1.2.3
+#   amika@v1.2.3-rc.1
+#   amika-server@v1.2.3
+#   amika-server@v1.2.3-beta.1
 
 on:
   workflow_dispatch:
@@ -97,7 +97,7 @@ jobs:
           COMPONENT: ${{ inputs.component }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          tag="${COMPONENT}/${VERSION}"
+          tag="${COMPONENT}@${VERSION}"
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "Tag $tag already exists." >&2
             exit 1
@@ -114,7 +114,7 @@ jobs:
           COMPONENT: ${{ inputs.component }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          tag="${COMPONENT}/${VERSION}"
+          tag="${COMPONENT}@${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$tag" -m "Release $tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 # Publishes a GitHub Release for a component-scoped tag created by
 # release-tag.yml. The workflow:
-# 1. Parses the component and semver from tags like amika/v1.2.3-rc.1
+# 1. Parses the component and semver from tags like amika@v1.2.3-rc.1
 # 2. Builds only that component for linux/darwin on amd64 and arm64
 # 3. Injects version, full commit SHA, and build date into the binary metadata
 # 4. Uploads platform tarballs plus a shared checksums.txt file
@@ -15,8 +15,8 @@ name: Release
 on:
   push:
     tags:
-      - "amika/v*"
-      - "amika-server/v*"
+      - "amika@v*"
+      - "amika-server@v*"
 
 permissions:
   contents: write
@@ -42,11 +42,11 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           case "$TAG" in
-            amika/*)
+            amika@*)
               component="amika"
               binary_name="amika"
               ;;
-            amika-server/*)
+            amika-server@*)
               component="amika-server"
               binary_name="amika-server"
               ;;
@@ -56,7 +56,7 @@ jobs:
               ;;
           esac
 
-          version="${TAG#*/}"
+          version="${TAG#*@}"
           if ! printf '%s' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'; then
             echo "Tag version is not valid semver: $version" >&2
             exit 1


### PR DESCRIPTION
## Summary

- Change tag format from `amika/v1.2.3` to `amika@v1.2.3` for both release-tag and release workflows
- Use a GitHub App installation token in release-tag workflow so the tag push triggers the downstream release workflow (the default `GITHUB_TOKEN` does not trigger other workflows)