### PR TITLE
feat: poll sandbox create endpoint until provisioning completes

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1827,6 +1827,13 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		return err
 	}
 
+	fmt.Fprintf(cmd.OutOrStdout(), "Sandbox %q initializing...\n", sb.Name)
+
+	sb, err = client.WaitForSandbox(sb.Name)
+	if err != nil {
+		return err
+	}
+
 	fmt.Fprintf(cmd.OutOrStdout(), "Sandbox %q created (remote)\n", sb.Name)
 
 	connect, _ := cmd.Flags().GetBool("connect")

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -66,12 +66,41 @@ func (c *Client) ListSandboxes() ([]RemoteSandbox, error) {
 }
 
 // CreateSandbox creates a sandbox on the remote API.
+// The endpoint returns 202 Accepted with the sandbox in "initializing" state.
+// Use GetSandbox or WaitForSandbox to poll until provisioning completes.
 func (c *Client) CreateSandbox(req CreateSandboxRequest) (*RemoteSandbox, error) {
 	var result RemoteSandbox
 	if err := c.doJSON("POST", "/api/sandboxes", req, &result); err != nil {
 		return nil, fmt.Errorf("remote create sandbox: %w", err)
 	}
 	return &result, nil
+}
+
+// GetSandbox fetches a single sandbox by name from the remote API.
+func (c *Client) GetSandbox(name string) (*RemoteSandbox, error) {
+	var result RemoteSandbox
+	if err := c.doJSON("GET", "/api/sandboxes/"+name, nil, &result); err != nil {
+		return nil, fmt.Errorf("remote get sandbox: %w", err)
+	}
+	return &result, nil
+}
+
+// WaitForSandbox polls GET /api/sandboxes/{name} until the sandbox reaches
+// a ready or terminal state. It polls every 3 seconds.
+func (c *Client) WaitForSandbox(name string) (*RemoteSandbox, error) {
+	for {
+		sb, err := c.GetSandbox(name)
+		if err != nil {
+			return nil, err
+		}
+		switch sb.State {
+		case "active", "running", "started":
+			return sb, nil
+		case "failed":
+			return sb, fmt.Errorf("sandbox provisioning failed")
+		}
+		time.Sleep(3 * time.Second)
+	}
 }
 
 // SSHInfo contains SSH connection details for a remote sandbox.


### PR DESCRIPTION
The remote sandbox create API is now asynchronous (returns 202 with state "initializing"). Add GetSandbox and WaitForSandbox to the API client, and update the CLI to poll every 3s until the sandbox reaches a ready state.