### PR TITLE
Add install.sh for one-liner binary installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+set -eu
+
+INSTALL_DIR="${AMIKA_INSTALL_DIR:-/usr/local/bin}"
+GITHUB_REPO="gofixpoint/amika"
+
+usage() {
+  cat <<EOF
+install.sh — install the amika CLI
+
+Downloads the latest amika release binary from GitHub and installs it.
+
+Usage:
+  sh install.sh [--help]
+
+Environment variables:
+  AMIKA_INSTALL_DIR   Override install directory (default: /usr/local/bin)
+
+Examples:
+  curl -fsSL https://raw.githubusercontent.com/gofixpoint/amika/main/install.sh | sh
+  AMIKA_INSTALL_DIR=~/.local/bin sh install.sh
+EOF
+}
+
+main() {
+  parse_args "$@"
+  detect_platform
+  find_latest_release
+  download_and_extract
+  install_binary
+  echo "amika ${VERSION} installed to ${INSTALL_DIR}/amika"
+}
+
+parse_args() {
+  for arg in "$@"; do
+    case "$arg" in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $arg" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+detect_platform() {
+  OS="$(uname -s)"
+  case "$OS" in
+    Linux)  OS="linux" ;;
+    Darwin) OS="darwin" ;;
+    *)
+      echo "Error: unsupported operating system: $OS" >&2
+      exit 1
+      ;;
+  esac
+
+  ARCH="$(uname -m)"
+  case "$ARCH" in
+    x86_64|amd64)   ARCH="amd64" ;;
+    aarch64|arm64)   ARCH="arm64" ;;
+    *)
+      echo "Error: unsupported architecture: $ARCH" >&2
+      exit 1
+      ;;
+  esac
+}
+
+find_latest_release() {
+  echo "Finding latest amika release..."
+
+  RELEASES_JSON="$(fetch_url "https://api.github.com/repos/${GITHUB_REPO}/releases")"
+
+  # Find the latest non-prerelease tag matching amika@v* (not amika-server@v*)
+  # The GitHub API returns releases newest-first.
+  TAG="$(echo "$RELEASES_JSON" | grep '"tag_name"' | grep '"amika@v' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')"
+
+  if [ -z "$TAG" ]; then
+    echo "Error: could not find a release matching amika@v*" >&2
+    exit 1
+  fi
+
+  # Extract version from tag: amika@v1.2.3 -> 1.2.3
+  VERSION="${TAG#amika@v}"
+  echo "Latest release: ${TAG} (version ${VERSION})"
+}
+
+download_and_extract() {
+  TMPDIR_INSTALL="$(mktemp -d)"
+  trap 'rm -rf "$TMPDIR_INSTALL"' EXIT
+
+  ARCHIVE_BASE="amika_${VERSION}_${OS}_${ARCH}"
+  ARCHIVE_NAME="${ARCHIVE_BASE}.tar.gz"
+  DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${ARCHIVE_NAME}"
+
+  echo "Downloading ${DOWNLOAD_URL}..."
+  fetch_url "$DOWNLOAD_URL" > "${TMPDIR_INSTALL}/${ARCHIVE_NAME}"
+
+  echo "Extracting..."
+  tar -xzf "${TMPDIR_INSTALL}/${ARCHIVE_NAME}" -C "$TMPDIR_INSTALL"
+
+  BINARY_PATH="${TMPDIR_INSTALL}/${ARCHIVE_BASE}/amika"
+  if [ ! -f "$BINARY_PATH" ]; then
+    echo "Error: expected binary not found at ${ARCHIVE_BASE}/amika in archive" >&2
+    exit 1
+  fi
+
+  # Remove macOS quarantine attribute if present
+  if [ "$OS" = "darwin" ]; then
+    xattr -d com.apple.quarantine "$BINARY_PATH" 2>/dev/null || true
+  fi
+}
+
+install_binary() {
+  mkdir -p "$INSTALL_DIR" 2>/dev/null || true
+
+  if [ -w "$INSTALL_DIR" ]; then
+    mv "$BINARY_PATH" "${INSTALL_DIR}/amika"
+  else
+    echo "Installing to ${INSTALL_DIR}/amika (requires sudo)..."
+    sudo mv "$BINARY_PATH" "${INSTALL_DIR}/amika"
+  fi
+
+  chmod +x "${INSTALL_DIR}/amika"
+}
+
+fetch_url() {
+  url="$1"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "$url"
+  else
+    echo "Error: neither curl nor wget found. Please install one of them." >&2
+    exit 1
+  fi
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -eu
 INSTALL_DIR="${AMIKA_INSTALL_DIR:-/usr/local/bin}"
 GITHUB_REPO="gofixpoint/amika"
 INCLUDE_PRERELEASE=false
+DRY_RUN=false
 
 usage() {
   cat <<EOF
@@ -12,10 +13,11 @@ install.sh — install the amika CLI
 Downloads the latest amika release binary from GitHub and installs it.
 
 Usage:
-  sh install.sh [--help] [--latest-prerelease]
+  sh install.sh [--help] [--latest-prerelease] [--dry-run]
 
 Flags:
   --latest-prerelease   Include prerelease versions when finding the latest release
+  --dry-run             Show what would be done without downloading or installing
 
 Environment variables:
   AMIKA_INSTALL_DIR   Override install directory (default: /usr/local/bin)
@@ -30,6 +32,21 @@ main() {
   parse_args "$@"
   detect_platform
   find_latest_release
+
+  ARCHIVE_BASE="amika_${VERSION}_${OS}_${ARCH}"
+  ARCHIVE_NAME="${ARCHIVE_BASE}.tar.gz"
+  DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${ARCHIVE_NAME}"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo ""
+    echo "Dry run — would perform the following:"
+    echo "  Platform:     ${OS}/${ARCH}"
+    echo "  Version:      ${VERSION} (${TAG})"
+    echo "  Download URL: ${DOWNLOAD_URL}"
+    echo "  Install to:   ${INSTALL_DIR}/amika"
+    exit 0
+  fi
+
   download_and_extract
   install_binary
   echo "amika ${VERSION} installed to ${INSTALL_DIR}/amika"
@@ -44,6 +61,9 @@ parse_args() {
         ;;
       --latest-prerelease)
         INCLUDE_PRERELEASE=true
+        ;;
+      --dry-run)
+        DRY_RUN=true
         ;;
       *)
         echo "Unknown argument: $arg" >&2
@@ -86,7 +106,9 @@ find_latest_release() {
   # Output format: one line per release as "tag_name prerelease_bool"
   RELEASE_LINES="$(echo "$RELEASES_JSON" \
     | grep -E '"tag_name"|"prerelease"' \
-    | sed 's/.*"tag_name": *"\([^"]*\)".*/TAG \1/; s/.*"prerelease": *\(true\|false\).*/PRE \1/' \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/TAG \1/' \
+    | sed 's/.*"prerelease": *true.*/PRE true/' \
+    | sed 's/.*"prerelease": *false.*/PRE false/' \
     | paste - - \
     | sed 's/TAG \([^ ]*\).*PRE \(.*\)/\1 \2/')"
 
@@ -113,10 +135,6 @@ find_latest_release() {
 download_and_extract() {
   TMPDIR_INSTALL="$(mktemp -d)"
   trap 'rm -rf "$TMPDIR_INSTALL"' EXIT
-
-  ARCHIVE_BASE="amika_${VERSION}_${OS}_${ARCH}"
-  ARCHIVE_NAME="${ARCHIVE_BASE}.tar.gz"
-  DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${ARCHIVE_NAME}"
 
   echo "Downloading ${DOWNLOAD_URL}..."
   fetch_url "$DOWNLOAD_URL" > "${TMPDIR_INSTALL}/${ARCHIVE_NAME}"

--- a/install.sh
+++ b/install.sh
@@ -75,10 +75,6 @@ parse_args() {
       --dry-run)
         DRY_RUN=true
         ;;
-      --latest-prerelease)
-        echo "Error: --latest-prerelease is no longer supported; use --install-version VERSION instead" >&2
-        exit 1
-        ;;
       *)
         echo "Unknown argument: $arg" >&2
         usage >&2

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ set -eu
 
 INSTALL_DIR="${AMIKA_INSTALL_DIR:-/usr/local/bin}"
 GITHUB_REPO="gofixpoint/amika"
+INCLUDE_PRERELEASE=false
 
 usage() {
   cat <<EOF
@@ -11,7 +12,10 @@ install.sh — install the amika CLI
 Downloads the latest amika release binary from GitHub and installs it.
 
 Usage:
-  sh install.sh [--help]
+  sh install.sh [--help] [--latest-prerelease]
+
+Flags:
+  --latest-prerelease   Include prerelease versions when finding the latest release
 
 Environment variables:
   AMIKA_INSTALL_DIR   Override install directory (default: /usr/local/bin)
@@ -37,6 +41,9 @@ parse_args() {
       --help|-h)
         usage
         exit 0
+        ;;
+      --latest-prerelease)
+        INCLUDE_PRERELEASE=true
         ;;
       *)
         echo "Unknown argument: $arg" >&2
@@ -74,9 +81,24 @@ find_latest_release() {
 
   RELEASES_JSON="$(fetch_url "https://api.github.com/repos/${GITHUB_REPO}/releases")"
 
-  # Find the latest non-prerelease tag matching amika@v* (not amika-server@v*)
+  # Extract tag_name and prerelease fields as paired lines, then filter.
   # The GitHub API returns releases newest-first.
-  TAG="$(echo "$RELEASES_JSON" | grep '"tag_name"' | grep '"amika@v' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')"
+  # Output format: one line per release as "tag_name prerelease_bool"
+  RELEASE_LINES="$(echo "$RELEASES_JSON" \
+    | grep -E '"tag_name"|"prerelease"' \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/TAG \1/; s/.*"prerelease": *\(true\|false\).*/PRE \1/' \
+    | paste - - \
+    | sed 's/TAG \([^ ]*\).*PRE \(.*\)/\1 \2/')"
+
+  # Filter for amika@v* tags (not amika-server@v*)
+  RELEASE_LINES="$(echo "$RELEASE_LINES" | grep '^amika@v')"
+
+  # Unless --latest-prerelease is set, exclude prereleases
+  if [ "$INCLUDE_PRERELEASE" = "false" ]; then
+    RELEASE_LINES="$(echo "$RELEASE_LINES" | grep ' false$')" || true
+  fi
+
+  TAG="$(echo "$RELEASE_LINES" | head -1 | awk '{print $1}')"
 
   if [ -z "$TAG" ]; then
     echo "Error: could not find a release matching amika@v*" >&2

--- a/install.sh
+++ b/install.sh
@@ -3,20 +3,21 @@ set -eu
 
 INSTALL_DIR="${AMIKA_INSTALL_DIR:-/usr/local/bin}"
 GITHUB_REPO="gofixpoint/amika"
-INCLUDE_PRERELEASE=false
+DEFAULT_VERSION="0.1.0-rc.1"
+INSTALL_VERSION="$DEFAULT_VERSION"
 DRY_RUN=false
 
 usage() {
   cat <<EOF
 install.sh — install the amika CLI
 
-Downloads the latest amika release binary from GitHub and installs it.
+Downloads a specific amika release binary from GitHub and installs it.
 
 Usage:
-  sh install.sh [--help] [--latest-prerelease] [--dry-run]
+  sh install.sh [--help] [--install-version VERSION] [--dry-run]
 
 Flags:
-  --latest-prerelease   Include prerelease versions when finding the latest release
+  --install-version     Install a specific version (default: ${DEFAULT_VERSION})
   --dry-run             Show what would be done without downloading or installing
 
 Environment variables:
@@ -24,6 +25,7 @@ Environment variables:
 
 Examples:
   curl -fsSL https://raw.githubusercontent.com/gofixpoint/amika/main/install.sh | sh
+  sh install.sh --install-version 0.1.0-rc.1
   AMIKA_INSTALL_DIR=~/.local/bin sh install.sh
 EOF
 }
@@ -31,11 +33,12 @@ EOF
 main() {
   parse_args "$@"
   detect_platform
-  find_latest_release
+  set_install_version
 
   ARCHIVE_BASE="amika_${VERSION}_${OS}_${ARCH}"
   ARCHIVE_NAME="${ARCHIVE_BASE}.tar.gz"
   DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${ARCHIVE_NAME}"
+  CHECKSUMS_URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/checksums.txt"
 
   if [ "$DRY_RUN" = "true" ]; then
     echo ""
@@ -43,6 +46,7 @@ main() {
     echo "  Platform:     ${OS}/${ARCH}"
     echo "  Version:      ${VERSION} (${TAG})"
     echo "  Download URL: ${DOWNLOAD_URL}"
+    echo "  Checksums:    ${CHECKSUMS_URL}"
     echo "  Install to:   ${INSTALL_DIR}/amika"
     exit 0
   fi
@@ -53,17 +57,27 @@ main() {
 }
 
 parse_args() {
-  for arg in "$@"; do
+  while [ "$#" -gt 0 ]; do
+    arg="$1"
     case "$arg" in
       --help|-h)
         usage
         exit 0
         ;;
-      --latest-prerelease)
-        INCLUDE_PRERELEASE=true
+      --install-version)
+        if [ "$#" -lt 2 ]; then
+          echo "Error: --install-version requires a value" >&2
+          exit 1
+        fi
+        INSTALL_VERSION="$2"
+        shift
         ;;
       --dry-run)
         DRY_RUN=true
+        ;;
+      --latest-prerelease)
+        echo "Error: --latest-prerelease is no longer supported; use --install-version VERSION instead" >&2
+        exit 1
         ;;
       *)
         echo "Unknown argument: $arg" >&2
