### PR TITLE
feat: rename `secrets` command to `secret` with hidden plural alias

### DIFF
--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -13,223 +13,248 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var secretsCmd = &cobra.Command{
-	Use:   "secrets",
+var secretCmd = &cobra.Command{
+	Use:   "secret",
 	Short: "Manage secrets",
 	Long:  `Discover local credentials and push them to the Amika remote secrets store.`,
 }
 
-var secretsExtractCmd = &cobra.Command{
-	Use:   "extract",
-	Short: "Extract and optionally push local credentials as secrets",
-	Long: `Discover local API credentials and display them.
+// secretsAliasCmd is a hidden alias so that "amika secrets" still works.
+var secretsAliasCmd = &cobra.Command{
+	Use:    "secrets",
+	Short:  "Manage secrets",
+	Long:   `Discover local credentials and push them to the Amika remote secrets store.`,
+	Hidden: true,
+}
+
+func newSecretExtractCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "extract",
+		Short: "Extract and optionally push local credentials as secrets",
+		Long: `Discover local API credentials and display them.
 
 With --push, push the discovered secrets to the remote Amika secrets store
 after confirmation. Use --only to restrict which secrets are pushed.
 
 Examples:
-  amika secrets extract
-  amika secrets extract --push
-  amika secrets extract --push --only=ANTHROPIC_API_KEY,OPENAI_API_KEY`,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
+  amika secret extract
+  amika secret extract --push
+  amika secret extract --push --only=ANTHROPIC_API_KEY,OPENAI_API_KEY`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 
-		homeDir, _ := cmd.Flags().GetString("homedir")
-		noOAuth, _ := cmd.Flags().GetBool("no-oauth")
-		push, _ := cmd.Flags().GetBool("push")
-		onlyFlag, _ := cmd.Flags().GetString("only")
-		scope, _ := cmd.Flags().GetString("scope")
+			homeDir, _ := cmd.Flags().GetString("homedir")
+			noOAuth, _ := cmd.Flags().GetBool("no-oauth")
+			push, _ := cmd.Flags().GetBool("push")
+			onlyFlag, _ := cmd.Flags().GetString("only")
+			scope, _ := cmd.Flags().GetString("scope")
 
-		result, err := auth.Discover(auth.Options{
-			HomeDir:      homeDir,
-			IncludeOAuth: !noOAuth,
-		})
-		if err != nil {
-			return err
-		}
-
-		env := auth.BuildEnvMap(result)
-		keys := env.SortedKeys()
-
-		if len(keys) == 0 {
-			fmt.Fprintln(cmd.OutOrStdout(), "No secrets discovered.")
-			return nil
-		}
-
-		// Apply --only filter.
-		if onlyFlag != "" {
-			allowed := parseOnlyFilter(onlyFlag)
-			keys = filterKeys(keys, allowed)
-			if len(keys) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "No secrets match the --only filter.")
-				return nil
-			}
-		}
-
-		// Display discovered secrets.
-		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "SECRET\tVALUE")
-		for _, key := range keys {
-			value, _ := env.Get(key)
-			fmt.Fprintf(w, "%s\t%s\n", key, maskValue(value))
-		}
-		w.Flush()
-
-		if !push {
-			return nil
-		}
-
-		// Confirm before pushing.
-		fmt.Fprintf(cmd.OutOrStdout(), "\nPush %d secret(s) to remote store? [y/N] ", len(keys))
-		reader := bufio.NewReader(cmd.InOrStdin())
-		answer, err := reader.ReadString('\n')
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		answer = strings.TrimSpace(strings.ToLower(answer))
-		if answer != "y" && answer != "yes" {
-			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
-			return nil
-		}
-
-		// Get remote API client.
-		client, err := getSecretsClient()
-		if err != nil {
-			return fmt.Errorf("authenticating with remote API: %w", err)
-		}
-
-		// Fetch existing remote secrets to decide create vs update.
-		existing, err := client.ListSecrets()
-		if err != nil {
-			return fmt.Errorf("listing remote secrets: %w", err)
-		}
-		existingByName := make(map[string]apiclient.Secret)
-		for _, s := range existing {
-			existingByName[s.Name] = s
-		}
-
-		// Push each secret.
-		for _, key := range keys {
-			value, _ := env.Get(key)
-			action, err := pushSecret(client, existingByName, key, value, scope)
+			result, err := auth.Discover(auth.Options{
+				HomeDir:      homeDir,
+				IncludeOAuth: !noOAuth,
+			})
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s %s\n", action, key)
-		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "\nPushed %d secret(s).\n", len(keys))
-		return nil
-	},
+			env := auth.BuildEnvMap(result)
+			keys := env.SortedKeys()
+
+			if len(keys) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No secrets discovered.")
+				return nil
+			}
+
+			// Apply --only filter.
+			if onlyFlag != "" {
+				allowed := parseOnlyFilter(onlyFlag)
+				keys = filterKeys(keys, allowed)
+				if len(keys) == 0 {
+					fmt.Fprintln(cmd.OutOrStdout(), "No secrets match the --only filter.")
+					return nil
+				}
+			}
+
+			// Display discovered secrets.
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "SECRET\tVALUE")
+			for _, key := range keys {
+				value, _ := env.Get(key)
+				fmt.Fprintf(w, "%s\t%s\n", key, maskValue(value))
+			}
+			w.Flush()
+
+			if !push {
+				return nil
+			}
+
+			// Confirm before pushing.
+			fmt.Fprintf(cmd.OutOrStdout(), "\nPush %d secret(s) to remote store? [y/N] ", len(keys))
+			reader := bufio.NewReader(cmd.InOrStdin())
+			answer, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("reading confirmation: %w", err)
+			}
+			answer = strings.TrimSpace(strings.ToLower(answer))
+			if answer != "y" && answer != "yes" {
+				fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+				return nil
+			}
+
+			// Get remote API client.
+			client, err := getSecretsClient()
+			if err != nil {
+				return fmt.Errorf("authenticating with remote API: %w", err)
+			}
+
+			// Fetch existing remote secrets to decide create vs update.
+			existing, err := client.ListSecrets()
+			if err != nil {
+				return fmt.Errorf("listing remote secrets: %w", err)
+			}
+			existingByName := make(map[string]apiclient.Secret)
+			for _, s := range existing {
+				existingByName[s.Name] = s
+			}
+
+			// Push each secret.
+			for _, key := range keys {
+				value, _ := env.Get(key)
+				action, err := pushSecret(client, existingByName, key, value, scope)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s %s\n", action, key)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "\nPushed %d secret(s).\n", len(keys))
+			return nil
+		},
+	}
+
+	cmd.Flags().String("homedir", "", "Override home directory used for credential discovery")
+	cmd.Flags().Bool("no-oauth", false, "Skip OAuth credential sources")
+	cmd.Flags().Bool("push", false, "Push discovered secrets to the remote Amika secrets store")
+	cmd.Flags().String("only", "", "Comma-separated list of secret names to include (e.g. ANTHROPIC_API_KEY,OPENAI_API_KEY)")
+	cmd.Flags().String("scope", "user", "Secret scope: \"user\" (default, private) or \"org\" (visible to org members)")
+
+	return cmd
 }
 
