### PR TITLE
WIP Add session TTL support and custom duration parsing

### DIFF
--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -30,7 +30,7 @@ Opens a browser for you to authorize the CLI.`,
 			clientID = defaultWorkOSClientID
 		}
 
-		session, err := auth.DeviceLogin(clientID)
+		session, err := auth.DeviceLogin(clientID, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/spf13/cobra"
@@ -30,7 +31,17 @@ Opens a browser for you to authorize the CLI.`,
 			clientID = defaultWorkOSClientID
 		}
 
-		session, err := auth.DeviceLogin(clientID, 0)
+		var sessionTTL time.Duration
+		ttlStr, _ := cmd.Flags().GetString("ttl")
+		if ttlStr != "" {
+			var err error
+			sessionTTL, err = auth.ParseDuration(ttlStr)
+			if err != nil {
+				return fmt.Errorf("invalid --ttl value: %w", err)
+			}
+		}
+
+		session, err := auth.DeviceLogin(clientID, sessionTTL)
 		if err != nil {
 			return err
 		}
@@ -86,4 +97,5 @@ func init() {
 	authCmd.AddCommand(authLogoutCmd)
 	authCmd.AddCommand(authStatusCmd)
 
+	authLoginCmd.Flags().String("ttl", "", "session lifetime (e.g. 60s, 120min, 2h, 7d, 3w); defaults to 7d")
 }

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -24,7 +24,12 @@ type deviceCodeResponse struct {
 }
 
 // DeviceLogin performs the OAuth 2.0 Device Authorization Flow via WorkOS.
