### PR TITLE
fix: configure PNPM_HOME so setup scripts can run `pnpm add -g`

### DIFF
--- a/internal/sandbox/presets/.zshrc
+++ b/internal/sandbox/presets/.zshrc
@@ -35,3 +35,6 @@ zstyle ':completion:*' verbose true
 
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
 zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+
+export PNPM_HOME="$HOME/.local/share/pnpm"
+export PATH="$PNPM_HOME:$PATH"

--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -70,4 +70,12 @@ if [[ -f /usr/local/etc/amika/dind-enabled ]]; then
   /usr/lib/amikad/docker-setup.sh
 fi
 
+# Configure pnpm global bin directory so setup.sh can run `pnpm add -g`.
+PNPM_HOME="/home/amika/.local/share/pnpm"
+sudo -H -u amika mkdir -p "$PNPM_HOME"
+cat > /usr/local/etc/amikad/setup/env.sh <<'ENVEOF'
+export PNPM_HOME="$HOME/.local/share/pnpm"
+export PATH="$PNPM_HOME:$PATH"
+ENVEOF
+
 sudo chown -R amika:amika /home/amika

--- a/internal/sandbox/presets/run-hook.sh
+++ b/internal/sandbox/presets/run-hook.sh
@@ -36,6 +36,12 @@ exec >>"$log_file" 2>&1
 
 echo "[$(date -Is)] starting $script_name"
 
+# Source the setup environment if it exists (written by pre-setup.sh).
+if [[ -f /usr/local/etc/amikad/setup/env.sh ]]; then
+  # shellcheck disable=SC1091
+  source /usr/local/etc/amikad/setup/env.sh
+fi
+
 set +e
 "$script_path"
 status=$?


### PR DESCRIPTION
pnpm is installed as root via npm, but the global bin directory is never configured for the amika user. This causes `pnpm add -g` in setup.sh to fail with ERR_PNPM_NO_GLOBAL_BIN_DIR.

pre-setup.sh now creates the PNPM_HOME directory and writes an env.sh file that run-hook.sh sources before executing setup scripts. .zshrc also exports PNPM_HOME for interactive sessions.