-var secretsPushCmd = &cobra.Command{
-	Use:   "push [KEY=VALUE ...]",
-	Short: "Push secrets to the remote Amika secrets store",
-	Long: `Push secrets to the remote Amika secrets store.
+func newSecretPushCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push [KEY=VALUE ...]",
+		Short: "Push secrets to the remote Amika secrets store",
+		Long: `Push secrets to the remote Amika secrets store.
 
 Secrets can be provided as KEY=VALUE positional arguments and/or read from
 the current environment using --from-env.
 
 Examples:
-  amika secrets push ANTHROPIC_API_KEY=sk-ant-xxx
-  amika secrets push --from-env=ANTHROPIC_API_KEY,OPENAI_API_KEY
-  amika secrets push CUSTOM_KEY=val --from-env=ANTHROPIC_API_KEY`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
+  amika secret push ANTHROPIC_API_KEY=sk-ant-xxx
+  amika secret push --from-env=ANTHROPIC_API_KEY,OPENAI_API_KEY
+  amika secret push CUSTOM_KEY=val --from-env=ANTHROPIC_API_KEY`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 
-		fromEnvFlag, _ := cmd.Flags().GetString("from-env")
-		scope, _ := cmd.Flags().GetString("scope")
+			fromEnvFlag, _ := cmd.Flags().GetString("from-env")
+			scope, _ := cmd.Flags().GetString("scope")
 
-		// Collect secrets from positional args.
-		secrets := make(map[string]string)
-		var keys []string
-		for _, arg := range args {
-			idx := strings.IndexByte(arg, '=')
-			if idx < 1 {
-				return fmt.Errorf("invalid argument %q: expected KEY=VALUE", arg)
-			}
-			key := arg[:idx]
-			value := arg[idx+1:]
-			if _, exists := secrets[key]; !exists {
-				keys = append(keys, key)
-			}
-			secrets[key] = value
-		}
-
-		// Collect secrets from environment.
-		if fromEnvFlag != "" {
-			for _, name := range strings.Split(fromEnvFlag, ",") {
-				name = strings.TrimSpace(name)
-				if name == "" {
-					continue
+			// Collect secrets from positional args.
+			secrets := make(map[string]string)
+			var keys []string
+			for _, arg := range args {
+				idx := strings.IndexByte(arg, '=')
+				if idx < 1 {
+					return fmt.Errorf("invalid argument %q: expected KEY=VALUE", arg)
 				}
-				value, ok := os.LookupEnv(name)
-				if !ok {
-					return fmt.Errorf("environment variable %q is not set", name)
+				key := arg[:idx]
+				value := arg[idx+1:]
+				if _, exists := secrets[key]; !exists {
+					keys = append(keys, key)
 				}
-				if _, exists := secrets[name]; !exists {
-					keys = append(keys, name)
-				}
-				secrets[name] = value
+				secrets[key] = value
 			}
-		}
 
-		if len(secrets) == 0 {
-			return fmt.Errorf("no secrets provided; pass KEY=VALUE args or use --from-env")
-		}
+			// Collect secrets from environment.
+			if fromEnvFlag != "" {
+				for _, name := range strings.Split(fromEnvFlag, ",") {
+					name = strings.TrimSpace(name)
+					if name == "" {
+						continue
+					}
+					value, ok := os.LookupEnv(name)
+					if !ok {
+						return fmt.Errorf("environment variable %q is not set", name)
+					}
+					if _, exists := secrets[name]; !exists {
+						keys = append(keys, name)
+					}
+					secrets[name] = value
+				}
+			}
 
-		// Display and confirm.
-		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "SECRET\tVALUE")
-		for _, key := range keys {
-			fmt.Fprintf(w, "%s\t%s\n", key, maskValue(secrets[key]))
-		}
-		w.Flush()
+			if len(secrets) == 0 {
+				return fmt.Errorf("no secrets provided; pass KEY=VALUE args or use --from-env")
+			}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "\nPush %d secret(s) to remote store? [y/N] ", len(keys))
-		reader := bufio.NewReader(cmd.InOrStdin())
-		answer, err := reader.ReadString('\n')
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		answer = strings.TrimSpace(strings.ToLower(answer))
-		if answer != "y" && answer != "yes" {
-			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
-			return nil
-		}
+			// Display and confirm.
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "SECRET\tVALUE")
+			for _, key := range keys {
+				fmt.Fprintf(w, "%s\t%s\n", key, maskValue(secrets[key]))
+			}
+			w.Flush()
 
-		// Get remote API client.
-		client, err := getSecretsClient()
-		if err != nil {
-			return fmt.Errorf("authenticating with remote API: %w", err)
-		}
-
-		// Fetch existing remote secrets to decide create vs update.
-		existing, err := client.ListSecrets()
-		if err != nil {
-			return fmt.Errorf("listing remote secrets: %w", err)
-		}
-		existingByName := make(map[string]apiclient.Secret)
-		for _, s := range existing {
-			existingByName[s.Name] = s
-		}
-
-		// Push each secret.
-		for _, key := range keys {
-			value := secrets[key]
-			action, err := pushSecret(client, existingByName, key, value, scope)
+			fmt.Fprintf(cmd.OutOrStdout(), "\nPush %d secret(s) to remote store? [y/N] ", len(keys))
+			reader := bufio.NewReader(cmd.InOrStdin())
+			answer, err := reader.ReadString('\n')
 			if err != nil {
-				return err
+				return fmt.Errorf("reading confirmation: %w", err)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s %s\n", action, key)
-		}
+			answer = strings.TrimSpace(strings.ToLower(answer))
+			if answer != "y" && answer != "yes" {
+				fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+				return nil
+			}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "\nPushed %d secret(s).\n", len(keys))
-		return nil
-	},
+			// Get remote API client.
+			client, err := getSecretsClient()
+			if err != nil {
+				return fmt.Errorf("authenticating with remote API: %w", err)
+			}
+
+			// Fetch existing remote secrets to decide create vs update.
+			existing, err := client.ListSecrets()
+			if err != nil {
+				return fmt.Errorf("listing remote secrets: %w", err)
+			}
+			existingByName := make(map[string]apiclient.Secret)
+			for _, s := range existing {
+				existingByName[s.Name] = s
+			}
+
+			// Push each secret.
+			for _, key := range keys {
+				value := secrets[key]
+				action, err := pushSecret(client, existingByName, key, value, scope)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s %s\n", action, key)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "\nPushed %d secret(s).\n", len(keys))
+			return nil
+		},
+	}
+
+	cmd.Flags().String("from-env", "", "Comma-separated list of environment variable names to read and push (e.g. ANTHROPIC_API_KEY,OPENAI_API_KEY)")
+	cmd.Flags().String("scope", "user", "Secret scope: \"user\" (default, private) or \"org\" (visible to org members)")
+
+	return cmd
 }
 
 // pushSecret creates or updates a single secret. It returns the action taken ("Created" or "Updated").
