### PR TITLE
Unify Amika config across global and repo scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ OpenAPI documentation is available at `/docs`. The API mirrors the CLI — creat
 
 See the [endpoint table in docs/cli-reference.md](docs/cli-reference.md#api-endpoints) for the full list of routes.
 
+## Configuration
+
+Amika reads config from both `${XDG_CONFIG_HOME}/amika/config.toml` and `.amika/config.toml`. The schema is shared between the two locations, repo config overrides global config, and environment variables override both.
+
+```toml
+[api]
+api_url = "https://app.amika.dev"
+auth_client_id = "client_..."
+```
+
+See [docs/sandbox-configuration.md](docs/sandbox-configuration.md) and [docs/auth.md](docs/auth.md) for details.
+
 ## Presets
 
 | Preset            | Image                 | Includes                                                                         |

--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/gofixpoint/amika/internal/amikaconfig"
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/spf13/cobra"
 )
-
-const defaultWorkOSClientID = "client_01KHA495MJS1KT6QBRTYJ239DY"
 
 var authCmd = &cobra.Command{
 	Use:   "auth",
@@ -25,9 +23,9 @@ Opens a browser for you to authorize the CLI.`,
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 
-		clientID := os.Getenv("AMIKA_WORKOS_CLIENT_ID")
-		if clientID == "" {
-			clientID = defaultWorkOSClientID
+		clientID, err := amikaconfig.EffectiveAuthClientIDForDir("")
+		if err != nil {
+			return err
 		}
 
 		session, err := auth.DeviceLogin(clientID)

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -34,8 +34,6 @@ var sandboxCmd = &cobra.Command{
 
 const sandboxConnectWorkdir = "/home/amika"
 
-const envAPIURL = "AMIKA_API_URL"
-
 // TODO: Parse env variables from an environment file (e.g. .amika/.env or ~/.config/amika/env)
 // so users don't need to export AMIKA_API_URL, AMIKA_WORKOS_CLIENT_ID, etc. in their shell profile.
 
@@ -54,7 +52,11 @@ func sandboxMode(cmd *cobra.Command) string {
 	// Default: if logged in with a valid session, include remote; otherwise local.
 	// GetValidSession refreshes expired tokens; if that fails the session is
 	// unusable and we fall back to local-only without blocking the command.
-	if _, err := auth.GetValidSession(defaultWorkOSClientID); err != nil {
+	clientID, err := amikaconfig.EffectiveAuthClientIDForDir("")
+	if err != nil {
+		return "local"
+	}
+	if _, err := auth.GetValidSession(clientID); err != nil {
 		return "local"
 	}
 	return "both"
@@ -62,7 +64,11 @@ func sandboxMode(cmd *cobra.Command) string {
 
 // isLoggedIn returns true if a valid (or refreshable) WorkOS session exists.
 func isLoggedIn() bool {
-	_, err := auth.GetValidSession(defaultWorkOSClientID)
+	clientID, err := amikaconfig.EffectiveAuthClientIDForDir("")
+	if err != nil {
+		return false
+	}
+	_, err = auth.GetValidSession(clientID)
 	return err == nil
 }
 
@@ -86,16 +92,20 @@ func getRemoteTarget(cmd *cobra.Command) (string, error) {
 }
 
 // getRemoteClient returns an API client authenticated with the current session.
-func getRemoteClient(target string) (*apiclient.Client, error) {
+func getRemoteClient(target, repoRoot string) (*apiclient.Client, error) {
 	// TODO: when named-remote config is added, look up target here.
 	_ = target
-	session, err := auth.GetValidSession(defaultWorkOSClientID)
+	clientID, err := amikaconfig.EffectiveAuthClientID(repoRoot)
 	if err != nil {
 		return nil, err
 	}
-	baseURL := os.Getenv(envAPIURL)
-	if baseURL == "" {
-		baseURL = apiclient.DefaultAPIURL
+	session, err := auth.GetValidSession(clientID)
+	if err != nil {
+		return nil, err
+	}
+	baseURL, err := amikaconfig.EffectiveAPIURL(repoRoot)
+	if err != nil {
+		return nil, err
 	}
 	return apiclient.NewClient(baseURL, session.AccessToken), nil
 }
@@ -381,7 +391,7 @@ var sandboxDeleteCmd = &cobra.Command{
 		// Build a remote client if we may need it.
 		var remoteClient *apiclient.Client
 		if mode == "remote" || mode == "both" {
-			remoteClient, err = getRemoteClient(target)
+			remoteClient, err = getRemoteClient(target, "")
 			if err != nil {
 				return err
 			}
@@ -492,7 +502,7 @@ var sandboxListCmd = &cobra.Command{
 		}
 
 		if mode == "remote" || mode == "both" {
-			client, err := getRemoteClient(target)
+			client, err := getRemoteClient(target, "")
 			if err != nil {
 				return err
 			}
@@ -1491,6 +1501,7 @@ func hasEnvKey(env []string, key string) bool {
 func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	name, _ := cmd.Flags().GetString("name")
 	gitValue, _ := cmd.Flags().GetString("git")
+	var err error
 
 	var gitURL string
 	if cmd.Flags().Changed("git") {
@@ -1501,7 +1512,15 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		gitURL = resolved
 	}
 
-	client, err := getRemoteClient(target)
+	repoRoot := ""
+	if cmd.Flags().Changed("git") && gitValue != "" && !isNetworkRemoteURL(gitValue) {
+		repoRoot, err = resolveGitRoot(gitValue)
+		if err != nil {
+			return err
+		}
+	}
+
+	client, err := getRemoteClient(target, repoRoot)
 	if err != nil {
 		return err
 	}
@@ -1579,7 +1598,7 @@ Examples:
 			return err
 		}
 
-		client, err := getRemoteClient(target)
+		client, err := getRemoteClient(target, "")
 		if err != nil {
 			return err
 		}

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/gofixpoint/amika/internal/amikaconfig"
 	"github.com/gofixpoint/amika/internal/apiclient"
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/spf13/cobra"
@@ -266,13 +267,17 @@ func pushSecret(client *apiclient.Client, existing map[string]apiclient.Secret, 
 
 // getSecretsClient returns an API client for secrets operations.
 func getSecretsClient() (*apiclient.Client, error) {
-	session, err := auth.GetValidSession(defaultWorkOSClientID)
+	clientID, err := amikaconfig.EffectiveAuthClientIDForDir("")
 	if err != nil {
 		return nil, err
 	}
-	baseURL := os.Getenv(envAPIURL)
-	if baseURL == "" {
-		baseURL = apiclient.DefaultAPIURL
+	session, err := auth.GetValidSession(clientID)
+	if err != nil {
+		return nil, err
+	}
+	baseURL, err := amikaconfig.EffectiveAPIURLForDir("")
+	if err != nil {
+		return nil, err
 	}
 	return apiclient.NewClient(baseURL, session.AccessToken), nil
 }

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -45,6 +45,23 @@ The path can be overridden with the `AMIKA_STATE_DIRECTORY` environment variable
 | `AMIKA_API_URL`          | `https://app.amika.dev` | Override the remote API base URL. Used by sandbox commands when operating on remote sandboxes                     |
 | `AMIKA_WORKOS_CLIENT_ID` |                         | Override the default WorkOS client ID. If you change `AMIKA_API_URL`, you likely need to update this variable too |
 
+### Config Files
+
+Amika also reads API settings from config files:
+
+- Global: `${XDG_CONFIG_HOME}/amika/config.toml`
+- Repo: `.amika/config.toml`
+
+Both files use the same schema:
+
+```toml
+[api]
+api_url = "https://app.amika.dev"
+auth_client_id = "client_..."
+```
+
+Precedence is `environment variables > repo config > global config > built-in defaults`.
+
 ---
 
 ## Credential Discovery

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -371,3 +371,20 @@ The HTTP API accepts some fields that are not available as CLI flags:
 | `AMIKA_WORKOS_CLIENT_ID`    | Override the default WorkOS client ID for `amika auth login`. If you change `AMIKA_API_URL`, you likely need to update this too                                    |
 | `AMIKA_RUN_EXPENSIVE_TESTS` | Set to `1` to enable expensive Docker rebuild integration tests during `go test`                                                                                   |
 | `PORT`                      | Override listen address for `amika-server`. Accepts a plain port (`8080` becomes `:8080`) or full address (`127.0.0.1:8080`). Mutually exclusive with `-addr` flag |
+
+## Config Files
+
+Amika reads config from:
+
+- Global: `${XDG_CONFIG_HOME}/amika/config.toml`
+- Repo: `.amika/config.toml`
+
+Shared schema:
+
+```toml
+[api]
+api_url = "https://app.amika.dev"
+auth_client_id = "client_..."
+```
+
+Repo config overrides global config. Environment variables override both.

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -92,7 +92,14 @@ The repository is cloned on the host, copied into a named Docker volume, and mou
 - The volume name is derived from the sandbox name and repo name, e.g. `amika-git-teal-tokyo-Hello-World-<timestamp>`.
 - Deleting the sandbox does not automatically delete the git volume; use `amika volume delete` when you no longer need it.
 
-## Per-repo configuration: `.amika/config.toml`
+## Amika config files
+
+Amika uses a shared config format in two locations:
+
+- Global: `${XDG_CONFIG_HOME}/amika/config.toml`
+- Repo: `.amika/config.toml`
+
+Repo config overrides global config. Environment variables override both.
 
 When you use `--git`, Amika looks for a `.amika/config.toml` file at the root of the repository and applies it automatically. This lets you commit sandbox configuration alongside your code so every collaborator gets the same environment without passing extra flags.
 
@@ -107,11 +114,24 @@ When you use `--git`, Amika looks for a `.amika/config.toml` file at the root of
 ### Supported fields
 
 ```toml
+[api]
+api_url = "https://app.amika.dev"
+auth_client_id = "client_..."
+
 [lifecycle]
 # Path to an executable that is mounted into the container at /usr/local/etc/amikad/setup/setup.sh.
 # Relative paths are resolved from the repository root.
 setup_script = "scripts/setup.sh"
 ```
+
+#### `[api]`
+
+These settings affect remote API access for the CLI and HTTP API:
+
+- `api_url` overrides the Amika API base URL
+- `auth_client_id` overrides the WorkOS client ID used for login and token refresh
+
+Because config is merged, you can put shared defaults in `${XDG_CONFIG_HOME}/amika/config.toml` and override them per repo in `.amika/config.toml`.
 
 #### `[lifecycle].setup_script`
 

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -12,8 +12,18 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gofixpoint/amika/internal/apiclient"
 	"github.com/gofixpoint/amika/internal/basedir"
 	"github.com/gofixpoint/amika/internal/constants"
+)
+
+const (
+	// EnvAPIURL overrides the configured API base URL.
+	EnvAPIURL = "AMIKA_API_URL"
+	// EnvWorkOSClientID overrides the configured WorkOS client ID.
+	EnvWorkOSClientID = "AMIKA_WORKOS_CLIENT_ID"
+	// DefaultWorkOSClientID is the built-in fallback WorkOS client ID.
+	DefaultWorkOSClientID = "client_01KHA495MJS1KT6QBRTYJ239DY"
 )
 
 // Config is the parsed Amika config file.
