### PR TITLE
feat: add `--secret` flag to `sandbox create` for remote secret injection

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -130,6 +130,10 @@ var sandboxCreateCmd = &cobra.Command{
 		}
 		printLocalOnlyNotice(cmd)
 
+		if secretFlags, _ := cmd.Flags().GetStringArray("secret"); len(secretFlags) > 0 {
+			return fmt.Errorf("--secret requires --remote mode; secrets are resolved by the remote API")
+		}
+
 		provider, _ := cmd.Flags().GetString("provider")
 		name, _ := cmd.Flags().GetString("name")
 		image, _ := cmd.Flags().GetString("image")
@@ -862,6 +866,80 @@ func parseVolumeFlags(flags []string) ([]sandbox.MountBinding, error) {
 		})
 	}
 	return mounts, nil
+}
+
+// parseSecretFlags parses --secret flag values. Supported syntax:
+//   - env:FOO=SECRET_NAME — inject secret SECRET_NAME as env var FOO
+//   - env:SECRET_NAME     — shorthand: env var name equals the secret name
+func parseSecretFlags(flags []string) ([]apiclient.SecretRef, error) {
+	var refs []apiclient.SecretRef
+	seenEnv := make(map[string]bool)
+
+	for _, raw := range flags {
+		idx := strings.Index(raw, ":")
+		if idx < 0 {
+			return nil, fmt.Errorf("invalid --secret format %q: expected type prefix (e.g. env:SECRET_NAME or env:FOO=SECRET_NAME)", raw)
+		}
+
+		prefix := raw[:idx]
+		value := raw[idx+1:]
+
+		switch prefix {
+		case "file":
+			return nil, fmt.Errorf("file: secret type is not yet supported")
+		case "env":
+			// ok
+		default:
+			return nil, fmt.Errorf("unknown secret type %q in %q: supported types are \"env\"", prefix, raw)
+		}
+
+		var envVar, secretName string
+		if eqIdx := strings.Index(value, "="); eqIdx >= 0 {
+			envVar = value[:eqIdx]
+			secretName = value[eqIdx+1:]
+		} else {
+			envVar = value
+			secretName = value
+		}
+
+		if envVar == "" {
+			return nil, fmt.Errorf("empty env var name in --secret %q", raw)
+		}
+		if secretName == "" {
+			return nil, fmt.Errorf("empty secret name in --secret %q", raw)
+		}
+		if seenEnv[envVar] {
+			return nil, fmt.Errorf("duplicate env var %q in --secret flags", envVar)
+		}
+		seenEnv[envVar] = true
+
+		refs = append(refs, apiclient.SecretRef{
+			Name:   secretName,
+			EnvVar: envVar,
+		})
+	}
+	return refs, nil
+}
+
+// parseEnvVarFlags parses --env flag values (KEY=VALUE) into a map.
+func parseEnvVarFlags(flags []string) (map[string]string, error) {
+	if len(flags) == 0 {
+		return nil, nil
+	}
+	envVars := make(map[string]string, len(flags))
+	for _, raw := range flags {
+		eqIdx := strings.Index(raw, "=")
+		if eqIdx < 0 {
+			return nil, fmt.Errorf("invalid --env format %q: expected KEY=VALUE", raw)
+		}
+		key := raw[:eqIdx]
+		val := raw[eqIdx+1:]
+		if key == "" {
+			return nil, fmt.Errorf("empty key in --env %q", raw)
+		}
+		envVars[key] = val
+	}
+	return envVars, nil
 }
 
 func validateMountTargets(bindMounts, volumeMounts []sandbox.MountBinding) error {
@@ -1636,6 +1714,8 @@ func hasEnvKey(env []string, key string) bool {
 func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	name, _ := cmd.Flags().GetString("name")
 	gitValue, _ := cmd.Flags().GetString("git")
+	secretFlags, _ := cmd.Flags().GetStringArray("secret")
+	envFlags, _ := cmd.Flags().GetStringArray("env")
 
 	var gitURL string
 	if cmd.Flags().Changed("git") {
@@ -1644,6 +1724,16 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 			return err
 		}
 		gitURL = resolved
+	}
+
+	secrets, err := parseSecretFlags(secretFlags)
+	if err != nil {
+		return err
+	}
+
+	envVars, err := parseEnvVarFlags(envFlags)
+	if err != nil {
+		return err
 	}
 
 	client, err := getRemoteClient(target)
@@ -1655,6 +1745,8 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		Name:      name,
 		Provider:  "daytona",
 		GitHubURL: gitURL,
+		EnvVars:   envVars,
+		Secrets:   secrets,
 	}
 
 	sb, err := client.CreateSandbox(req)
