### PR TITLE
fix: auto-refresh WorkOS auth and centralize env var resolution

### DIFF
--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/gofixpoint/amika/internal/auth"
+	"github.com/gofixpoint/amika/internal/config"
 	"github.com/spf13/cobra"
 )
-
-const defaultWorkOSClientID = "client_01KHA495MJS1KT6QBRTYJ239DY"
 
 var authCmd = &cobra.Command{
 	Use:   "auth",
@@ -25,12 +23,7 @@ Opens a browser for you to authorize the CLI.`,
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 
-		clientID := os.Getenv("AMIKA_WORKOS_CLIENT_ID")
-		if clientID == "" {
-			clientID = defaultWorkOSClientID
-		}
-
-		session, err := auth.DeviceLogin(clientID)
+		session, err := auth.DeviceLogin(config.WorkOSClientID())
 		if err != nil {
 			return err
 		}

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -89,15 +89,11 @@ func getRemoteTarget(cmd *cobra.Command) (string, error) {
 func getRemoteClient(target string) (*apiclient.Client, error) {
 	// TODO: when named-remote config is added, look up target here.
 	_ = target
-	session, err := auth.GetValidSession(defaultWorkOSClientID)
-	if err != nil {
-		return nil, err
-	}
 	baseURL := os.Getenv(envAPIURL)
 	if baseURL == "" {
 		baseURL = apiclient.DefaultAPIURL
 	}
-	return apiclient.NewClient(baseURL, session.AccessToken), nil
+	return apiclient.NewClientWithTokenSource(baseURL, apiclient.NewWorkOSTokenSource(defaultWorkOSClientID)), nil
 }
 
 var runSandboxConnect = func(name, shell string, stdin io.Reader, stdout, stderr io.Writer) error {

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -34,8 +34,6 @@ var sandboxCmd = &cobra.Command{
 
 const sandboxConnectWorkdir = "/home/amika"
 
-const envAPIURL = "AMIKA_API_URL"
-
 // TODO: Parse env variables from an environment file (e.g. .amika/.env or ~/.config/amika/env)
 // so users don't need to export AMIKA_API_URL, AMIKA_WORKOS_CLIENT_ID, etc. in their shell profile.
 
@@ -54,7 +52,7 @@ func sandboxMode(cmd *cobra.Command) string {
 	// Default: if logged in with a valid session, include remote; otherwise local.
 	// GetValidSession refreshes expired tokens; if that fails the session is
 	// unusable and we fall back to local-only without blocking the command.
-	if _, err := auth.GetValidSession(defaultWorkOSClientID); err != nil {
+	if _, err := auth.GetValidSession(config.WorkOSClientID()); err != nil {
 		return "local"
 	}
 	return "both"
@@ -62,7 +60,7 @@ func sandboxMode(cmd *cobra.Command) string {
 
 // isLoggedIn returns true if a valid (or refreshable) WorkOS session exists.
 func isLoggedIn() bool {
-	_, err := auth.GetValidSession(defaultWorkOSClientID)
+	_, err := auth.GetValidSession(config.WorkOSClientID())
 	return err == nil
 }
 
@@ -89,11 +87,7 @@ func getRemoteTarget(cmd *cobra.Command) (string, error) {
 func getRemoteClient(target string) (*apiclient.Client, error) {
 	// TODO: when named-remote config is added, look up target here.
 	_ = target
-	baseURL := os.Getenv(envAPIURL)
-	if baseURL == "" {
-		baseURL = apiclient.DefaultAPIURL
-	}
-	return apiclient.NewClientWithTokenSource(baseURL, apiclient.NewWorkOSTokenSource(defaultWorkOSClientID)), nil
+	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewWorkOSTokenSource(config.WorkOSClientID())), nil
 }
 
 var runSandboxConnect = func(name, shell string, stdin io.Reader, stdout, stderr io.Writer) error {

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gofixpoint/amika/internal/apiclient"
 	"github.com/gofixpoint/amika/internal/auth"
+	"github.com/gofixpoint/amika/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -266,11 +267,7 @@ func pushSecret(client *apiclient.Client, existing map[string]apiclient.Secret, 
 
 // getSecretsClient returns an API client for secrets operations.
 func getSecretsClient() (*apiclient.Client, error) {
-	baseURL := os.Getenv(envAPIURL)
-	if baseURL == "" {
-		baseURL = apiclient.DefaultAPIURL
-	}
-	return apiclient.NewClientWithTokenSource(baseURL, apiclient.NewWorkOSTokenSource(defaultWorkOSClientID)), nil
+	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewWorkOSTokenSource(config.WorkOSClientID())), nil
 }
 
 // parseOnlyFilter splits a comma-separated list of secret names into a set.

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -266,15 +266,11 @@ func pushSecret(client *apiclient.Client, existing map[string]apiclient.Secret, 
 
 // getSecretsClient returns an API client for secrets operations.
 func getSecretsClient() (*apiclient.Client, error) {
-	session, err := auth.GetValidSession(defaultWorkOSClientID)
-	if err != nil {
-		return nil, err
-	}
 	baseURL := os.Getenv(envAPIURL)
 	if baseURL == "" {
 		baseURL = apiclient.DefaultAPIURL
 	}
-	return apiclient.NewClient(baseURL, session.AccessToken), nil
+	return apiclient.NewClientWithTokenSource(baseURL, apiclient.NewWorkOSTokenSource(defaultWorkOSClientID)), nil
 }
 
 // parseOnlyFilter splits a comma-separated list of secret names into a set.

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -17,15 +17,20 @@ const DefaultAPIURL = "https://app.amika.dev"
 // Client calls the remote Amika API with a bearer token.
 type Client struct {
 	BaseURL     string
-	AccessToken string
+	TokenSource TokenSource
 	HTTP        *http.Client
 }
 
-// NewClient creates a Client for the given base URL and access token.
+// NewClient creates a Client for the given base URL and static access token.
 func NewClient(baseURL, accessToken string) *Client {
+	return NewClientWithTokenSource(baseURL, NewStaticTokenSource(accessToken))
+}
+
+// NewClientWithTokenSource creates a Client that obtains its bearer token from the given TokenSource.
+func NewClientWithTokenSource(baseURL string, ts TokenSource) *Client {
 	return &Client{
 		BaseURL:     strings.TrimRight(baseURL, "/"),
-		AccessToken: accessToken,
+		TokenSource: ts,
 		HTTP:        &http.Client{Timeout: 30 * time.Second},
 	}
 }
@@ -163,7 +168,11 @@ func (c *Client) doJSON(method, path string, body interface{}, out interface{}) 
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	token, err := c.TokenSource.Token()
+	if err != nil {
+		return fmt.Errorf("obtaining auth token: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -11,9 +11,6 @@ import (
 	"time"
 )
 
-// DefaultAPIURL is the default remote API base URL.
-const DefaultAPIURL = "https://app.amika.dev"
-
 // Client calls the remote Amika API with a bearer token.
 type Client struct {
 	BaseURL     string

--- a/internal/apiclient/token.go
+++ b/internal/apiclient/token.go
@@ -1,0 +1,39 @@
+package apiclient
+
+import "github.com/gofixpoint/amika/internal/auth"
+
+// TokenSource provides a bearer token for API requests.
+type TokenSource interface {
+	Token() (string, error)
+}
+
+type staticTokenSource struct {
+	accessToken string
+}
+
+// NewStaticTokenSource returns a TokenSource that always returns the given token.
+func NewStaticTokenSource(accessToken string) TokenSource {
+	return &staticTokenSource{accessToken: accessToken}
+}
+
+func (s *staticTokenSource) Token() (string, error) {
+	return s.accessToken, nil
+}
+
+type workosTokenSource struct {
+	clientID string
+}
+
+// NewWorkOSTokenSource returns a TokenSource that loads and auto-refreshes
+// a WorkOS session, returning the current access token.
+func NewWorkOSTokenSource(clientID string) TokenSource {
+	return &workosTokenSource{clientID: clientID}
+}
+
+func (s *workosTokenSource) Token() (string, error) {
+	session, err := auth.GetValidSession(s.clientID)
+	if err != nil {
+		return "", err
+	}
+	return session.AccessToken, nil
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -12,8 +12,6 @@ import (
 	"github.com/gofixpoint/amika/internal/config"
 )
 
-const sessionFileName = "workos-session.json"
-
 // WorkOSSession holds the persisted WorkOS authentication state.
 type WorkOSSession struct {
 	AccessToken  string    `json:"access_token"`
@@ -24,17 +22,9 @@ type WorkOSSession struct {
 	ExpiresAt    time.Time `json:"expires_at"`
 }
 
-func sessionPath() (string, error) {
-	dir, err := config.StateDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, sessionFileName), nil
-}
-
 // SaveSession writes the session to disk with restricted permissions.
 func SaveSession(session WorkOSSession) error {
-	path, err := sessionPath()
+	path, err := config.WorkOSAuthSessionFile()
 	if err != nil {
 		return err
 	}
@@ -50,7 +40,7 @@ func SaveSession(session WorkOSSession) error {
 
 // LoadSession reads the persisted session. Returns nil, nil if no session file exists.
 func LoadSession() (*WorkOSSession, error) {
-	path, err := sessionPath()
+	path, err := config.WorkOSAuthSessionFile()
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +60,7 @@ func LoadSession() (*WorkOSSession, error) {
 
 // DeleteSession removes the persisted session file.
 func DeleteSession() error {
-	path, err := sessionPath()
+	path, err := config.WorkOSAuthSessionFile()
 	if err != nil {
 		return err
 	}

--- a/internal/basedir/basedir.go
+++ b/internal/basedir/basedir.go
@@ -17,6 +17,7 @@ const (
 	volumesStateFile    = "volumes.jsonl"
 	fileMountsStateFile = "rwcopy-mounts.jsonl"
 	fileMountsDir       = "rwcopy-mounts.d"
+	workosSessionFile   = "workos-session.json"
 	envXDGConfigHome    = "XDG_CONFIG_HOME"
 	envXDGDataHome      = "XDG_DATA_HOME"
 	envXDGCacheHome     = "XDG_CACHE_HOME"
@@ -44,6 +45,7 @@ type Paths interface {
 	VolumesStateFile() (string, error)
 	FileMountsStateFile() (string, error)
 	FileMountsDir() (string, error)
+	WorkOSAuthSessionFile() (string, error)
 }
 
 type xdgPaths struct {
@@ -207,6 +209,14 @@ func (p *xdgPaths) FileMountsDir() (string, error) {
 	return FileMountsDirIn(dir), nil
 }
 
+func (p *xdgPaths) WorkOSAuthSessionFile() (string, error) {
+	dir, err := p.AmikaStateDir()
+	if err != nil {
+		return "", err
+	}
+	return WorkOSAuthSessionFileIn(dir), nil
+}
+
 // MountsStateFileIn returns the mounts state file path under the given state directory.
 func MountsStateFileIn(stateDir string) string {
 	return filepath.Join(stateDir, mountsStateFile)
@@ -230,4 +240,9 @@ func FileMountsStateFileIn(stateDir string) string {
 // FileMountsDirIn returns the file mounts directory path under the given state directory.
 func FileMountsDirIn(stateDir string) string {
 	return filepath.Join(stateDir, fileMountsDir)
+}
+
+// WorkOSAuthSessionFileIn returns the WorkOS auth session file path under the given state directory.
+func WorkOSAuthSessionFileIn(stateDir string) string {
+	return filepath.Join(stateDir, workosSessionFile)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,32 @@ import (
 const (
 	// EnvStateDirectory is the environment variable that overrides the default state directory.
 	EnvStateDirectory = "AMIKA_STATE_DIRECTORY"
+	// EnvAPIURL is the environment variable that overrides the default API base URL.
+	EnvAPIURL = "AMIKA_API_URL"
+	// EnvWorkOSClientID is the environment variable that overrides the default WorkOS client ID.
+	EnvWorkOSClientID = "AMIKA_WORKOS_CLIENT_ID"
+
+	// DefaultAPIURL is the default remote API base URL.
+	DefaultAPIURL = "https://app.amika.dev"
+	// DefaultWorkOSClientID is the default WorkOS client ID for device auth.
+	DefaultWorkOSClientID = "client_01KHA495MJS1KT6QBRTYJ239DY"
 )
+
+// APIURL returns the API base URL, checking AMIKA_API_URL first.
+func APIURL() string {
+	if u := os.Getenv(EnvAPIURL); u != "" {
+		return u
+	}
+	return DefaultAPIURL
+}
+
+// WorkOSClientID returns the WorkOS client ID, checking AMIKA_WORKOS_CLIENT_ID first.
+func WorkOSClientID() string {
+	if id := os.Getenv(EnvWorkOSClientID); id != "" {
+		return id
+	}
+	return DefaultWorkOSClientID
+}
 
 // StateDir returns the resolved amika state directory path.
 // It checks AMIKA_STATE_DIRECTORY first, falling back to XDG_STATE_HOME/amika

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,3 +61,11 @@ func FileMountsDir() (string, error) {
 	}
 	return basedir.New("").FileMountsDir()
 }
+
+// WorkOSAuthSessionFile returns the resolved WorkOS auth session file path.
+func WorkOSAuthSessionFile() (string, error) {
+	if dir := os.Getenv(EnvStateDirectory); dir != "" {
+		return basedir.WorkOSAuthSessionFileIn(dir), nil
+	}
+	return basedir.New("").WorkOSAuthSessionFile()
+}


### PR DESCRIPTION
## Summary
- Add `TokenSource` interface to `apiclient` so the API client auto-refreshes WorkOS sessions before each request, instead of callers manually fetching tokens upfront
- Move WorkOS session file path resolution into the `basedir.Paths` interface, following the existing XDG pattern
- Centralize `AMIKA_WORKOS_CLIENT_ID` and `AMIKA_API_URL` env var resolution into `internal/config`, fixing a bug where `auth login` honored the env var but all other callers (sandbox, secrets) used the hardcoded default — causing token refresh to fail when the env var was set