### PR TITLE
feat: add `amika sandbox start` command

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -413,6 +413,80 @@ var sandboxStopCmd = &cobra.Command{
 	},
 }
 
+var sandboxStartCmd = &cobra.Command{
+	Use:   "start <name> [<name>...]",
+	Short: "Start one or more sandboxes",
+	Long:  `Start one or more stopped sandboxes.`,
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		target, err := getRemoteTarget(cmd)
+		if err != nil {
+			return err
+		}
+
+		mode := sandboxMode(cmd)
+
+		sandboxesFile, err := config.SandboxesStateFile()
+		if err != nil {
+			return err
+		}
+		store := sandbox.NewStore(sandboxesFile)
+
+		var remoteClient *apiclient.Client
+		if mode == "remote" || mode == "both" {
+			remoteClient, err = getRemoteClient(target)
+			if err != nil {
+				return err
+			}
+		}
+
+		var errs []string
+		for _, name := range args {
+			// Remote-only mode: skip local entirely.
+			if mode == "remote" {
+				if remoteClient != nil {
+					if remoteErr := remoteClient.StartSandbox(name); remoteErr != nil {
+						errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
+					} else {
+						fmt.Printf("Sandbox %q started (remote)\n", name)
+					}
+				}
+				continue
+			}
+
+			info, localErr := store.Get(name)
+			if localErr != nil && mode == "both" && remoteClient != nil {
+				// Not found locally, try remote.
+				if remoteErr := remoteClient.StartSandbox(name); remoteErr != nil {
+					errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
+				} else {
+					fmt.Printf("Sandbox %q started (remote)\n", name)
+				}
+				continue
+			}
+			if localErr != nil {
+				errs = append(errs, fmt.Sprintf("sandbox %q not found", name))
+				continue
+			}
+
+			if info.Provider == "docker" {
+				if err := sandbox.StartDockerSandbox(name); err != nil {
+					errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, err))
+					continue
+				}
+			}
+
+			fmt.Printf("Sandbox %q started\n", name)
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("%s", strings.Join(errs, "\n"))
+		}
+		return nil
+	},
+}
+
 var sandboxDeleteCmd = &cobra.Command{
 	Use:     "delete <name> [<name>...]",
 	Aliases: []string{"rm", "remove"},
@@ -1987,6 +2061,7 @@ func init() {
 	rootCmd.AddCommand(sandboxCmd)
 	sandboxCmd.AddCommand(sandboxCreateCmd)
 	sandboxCmd.AddCommand(sandboxStopCmd)
+	sandboxCmd.AddCommand(sandboxStartCmd)
 	sandboxCmd.AddCommand(sandboxDeleteCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxConnectCmd)

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -113,6 +113,14 @@ func (c *Client) StopSandbox(name string) error {
 	return nil
 }
 
+// StartSandbox starts a sandbox on the remote API.
+func (c *Client) StartSandbox(name string) error {
+	if err := c.doJSON("POST", "/api/sandboxes/"+name+"/start", nil, nil); err != nil {
+		return fmt.Errorf("remote start sandbox: %w", err)
+	}
+	return nil
+}
+
 // DeleteSandbox deletes a sandbox on the remote API.
 func (c *Client) DeleteSandbox(name string) error {
 	if err := c.doJSON("DELETE", "/api/sandboxes/"+name, nil, nil); err != nil {

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -76,6 +76,16 @@ func StopDockerSandbox(name string) error {
 	return nil
 }
 
+// StartDockerSandbox starts a stopped Docker container with the given name.
+func StartDockerSandbox(name string) error {
+	cmd := exec.Command("docker", "start", name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start docker sandbox: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 // RemoveDockerSandbox stops and removes the Docker container with the given name.
 func RemoveDockerSandbox(name string) error {
 	cmd := exec.Command("docker", "rm", "-f", name)


### PR DESCRIPTION
## Summary
- Adds `amika sandbox start` command to restart stopped sandboxes without recreating them
- Mirrors the existing `sandbox stop` implementation with local/remote/both mode support
- Adds `StartDockerSandbox()` (runs `docker start`) and `StartSandbox()` API client method (`POST /api/sandboxes/{name}/start`)

## Test plan
- [x] `make build` compiles successfully
- [x] `make lint` and `make vet` pass
- [x] `amika sandbox create --name test && amika sandbox stop test && amika sandbox start test && amika sandbox delete test --force`
- [ ] `amika sandbox start --remote <name>` works against remote API