@@ -307,16 +332,11 @@ func maskValue(value string) string {
 }
 
 func init() {
-	rootCmd.AddCommand(secretsCmd)
-	secretsCmd.AddCommand(secretsExtractCmd)
-	secretsCmd.AddCommand(secretsPushCmd)
+	rootCmd.AddCommand(secretCmd)
+	secretCmd.AddCommand(newSecretExtractCmd())
+	secretCmd.AddCommand(newSecretPushCmd())
 
-	secretsExtractCmd.Flags().String("homedir", "", "Override home directory used for credential discovery")
-	secretsExtractCmd.Flags().Bool("no-oauth", false, "Skip OAuth credential sources")
-	secretsExtractCmd.Flags().Bool("push", false, "Push discovered secrets to the remote Amika secrets store")
-	secretsExtractCmd.Flags().String("only", "", "Comma-separated list of secret names to include (e.g. ANTHROPIC_API_KEY,OPENAI_API_KEY)")
-	secretsExtractCmd.Flags().String("scope", "user", "Secret scope: \"user\" (default, private) or \"org\" (visible to org members)")
-
-	secretsPushCmd.Flags().String("from-env", "", "Comma-separated list of environment variable names to read and push (e.g. ANTHROPIC_API_KEY,OPENAI_API_KEY)")
-	secretsPushCmd.Flags().String("scope", "user", "Secret scope: \"user\" (default, private) or \"org\" (visible to org members)")
+	rootCmd.AddCommand(secretsAliasCmd)
+	secretsAliasCmd.AddCommand(newSecretExtractCmd())
+	secretsAliasCmd.AddCommand(newSecretPushCmd())
 }

