### PR TITLE
feat: send --setup-script contents as setup_script_text for remote sandboxes

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1698,6 +1698,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	envFlags, _ := cmd.Flags().GetStringArray("env")
 	preset, _ := cmd.Flags().GetString("preset")
 	size, _ := cmd.Flags().GetString("size")
+	setupScript, _ := cmd.Flags().GetString("setup-script")
 
 	if name == "" {
 		name = sandbox.GenerateName()
@@ -1727,14 +1728,24 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		return err
 	}
 
+	var setupScriptText string
+	if setupScript != "" {
+		data, err := os.ReadFile(setupScript)
+		if err != nil {
+			return fmt.Errorf("reading setup script %q: %w", setupScript, err)
+		}
+		setupScriptText = string(data)
+	}
+
 	req := apiclient.CreateSandboxRequest{
-		Name:          name,
-		Provider:      "daytona",
-		GitHubURL:     gitURL,
-		EnvVars:       envVars,
-		SecretEnvVars: secretEnvVars,
-		Preset:        preset,
-		Size:          size,
+		Name:            name,
+		Provider:        "daytona",
+		GitHubURL:       gitURL,
+		EnvVars:         envVars,
+		SecretEnvVars:   secretEnvVars,
+		Preset:          preset,
+		Size:            size,
+		SetupScriptText: setupScriptText,
 	}
 
 	sb, err := client.CreateSandbox(req)

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -43,6 +43,7 @@ type CreateSandboxRequest struct {
 	SecretEnvVars      map[string]string `json:"secret_env_vars,omitempty"`
 	Preset             string            `json:"preset,omitempty"`
 	Size               string            `json:"size,omitempty"`
+	SetupScriptText    string            `json:"setup_script_text,omitempty"`
 }
 
 // RemoteSandbox represents a sandbox returned by the remote API.


### PR DESCRIPTION
The --setup-script flag was silently ignored for remote sandbox creation. Now reads the local file and sends its contents via the setup_script_text API field.