### PR TITLE
feat: update sandbox create API to use secret_env_vars, preset, and size

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -849,18 +849,15 @@ func parseVolumeFlags(flags []string) ([]sandbox.MountBinding, error) {
 	return mounts, nil
 }
 
-// secretMapping holds a parsed --secret flag entry before resolution.
-type secretMapping struct {
-	envVar     string
-	secretName string
-}
-
-// parseSecretFlags parses --secret flag values. Supported syntax:
+// parseSecretFlags parses --secret flag values into a map of env var name → secret name.
+// Supported syntax:
 //   - env:FOO=SECRET_NAME — inject secret SECRET_NAME as env var FOO
 //   - env:SECRET_NAME     — shorthand: env var name equals the secret name
-func parseSecretFlags(flags []string) ([]secretMapping, error) {
-	var mappings []secretMapping
-	seenEnv := make(map[string]bool)
+func parseSecretFlags(flags []string) (map[string]string, error) {
+	if len(flags) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]string, len(flags))
 
 	for _, raw := range flags {
 		idx := strings.Index(raw, ":")
@@ -895,42 +892,11 @@ func parseSecretFlags(flags []string) ([]secretMapping, error) {
 		if secretName == "" {
 			return nil, fmt.Errorf("empty secret name in --secret %q", raw)
 		}
-		if seenEnv[envVar] {
+		if _, dup := result[envVar]; dup {
 			return nil, fmt.Errorf("duplicate env var %q in --secret flags", envVar)
 		}
-		seenEnv[envVar] = true
 
-		mappings = append(mappings, secretMapping{
-			envVar:     envVar,
-			secretName: secretName,
-		})
-	}
-	return mappings, nil
-}
-
-// resolveSecretEnvVars resolves secret names to IDs and returns a map of env var name → secret ID
-// suitable for the secret_env_vars field in the API request.
-func resolveSecretEnvVars(client *apiclient.Client, mappings []secretMapping) (map[string]string, error) {
-	if len(mappings) == 0 {
-		return nil, nil
-	}
-
-	secrets, err := client.ListSecrets()
-	if err != nil {
-		return nil, fmt.Errorf("listing secrets for resolution: %w", err)
-	}
-	byName := make(map[string]string, len(secrets))
-	for _, s := range secrets {
-		byName[s.Name] = s.ID
-	}
-
-	result := make(map[string]string, len(mappings))
-	for _, m := range mappings {
-		id, ok := byName[m.secretName]
-		if !ok {
-			return nil, fmt.Errorf("secret %q not found; push it first with: amika secret push", m.secretName)
-		}
-		result[m.envVar] = id
+		result[envVar] = secretName
 	}
 	return result, nil
 }
@@ -1746,7 +1712,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		gitURL = resolved
 	}
 
-	secretMappings, err := parseSecretFlags(secretFlags)
+	secretEnvVars, err := parseSecretFlags(secretFlags)
 	if err != nil {
 		return err
 	}
@@ -1757,11 +1723,6 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	}
 
 	client, err := getRemoteClient(target)
-	if err != nil {
-		return err
-	}
-
-	secretEnvVars, err := resolveSecretEnvVars(client, secretMappings)
 	if err != nil {
 		return err
 	}

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -849,11 +849,17 @@ func parseVolumeFlags(flags []string) ([]sandbox.MountBinding, error) {
 	return mounts, nil
 }
 
+// secretMapping holds a parsed --secret flag entry before resolution.
+type secretMapping struct {
+	envVar     string
+	secretName string
+}
+
 // parseSecretFlags parses --secret flag values. Supported syntax:
 //   - env:FOO=SECRET_NAME — inject secret SECRET_NAME as env var FOO
 //   - env:SECRET_NAME     — shorthand: env var name equals the secret name
