### PR TITLE
feat: add `--from-file` flag to `secret push` for .env file support

### DIFF
--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -148,23 +148,46 @@ func newSecretPushCmd() *cobra.Command {
 		Short: "Push secrets to the remote Amika secrets store",
 		Long: `Push secrets to the remote Amika secrets store.
 
-Secrets can be provided as KEY=VALUE positional arguments and/or read from
-the current environment using --from-env.
+Secrets can be provided as KEY=VALUE positional arguments, read from
+the current environment using --from-env, or loaded from a .env file
+using --from-file.
+
+When multiple sources are used, positional arguments override --from-file
+values, and --from-env overrides both.
+
+The .env file format is Docker-style: blank lines and lines starting with #
+are skipped, and values are taken verbatim (no quote stripping).
 
 Examples:
   amika secret push ANTHROPIC_API_KEY=sk-ant-xxx
   amika secret push --from-env=ANTHROPIC_API_KEY,OPENAI_API_KEY
-  amika secret push CUSTOM_KEY=val --from-env=ANTHROPIC_API_KEY`,
+  amika secret push --from-file=.env
+  amika secret push --from-file=.env CUSTOM_KEY=val --from-env=ANTHROPIC_API_KEY`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 
 			fromEnvFlag, _ := cmd.Flags().GetString("from-env")
+			fromFileFlag, _ := cmd.Flags().GetString("from-file")
 			scope, _ := cmd.Flags().GetString("scope")
 
-			// Collect secrets from positional args.
+			// Collect secrets from --from-file first (lowest priority).
 			secrets := make(map[string]string)
 			var keys []string
+			if fromFileFlag != "" {
+				fileSecrets, fileKeys, err := parseEnvFile(fromFileFlag)
+				if err != nil {
+					return err
+				}
+				for _, key := range fileKeys {
+					if _, exists := secrets[key]; !exists {
+						keys = append(keys, key)
+					}
+					secrets[key] = fileSecrets[key]
+				}
+			}
+
+			// Collect secrets from positional args (override file).
 			for _, arg := range args {
 				idx := strings.IndexByte(arg, '=')
 				if idx < 1 {
@@ -178,7 +201,7 @@ Examples:
 				secrets[key] = value
 			}
 
-			// Collect secrets from environment.
+			// Collect secrets from environment (override both).
 			if fromEnvFlag != "" {
 				for _, name := range strings.Split(fromEnvFlag, ",") {
 					name = strings.TrimSpace(name)
@@ -197,7 +220,7 @@ Examples:
 			}
 
 			if len(secrets) == 0 {
-				return fmt.Errorf("no secrets provided; pass KEY=VALUE args or use --from-env")
+				return fmt.Errorf("no secrets provided; pass KEY=VALUE args, use --from-env, or use --from-file")
 			}
 
 			// Display and confirm.
@@ -252,9 +275,53 @@ Examples:
 	}
 
 	cmd.Flags().String("from-env", "", "Comma-separated list of environment variable names to read and push (e.g. ANTHROPIC_API_KEY,OPENAI_API_KEY)")
+	cmd.Flags().String("from-file", "", "Path to a .env file containing KEY=VALUE secrets (one per line)")
 	cmd.Flags().String("scope", "user", "Secret scope: \"user\" (default, private) or \"org\" (visible to org members)")
 
 	return cmd
+}
+
+// parseEnvFile reads a .env file and returns the secrets and their keys in order.
+// The format is Docker-style: blank lines and lines starting with # are skipped.
+// Each non-empty, non-comment line must contain KEY=VALUE, split on the first =.
+// Values are taken verbatim (no quote stripping or inline comment handling).
+func parseEnvFile(path string) (map[string]string, []string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening env file: %w", err)
+	}
+	defer f.Close()
+
+	secrets := make(map[string]string)
+	var keys []string
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		// Skip blank lines and comments.
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		idx := strings.IndexByte(line, '=')
+		if idx < 1 {
+			return nil, nil, fmt.Errorf("%s:%d: invalid line %q: expected KEY=VALUE", path, lineNum, line)
+		}
+
+		key := strings.TrimSpace(line[:idx])
+		value := line[idx+1:]
+		if _, exists := secrets[key]; !exists {
+			keys = append(keys, key)
+		}
+		secrets[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, nil, fmt.Errorf("reading env file %s: %w", path, err)
+	}
+	return secrets, keys, nil
 }
 
 // pushSecret creates or updates a single secret. It returns the action taken ("Created" or "Updated").

--- a/cmd/amika/secrets_test.go
+++ b/cmd/amika/secrets_test.go
@@ -196,6 +196,173 @@ func TestSecretsPluralAlias(t *testing.T) {
 	}
 }
 
+func TestParseEnvFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantKeys []string
+		wantVals map[string]string
+		wantErr  string
+	}{
+		{
+			name:     "basic key-value pairs",
+			content:  "FOO=bar\nBAZ=qux\n",
+			wantKeys: []string{"FOO", "BAZ"},
+			wantVals: map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name:     "comments and blank lines",
+			content:  "# This is a comment\n\nFOO=bar\n  # Indented comment\n\nBAZ=qux\n",
+			wantKeys: []string{"FOO", "BAZ"},
+			wantVals: map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name:     "values with hash kept verbatim",
+			content:  "PASSWORD=abc#123\nURL=https://example.com#fragment\n",
+			wantKeys: []string{"PASSWORD", "URL"},
+			wantVals: map[string]string{"PASSWORD": "abc#123", "URL": "https://example.com#fragment"},
+		},
+		{
+			name:     "quotes kept verbatim",
+			content:  "FOO=\"bar baz\"\nBAR='single'\n",
+			wantKeys: []string{"FOO", "BAR"},
+			wantVals: map[string]string{"FOO": "\"bar baz\"", "BAR": "'single'"},
+		},
+		{
+			name:     "empty value",
+			content:  "FOO=\n",
+			wantKeys: []string{"FOO"},
+			wantVals: map[string]string{"FOO": ""},
+		},
+		{
+			name:     "value with equals sign",
+			content:  "CONNECTION=postgres://user:pass@host/db?opt=val\n",
+			wantKeys: []string{"CONNECTION"},
+			wantVals: map[string]string{"CONNECTION": "postgres://user:pass@host/db?opt=val"},
+		},
+		{
+			name:     "duplicate keys last wins",
+			content:  "FOO=first\nFOO=second\n",
+			wantKeys: []string{"FOO"},
+			wantVals: map[string]string{"FOO": "second"},
+		},
+		{
+			name:     "empty file",
+			content:  "",
+			wantKeys: nil,
+			wantVals: map[string]string{},
+		},
+		{
+			name:     "only comments",
+			content:  "# comment\n# another\n",
+			wantKeys: nil,
+			wantVals: map[string]string{},
+		},
+		{
+			name:    "line without equals",
+			content: "FOO=bar\nBADLINE\n",
+			wantErr: "invalid line",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".env")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+
+			gotVals, gotKeys, err := parseEnvFile(path)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(gotKeys) != len(tt.wantKeys) {
+				t.Fatalf("keys = %v, want %v", gotKeys, tt.wantKeys)
+			}
+			for i, k := range gotKeys {
+				if k != tt.wantKeys[i] {
+					t.Errorf("keys[%d] = %q, want %q", i, k, tt.wantKeys[i])
+				}
+			}
+			for k, want := range tt.wantVals {
+				if got := gotVals[k]; got != want {
+					t.Errorf("value[%q] = %q, want %q", k, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEnvFile_NotFound(t *testing.T) {
+	_, _, err := parseEnvFile("/nonexistent/path/.env")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "opening env file") {
+		t.Fatalf("expected 'opening env file' error, got: %v", err)
+	}
+}
+
+func TestSecretsPush_FromFile(t *testing.T) {
+	bin := buildAmika(t)
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("# API keys\nANTHROPIC_API_KEY=sk-ant-test-key-12345678\nOPENAI_API_KEY=sk-openai-test-key-12345678\n"), 0644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	// Run with --from-file; it will display the secrets and prompt, then fail
+	// because stdin is empty (no "y" confirmation). That's fine — we just
+	// verify the parsing and display worked.
+	cmd := exec.Command(bin, "secret", "push", "--from-file="+envFile)
+	out, _ := cmd.CombinedOutput()
+	text := string(out)
+	if !strings.Contains(text, "ANTHROPIC_API_KEY") {
+		t.Errorf("expected ANTHROPIC_API_KEY in output, got:\n%s", text)
+	}
+	if !strings.Contains(text, "OPENAI_API_KEY") {
+		t.Errorf("expected OPENAI_API_KEY in output, got:\n%s", text)
+	}
+}
+
+func TestSecretsPush_FromFileMissing(t *testing.T) {
+	bin := buildAmika(t)
+
+	cmd := exec.Command(bin, "secret", "push", "--from-file=/nonexistent/.env")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit code, got success\noutput:\n%s", out)
+	}
+	if !strings.Contains(string(out), "opening env file") {
+		t.Fatalf("expected 'opening env file' error, got:\n%s", out)
+	}
+}
+
+func TestSecretsPush_FromFileBadLine(t *testing.T) {
+	bin := buildAmika(t)
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("GOOD=value\nBADLINE\n"), 0644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	cmd := exec.Command(bin, "secret", "push", "--from-file="+envFile)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit code, got success\noutput:\n%s", out)
+	}
+	if !strings.Contains(string(out), "invalid line") {
+		t.Fatalf("expected 'invalid line' error, got:\n%s", out)
+	}
+}
+
 func TestMaskValue(t *testing.T) {
 	tests := []struct {
 		input string

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -241,6 +241,49 @@ See [auth.md](auth.md) for details on supported credential sources and priority.
 
 ---
 
+## `amika secret`
+
+Manage secrets in the remote Amika secrets store. See [secrets.md](secrets.md) for details on the env file format and usage.
+
+### `amika secret extract`
+
+Discover locally stored credentials and optionally push them to the remote store.
+
+```bash
+amika secret extract
+amika secret extract --push
+amika secret extract --push --only=ANTHROPIC_API_KEY,OPENAI_API_KEY
+```
+
+| Flag               | Default | Description                                                                                |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------ |
+| `--push`           | `false` | Push discovered secrets to the remote store after confirmation                             |
+| `--only <keys>`    |         | Comma-separated list of secret names to include (e.g. `ANTHROPIC_API_KEY,OPENAI_API_KEY`) |
+| `--scope <scope>`  | `user`  | Secret scope: `user` (private) or `org` (visible to org members)                          |
+| `--homedir <path>` |         | Override home directory used for credential discovery                                      |
+| `--no-oauth`       | `false` | Skip OAuth credential sources                                                              |
+
+### `amika secret push`
+
+Push secrets to the remote store from inline arguments, environment variables, or a `.env` file.
+
+```bash
+amika secret push ANTHROPIC_API_KEY=sk-ant-xxx
+amika secret push --from-env=ANTHROPIC_API_KEY,OPENAI_API_KEY
+amika secret push --from-file=.env
+amika secret push --from-file=.env CUSTOM_KEY=val --from-env=ANTHROPIC_API_KEY
+```
+
+| Flag               | Default | Description                                                                                |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------ |
+| `--from-env <keys>` |         | Comma-separated list of environment variable names to read and push                        |
+| `--from-file <path>`|         | Path to a `.env` file containing `KEY=VALUE` secrets. See [secrets.md](secrets.md)         |
+| `--scope <scope>`  | `user`  | Secret scope: `user` (private) or `org` (visible to org members)                          |
+
+When multiple sources are used, positional arguments override `--from-file` values, and `--from-env` overrides both.
+
+---
+
 ## `amika materialize`
 
 Run a script or command in an ephemeral Docker container and copy outputs to a destination directory.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -255,13 +255,13 @@ amika secret extract --push
 amika secret extract --push --only=ANTHROPIC_API_KEY,OPENAI_API_KEY
 ```
 
-| Flag               | Default | Description                                                                                |
-| ------------------ | ------- | ------------------------------------------------------------------------------------------ |
-| `--push`           | `false` | Push discovered secrets to the remote store after confirmation                             |
+| Flag               | Default | Description                                                                               |
+| ------------------ | ------- | ----------------------------------------------------------------------------------------- |
+| `--push`           | `false` | Push discovered secrets to the remote store after confirmation                            |
 | `--only <keys>`    |         | Comma-separated list of secret names to include (e.g. `ANTHROPIC_API_KEY,OPENAI_API_KEY`) |
 | `--scope <scope>`  | `user`  | Secret scope: `user` (private) or `org` (visible to org members)                          |
-| `--homedir <path>` |         | Override home directory used for credential discovery                                      |
-| `--no-oauth`       | `false` | Skip OAuth credential sources                                                              |
+| `--homedir <path>` |         | Override home directory used for credential discovery                                     |
+| `--no-oauth`       | `false` | Skip OAuth credential sources                                                             |
 
 ### `amika secret push`
 
@@ -274,11 +274,11 @@ amika secret push --from-file=.env
 amika secret push --from-file=.env CUSTOM_KEY=val --from-env=ANTHROPIC_API_KEY
 ```
 
-| Flag               | Default | Description                                                                                |
-| ------------------ | ------- | ------------------------------------------------------------------------------------------ |
-| `--from-env <keys>` |         | Comma-separated list of environment variable names to read and push                        |
-| `--from-file <path>`|         | Path to a `.env` file containing `KEY=VALUE` secrets. See [secrets.md](secrets.md)         |
-| `--scope <scope>`  | `user`  | Secret scope: `user` (private) or `org` (visible to org members)                          |
+| Flag                 | Default | Description                                                                        |
+| -------------------- | ------- | ---------------------------------------------------------------------------------- |
+| `--from-env <keys>`  |         | Comma-separated list of environment variable names to read and push                |
+| `--from-file <path>` |         | Path to a `.env` file containing `KEY=VALUE` secrets. See [secrets.md](secrets.md) |
+| `--scope <scope>`    | `user`  | Secret scope: `user` (private) or `org` (visible to org members)                   |
 
 When multiple sources are used, positional arguments override `--from-file` values, and `--from-env` overrides both.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,79 @@
+# Secrets
+
+Secrets are credentials stored in the remote Amika secrets store. They can be injected into sandboxes at creation time using the `--secret` flag on `sandbox create`.
+
+Each secret has a **name** (e.g. `ANTHROPIC_API_KEY`), a **value**, and a **scope**:
+
+- **user** (default): Private to your account.
+- **org**: Visible to all members of your organization.
+
+## Extracting local credentials
+
+`amika secret extract` discovers credentials stored locally by various AI coding tools (Claude, Codex, OpenCode, Amp) and displays them.
+
+```bash
+# Show discovered credentials
+amika secret extract
+
+# Discover and push to the remote store
+amika secret extract --push
+
+# Only push specific keys
+amika secret extract --push --only=ANTHROPIC_API_KEY,OPENAI_API_KEY
+```
+
+See [auth.md](auth.md) for details on supported credential sources.
+
+## Pushing secrets
+
+`amika secret push` pushes secrets to the remote store. Secrets can come from three sources:
+
+```bash
+# Inline KEY=VALUE arguments
+amika secret push ANTHROPIC_API_KEY=sk-ant-xxx
+
+# Read from environment variables
+amika secret push --from-env=ANTHROPIC_API_KEY,OPENAI_API_KEY
+
+# Load from a .env file
+amika secret push --from-file=.env
+```
+
+Sources can be combined. When the same key appears in multiple sources, later sources override earlier ones: `--from-file` (base) < positional args < `--from-env`.
+
+Before pushing, the command displays all secrets with masked values and asks for confirmation.
+
+If a secret already exists remotely with the same scope, it is updated. If it exists with a different scope, the command errors and suggests using `--scope` to match.
+
+## Env file format
+
+The `--from-file` flag reads a `.env` file using Docker-style parsing. The format is intentionally simple to avoid accidentally mangling secret values.
+
+### Rules
+
+- **Blank lines** are skipped.
+- **Comment lines** starting with `#` (with optional leading whitespace) are skipped.
+- **Key-value lines** must contain `=`. The key is everything before the first `=` (trimmed of whitespace). The value is everything after the first `=`, taken **verbatim**.
+- **Lines without `=`** that are not blank or comments produce an error with the line number.
+
+### What is NOT supported
+
+- **Quote stripping**: `KEY="value"` sets the value to `"value"` (with quotes). If you don't want quotes in the value, don't put them in the file.
+- **Inline comments**: `KEY=value # comment` sets the value to `value # comment`. The `#` is part of the value.
+- **`export` prefix**: `export KEY=value` is treated as key `export KEY`, not `KEY`.
+- **Variable substitution**: `${OTHER_VAR}` is taken literally.
+- **Multiline values**: Each line is parsed independently.
+
+### Example
+
+```bash
+# API credentials
+ANTHROPIC_API_KEY=sk-ant-a1b2c3d4e5f6
+OPENAI_API_KEY=sk-proj-abcdef123456
+
+# Database
+DATABASE_URL=postgres://user:pass#123@db.example.com:5432/mydb
+
+# Empty value is allowed
+OPTIONAL_FLAG=
+```


### PR DESCRIPTION
Allow `amika secret push --from-file=.env` to load secrets from a .env file using Docker-style parsing (skip comments and blank lines, split on first `=`, values taken verbatim). When combined with other sources, --from-file is lowest priority, then positional args, then --from-env.