### PR TITLE
feat: add STATE column to sandbox list output

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -481,6 +481,14 @@ var sandboxListCmd = &cobra.Command{
 			}
 			for i := range result.Items {
 				result.Items[i].Location = "local"
+				if result.Items[i].Provider == "docker" {
+					state, err := sandbox.GetDockerContainerState(result.Items[i].Name)
+					if err != nil {
+						result.Items[i].State = "unknown"
+					} else {
+						result.Items[i].State = state
+					}
+				}
 			}
 			allItems = append(allItems, result.Items...)
 		}
@@ -497,6 +505,7 @@ var sandboxListCmd = &cobra.Command{
 			for _, rs := range remoteSandboxes {
 				allItems = append(allItems, amika.Sandbox{
 					Name:      rs.Name,
+					State:     rs.State,
 					Provider:  rs.Provider,
 					CreatedAt: rs.CreatedAt,
 					Location:  "remote",
@@ -510,9 +519,9 @@ var sandboxListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tLOCATION\tPROVIDER\tIMAGE\tPORTS\tCREATED")
+		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tPROVIDER\tIMAGE\tPORTS\tCREATED")
 		for _, sb := range allItems {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.Location, sb.Provider, sb.Image, formatPortBindings(sb.Ports), sb.CreatedAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Provider, sb.Image, formatPortBindings(sb.Ports), sb.CreatedAt)
 		}
 		w.Flush()
 		return nil

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -47,7 +47,7 @@ type RemoteSandbox struct {
 	Name      string `json:"name"`
 	Provider  string `json:"provider"`
 	GitHubURL string `json:"github_url"`
-	Status    string `json:"status"`
+	State     string `json:"state"`
 	CreatedAt string `json:"created_at"`
 }
 

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -56,6 +56,16 @@ func buildDockerImageWithArgs(name string, contextDir string, dockerfileRelPath 
 	return nil
 }
 
+// GetDockerContainerState returns the state of a Docker container (e.g. "running", "exited").
+func GetDockerContainerState(name string) (string, error) {
+	cmd := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect docker container %q: %s", name, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // RemoveDockerSandbox stops and removes the Docker container with the given name.
 func RemoveDockerSandbox(name string) error {
 	cmd := exec.Command("docker", "rm", "-f", name)

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -3,6 +3,7 @@ package amika
 // Sandbox is a tracked sandbox description.
 type Sandbox struct {
 	Name        string
+	State       string
 	Provider    string
 	ContainerID string
 	Image       string


### PR DESCRIPTION
Show sandbox state (e.g. running, exited, active) in the list table. For local Docker sandboxes, state is queried via docker inspect. For remote sandboxes, the state field from the API is used. Also fixes the RemoteSandbox JSON tag from "status" to "state" to match the API response field name.