### PR TITLE
ci: add checkout step to publish job in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,8 @@ jobs:
       - build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: release-artifacts


### PR DESCRIPTION
The publish job runs `gh release create/upload` which requires a .git directory to resolve the repository. Without a checkout step, the job fails with "fatal: not a git repository".