### PR TITLE
feat: add .amika/config.toml with Go install setup script

### DIFF
--- a/.amika/config.toml
+++ b/.amika/config.toml
@@ -1,0 +1,2 @@
+[lifecycle]
+setup_script = ".amika/scripts/setup.sh"

--- a/.amika/scripts/setup.sh
+++ b/.amika/scripts/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# Check if Go is already installed
+if command -v go &>/dev/null; then
+    echo "Go is already installed: $(go version)"
+    exit 0
+fi
+
+echo "Go not found. Installing..."
+
+GO_VERSION="1.26.1"
+ARCH=$(dpkg --print-architecture 2>/dev/null || uname -m)
+
+# Normalize architecture name
+case "$ARCH" in
+    x86_64|amd64) ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz
+tar -C /usr/local -xzf /tmp/go.tar.gz
+rm /tmp/go.tar.gz
+
+# Make Go available system-wide
+echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/golang.sh
+
+export PATH=$PATH:/usr/local/go/bin
+echo "Installed: $(go version)"


### PR DESCRIPTION
## Summary
- Adds `.amika/config.toml` with a lifecycle setup script (no services)
- Adds `.amika/scripts/setup.sh` that checks if Go is installed and installs Go 1.26.1 if missing
- Supports both amd64 and arm64 architectures

## Test plan
- [ ] Verify `amika sandbox create --git` picks up the config and mounts the setup script
- [ ] Test in a sandbox without Go pre-installed to confirm installation works
- [ ] Test in a sandbox with Go already installed to confirm it skips installation