@@ -65,7 +75,7 @@ func LoadConfig(repoRoot string) (*Config, error) {
 // LoadRepoConfig reads $repoRoot/.amika/config.toml.
 // Returns nil, nil if the file does not exist.
 func LoadRepoConfig(repoRoot string) (*Config, error) {
-	path := filepath.Join(repoRoot, ".amika", "config.toml")
+	path := repoConfigPath(repoRoot)
 	return loadConfigFile(path)
 }
 
@@ -163,6 +173,94 @@ func cloneServiceConfig(svc ServiceConfig) ServiceConfig {
 		cloned.Ports = append([]interface{}(nil), svc.Ports...)
 	}
 	return cloned
+}
+
+// EffectiveAPIURL resolves the API URL with precedence env > repo > global > default.
+func EffectiveAPIURL(repoRoot string) (string, error) {
+	if value := os.Getenv(EnvAPIURL); value != "" {
+		return value, nil
+	}
+
+	cfg, err := LoadEffectiveConfig(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	if cfg != nil && cfg.API.APIURL != "" {
+		return cfg.API.APIURL, nil
+	}
+	return apiclient.DefaultAPIURL, nil
+}
+
+// EffectiveAuthClientID resolves the WorkOS client ID with precedence
+// env > repo > global > default.
+func EffectiveAuthClientID(repoRoot string) (string, error) {
+	if value := os.Getenv(EnvWorkOSClientID); value != "" {
+		return value, nil
+	}
+
+	cfg, err := LoadEffectiveConfig(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	if cfg != nil && cfg.API.AuthClientID != "" {
+		return cfg.API.AuthClientID, nil
+	}
+	return DefaultWorkOSClientID, nil
+}
+
+// EffectiveAPIURLForDir resolves the API URL using the nearest repo config, if any.
+func EffectiveAPIURLForDir(startDir string) (string, error) {
+	repoRoot, err := FindRepoRoot(startDir)
+	if err != nil {
+		return "", err
+	}
+	return EffectiveAPIURL(repoRoot)
+}
+
+// EffectiveAuthClientIDForDir resolves the WorkOS client ID using the nearest
+// repo config, if any.
+func EffectiveAuthClientIDForDir(startDir string) (string, error) {
+	repoRoot, err := FindRepoRoot(startDir)
+	if err != nil {
+		return "", err
+	}
+	return EffectiveAuthClientID(repoRoot)
+}
+
+// FindRepoRoot returns the nearest ancestor directory containing .amika/config.toml.
+// It returns an empty string when no repo config is present.
+func FindRepoRoot(startDir string) (string, error) {
+	dir := startDir
+	if dir == "" {
+		var err error
+		dir, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get current working directory: %w", err)
+		}
+	}
+
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve config search path %q: %w", dir, err)
+	}
+
+	for {
+		if _, err := os.Stat(repoConfigPath(dir)); err == nil {
+			return dir, nil
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("failed to inspect repo config in %q: %w", dir, err)
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
+}
+
+func repoConfigPath(repoRoot string) string {
+	return filepath.Join(repoRoot, ".amika", "config.toml")
 }
 
 // ParsedServices validates the service declarations and returns a normalized list.

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -1,4 +1,4 @@
-// Package amikaconfig loads per-repo Amika configuration from .amika/config.toml.
+// Package amikaconfig loads Amika configuration from global and repo config files.
 package amikaconfig
 
 import (
@@ -15,10 +15,17 @@ import (
 	"github.com/gofixpoint/amika/internal/constants"
 )
 
-// Config is the parsed .amika/config.toml file.
+// Config is the parsed Amika config file.
 type Config struct {
+	API       APIConfig                `toml:"api"`
 	Lifecycle LifecycleConfig          `toml:"lifecycle"`
 	Services  map[string]ServiceConfig `toml:"services"`
+}
+
+// APIConfig holds API client configuration.
+type APIConfig struct {
+	APIURL       string `toml:"api_url"`
+	AuthClientID string `toml:"auth_client_id"`
 }
 
 // LifecycleConfig holds sandbox lifecycle hooks.

--- a/internal/amikaconfig/config.go
+++ b/internal/amikaconfig/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gofixpoint/amika/internal/basedir"
 	"github.com/gofixpoint/amika/internal/constants"
 )
 
@@ -58,7 +59,45 @@ type ServiceParsed struct {
 // LoadConfig reads $repoRoot/.amika/config.toml.
 // Returns nil, nil if the file does not exist.
 func LoadConfig(repoRoot string) (*Config, error) {
+	return LoadRepoConfig(repoRoot)
+}
+
+// LoadRepoConfig reads $repoRoot/.amika/config.toml.
+// Returns nil, nil if the file does not exist.
+func LoadRepoConfig(repoRoot string) (*Config, error) {
 	path := filepath.Join(repoRoot, ".amika", "config.toml")
+	return loadConfigFile(path)
+}
+
+// LoadGlobalConfig reads $XDG_CONFIG_HOME/amika/config.toml.
+// Returns nil, nil if the file does not exist.
+func LoadGlobalConfig() (*Config, error) {
+	path, err := basedir.New("").AmikaConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	return loadConfigFile(path)
+}
+
+// LoadEffectiveConfig merges global and repo config files, with repo values
+// overriding global values when both are present.
+func LoadEffectiveConfig(repoRoot string) (*Config, error) {
+	globalCfg, err := LoadGlobalConfig()
+	if err != nil {
+		return nil, err
+	}
+	if repoRoot == "" {
+		return globalCfg, nil
+	}
+
+	repoCfg, err := LoadRepoConfig(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	return Merge(globalCfg, repoCfg), nil
+}
+
+func loadConfigFile(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -71,6 +110,59 @@ func LoadConfig(repoRoot string) (*Config, error) {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 	return &cfg, nil
+}
+
+// Merge combines global and repo config, with repo values overriding global values.
+func Merge(globalCfg, repoCfg *Config) *Config {
+	switch {
+	case globalCfg == nil:
+		return cloneConfig(repoCfg)
+	case repoCfg == nil:
+		return cloneConfig(globalCfg)
+	}
+
+	merged := cloneConfig(globalCfg)
+	if repoCfg.API.APIURL != "" {
+		merged.API.APIURL = repoCfg.API.APIURL
+	}
+	if repoCfg.API.AuthClientID != "" {
+		merged.API.AuthClientID = repoCfg.API.AuthClientID
+	}
+	if repoCfg.Lifecycle.SetupScript != "" {
+		merged.Lifecycle.SetupScript = repoCfg.Lifecycle.SetupScript
+	}
+	if len(repoCfg.Services) > 0 {
+		if merged.Services == nil {
+			merged.Services = make(map[string]ServiceConfig, len(repoCfg.Services))
+		}
+		for name, svc := range repoCfg.Services {
+			merged.Services[name] = svc
+		}
+	}
+	return merged
+}
+
+func cloneConfig(cfg *Config) *Config {
+	if cfg == nil {
+		return nil
+	}
+
+	cloned := *cfg
+	if cfg.Services != nil {
+		cloned.Services = make(map[string]ServiceConfig, len(cfg.Services))
+		for name, svc := range cfg.Services {
+			cloned.Services[name] = cloneServiceConfig(svc)
+		}
+	}
+	return &cloned
+}
+
+func cloneServiceConfig(svc ServiceConfig) ServiceConfig {
+	cloned := svc
+	if svc.Ports != nil {
+		cloned.Ports = append([]interface{}(nil), svc.Ports...)
+	}
+	return cloned
 }
 
 // ParsedServices validates the service declarations and returns a normalized list.

--- a/internal/amikaconfig/config_test.go
+++ b/internal/amikaconfig/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gofixpoint/amika/internal/amikaconfig"
+	"github.com/gofixpoint/amika/internal/apiclient"
 )
 
 func TestLoadConfig_NotExist(t *testing.T) {
@@ -252,6 +253,134 @@ port = 3000
 	}
 }
 
+func TestFindRepoRoot_FindsNearestConfig(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeConfigFile(t, filepath.Join(repoRoot, ".amika", "config.toml"), `[api]
+api_url = "https://repo.example.test"
+`)
+	nested := filepath.Join(repoRoot, "subdir", "deeper")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := amikaconfig.FindRepoRoot(nested)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != repoRoot {
+		t.Fatalf("FindRepoRoot() = %q, want %q", got, repoRoot)
+	}
+}
+
+func TestEffectiveAPIURL_PreferenceOrder(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	setXDGConfigHome(t, configHome)
+	writeConfigFile(t, filepath.Join(configHome, "amika", "config.toml"), `[api]
+api_url = "https://global.example.test"
+`)
+	repoRoot := t.TempDir()
+	writeConfigFile(t, filepath.Join(repoRoot, ".amika", "config.toml"), `[api]
+api_url = "https://repo.example.test"
+`)
+
+	clearEnv(t, amikaconfig.EnvAPIURL)
+	got, err := amikaconfig.EffectiveAPIURL(repoRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://repo.example.test" {
+		t.Fatalf("EffectiveAPIURL() = %q, want repo value", got)
+	}
+
+	setEnvValue(t, amikaconfig.EnvAPIURL, "https://env.example.test")
+	got, err = amikaconfig.EffectiveAPIURL(repoRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://env.example.test" {
+		t.Fatalf("EffectiveAPIURL() with env = %q, want env value", got)
+	}
+}
+
+func TestEffectiveAuthClientID_PreferenceOrder(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	setXDGConfigHome(t, configHome)
+	writeConfigFile(t, filepath.Join(configHome, "amika", "config.toml"), `[api]
+auth_client_id = "global-client"
+`)
+	repoRoot := t.TempDir()
+	writeConfigFile(t, filepath.Join(repoRoot, ".amika", "config.toml"), `[api]
+auth_client_id = "repo-client"
+`)
+
+	clearEnv(t, amikaconfig.EnvWorkOSClientID)
+	got, err := amikaconfig.EffectiveAuthClientID(repoRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "repo-client" {
+		t.Fatalf("EffectiveAuthClientID() = %q, want repo value", got)
+	}
+
+	setEnvValue(t, amikaconfig.EnvWorkOSClientID, "env-client")
+	got, err = amikaconfig.EffectiveAuthClientID(repoRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "env-client" {
+		t.Fatalf("EffectiveAuthClientID() with env = %q, want env value", got)
+	}
+}
+
+func TestEffectiveValues_GlobalOnlyAndDefaults(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	setXDGConfigHome(t, configHome)
+	writeConfigFile(t, filepath.Join(configHome, "amika", "config.toml"), `[api]
+api_url = "https://global.example.test"
+auth_client_id = "global-client"
+`)
+
+	clearEnv(t, amikaconfig.EnvAPIURL)
+	clearEnv(t, amikaconfig.EnvWorkOSClientID)
+
+	apiURL, err := amikaconfig.EffectiveAPIURL("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if apiURL != "https://global.example.test" {
+		t.Fatalf("EffectiveAPIURL() = %q, want global value", apiURL)
+	}
+
+	clientID, err := amikaconfig.EffectiveAuthClientID("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clientID != "global-client" {
+		t.Fatalf("EffectiveAuthClientID() = %q, want global value", clientID)
+	}
+
+	os.Remove(filepath.Join(configHome, "amika", "config.toml"))
+
+	apiURL, err = amikaconfig.EffectiveAPIURL("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if apiURL != apiclient.DefaultAPIURL {
+		t.Fatalf("EffectiveAPIURL() default = %q, want built-in default", apiURL)
+	}
+
+	clientID, err = amikaconfig.EffectiveAuthClientID("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clientID != amikaconfig.DefaultWorkOSClientID {
+		t.Fatalf("EffectiveAuthClientID() default = %q, want built-in default", clientID)
+	}
+}
+
 // Helper to load a config from TOML content.
 func loadFromTOML(t *testing.T, content string) *amikaconfig.Config {
 	t.Helper()
@@ -296,6 +425,36 @@ func writeConfigFile(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
 	}
+}
+
+func setEnvValue(t *testing.T, key, value string) {
+	t.Helper()
+	orig, had := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("Setenv(%s): %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, orig)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func clearEnv(t *testing.T, key string) {
+	t.Helper()
+	orig, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("Unsetenv(%s): %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, orig)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
 }
 
 // Test 1: Single port = 4838 → 4838/tcp

--- a/internal/amikaconfig/config_test.go
+++ b/internal/amikaconfig/config_test.go
@@ -25,7 +25,11 @@ func TestLoadConfig_ValidConfig(t *testing.T) {
 	if err := os.Mkdir(amikaDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	content := `[lifecycle]
+	content := `[api]
+api_url = "https://example.amika.dev"
+auth_client_id = "client_123"
+
+[lifecycle]
 setup_script = "scripts/setup.sh"
 `
 	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte(content), 0644); err != nil {
@@ -38,6 +42,12 @@ setup_script = "scripts/setup.sh"
 	}
 	if cfg == nil {
 		t.Fatal("expected non-nil config")
+	}
+	if cfg.API.APIURL != "https://example.amika.dev" {
+		t.Errorf("expected api_url %q, got %q", "https://example.amika.dev", cfg.API.APIURL)
+	}
+	if cfg.API.AuthClientID != "client_123" {
+		t.Errorf("expected auth_client_id %q, got %q", "client_123", cfg.API.AuthClientID)
 	}
 	if cfg.Lifecycle.SetupScript != "scripts/setup.sh" {
 		t.Errorf("expected setup_script %q, got %q", "scripts/setup.sh", cfg.Lifecycle.SetupScript)
@@ -81,6 +91,35 @@ func TestLoadConfig_EmptyLifecycleSection(t *testing.T) {
 	}
 	if cfg.Lifecycle.SetupScript != "" {
 		t.Errorf("expected empty setup_script, got %q", cfg.Lifecycle.SetupScript)
+	}
+}
+
+func TestLoadConfig_APISectionOnly(t *testing.T) {
+	dir := t.TempDir()
+	amikaDir := filepath.Join(dir, ".amika")
+	if err := os.Mkdir(amikaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `[api]
+api_url = "https://api.example.test"
+auth_client_id = "client_abc"
+`
+	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := amikaconfig.LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.API.APIURL != "https://api.example.test" {
+		t.Errorf("expected api_url %q, got %q", "https://api.example.test", cfg.API.APIURL)
+	}
+	if cfg.API.AuthClientID != "client_abc" {
+		t.Errorf("expected auth_client_id %q, got %q", "client_abc", cfg.API.AuthClientID)
 	}
 }
 

--- a/internal/amikaconfig/config_test.go
+++ b/internal/amikaconfig/config_test.go
@@ -123,6 +123,135 @@ auth_client_id = "client_abc"
 	}
 }
 
+func TestLoadGlobalConfig_NotExist(t *testing.T) {
+	home := t.TempDir()
+	setXDGConfigHome(t, filepath.Join(home, ".config"))
+
+	cfg, err := amikaconfig.LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config, got %+v", cfg)
+	}
+}
+
+func TestLoadGlobalConfig_ValidConfig(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	setXDGConfigHome(t, configHome)
+	writeConfigFile(t, filepath.Join(configHome, "amika", "config.toml"), `[api]
+api_url = "https://global.example.test"
+auth_client_id = "global-client"
+`)
+
+	cfg, err := amikaconfig.LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.API.APIURL != "https://global.example.test" {
+		t.Errorf("expected api_url %q, got %q", "https://global.example.test", cfg.API.APIURL)
+	}
+	if cfg.API.AuthClientID != "global-client" {
+		t.Errorf("expected auth_client_id %q, got %q", "global-client", cfg.API.AuthClientID)
+	}
+}
+
+func TestMerge_RepoOverridesGlobal(t *testing.T) {
+	globalCfg := &amikaconfig.Config{
+		API: amikaconfig.APIConfig{
+			APIURL:       "https://global.example.test",
+			AuthClientID: "global-client",
+		},
+		Lifecycle: amikaconfig.LifecycleConfig{
+			SetupScript: "global-setup.sh",
+		},
+		Services: map[string]amikaconfig.ServiceConfig{
+			"api": {Port: int64(8080)},
+			"web": {Port: int64(3000)},
+		},
+	}
+	repoCfg := &amikaconfig.Config{
+		API: amikaconfig.APIConfig{
+			APIURL: "https://repo.example.test",
+		},
+		Lifecycle: amikaconfig.LifecycleConfig{
+			SetupScript: "repo-setup.sh",
+		},
+		Services: map[string]amikaconfig.ServiceConfig{
+			"api":     {Port: int64(9090)},
+			"metrics": {Port: "9091/tcp"},
+		},
+	}
+
+	merged := amikaconfig.Merge(globalCfg, repoCfg)
+	if merged == nil {
+		t.Fatal("expected non-nil merged config")
+	}
+	if merged.API.APIURL != "https://repo.example.test" {
+		t.Errorf("expected repo api_url override, got %q", merged.API.APIURL)
+	}
+	if merged.API.AuthClientID != "global-client" {
+		t.Errorf("expected inherited auth_client_id, got %q", merged.API.AuthClientID)
+	}
+	if merged.Lifecycle.SetupScript != "repo-setup.sh" {
+		t.Errorf("expected repo setup_script override, got %q", merged.Lifecycle.SetupScript)
+	}
+	if got := merged.Services["api"].Port; got != int64(9090) {
+		t.Errorf("expected repo api service override, got %#v", got)
+	}
+	if got := merged.Services["web"].Port; got != int64(3000) {
+		t.Errorf("expected inherited web service, got %#v", got)
+	}
+	if got := merged.Services["metrics"].Port; got != "9091/tcp" {
+		t.Errorf("expected repo metrics service, got %#v", got)
+	}
+}
+
+func TestLoadEffectiveConfig_MergesGlobalAndRepo(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	setXDGConfigHome(t, configHome)
+	writeConfigFile(t, filepath.Join(configHome, "amika", "config.toml"), `[api]
+api_url = "https://global.example.test"
+auth_client_id = "global-client"
+
+[services.api]
+port = 8080
+`)
+
+	repoRoot := t.TempDir()
+	writeConfigFile(t, filepath.Join(repoRoot, ".amika", "config.toml"), `[api]
+auth_client_id = "repo-client"
+
+[services.web]
+port = 3000
+`)
+
+	cfg, err := amikaconfig.LoadEffectiveConfig(repoRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.API.APIURL != "https://global.example.test" {
+		t.Errorf("expected inherited api_url, got %q", cfg.API.APIURL)
+	}
+	if cfg.API.AuthClientID != "repo-client" {
+		t.Errorf("expected repo auth_client_id override, got %q", cfg.API.AuthClientID)
+	}
+	if got := cfg.Services["api"].Port; got != int64(8080) {
+		t.Errorf("expected inherited api service, got %#v", got)
+	}
+	if got := cfg.Services["web"].Port; got != int64(3000) {
+		t.Errorf("expected repo web service, got %#v", got)
+	}
+}
+
 // Helper to load a config from TOML content.
 func loadFromTOML(t *testing.T, content string) *amikaconfig.Config {
 	t.Helper()
@@ -142,6 +271,31 @@ func loadFromTOML(t *testing.T, content string) *amikaconfig.Config {
 		t.Fatal("expected non-nil config")
 	}
 	return cfg
+}
+
+func setXDGConfigHome(t *testing.T, path string) {
+	t.Helper()
+	orig, had := os.LookupEnv("XDG_CONFIG_HOME")
+	if err := os.Setenv("XDG_CONFIG_HOME", path); err != nil {
+		t.Fatalf("Setenv(XDG_CONFIG_HOME): %v", err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("XDG_CONFIG_HOME", orig)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
+	})
+}
+
+func writeConfigFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
 }
 
 // Test 1: Single port = 4838 → 4838/tcp

--- a/internal/basedir/basedir.go
+++ b/internal/basedir/basedir.go
@@ -10,6 +10,7 @@ import (
 const (
 	appName             = "amika"
 	envCacheFile        = "env-cache.json"
+	configFile          = "config.toml"
 	keychainFile        = "keychain.json"
 	oauthFile           = "oauth.json"
 	mountsStateFile     = "mounts.jsonl"
@@ -36,6 +37,7 @@ type Paths interface {
 	AmikaCacheDir() (string, error)
 	AmikaStateDir() (string, error)
 
+	AmikaConfigFile() (string, error)
 	AuthEnvCacheFile() (string, error)
 	AuthKeychainFile() (string, error)
 	AuthOAuthFile() (string, error)
@@ -117,6 +119,14 @@ func (p *xdgPaths) AmikaConfigDir() (string, error) {
 		return "", err
 	}
 	return filepath.Join(base, appName), nil
+}
+
+func (p *xdgPaths) AmikaConfigFile() (string, error) {
+	dir, err := p.AmikaConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, configFile), nil
 }
 
 func (p *xdgPaths) AmikaDataDir() (string, error) {

--- a/internal/basedir/basedir_test.go
+++ b/internal/basedir/basedir_test.go
@@ -54,6 +54,9 @@ func TestPaths_XDGOverrides(t *testing.T) {
 	if got, _ := p.AuthEnvCacheFile(); got != filepath.Join(cache, "amika", "env-cache.json") {
 		t.Fatalf("AuthEnvCacheFile = %q", got)
 	}
+	if got, _ := p.AmikaConfigFile(); got != filepath.Join(config, "amika", "config.toml") {
+		t.Fatalf("AmikaConfigFile = %q", got)
+	}
 	if got, _ := p.AuthKeychainFile(); got != filepath.Join(data, "amika", "keychain.json") {
 		t.Fatalf("AuthKeychainFile = %q", got)
 	}


### PR DESCRIPTION
## Summary
- add a shared Amika config schema with  support for global and repo config files
- load  and merge it with 
- centralize API URL and WorkOS client ID resolution with precedence 
- update docs to describe the shared config format and precedence rules

## Testing
- go test ./...
