### PR TITLE
feat: support API key auth via AMIKA_API_KEY environment variable

### DIFF
--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/gofixpoint/amika/internal/config"
@@ -55,20 +56,28 @@ var authStatusCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 
+		out := cmd.OutOrStdout()
+
+		// Check for API key auth.
+		if apiKey := os.Getenv("AMIKA_API_KEY"); apiKey != "" {
+			fmt.Fprintln(out, "Authenticated via AMIKA_API_KEY environment variable")
+			return nil
+		}
+
 		session, err := auth.LoadSession()
 		if err != nil {
 			return err
 		}
 		if session == nil {
-			fmt.Fprintln(cmd.OutOrStdout(), "Not logged in")
+			fmt.Fprintln(out, "Not logged in")
 			return nil
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Logged in as %s", session.Email)
+		fmt.Fprintf(out, "Logged in as %s", session.Email)
 		if session.OrgID != "" {
-			fmt.Fprintf(cmd.OutOrStdout(), " (org: %s)", session.OrgID)
+			fmt.Fprintf(out, " (org: %s)", session.OrgID)
 		}
-		fmt.Fprintln(cmd.OutOrStdout())
+		fmt.Fprintln(out)
 		return nil
 	},
 }

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -84,9 +84,13 @@ func getRemoteTarget(cmd *cobra.Command) (string, error) {
 }
 
 // getRemoteClient returns an API client authenticated with the current session.
+// If AMIKA_API_KEY is set, it is used as a static bearer token instead of the WorkOS session.
 func getRemoteClient(target string) (*apiclient.Client, error) {
 	// TODO: when named-remote config is added, look up target here.
 	_ = target
+	if apiKey := os.Getenv("AMIKA_API_KEY"); apiKey != "" {
+		return apiclient.NewClient(config.APIURL(), apiKey), nil
+	}
 	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewWorkOSTokenSource(config.WorkOSClientID())), nil
 }
 

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -266,7 +266,11 @@ func pushSecret(client *apiclient.Client, existing map[string]apiclient.Secret, 
 }
 
 // getSecretsClient returns an API client for secrets operations.
+// If AMIKA_API_KEY is set, it is used as a static bearer token instead of the WorkOS session.
 func getSecretsClient() (*apiclient.Client, error) {
+	if apiKey := os.Getenv("AMIKA_API_KEY"); apiKey != "" {
+		return apiclient.NewClient(config.APIURL(), apiKey), nil
+	}
 	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewWorkOSTokenSource(config.WorkOSClientID())), nil
 }
 


### PR DESCRIPTION
Allow authenticating with a static API key as an alternative to the WorkOS device flow. When AMIKA_API_KEY is set, it is used as a bearer token for all remote API requests (sandbox and secrets commands).

Update `auth status` to report when API key auth is active.