-func parseSecretFlags(flags []string) ([]apiclient.SecretRef, error) {
-	var refs []apiclient.SecretRef
+func parseSecretFlags(flags []string) ([]secretMapping, error) {
+	var mappings []secretMapping
 	seenEnv := make(map[string]bool)
 
 	for _, raw := range flags {
@@ -894,12 +900,39 @@ func parseSecretFlags(flags []string) ([]apiclient.SecretRef, error) {
 		}
 		seenEnv[envVar] = true
 
-		refs = append(refs, apiclient.SecretRef{
-			Name:   secretName,
-			EnvVar: envVar,
+		mappings = append(mappings, secretMapping{
+			envVar:     envVar,
+			secretName: secretName,
 		})
 	}
-	return refs, nil
+	return mappings, nil
+}
+
+// resolveSecretEnvVars resolves secret names to IDs and returns a map of env var name → secret ID
+// suitable for the secret_env_vars field in the API request.
+func resolveSecretEnvVars(client *apiclient.Client, mappings []secretMapping) (map[string]string, error) {
+	if len(mappings) == 0 {
+		return nil, nil
+	}
+
+	secrets, err := client.ListSecrets()
+	if err != nil {
+		return nil, fmt.Errorf("listing secrets for resolution: %w", err)
+	}
+	byName := make(map[string]string, len(secrets))
+	for _, s := range secrets {
+		byName[s.Name] = s.ID
+	}
+
+	result := make(map[string]string, len(mappings))
+	for _, m := range mappings {
+		id, ok := byName[m.secretName]
+		if !ok {
+			return nil, fmt.Errorf("secret %q not found; push it first with: amika secret push", m.secretName)
+		}
+		result[m.envVar] = id
+	}
+	return result, nil
 }
 
 // parseEnvVarFlags parses --env flag values (KEY=VALUE) into a map.
@@ -1697,6 +1730,12 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	gitValue, _ := cmd.Flags().GetString("git")
 	secretFlags, _ := cmd.Flags().GetStringArray("secret")
 	envFlags, _ := cmd.Flags().GetStringArray("env")
+	preset, _ := cmd.Flags().GetString("preset")
+	size, _ := cmd.Flags().GetString("size")
+
+	if name == "" {
+		name = sandbox.GenerateName()
+	}
 
 	var gitURL string
 	if cmd.Flags().Changed("git") {
@@ -1707,7 +1746,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		gitURL = resolved
 	}
 
-	secrets, err := parseSecretFlags(secretFlags)
+	secretMappings, err := parseSecretFlags(secretFlags)
 	if err != nil {
 		return err
 	}
@@ -1722,12 +1761,19 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		return err
 	}
 
+	secretEnvVars, err := resolveSecretEnvVars(client, secretMappings)
+	if err != nil {
+		return err
+	}
+
 	req := apiclient.CreateSandboxRequest{
-		Name:      name,
-		Provider:  "daytona",
-		GitHubURL: gitURL,
-		EnvVars:   envVars,
-		Secrets:   secrets,
+		Name:          name,
+		Provider:      "daytona",
+		GitHubURL:     gitURL,
+		EnvVars:       envVars,
+		SecretEnvVars: secretEnvVars,
+		Preset:        preset,
+		Size:          size,
 	}
 
 	sb, err := client.CreateSandbox(req)
@@ -1993,6 +2039,7 @@ func init() {
 	sandboxCreateCmd.Flags().String("git", "", "Mount the current git repo root (or repo containing PATH) into /home/amika/workspace/{repo}")
 	sandboxCreateCmd.Flags().Lookup("git").NoOptDefVal = "."
 	sandboxCreateCmd.Flags().Bool("no-clean", false, "With --git, include untracked files from working tree instead of a clean clone")
+	sandboxCreateCmd.Flags().String("size", "", "Sandbox size: \"xs\" or \"m\" (default \"m\", remote only)")
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().StringArray("secret", nil, "Inject a remote secret (env:FOO=SECRET_NAME or env:SECRET_NAME)")
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gofixpoint/amika/internal/apiclient"
 	"github.com/gofixpoint/amika/internal/sandbox"
 )
 
@@ -1055,25 +1054,25 @@ func TestParseSecretFlags(t *testing.T) {
 	tests := []struct {
 		name    string
 		flags   []string
-		want    []apiclient.SecretRef
+		want    []secretMapping
 		wantErr string
 	}{
 		{
 			name:  "env with explicit env var",
 			flags: []string{"env:FOO=MY_SECRET"},
-			want:  []apiclient.SecretRef{{Name: "MY_SECRET", EnvVar: "FOO"}},
+			want:  []secretMapping{{envVar: "FOO", secretName: "MY_SECRET"}},
 		},
 		{
 			name:  "env shorthand",
 			flags: []string{"env:MY_SECRET"},
-			want:  []apiclient.SecretRef{{Name: "MY_SECRET", EnvVar: "MY_SECRET"}},
+			want:  []secretMapping{{envVar: "MY_SECRET", secretName: "MY_SECRET"}},
 		},
 		{
 			name:  "multiple secrets",
 			flags: []string{"env:FOO=SECRET_A", "env:BAR=SECRET_B"},
-			want: []apiclient.SecretRef{
-				{Name: "SECRET_A", EnvVar: "FOO"},
-				{Name: "SECRET_B", EnvVar: "BAR"},
+			want: []secretMapping{
+				{envVar: "FOO", secretName: "SECRET_A"},
+				{envVar: "BAR", secretName: "SECRET_B"},
 			},
 		},
 		{

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -1054,26 +1054,23 @@ func TestParseSecretFlags(t *testing.T) {
 	tests := []struct {
 		name    string
 		flags   []string
-		want    []secretMapping
+		want    map[string]string
 		wantErr string
 	}{
 		{
 			name:  "env with explicit env var",
 			flags: []string{"env:FOO=MY_SECRET"},
-			want:  []secretMapping{{envVar: "FOO", secretName: "MY_SECRET"}},
+			want:  map[string]string{"FOO": "MY_SECRET"},
 		},
 		{
 			name:  "env shorthand",
 			flags: []string{"env:MY_SECRET"},
-			want:  []secretMapping{{envVar: "MY_SECRET", secretName: "MY_SECRET"}},
+			want:  map[string]string{"MY_SECRET": "MY_SECRET"},
 		},
 		{
 			name:  "multiple secrets",
 			flags: []string{"env:FOO=SECRET_A", "env:BAR=SECRET_B"},
-			want: []secretMapping{
-				{envVar: "FOO", secretName: "SECRET_A"},
-				{envVar: "BAR", secretName: "SECRET_B"},
-			},
+			want:  map[string]string{"FOO": "SECRET_A", "BAR": "SECRET_B"},
 		},
 		{
 			name:  "no flags",

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -40,13 +40,9 @@ type CreateSandboxRequest struct {
 	AutoStopInterval   *int              `json:"auto_stop_interval,omitempty"`
 	AutoDeleteInterval *int              `json:"auto_delete_interval,omitempty"`
 	EnvVars            map[string]string `json:"env_vars,omitempty"`
-	Secrets            []SecretRef       `json:"secrets,omitempty"`
-}
-
-// SecretRef references a named secret to inject into a sandbox.
-type SecretRef struct {
-	Name   string `json:"name"`
-	EnvVar string `json:"env_var,omitempty"`
+	SecretEnvVars      map[string]string `json:"secret_env_vars,omitempty"`
+	Preset             string            `json:"preset,omitempty"`
+	Size               string            `json:"size,omitempty"`
 }
 
 // RemoteSandbox represents a sandbox returned by the remote API.


### PR DESCRIPTION
The remote API replaced the secrets array with a secret_env_vars map (env var name → secret ID) and added preset/size fields. This updates the CLI to match:

- Replace Secrets []SecretRef with SecretEnvVars map[string]string
- Resolve --secret flag names to IDs via ListSecrets before sending
- Pass --preset and --size flags through to remote sandbox creation
- Auto-generate sandbox name when --name is omitted (remote mode)