--- a/cmd/amika/secrets_test.go
+++ b/cmd/amika/secrets_test.go
@@ -17,11 +17,11 @@ func TestSecretsExtract_MappingAndSorting(t *testing.T) {
 	writeJSONFixture(t, filepath.Join(home, ".codex", "auth.json"), `{"OPENAI_API_KEY":"open-key"}`)
 	writeJSONFixture(t, filepath.Join(home, ".local", "share", "opencode", "auth.json"), `{"foo-bar":{"type":"api","key":"foo-key"}}`)
 
-	cmd := exec.Command(bin, "secrets", "extract", "--homedir", home)
+	cmd := exec.Command(bin, "secret", "extract", "--homedir", home)
 	cmd.Env = withXDGEnv(home)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("amika secrets extract failed: %v\n%s", err, out)
+		t.Fatalf("amika secret extract failed: %v\n%s", err, out)
 	}
 
 	text := string(out)
@@ -41,11 +41,11 @@ func TestSecretsExtract_NoOAuth(t *testing.T) {
 	writeJSONFixture(t, filepath.Join(home, ".codex", "auth.json"), `{"tokens":{"access_token":"codex-oauth"}}`)
 	writeJSONFixture(t, filepath.Join(home, ".local", "share", "opencode", "auth.json"), `{"openai":{"type":"oauth","access":"op-open"},"groq":{"type":"oauth","access":"op-groq"}}`)
 
-	cmdWithOAuth := exec.Command(bin, "secrets", "extract", "--homedir", home)
+	cmdWithOAuth := exec.Command(bin, "secret", "extract", "--homedir", home)
 	cmdWithOAuth.Env = withXDGEnv(home)
 	outWithOAuth, err := cmdWithOAuth.CombinedOutput()
 	if err != nil {
-		t.Fatalf("amika secrets extract failed: %v\n%s", err, outWithOAuth)
+		t.Fatalf("amika secret extract failed: %v\n%s", err, outWithOAuth)
 	}
 	textWithOAuth := string(outWithOAuth)
 	if !strings.Contains(textWithOAuth, "ANTHROPIC_API_KEY") {
@@ -58,11 +58,11 @@ func TestSecretsExtract_NoOAuth(t *testing.T) {
 		t.Fatalf("expected OpenCode OAuth generic credential in output, got:\n%s", textWithOAuth)
 	}
 
-	cmdNoOAuth := exec.Command(bin, "secrets", "extract", "--homedir", home, "--no-oauth")
+	cmdNoOAuth := exec.Command(bin, "secret", "extract", "--homedir", home, "--no-oauth")
 	cmdNoOAuth.Env = withXDGEnv(home)
 	outNoOAuth, err := cmdNoOAuth.CombinedOutput()
 	if err != nil {
-		t.Fatalf("amika secrets extract --no-oauth failed: %v\n%s", err, outNoOAuth)
+		t.Fatalf("amika secret extract --no-oauth failed: %v\n%s", err, outNoOAuth)
 	}
 	text := string(outNoOAuth)
 	if !strings.Contains(text, "No secrets discovered") {
@@ -77,11 +77,11 @@ func TestSecretsExtract_OnlyFilter(t *testing.T) {
 	writeJSONFixture(t, filepath.Join(home, ".claude.json"), `{"apiKey":"sk-ant-anth-key"}`)
 	writeJSONFixture(t, filepath.Join(home, ".codex", "auth.json"), `{"OPENAI_API_KEY":"open-key"}`)
 
-	cmd := exec.Command(bin, "secrets", "extract", "--homedir", home, "--only=ANTHROPIC_API_KEY")
+	cmd := exec.Command(bin, "secret", "extract", "--homedir", home, "--only=ANTHROPIC_API_KEY")
 	cmd.Env = withXDGEnv(home)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("amika secrets extract --only failed: %v\n%s", err, out)
+		t.Fatalf("amika secret extract --only failed: %v\n%s", err, out)
 	}
 
 	text := string(out)
@@ -99,11 +99,11 @@ func TestSecretsExtract_OnlyFilterNoMatch(t *testing.T) {
 
 	writeJSONFixture(t, filepath.Join(home, ".claude.json"), `{"apiKey":"sk-ant-anth-key"}`)
 
-	cmd := exec.Command(bin, "secrets", "extract", "--homedir", home, "--only=NONEXISTENT_KEY")
+	cmd := exec.Command(bin, "secret", "extract", "--homedir", home, "--only=NONEXISTENT_KEY")
 	cmd.Env = withXDGEnv(home)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("amika secrets extract --only failed: %v\n%s", err, out)
+		t.Fatalf("amika secret extract --only failed: %v\n%s", err, out)
 	}
 
 	if !strings.Contains(string(out), "No secrets match the --only filter") {
@@ -117,7 +117,7 @@ func TestSecretsExtract_ParseError(t *testing.T) {
 
 	writeJSONFixture(t, filepath.Join(home, ".claude.json"), `{not-json}`)
 
-	cmd := exec.Command(bin, "secrets", "extract", "--homedir", home)
+	cmd := exec.Command(bin, "secret", "extract", "--homedir", home)
 	cmd.Env = withXDGEnv(home)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
@@ -131,7 +131,7 @@ func TestSecretsExtract_ParseError(t *testing.T) {
 func TestSecretsPush_InvalidArg(t *testing.T) {
 	bin := buildAmika(t)
 
-	cmd := exec.Command(bin, "secrets", "push", "NOEQUALS")
+	cmd := exec.Command(bin, "secret", "push", "NOEQUALS")
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected non-zero exit code, got success\noutput:\n%s", out)
@@ -144,7 +144,7 @@ func TestSecretsPush_InvalidArg(t *testing.T) {
 func TestSecretsPush_NoArgs(t *testing.T) {
 	bin := buildAmika(t)
 
-	cmd := exec.Command(bin, "secrets", "push")
+	cmd := exec.Command(bin, "secret", "push")
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected non-zero exit code, got success\noutput:\n%s", out)
@@ -157,7 +157,7 @@ func TestSecretsPush_NoArgs(t *testing.T) {
 func TestSecretsPush_FromEnvMissing(t *testing.T) {
 	bin := buildAmika(t)
 
-	cmd := exec.Command(bin, "secrets", "push", "--from-env=DEFINITELY_NOT_SET_XYZ")
+	cmd := exec.Command(bin, "secret", "push", "--from-env=DEFINITELY_NOT_SET_XYZ")
 	// Ensure the env var is not set.
 	cmd.Env = append(os.Environ(), "DEFINITELY_NOT_SET_XYZ=")
 	// Actually remove it by filtering.
@@ -175,6 +175,24 @@ func TestSecretsPush_FromEnvMissing(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "is not set") {
 		t.Fatalf("expected 'is not set' error, got:\n%s", out)
+	}
+}
+
+func TestSecretsPluralAlias(t *testing.T) {
+	bin := buildAmika(t)
+	home := t.TempDir()
+
+	writeJSONFixture(t, filepath.Join(home, ".claude.json"), `{"apiKey":"sk-ant-anth-key"}`)
+
+	cmd := exec.Command(bin, "secrets", "extract", "--homedir", home)
+	cmd.Env = withXDGEnv(home)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("amika secrets (plural alias) extract failed: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "ANTHROPIC_API_KEY") {
+		t.Fatalf("expected ANTHROPIC_API_KEY in output from plural alias, got:\n%s", out)
 	}
 }
 

--- a/test/contract/cli_contract_test.go
+++ b/test/contract/cli_contract_test.go
@@ -21,13 +21,13 @@ func TestSandboxCreateNoCleanRequiresGit(t *testing.T) {
 	}
 }
 
-func TestSecretsExtractHelpContract(t *testing.T) {
+func TestSecretExtractHelpContract(t *testing.T) {
 	bin := testutil.BuildAmikaBinary(t)
 
-	cmd := exec.Command(bin, "secrets", "extract", "--help")
+	cmd := exec.Command(bin, "secret", "extract", "--help")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("secrets extract --help failed: %v\n%s", err, string(out))
+		t.Fatalf("secret extract --help failed: %v\n%s", err, string(out))
 	}
 	text := string(out)
 	if !strings.Contains(text, "--push") {
@@ -41,13 +41,13 @@ func TestSecretsExtractHelpContract(t *testing.T) {
 	}
 }
 
-func TestSecretsPushHelpContract(t *testing.T) {
+func TestSecretPushHelpContract(t *testing.T) {
 	bin := testutil.BuildAmikaBinary(t)
 
-	cmd := exec.Command(bin, "secrets", "push", "--help")
+	cmd := exec.Command(bin, "secret", "push", "--help")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("secrets push --help failed: %v\n%s", err, string(out))
+		t.Fatalf("secret push --help failed: %v\n%s", err, string(out))
 	}
 	text := string(out)
 	if !strings.Contains(text, "--from-env") {

--- a/test/integration/cli/auth_extract_test.go
+++ b/test/integration/cli/auth_extract_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/gofixpoint/amika/test/testutil"
 )
 
-func TestSecretsExtractHelp(t *testing.T) {
+func TestSecretExtractHelp(t *testing.T) {
 	bin := testutil.BuildAmikaBinary(t)
 
-	cmd := exec.Command(bin, "secrets", "extract", "--help")
+	cmd := exec.Command(bin, "secret", "extract", "--help")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("secrets extract --help failed: %v\n%s", err, string(out))
+		t.Fatalf("secret extract --help failed: %v\n%s", err, string(out))
 	}
 
 	output := string(out)


### PR DESCRIPTION
The canonical CLI command is now `amika secret` (singular). The plural `amika secrets` still works as a hidden alias so existing usage isn't broken, but it no longer appears in help text.