@@ -71,6 +85,7 @@ parse_args() {
         exit 1
         ;;
     esac
+    shift
   done
 }
 
@@ -96,40 +111,10 @@ detect_platform() {
   esac
 }
 
-find_latest_release() {
-  echo "Finding latest amika release..."
-
-  RELEASES_JSON="$(fetch_url "https://api.github.com/repos/${GITHUB_REPO}/releases")"
-
-  # Extract tag_name and prerelease fields as paired lines, then filter.
-  # The GitHub API returns releases newest-first.
-  # Output format: one line per release as "tag_name prerelease_bool"
-  RELEASE_LINES="$(echo "$RELEASES_JSON" \
-    | grep -E '"tag_name"|"prerelease"' \
-    | sed 's/.*"tag_name": *"\([^"]*\)".*/TAG \1/' \
-    | sed 's/.*"prerelease": *true.*/PRE true/' \
-    | sed 's/.*"prerelease": *false.*/PRE false/' \
-    | paste - - \
-    | sed 's/TAG \([^ ]*\).*PRE \(.*\)/\1 \2/')"
-
-  # Filter for amika@v* tags (not amika-server@v*)
-  RELEASE_LINES="$(echo "$RELEASE_LINES" | grep '^amika@v')"
-
-  # Unless --latest-prerelease is set, exclude prereleases
-  if [ "$INCLUDE_PRERELEASE" = "false" ]; then
-    RELEASE_LINES="$(echo "$RELEASE_LINES" | grep ' false$')" || true
-  fi
-
-  TAG="$(echo "$RELEASE_LINES" | head -1 | awk '{print $1}')"
-
-  if [ -z "$TAG" ]; then
-    echo "Error: could not find a release matching amika@v*" >&2
-    exit 1
-  fi
-
-  # Extract version from tag: amika@v1.2.3 -> 1.2.3
-  VERSION="${TAG#amika@v}"
-  echo "Latest release: ${TAG} (version ${VERSION})"
+set_install_version() {
+  VERSION="${INSTALL_VERSION#v}"
+  TAG="amika@v${VERSION}"
+  echo "Installing amika release: ${TAG}"
 }
 
 download_and_extract() {
@@ -138,6 +123,7 @@ download_and_extract() {
 
   echo "Downloading ${DOWNLOAD_URL}..."
   fetch_url "$DOWNLOAD_URL" > "${TMPDIR_INSTALL}/${ARCHIVE_NAME}"
+  verify_checksum "${TMPDIR_INSTALL}/${ARCHIVE_NAME}"
 
   echo "Extracting..."
   tar -xzf "${TMPDIR_INSTALL}/${ARCHIVE_NAME}" -C "$TMPDIR_INSTALL"
@@ -155,16 +141,68 @@ download_and_extract() {
 }
 
 install_binary() {
-  mkdir -p "$INSTALL_DIR" 2>/dev/null || true
+  ensure_install_dir
+  DEST_PATH="${INSTALL_DIR}/amika"
 
   if [ -w "$INSTALL_DIR" ]; then
-    mv "$BINARY_PATH" "${INSTALL_DIR}/amika"
+    install -m 0755 "$BINARY_PATH" "$DEST_PATH"
   else
-    echo "Installing to ${INSTALL_DIR}/amika (requires sudo)..."
-    sudo mv "$BINARY_PATH" "${INSTALL_DIR}/amika"
+    echo "Installing to ${DEST_PATH} (requires sudo)..."
+    sudo install -m 0755 "$BINARY_PATH" "$DEST_PATH"
+  fi
+}
+
+ensure_install_dir() {
+  if [ -d "$INSTALL_DIR" ]; then
+    return 0
   fi
 
-  chmod +x "${INSTALL_DIR}/amika"
+  if [ -e "$INSTALL_DIR" ]; then
+    echo "Error: install path exists and is not a directory: $INSTALL_DIR" >&2
+    exit 1
+  fi
+
+  if mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+    return 0
+  fi
+
+  echo "Creating install directory ${INSTALL_DIR} (requires sudo)..."
+  sudo mkdir -p "$INSTALL_DIR"
+}
+
+verify_checksum() {
+  archive_path="$1"
+  checksums_path="${TMPDIR_INSTALL}/checksums.txt"
+
+  echo "Verifying checksum..."
+  fetch_url "$CHECKSUMS_URL" > "$checksums_path"
+
+  checksum_line="$(grep "  ${ARCHIVE_NAME}\$" "$checksums_path" || true)"
+  if [ -z "$checksum_line" ]; then
+    echo "Error: checksum for ${ARCHIVE_NAME} not found in checksums.txt" >&2
+    exit 1
+  fi
+
+  expected_checksum="$(printf '%s\n' "$checksum_line" | awk '{print $1}')"
+  actual_checksum="$(compute_sha256 "$archive_path")"
+
+  if [ "$expected_checksum" != "$actual_checksum" ]; then
+    echo "Error: checksum mismatch for ${ARCHIVE_NAME}" >&2
+    exit 1
+  fi
+}
+
+compute_sha256() {
+  file_path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file_path" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file_path" | awk '{print $1}'
+  else
+    echo "Error: neither sha256sum nor shasum found. Please install one of them." >&2
+    exit 1
+  fi
 }
 
 fetch_url() {


### PR DESCRIPTION
## Summary
- Adds `install.sh` shell script for downloading and installing the amika CLI binary from GitHub releases
- Supports Linux/macOS, amd64/arm64, curl/wget fallback, SHA256 checksum verification, sudo escalation, and `AMIKA_INSTALL_DIR` override
- Includes `--install-version` flag (defaults to pinned version `0.1.0-rc.1`) and `--dry-run` flag to preview actions without installing