-func DeviceLogin(clientID string) (*WorkOSSession, error) {
+// The sessionTTL controls how long the overall session remains valid before
+// the user must log in again. Pass 0 to use DefaultSessionTTL.
+func DeviceLogin(clientID string, sessionTTL time.Duration) (*WorkOSSession, error) {
+	if sessionTTL == 0 {
+		sessionTTL = DefaultSessionTTL
+	}
 	// Step 1: Request device code.
 	dc, err := requestDeviceCode(clientID)
 	if err != nil {
@@ -38,7 +43,7 @@ func DeviceLogin(clientID string) (*WorkOSSession, error) {
 	openBrowser(dc.VerificationURIComplete)
 
 	// Step 3: Poll for token.
-	return pollForToken(clientID, dc)
+	return pollForToken(clientID, dc, sessionTTL)
 }
 
 func requestDeviceCode(clientID string) (*deviceCodeResponse, error) {
@@ -72,7 +77,7 @@ func requestDeviceCode(clientID string) (*deviceCodeResponse, error) {
 	return &dc, nil
 }
 
-func pollForToken(clientID string, dc *deviceCodeResponse) (*WorkOSSession, error) {
+func pollForToken(clientID string, dc *deviceCodeResponse, sessionTTL time.Duration) (*WorkOSSession, error) {
 	interval := time.Duration(dc.Interval) * time.Second
 	deadline := time.Now().Add(time.Duration(dc.ExpiresIn) * time.Second)
 
@@ -106,7 +111,7 @@ func pollForToken(clientID string, dc *deviceCodeResponse) (*WorkOSSession, erro
 
 		if resp.StatusCode == http.StatusOK {
 			fmt.Println()
-			return parseTokenResponse(respBody)
+			return parseTokenResponse(respBody, sessionTTL)
 		}
 
 		var errResp struct {
@@ -134,7 +139,7 @@ func pollForToken(clientID string, dc *deviceCodeResponse) (*WorkOSSession, erro
 	}
 }
 
-func parseTokenResponse(respBody []byte) (*WorkOSSession, error) {
+func parseTokenResponse(respBody []byte, sessionTTL time.Duration) (*WorkOSSession, error) {
 	var result struct {
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
@@ -154,12 +159,13 @@ func parseTokenResponse(respBody []byte) (*WorkOSSession, error) {
 	}
 
 	session := &WorkOSSession{
-		AccessToken:  result.AccessToken,
-		RefreshToken: result.RefreshToken,
-		UserID:       result.User.ID,
-		Email:        result.User.Email,
-		OrgID:        result.OrganizationID,
-		ExpiresAt:    expiresAt,
+		AccessToken:      result.AccessToken,
+		RefreshToken:     result.RefreshToken,
+		UserID:           result.User.ID,
+		Email:            result.User.Email,
+		OrgID:            result.OrganizationID,
+		ExpiresAt:        expiresAt,
+		SessionExpiresAt: time.Now().Add(sessionTTL),
 	}
 
 	if err := SaveSession(*session); err != nil {

--- a/internal/auth/duration.go
+++ b/internal/auth/duration.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseDuration parses a human-friendly duration string.
+// Supported suffixes: s (seconds), min (minutes), h (hours), d (days), w (weeks).
+// Examples: "60s", "120min", "2h", "7d", "3w".
+func ParseDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration string")
+	}
+
+	// Try suffixes longest-first to avoid "min" matching "m" first.
+	suffixes := []struct {
+		suffix     string
+		multiplier time.Duration
+	}{
+		{"min", time.Minute},
+		{"s", time.Second},
+		{"h", time.Hour},
+		{"d", 24 * time.Hour},
+		{"w", 7 * 24 * time.Hour},
+	}
+
+	for _, sf := range suffixes {
+		if strings.HasSuffix(s, sf.suffix) {
+			numStr := strings.TrimSuffix(s, sf.suffix)
+			n, err := strconv.ParseFloat(numStr, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+			}
+			if n <= 0 {
+				return 0, fmt.Errorf("duration must be positive: %q", s)
+			}
+			return time.Duration(n * float64(sf.multiplier)), nil
+		}
+	}
+
+	return 0, fmt.Errorf("invalid duration %q: must end with s, min, h, d, or w", s)
+}

--- a/internal/auth/duration_test.go
+++ b/internal/auth/duration_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+	}{
+		{"60s", 60 * time.Second},
+		{"120min", 120 * time.Minute},
+		{"2h", 2 * time.Hour},
+		{"7d", 7 * 24 * time.Hour},
+		{"3w", 3 * 7 * 24 * time.Hour},
+		{"0.5h", 30 * time.Minute},
+		{"1d", 24 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseDuration(tt.input)
+			if err != nil {
+				t.Fatalf("ParseDuration(%q) error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseDuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDurationErrors(t *testing.T) {
+	tests := []string{
+		"",
+		"abc",
+		"10",
+		"10x",
+		"-5d",
+		"0s",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := ParseDuration(input)
+			if err == nil {
+				t.Errorf("ParseDuration(%q) expected error, got nil", input)
+			}
+		})
+	}
+}

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -12,7 +12,9 @@ import (
 const workosAuthenticateURL = "https://api.workos.com/user_management/authenticate"
 
 // RefreshAccessToken exchanges a refresh token for a new access token via WorkOS.
-func RefreshAccessToken(clientID, refreshToken string) (*WorkOSSession, error) {
+// The sessionExpiresAt value is carried forward from the original login session.
+func RefreshAccessToken(clientID string, oldSession *WorkOSSession) (*WorkOSSession, error) {
+	refreshToken := oldSession.RefreshToken
 	body := url.Values{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {refreshToken},
@@ -53,12 +55,13 @@ func RefreshAccessToken(clientID, refreshToken string) (*WorkOSSession, error) {
 	}
 
 	session := &WorkOSSession{
-		AccessToken:  result.AccessToken,
-		RefreshToken: result.RefreshToken,
-		UserID:       result.User.ID,
-		Email:        result.User.Email,
-		OrgID:        result.OrganizationID,
-		ExpiresAt:    expiresAt,
+		AccessToken:      result.AccessToken,
+		RefreshToken:     result.RefreshToken,
+		UserID:           result.User.ID,
+		Email:            result.User.Email,
+		OrgID:            result.OrganizationID,
+		ExpiresAt:        expiresAt,
+		SessionExpiresAt: oldSession.SessionExpiresAt,
 	}
 
 	if err := SaveSession(*session); err != nil {

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -16,9 +16,14 @@ func GetValidSession(clientID string) (*WorkOSSession, error) {
 		return nil, fmt.Errorf("not logged in, run: amika auth login")
 	}
 
+	// If the overall session has expired, require a fresh login.
+	if !session.SessionExpiresAt.IsZero() && time.Now().After(session.SessionExpiresAt) {
+		return nil, fmt.Errorf("session expired, run: amika auth login")
+	}
+
 	// Refresh if token expires within 60 seconds.
 	if time.Until(session.ExpiresAt) < 60*time.Second {
-		session, err = RefreshAccessToken(clientID, session.RefreshToken)
+		session, err = RefreshAccessToken(clientID, session)
 		if err != nil {
 			return nil, fmt.Errorf("session expired and refresh failed: %w", err)
 		}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -14,14 +14,18 @@ import (
 
 const sessionFileName = "workos-session.json"
 
+// DefaultSessionTTL is the default duration a login session remains valid.
+const DefaultSessionTTL = 7 * 24 * time.Hour
+
 // WorkOSSession holds the persisted WorkOS authentication state.
 type WorkOSSession struct {
-	AccessToken  string    `json:"access_token"`
-	RefreshToken string    `json:"refresh_token"`
-	UserID       string    `json:"user_id"`
-	Email        string    `json:"email"`
-	OrgID        string    `json:"organization_id"`
-	ExpiresAt    time.Time `json:"expires_at"`
+	AccessToken      string    `json:"access_token"`
+	RefreshToken     string    `json:"refresh_token"`
+	UserID           string    `json:"user_id"`
+	Email            string    `json:"email"`
+	OrgID            string    `json:"organization_id"`
+	ExpiresAt        time.Time `json:"expires_at"`
+	SessionExpiresAt time.Time `json:"session_expires_at"`
 }
 
 func sessionPath() (string, error) {


### PR DESCRIPTION
## Summary
This PR adds support for configurable session time-to-live (TTL) in the authentication flow, allowing users to specify how long a login session remains valid before requiring re-authentication. It also introduces a human-friendly duration parser to support flexible time specifications.

## Key Changes

- **New duration parser** (`internal/auth/duration.go`): Added `ParseDuration()` function that parses human-friendly duration strings with support for seconds (s), minutes (min), hours (h), days (d), and weeks (w). Includes comprehensive test coverage for valid inputs and error cases.

- **Session TTL tracking**: Extended `WorkOSSession` struct with a new `SessionExpiresAt` field to track when the overall session expires, separate from the access token expiration.

- **Device login enhancement**: Modified `DeviceLogin()` to accept a `sessionTTL` parameter, with a default of 7 days (`DefaultSessionTTL`). The TTL is propagated through the token polling and parsing flow.

- **Refresh token handling**: Updated `RefreshAccessToken()` to accept the full session object instead of just the refresh token, allowing it to preserve the original `SessionExpiresAt` across token refreshes.

- **Session validation**: Enhanced `GetValidSession()` to check if the overall session has expired (not just the access token), returning an error if re-login is required.

- **CLI integration**: Added `--ttl` flag to the `auth login` command, allowing users to specify custom session lifetimes (e.g., `--ttl 2h`, `--ttl 30d`).

## Implementation Details

- The duration parser uses longest-suffix matching to correctly handle "min" before "m" to avoid ambiguity.
- Negative and zero durations are rejected as invalid.
- Session expiration is checked before attempting token refresh, providing clearer error messaging.
- The `SessionExpiresAt` field is preserved across token refreshes to maintain the original session lifetime.

https://claude.ai/code/session_01RWDuSnj9JVUg867CKjSbZH