### PR TITLE
feat: add Docker-in-Docker preset images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: goenv build build-cli build-server clean test test-unit test-integration test-contract test-expensive test-all coverage vet fmt fmtcheck lint ci setup
+.PHONY: goenv build build-cli build-server clean test test-unit test-integration test-contract test-expensive test-all coverage vet fmt fmtcheck lint shellcheck ci setup
 
 UNIT_PACKAGES = $$(go list ./... | grep -Ev '/test/(integration|contract)($$|/)')
 GOFMT_FILES = git ls-files -z --cached --others --exclude-standard -- '*.go'
@@ -63,7 +63,10 @@ fmtcheck:
 lint: goenv
 	go run github.com/mgechev/revive@v1.14.0 -set_exit_status -config revive.toml ./...
 
-ci: fmtcheck vet lint build test-unit test-integration test-contract coverage
+shellcheck:
+	shellcheck bin/* internal/sandbox/presets/*.sh scripts/test/*.sh install.sh setup-repo.sh materialization-scripts/*.sh
+
+ci: shellcheck fmtcheck vet lint build test-unit test-integration test-contract coverage
 
 setup:
 	./setup-repo.sh

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -rf dist .gocache .gotmp .gomodcache
 
 clean-docker:
-	docker image rm amika/coder:latest amika/base:latest
+	docker image rm amika/coder:latest amika/base:latest amika/dind:latest amika/coder-dind:latest amika/daytona-coder-dind:latest
 
 test: goenv
 	go test ./...

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -118,13 +118,16 @@ fi
 # Merge all requested images into a single deduplicated preset list,
 # preserving dependency order.
 PRESETS=()
-declare -A SEEN_PRESETS=()
+SEEN_PRESETS=""
 for img in "${IMAGES[@]}"; do
   for p in $(image_presets "$img"); do
-    if [ -z "${SEEN_PRESETS[$p]:-}" ]; then
-      PRESETS+=("$p")
-      SEEN_PRESETS[$p]=1
-    fi
+    case " $SEEN_PRESETS " in
+      *" $p "*) ;;  # already seen
+      *)
+        PRESETS+=("$p")
+        SEEN_PRESETS="$SEEN_PRESETS $p"
+        ;;
+    esac
   done
 done
 

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-#/ Usage: bin/build-docker-images <image> [--platform <platform>] [--ignore-unstaged] [--push-daytona]
+#/ Usage: bin/build-docker-images <image>... [--platform <platform>] [--ignore-unstaged] [--push-daytona]
 #/
 #/ Build preset Docker images and tag them with the current git commit.
 #/ By default, builds for the host architecture. With --push-daytona,
@@ -9,8 +9,10 @@ set -euo pipefail
 #/ Daytona variant images.
 #/
 #/ Arguments:
-#/   <image>              One of: amika/base, amika/coder, amika/claude,
-#/                        amika/daytona-coder, amika/daytona-claude, all
+#/   <image>...            One or more of: amika/base, amika/coder, amika/claude,
+#/                         amika/daytona-coder, amika/daytona-claude,
+#/                         amika/dind, amika/coder-dind,
+#/                         amika/daytona-coder-dind, all
 #/
 #/ Options:
 #/   --platform <plat>    Override build platform (linux/amd64 or linux/arm64)
@@ -23,12 +25,30 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Determine git version tag
 VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
+VALID_IMAGES="amika/base, amika/coder, amika/claude, amika/daytona-coder, amika/daytona-claude, amika/dind, amika/coder-dind, amika/daytona-coder-dind, all"
+
 usage() {
   grep '^#/' "$0" | cut -c4-
 }
 
+# Returns the preset dependency chain for a given image name.
+image_presets() {
+  case "$1" in
+    amika/base)              echo "base" ;;
+    amika/coder)             echo "base coder" ;;
+    amika/claude)            echo "base claude" ;;
+    amika/daytona-coder)     echo "base coder daytona-coder" ;;
+    amika/daytona-claude)    echo "base claude daytona-claude" ;;
+    amika/dind)              echo "base dind" ;;
+    amika/coder-dind)        echo "base dind coder-dind" ;;
+    amika/daytona-coder-dind) echo "base dind coder-dind daytona-coder-dind" ;;
+    all)                     echo "base coder claude daytona-coder daytona-claude dind coder-dind daytona-coder-dind" ;;
+    *) return 1 ;;
+  esac
+}
+
 # Parse arguments
-IMAGE=""
+IMAGES=()
 PLATFORM=""
 IGNORE_UNSTAGED=false
 PUSH_DAYTONA=false
@@ -44,28 +64,24 @@ while [ $# -gt 0 ]; do
     --push-daytona)    PUSH_DAYTONA=true; shift ;;
     --help)            usage; exit 0 ;;
     -*)                echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
-    *)
-      if [ -z "$IMAGE" ]; then
-        IMAGE="$1"
-      else
-        echo "Unexpected argument: $1" >&2; usage >&2; exit 1
-      fi
-      shift ;;
+    *)                 IMAGES+=("$1"); shift ;;
   esac
 done
 
-if [ -z "$IMAGE" ]; then
-  echo "Error: <image> argument is required." >&2
+if [ ${#IMAGES[@]} -eq 0 ]; then
+  echo "Error: at least one <image> argument is required." >&2
   echo "" >&2
   usage >&2
   exit 1
 fi
 
-# Validate image argument
-case "$IMAGE" in
-  amika/base|amika/coder|amika/claude|amika/daytona-coder|amika/daytona-claude|all) ;;
-  *) echo "Error: <image> must be one of: amika/base, amika/coder, amika/claude, amika/daytona-coder, amika/daytona-claude, all" >&2; exit 1 ;;
-esac
+# Validate image arguments
+for img in "${IMAGES[@]}"; do
+  if ! image_presets "$img" > /dev/null 2>&1; then
+    echo "Error: unknown image \"$img\". Must be one of: $VALID_IMAGES" >&2
+    exit 1
+  fi
+done
 
 # Validate --platform value
 if [ -n "$PLATFORM" ]; then
@@ -99,16 +115,18 @@ if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
   fi
 fi
 
-# Determine which presets to build in dependency order.
+# Merge all requested images into a single deduplicated preset list,
+# preserving dependency order.
 PRESETS=()
-case "$IMAGE" in
-  amika/base)            PRESETS=(base) ;;
-  amika/coder)           PRESETS=(base coder) ;;
-  amika/claude)          PRESETS=(base claude) ;;
-  amika/daytona-coder)   PRESETS=(base coder daytona-coder) ;;
-  amika/daytona-claude)  PRESETS=(base claude daytona-claude) ;;
-  all)                   PRESETS=(base coder claude daytona-coder daytona-claude) ;;
-esac
+declare -A SEEN_PRESETS=()
+for img in "${IMAGES[@]}"; do
+  for p in $(image_presets "$img"); do
+    if [ -z "${SEEN_PRESETS[$p]:-}" ]; then
+      PRESETS+=("$p")
+      SEEN_PRESETS[$p]=1
+    fi
+  done
+done
 
 # Track what we built/pushed for the summary
 BUILT_IMAGES=()
@@ -137,6 +155,15 @@ for preset in "${PRESETS[@]}"; do
       ;;
     daytona-claude)
       docker_args+=(--build-arg "CLAUDE_IMAGE=amika/claude:${VERSION}")
+      ;;
+    dind)
+      docker_args+=(--build-arg "BASE_IMAGE=amika/base:${VERSION}")
+      ;;
+    coder-dind)
+      docker_args+=(--build-arg "DIND_IMAGE=amika/dind:${VERSION}")
+      ;;
+    daytona-coder-dind)
+      docker_args+=(--build-arg "CODER_DIND_IMAGE=amika/coder-dind:${VERSION}")
       ;;
   esac
 

--- a/internal/sandbox/preset_build.go
+++ b/internal/sandbox/preset_build.go
@@ -39,6 +39,12 @@ func presetBuildOrder(preset string) ([]string, error) {
 		return []string{"base", "coder", "daytona-coder"}, nil
 	case "daytona-claude":
 		return []string{"base", "claude", "daytona-claude"}, nil
+	case "dind":
+		return []string{"base", "dind"}, nil
+	case "coder-dind":
+		return []string{"base", "dind", "coder-dind"}, nil
+	case "daytona-coder-dind":
+		return []string{"base", "dind", "coder-dind", "daytona-coder-dind"}, nil
 	default:
 		return nil, fmt.Errorf("unknown preset %q", preset)
 	}
@@ -52,6 +58,12 @@ func presetBuildArgs(preset string) map[string]string {
 		return map[string]string{"CODER_IMAGE": presetImageName("coder")}
 	case "daytona-claude":
 		return map[string]string{"CLAUDE_IMAGE": presetImageName("claude")}
+	case "dind":
+		return map[string]string{"BASE_IMAGE": presetImageName("base")}
+	case "coder-dind":
+		return map[string]string{"DIND_IMAGE": presetImageName("dind")}
+	case "daytona-coder-dind":
+		return map[string]string{"CODER_DIND_IMAGE": presetImageName("coder-dind")}
 	default:
 		return nil
 	}

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -62,8 +62,8 @@ RUN mkdir -p \
 # post-setup.sh runs last as root to restore expected ownership after setup.
 # run-hook.sh wraps each hook so stdout, stderr, and Bash ERR trap output land
 # in /var/log/amika/<hook>.log and are mirrored to /var/log/amikad/<hook>.log.
-COPY pre-setup.sh post-setup.sh opencode-setup.sh run-hook.sh bash-error-prelude.sh /usr/lib/amikad/
-RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/post-setup.sh /usr/lib/amikad/opencode-setup.sh /usr/lib/amikad/run-hook.sh
+COPY pre-setup.sh post-setup.sh opencode-setup.sh docker-setup.sh run-hook.sh bash-error-prelude.sh /usr/lib/amikad/
+RUN chmod +x /usr/lib/amikad/pre-setup.sh /usr/lib/amikad/post-setup.sh /usr/lib/amikad/opencode-setup.sh /usr/lib/amikad/docker-setup.sh /usr/lib/amikad/run-hook.sh
 
 # Create user with home directory.
 RUN useradd -m -s /usr/bin/zsh amika

--- a/internal/sandbox/presets/bash-error-prelude.sh
+++ b/internal/sandbox/presets/bash-error-prelude.sh
@@ -6,4 +6,5 @@
 
 set -E
 
+# shellcheck disable=SC2154  # status and line are assigned inside the trap
 trap 'status=$?; if [[ $status -ne 0 ]]; then line="$(caller 0 2>/dev/null || true)"; echo "[$(date -Is)] ERROR ${AMIKA_HOOK_SCRIPT_NAME:-hook} exit=$status line=${line:-unknown} command=${BASH_COMMAND@Q}" >&2; fi' ERR

--- a/internal/sandbox/presets/coder-dind/Dockerfile
+++ b/internal/sandbox/presets/coder-dind/Dockerfile
@@ -1,0 +1,19 @@
+# Locally, this image is called "amika/coder-dind"
+
+ARG DIND_IMAGE=amika/dind:latest
+FROM ${DIND_IMAGE}
+
+USER root
+
+# Install coding agent CLIs.
+RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai
+
+USER amika
+
+# Lifecycle order is pre-setup -> setup -> post-setup.
+# pre-setup and post-setup run as root because they manage container-owned
+# state. setup.sh runs as the amika user because it is the user-facing hook.
+# Each hook is invoked through run-hook.sh so its stdout, stderr, and ERR trap
+# output are written to /var/log/amika/*.log and mirrored to
+# /var/log/amikad/*.log.
+ENTRYPOINT ["/bin/bash", "-c", "sudo AMIKA_AGENT_CWD=\"$AMIKA_AGENT_CWD\" AMIKA_OPENCODE_WEB=\"$AMIKA_OPENCODE_WEB\" OPENCODE_SERVER_PASSWORD=\"$OPENCODE_SERVER_PASSWORD\" /usr/lib/amikad/run-hook.sh /usr/lib/amikad/pre-setup.sh && /usr/lib/amikad/run-hook.sh /usr/local/etc/amikad/setup/setup.sh && sudo /usr/lib/amikad/run-hook.sh /usr/lib/amikad/post-setup.sh && exec \"$@\"", "--"]

--- a/internal/sandbox/presets/daytona-coder-dind/Dockerfile
+++ b/internal/sandbox/presets/daytona-coder-dind/Dockerfile
@@ -1,0 +1,9 @@
+# Locally, this image is called "amika/daytona-coder-dind"
+
+ARG CODER_DIND_IMAGE=amika/coder-dind:latest
+FROM ${CODER_DIND_IMAGE}
+
+# In Daytona we do not manage container/sandbox lifecycle via Docker ENTRYPOINT.
+# That lifecycle is orchestrated by our external control plane, so the image
+# must not run Amika setup hooks from the Docker entrypoint.
+ENTRYPOINT []

--- a/internal/sandbox/presets/dind/Dockerfile
+++ b/internal/sandbox/presets/dind/Dockerfile
@@ -1,0 +1,30 @@
+# Locally, this image is called "amika/dind"
+
+ARG BASE_IMAGE=amika/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Install Docker CE (https://docs.docker.com/engine/install/ubuntu/).
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+       -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+       $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y \
+       docker-ce \
+       docker-ce-cli \
+       containerd.io \
+       docker-buildx-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Let the amika user run Docker commands without sudo.
+RUN usermod -aG docker amika
+
+# Marker file so pre-setup.sh knows to start dockerd.
+RUN mkdir -p /usr/local/etc/amika && touch /usr/local/etc/amika/dind-enabled
+
+USER amika

--- a/internal/sandbox/presets/docker-setup.sh
+++ b/internal/sandbox/presets/docker-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# docker-setup.sh starts the Docker daemon inside a DinD container.
+# Called from pre-setup.sh when /usr/local/etc/amika/dind-enabled exists.
+
+set -euo pipefail
+
+DOCKERD_LOG="/var/log/amikad/dockerd.log"
+DOCKERD_PID_FILE="/run/amikad/dockerd.pid"
+DOCKER_READY_TIMEOUT=30
+
+# Start dockerd in the background.
+nohup dockerd --storage-driver=overlay2 > "$DOCKERD_LOG" 2>&1 &
+echo "$!" > "$DOCKERD_PID_FILE"
+
+# Wait for the Docker socket to become available.
+elapsed=0
+until docker info > /dev/null 2>&1; do
+  if [ "$elapsed" -ge "$DOCKER_READY_TIMEOUT" ]; then
+    echo "ERROR: dockerd did not become ready within ${DOCKER_READY_TIMEOUT}s" >&2
+    echo "  Check $DOCKERD_LOG for details." >&2
+    exit 1
+  fi
+  sleep 1
+  elapsed=$((elapsed + 1))
+done
+
+echo "dockerd is ready (took ${elapsed}s)."

--- a/internal/sandbox/presets/docker-setup.sh
+++ b/internal/sandbox/presets/docker-setup.sh
@@ -9,8 +9,9 @@ DOCKERD_LOG="/var/log/amikad/dockerd.log"
 DOCKERD_PID_FILE="/run/amikad/dockerd.pid"
 DOCKER_READY_TIMEOUT=30
 
-# Start dockerd in the background.
-nohup dockerd --storage-driver=overlay2 > "$DOCKERD_LOG" 2>&1 &
+# Start dockerd in a new session so it survives process group cleanup
+# when the calling hook (pre-setup.sh) exits.
+setsid dockerd > "$DOCKERD_LOG" 2>&1 &
 echo "$!" > "$DOCKERD_PID_FILE"
 
 # Wait for the Docker socket to become available.

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -55,6 +55,7 @@ if command -v opencode &> /dev/null && [[ "${AMIKA_OPENCODE_WEB:-1}" != "0" ]]; 
     exit 1
   fi
 
+  # shellcheck disable=SC2024  # redirect is by root shell (intended); sudo switches the process user
   sudo -H -u amika \
     nohup env OPENCODE_SERVER_PASSWORD="$OPENCODE_SERVER_PASSWORD" \
     /usr/lib/amikad/opencode-setup.sh "$amika_agent_cwd" "$OPENCODE_WEB_PORT" \

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -64,4 +64,9 @@ if command -v opencode &> /dev/null && [[ "${AMIKA_OPENCODE_WEB:-1}" != "0" ]]; 
   echo "$OPENCODE_WEB_PORT" > "$AMIKA_RUN_DIR/opencode-web.port"
 fi
 
+# Start Docker daemon if this is a DinD image (marker file baked into the image).
+if [[ -f /usr/local/etc/amika/dind-enabled ]]; then
+  /usr/lib/amikad/docker-setup.sh
+fi
+
 sudo chown -R amika:amika /home/amika

--- a/internal/sandbox/presets_test.go
+++ b/internal/sandbox/presets_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetPresetDockerfile_ReturnsDockerfilesForKnownPresets(t *testing.T) {
-	for _, preset := range []string{"base", "coder", "claude", "daytona-coder", "daytona-claude"} {
+	for _, preset := range []string{"base", "coder", "claude", "daytona-coder", "daytona-claude", "dind", "coder-dind", "daytona-coder-dind"} {
 		data, err := GetPresetDockerfile(preset)
 		if err != nil {
 			t.Fatalf("unexpected error for %s: %v", preset, err)
@@ -20,7 +20,7 @@ func TestGetPresetDockerfile_ReturnsDockerfilesForKnownPresets(t *testing.T) {
 }
 
 func TestGetPresetDockerfile_PreservesAgentCWDForPreSetup(t *testing.T) {
-	for _, preset := range []string{"coder", "claude"} {
+	for _, preset := range []string{"coder", "claude", "coder-dind"} {
 		data, err := GetPresetDockerfile(preset)
 		if err != nil {
 			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
@@ -33,7 +33,7 @@ func TestGetPresetDockerfile_PreservesAgentCWDForPreSetup(t *testing.T) {
 }
 
 func TestGetPresetDockerfile_PreservesOpenCodeEnvForPreSetup(t *testing.T) {
-	for _, preset := range []string{"coder", "claude"} {
+	for _, preset := range []string{"coder", "claude", "coder-dind"} {
 		data, err := GetPresetDockerfile(preset)
 		if err != nil {
 			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
@@ -49,7 +49,7 @@ func TestGetPresetDockerfile_PreservesOpenCodeEnvForPreSetup(t *testing.T) {
 }
 
 func TestGetPresetDockerfile_RunsAllHooksThroughLogger(t *testing.T) {
-	for _, preset := range []string{"coder", "claude"} {
+	for _, preset := range []string{"coder", "claude", "coder-dind"} {
 		data, err := GetPresetDockerfile(preset)
 		if err != nil {
 			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
@@ -113,7 +113,7 @@ func TestGetPresetDockerfile_BaseChownsUserManagedAmikaDirectories(t *testing.T)
 }
 
 func TestGetPresetDockerfile_DaytonaVariantsClearEntrypoint(t *testing.T) {
-	for _, preset := range []string{"daytona-coder", "daytona-claude"} {
+	for _, preset := range []string{"daytona-coder", "daytona-claude", "daytona-coder-dind"} {
 		data, err := GetPresetDockerfile(preset)
 		if err != nil {
 			t.Fatalf("unexpected error loading %s preset: %v", preset, err)
@@ -161,6 +161,9 @@ func TestWritePresetBuildContext_ExtractsZshrc(t *testing.T) {
 		filepath.Join("claude", "Dockerfile"),
 		filepath.Join("daytona-coder", "Dockerfile"),
 		filepath.Join("daytona-claude", "Dockerfile"),
+		filepath.Join("dind", "Dockerfile"),
+		filepath.Join("coder-dind", "Dockerfile"),
+		filepath.Join("daytona-coder-dind", "Dockerfile"),
 	} {
 		data, err = os.ReadFile(filepath.Join(contextDir, relPath))
 		if err != nil {

--- a/scripts/test/check_coverage.sh
+++ b/scripts/test/check_coverage.sh
@@ -18,6 +18,7 @@ cleanup() {
 trap cleanup EXIT
 
 internal_pkgs="$(go list ./internal/... | grep -Ev '/internal/mount($|/)')"
+# shellcheck disable=SC2086  # intentional word-splitting: $internal_pkgs contains multiple package paths
 go test $internal_pkgs -coverprofile="$tmp_internal" >/dev/null
 go test ./cmd/amika -coverprofile="$tmp_cmd" >/dev/null
 


### PR DESCRIPTION
## Summary

- Add new DinD preset image layer: `dind` (FROM base), `coder-dind` (FROM dind), `daytona-coder-dind` (FROM coder-dind)
- `dind` image installs Docker CE and uses a marker file (`/usr/local/etc/amika/dind-enabled`) to trigger `dockerd` startup in `pre-setup.sh`
- Update `bin/build-docker-images` to accept multiple image arguments (e.g., `bin/build-docker-images amika/coder amika/dind`)
- Add `shellcheck` linting to `make ci`