@@ -1913,6 +2005,7 @@ func init() {
 	sandboxCreateCmd.Flags().Lookup("git").NoOptDefVal = "."
 	sandboxCreateCmd.Flags().Bool("no-clean", false, "With --git, include untracked files from working tree instead of a clean clone")
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
+	sandboxCreateCmd.Flags().StringArray("secret", nil, "Inject a remote secret (env:FOO=SECRET_NAME or env:SECRET_NAME)")
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 	sandboxCreateCmd.Flags().Bool("connect", false, "Connect to the sandbox shell immediately after creation")
 	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /usr/local/etc/amikad/setup/setup.sh in the container (read-only)")

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gofixpoint/amika/internal/apiclient"
 	"github.com/gofixpoint/amika/internal/sandbox"
 )
 
@@ -1047,5 +1048,94 @@ func TestSandboxListCommand_PrintsRows(t *testing.T) {
 	}
 	if !strings.Contains(out, "127.0.0.1:8080->80/tcp") {
 		t.Fatalf("missing ports in row: %s", out)
+	}
+}
+
+func TestParseSecretFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   []string
+		want    []apiclient.SecretRef
+		wantErr string
+	}{
+		{
+			name:  "env with explicit env var",
+			flags: []string{"env:FOO=MY_SECRET"},
+			want:  []apiclient.SecretRef{{Name: "MY_SECRET", EnvVar: "FOO"}},
+		},
+		{
+			name:  "env shorthand",
+			flags: []string{"env:MY_SECRET"},
+			want:  []apiclient.SecretRef{{Name: "MY_SECRET", EnvVar: "MY_SECRET"}},
+		},
+		{
+			name:  "multiple secrets",
+			flags: []string{"env:FOO=SECRET_A", "env:BAR=SECRET_B"},
+			want: []apiclient.SecretRef{
+				{Name: "SECRET_A", EnvVar: "FOO"},
+				{Name: "SECRET_B", EnvVar: "BAR"},
+			},
+		},
+		{
+			name:  "no flags",
+			flags: nil,
+			want:  nil,
+		},
+		{
+			name:    "missing type prefix",
+			flags:   []string{"MY_SECRET"},
+			wantErr: "expected type prefix",
+		},
+		{
+			name:    "empty after env:",
+			flags:   []string{"env:"},
+			wantErr: "empty env var name",
+		},
+		{
+			name:    "empty env var name",
+			flags:   []string{"env:=SECRET"},
+			wantErr: "empty env var name",
+		},
+		{
+			name:    "empty secret name",
+			flags:   []string{"env:FOO="},
+			wantErr: "empty secret name",
+		},
+		{
+			name:    "duplicate env var",
+			flags:   []string{"env:FOO=SECRET_A", "env:FOO=SECRET_B"},
+			wantErr: "duplicate env var",
+		},
+		{
+			name:    "file type not supported",
+			flags:   []string{"file:/path=SECRET"},
+			wantErr: "not yet supported",
+		},
+		{
+			name:    "unknown type prefix",
+			flags:   []string{"unknown:FOO"},
+			wantErr: "unknown secret type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSecretFlags(tt.flags)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -34,11 +34,19 @@ func NewClientWithTokenSource(baseURL string, ts TokenSource) *Client {
 
 // CreateSandboxRequest is the request body for POST /api/sandboxes.
 type CreateSandboxRequest struct {
-	Name               string `json:"name,omitempty"`
-	Provider           string `json:"provider,omitempty"`
-	GitHubURL          string `json:"github_url,omitempty"`
-	AutoStopInterval   *int   `json:"auto_stop_interval,omitempty"`
-	AutoDeleteInterval *int   `json:"auto_delete_interval,omitempty"`
+	Name               string            `json:"name,omitempty"`
+	Provider           string            `json:"provider,omitempty"`
+	GitHubURL          string            `json:"github_url,omitempty"`
+	AutoStopInterval   *int              `json:"auto_stop_interval,omitempty"`
+	AutoDeleteInterval *int              `json:"auto_delete_interval,omitempty"`
+	EnvVars            map[string]string `json:"env_vars,omitempty"`
+	Secrets            []SecretRef       `json:"secrets,omitempty"`
+}
+
+// SecretRef references a named secret to inject into a sandbox.
+type SecretRef struct {
+	Name   string `json:"name"`
+	EnvVar string `json:"env_var,omitempty"`
 }
 
 // RemoteSandbox represents a sandbox returned by the remote API.


### PR DESCRIPTION
Parse `--secret env:FOO=SECRET_NAME` (or shorthand `env:SECRET_NAME`) flags and pass them through to the remote API when creating sandboxes. Also wire `--env` flags into the remote create request as `env_vars`.

Using `--secret` in local mode returns a clear error since secrets are resolved server-side.