### PR TITLE
feat: add `secret claude` commands for credential upload, list, and delete

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1811,15 +1811,19 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		setupScriptText = string(data)
 	}
 
+	// Auto-select Claude credential if one exists.
+	claudeCredentialName := autoSelectClaudeCredential(client)
+
 	req := apiclient.CreateSandboxRequest{
-		Name:            name,
-		Provider:        "daytona",
-		GitHubURL:       gitURL,
-		EnvVars:         envVars,
-		SecretEnvVars:   secretEnvVars,
-		Preset:          preset,
-		Size:            size,
-		SetupScriptText: setupScriptText,
+		Name:                 name,
+		Provider:             "daytona",
+		GitHubURL:            gitURL,
+		EnvVars:              envVars,
+		SecretEnvVars:        secretEnvVars,
+		Preset:               preset,
+		Size:                 size,
+		SetupScriptText:      setupScriptText,
+		ClaudeCredentialName: claudeCredentialName,
 	}
 
 	sb, err := client.CreateSandbox(req)
@@ -1848,6 +1852,17 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 // remote sandbox creation. If the value is already an HTTP(S) or SSH URL, it is
 // returned directly. Otherwise it is treated as a local path and the origin
 // remote URL is extracted.
+// autoSelectClaudeCredential returns the name of the user's Claude credential
+// if exactly one exists on the remote. Returns empty string on any error or
+// if no credentials are uploaded.
+func autoSelectClaudeCredential(client *apiclient.Client) string {
+	creds, err := client.ListClaudeSecrets()
+	if err != nil || len(creds) != 1 {
+		return ""
+	}
+	return creds[0].Name
+}
+
 func resolveGitURL(value string) (string, error) {
 	// Already a URL — use as-is.
 	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "git@") {

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -2,8 +2,13 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -398,12 +403,340 @@ func maskValue(value string) string {
 	return value[:4] + strings.Repeat("*", len(value)-8) + value[len(value)-4:]
 }
 
+var secretClaudeCmd = &cobra.Command{
+	Use:   "claude",
+	Short: "Manage Claude Code credentials",
+	Long:  `Upload and list Claude Code credentials for sandbox authentication.`,
+}
+
+func newSecretClaudeUploadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "Upload Claude Code credentials to the remote secrets store",
+		Long: `Upload Claude Code credentials to the remote Amika secrets store.
+
+Scans your system for Claude credentials (API keys and OAuth tokens) and
+lets you choose which one to upload. On macOS, the keychain is also checked.
+
+You can also provide credentials directly via --value or from a file via --from-file.
+
+Examples:
+  amika secret claude upload
+  amika secret claude upload --name "Claude OAuth (Work Laptop)"
+  amika secret claude upload --from-file ~/.claude/.credentials.json
+  amika secret claude upload --value '{"claudeAiOauth":{...}}'`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			nameFlag, _ := cmd.Flags().GetString("name")
+			value, _ := cmd.Flags().GetString("value")
+			fromFile, _ := cmd.Flags().GetString("from-file")
+			typeFlag, _ := cmd.Flags().GetString("type")
+
+			var credValue string
+			var credType string // "oauth" or "api_key"
+
+			switch {
+			case value != "":
+				credValue = value
+				credType = typeFlag
+			case fromFile != "":
+				data, err := os.ReadFile(fromFile)
+				if err != nil {
+					return fmt.Errorf("reading credentials file: %w", err)
+				}
+				credValue = strings.TrimSpace(string(data))
+				credType = typeFlag
+			case cmd.Flags().Changed("type"):
+				// --type was set explicitly without --value/--from-file;
+				// auto-resolve based on the requested type.
+				resolved, err := autoResolveClaudeCredential(typeFlag)
+				if err != nil {
+					return err
+				}
+				credValue = resolved
+				credType = typeFlag
+			default:
+				// Interactive discovery — show all found credentials.
+				cred, err := discoverAndPickClaudeCredential(cmd)
+				if err != nil {
+					return err
+				}
+				credValue = cred.Value
+				credType = claudeCredentialTypeToAPI(cred.Type)
+			}
+
+			// Validate: OAuth credentials must be valid JSON.
+			if credType == "oauth" && !json.Valid([]byte(credValue)) {
+				return fmt.Errorf("OAuth credentials must be valid JSON")
+			}
+
+			// Name is required.
+			name := nameFlag
+			if name == "" {
+				reader := bufio.NewReader(cmd.InOrStdin())
+				defaultName := "Claude OAuth"
+				if credType == "api_key" {
+					defaultName = "Claude API Key"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Name for this credential [%s]: ", defaultName)
+				input, err := reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("reading name: %w", err)
+				}
+				name = strings.TrimSpace(input)
+				if name == "" {
+					name = defaultName
+				}
+			}
+
+			client, err := getSecretsClient()
+			if err != nil {
+				return fmt.Errorf("authenticating with remote API: %w", err)
+			}
+
+			summary, err := client.CreateClaudeSecret(apiclient.CreateClaudeSecretRequest{
+				Name:  name,
+				Value: credValue,
+				Type:  credType,
+			})
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Created Claude credential %q\n", summary.Name)
+			return nil
+		},
+	}
+
+	cmd.Flags().String("name", "", "Human-readable label for the credential (required, prompted if omitted)")
+	cmd.Flags().String("value", "", "Credential value (skips interactive discovery)")
+	cmd.Flags().String("from-file", "", "Path to a credentials file (skips interactive discovery)")
+	cmd.Flags().String("type", "oauth", "Credential type: \"oauth\" (default) or \"api_key\"")
+
+	return cmd
+}
+
+// discoverAndPickClaudeCredential scans the local system for Claude credentials,
+// displays them, and lets the user pick one to upload.
+func discoverAndPickClaudeCredential(cmd *cobra.Command) (auth.ClaudeCredential, error) {
+	// Also check macOS keychain if on darwin.
+	creds, err := discoverAllClaudeCredentials()
+	if err != nil {
+		return auth.ClaudeCredential{}, err
+	}
+
+	if len(creds) == 0 {
+		return auth.ClaudeCredential{}, fmt.Errorf("no Claude credentials found on this system\n\nUse --value or --from-file to provide credentials manually")
+	}
+
+	// Display discovered credentials.
+	fmt.Fprintln(cmd.OutOrStdout(), "Discovered Claude credentials:")
+	fmt.Fprintln(cmd.OutOrStdout())
+	for i, c := range creds {
+		fmt.Fprintf(cmd.OutOrStdout(), "  [%d] %s  (%s)\n", i+1, c.Type, c.Source)
+	}
+	fmt.Fprintln(cmd.OutOrStdout())
+
+	// If only one, ask for confirmation directly.
+	var selected auth.ClaudeCredential
+	reader := bufio.NewReader(cmd.InOrStdin())
+	if len(creds) == 1 {
+		selected = creds[0]
+		fmt.Fprintf(cmd.OutOrStdout(), "Upload this credential? [y/N] ")
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "Select credential to upload [1-%d]: ", len(creds))
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return auth.ClaudeCredential{}, fmt.Errorf("reading selection: %w", err)
+		}
+		input = strings.TrimSpace(input)
+		choice, err := strconv.Atoi(input)
+		if err != nil || choice < 1 || choice > len(creds) {
+			return auth.ClaudeCredential{}, fmt.Errorf("invalid selection: %q", input)
+		}
+		selected = creds[choice-1]
+
+		fmt.Fprintf(cmd.OutOrStdout(), "\nUpload %s from %s? [y/N] ", selected.Type, selected.Source)
+	}
+
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return auth.ClaudeCredential{}, fmt.Errorf("reading confirmation: %w", err)
+	}
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		return auth.ClaudeCredential{}, fmt.Errorf("aborted")
+	}
+
+	return selected, nil
+}
+
+// discoverAllClaudeCredentials finds Claude credentials from files and (on macOS) keychain.
+func discoverAllClaudeCredentials() ([]auth.ClaudeCredential, error) {
+	creds, err := auth.DiscoverClaudeCredentials("")
+	if err != nil {
+		return nil, err
+	}
+
+	// On macOS, also try the keychain.
+	if runtime.GOOS == "darwin" {
+		keychainValue, err := readClaudeCredentialFromKeychain()
+		if err == nil && keychainValue != "" && json.Valid([]byte(keychainValue)) {
+			creds = append(creds, auth.ClaudeCredential{
+				Type:   "OAuth",
+				Source: "macOS Keychain",
+				Value:  keychainValue,
+			})
+		}
+	}
+
+	return creds, nil
+}
+
+// readClaudeCredentialFromKeychain reads Claude Code credentials from the macOS keychain.
+func readClaudeCredentialFromKeychain() (string, error) {
+	out, err := exec.Command("security", "find-generic-password", "-s", "Claude Code-credentials", "-w").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func newSecretClaudeListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List uploaded Claude credentials",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			client, err := getSecretsClient()
+			if err != nil {
+				return fmt.Errorf("authenticating with remote API: %w", err)
+			}
+
+			items, err := client.ListClaudeSecrets()
+			if err != nil {
+				return err
+			}
+
+			if len(items) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No Claude credentials found.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tNAME\tTYPE")
+			for _, item := range items {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", item.ID, item.Name, item.Type)
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func newSecretClaudeDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a Claude credential by ID",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			client, err := getSecretsClient()
+			if err != nil {
+				return fmt.Errorf("authenticating with remote API: %w", err)
+			}
+
+			if err := client.DeleteClaudeSecret(args[0]); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted credential %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+// autoResolveClaudeCredential resolves a credential value automatically based
+// on the requested type, without interactive prompts.
+//   - "api_key": reads the ANTHROPIC_API_KEY environment variable.
+//   - "oauth": on macOS reads from the keychain, otherwise from credential files.
+func autoResolveClaudeCredential(credType string) (string, error) {
+	if credType == "api_key" {
+		key := os.Getenv("ANTHROPIC_API_KEY")
+		if key == "" {
+			return "", fmt.Errorf("ANTHROPIC_API_KEY environment variable is not set")
+		}
+		return key, nil
+	}
+
+	// OAuth: try keychain on macOS, then credential files.
+	if runtime.GOOS == "darwin" {
+		value, err := readClaudeCredentialFromKeychain()
+		if err == nil && value != "" {
+			return value, nil
+		}
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+
+	oauthPaths := []string{
+		filepath.Join(homeDir, ".claude", ".credentials.json"),
+		filepath.Join(homeDir, ".claude-oauth-credentials.json"),
+	}
+	for _, path := range oauthPaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		value := strings.TrimSpace(string(data))
+		if json.Valid([]byte(value)) {
+			return value, nil
+		}
+	}
+
+	return "", fmt.Errorf("no OAuth credentials found; on macOS check keychain, or provide --value or --from-file")
+}
+
+// claudeCredentialTypeToAPI maps the discovery type label to the API type field.
+func claudeCredentialTypeToAPI(discoveryType string) string {
+	switch discoveryType {
+	case "API Key":
+		return "api_key"
+	default:
+		return "oauth"
+	}
+}
+
 func init() {
 	rootCmd.AddCommand(secretCmd)
 	secretCmd.AddCommand(newSecretExtractCmd())
 	secretCmd.AddCommand(newSecretPushCmd())
+	secretCmd.AddCommand(secretClaudeCmd)
+	secretClaudeCmd.AddCommand(newSecretClaudeUploadCmd())
+	secretClaudeCmd.AddCommand(newSecretClaudeListCmd())
+	secretClaudeCmd.AddCommand(newSecretClaudeDeleteCmd())
 
 	rootCmd.AddCommand(secretsAliasCmd)
 	secretsAliasCmd.AddCommand(newSecretExtractCmd())
 	secretsAliasCmd.AddCommand(newSecretPushCmd())
+
+	// Add claude subcommand to the alias too.
+	secretsClaudeAlias := &cobra.Command{
+		Use:    "claude",
+		Short:  "Manage Claude Code credentials",
+		Long:   `Upload and list Claude Code credentials for sandbox authentication.`,
+		Hidden: true,
+	}
+	secretsAliasCmd.AddCommand(secretsClaudeAlias)
+	secretsClaudeAlias.AddCommand(newSecretClaudeUploadCmd())
+	secretsClaudeAlias.AddCommand(newSecretClaudeListCmd())
+	secretsClaudeAlias.AddCommand(newSecretClaudeDeleteCmd())
 }

--- a/cmd/amika/secrets_test.go
+++ b/cmd/amika/secrets_test.go
@@ -380,6 +380,210 @@ func TestMaskValue(t *testing.T) {
 	}
 }
 
+func TestClaudeCredentialTypeToAPI(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"OAuth", "oauth"},
+		{"API Key", "api_key"},
+		{"something else", "oauth"},
+		{"", "oauth"},
+	}
+	for _, tt := range tests {
+		got := claudeCredentialTypeToAPI(tt.input)
+		if got != tt.want {
+			t.Errorf("claudeCredentialTypeToAPI(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSecretClaudeUpload_ValueFlag(t *testing.T) {
+	bin := buildAmika(t)
+
+	// With --value and --name, the command will try to hit the API and fail,
+	// but we can verify it gets past validation.
+	cmd := exec.Command(bin, "secret", "claude", "upload",
+		"--value", `{"claudeAiOauth":{"accessToken":"test"}}`,
+		"--name", "Test OAuth")
+	out, err := cmd.CombinedOutput()
+	// Expect failure due to no auth, but NOT a validation error.
+	if err == nil {
+		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	}
+	text := string(out)
+	if strings.Contains(text, "must be valid JSON") {
+		t.Fatalf("unexpected validation error for valid JSON:\n%s", text)
+	}
+}
+
+func TestSecretClaudeUpload_InvalidOAuthJSON(t *testing.T) {
+	bin := buildAmika(t)
+
+	cmd := exec.Command(bin, "secret", "claude", "upload",
+		"--value", "not-json",
+		"--type", "oauth",
+		"--name", "Bad")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error, got success\noutput:\n%s", out)
+	}
+	if !strings.Contains(string(out), "OAuth credentials must be valid JSON") {
+		t.Fatalf("expected JSON validation error, got:\n%s", out)
+	}
+}
+
+func TestSecretClaudeUpload_APIKeyNoJSONValidation(t *testing.T) {
+	bin := buildAmika(t)
+
+	// api_key type should NOT require valid JSON — it should get past validation
+	// and fail at the auth step.
+	cmd := exec.Command(bin, "secret", "claude", "upload",
+		"--value", "sk-ant-api03-plaintext",
+		"--type", "api_key",
+		"--name", "My Key")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	}
+	text := string(out)
+	if strings.Contains(text, "must be valid JSON") {
+		t.Fatalf("api_key should not require JSON validation:\n%s", text)
+	}
+}
+
+func TestSecretClaudeUpload_TypeAPIKeyReadsEnv(t *testing.T) {
+	bin := buildAmika(t)
+
+	// --type api_key without --value should read ANTHROPIC_API_KEY.
+	// With the env var unset, it should produce an error.
+	cmd := exec.Command(bin, "secret", "claude", "upload",
+		"--type", "api_key",
+		"--name", "Key")
+	cmd.Env = withEnv(os.Environ(), "ANTHROPIC_API_KEY=")
+	// Filter out the env var entirely.
+	var env []string
+	for _, e := range cmd.Env {
+		if !strings.HasPrefix(e, "ANTHROPIC_API_KEY=") {
+			env = append(env, e)
+		}
+	}
+	cmd.Env = env
+
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error, got success\noutput:\n%s", out)
+	}
+	if !strings.Contains(string(out), "ANTHROPIC_API_KEY environment variable is not set") {
+		t.Fatalf("expected ANTHROPIC_API_KEY error, got:\n%s", out)
+	}
+}
+
+func TestSecretClaudeUpload_TypeAPIKeyWithEnvSet(t *testing.T) {
+	bin := buildAmika(t)
+
+	// With ANTHROPIC_API_KEY set, it should get past resolution and fail at auth.
+	cmd := exec.Command(bin, "secret", "claude", "upload",
+		"--type", "api_key",
+		"--name", "Key From Env")
+	cmd.Env = withEnv(os.Environ(), "ANTHROPIC_API_KEY=sk-ant-api03-test")
+
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	}
+	text := string(out)
+	// Should NOT be a resolution error.
+	if strings.Contains(text, "ANTHROPIC_API_KEY environment variable is not set") {
+		t.Fatalf("unexpected resolution error when env var is set:\n%s", text)
+	}
+}
+
+func TestSecretClaudeUpload_FromFile(t *testing.T) {
+	bin := buildAmika(t)
+
+	credFile := filepath.Join(t.TempDir(), "creds.json")
+	if err := os.WriteFile(credFile, []byte(`{"claudeAiOauth":{"accessToken":"test"}}`), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cmd := exec.Command(bin, "secret", "claude", "upload",
+		"--from-file", credFile,
+		"--name", "From File")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	}
+	text := string(out)
+	// Should get past file reading and validation.
+	if strings.Contains(text, "reading credentials file") {
+		t.Fatalf("unexpected file read error:\n%s", text)
+	}
+	if strings.Contains(text, "must be valid JSON") {
+		t.Fatalf("unexpected validation error:\n%s", text)
+	}
+}
+
+func TestSecretClaudeUpload_FromFileMissing(t *testing.T) {
+	bin := buildAmika(t)
+
+	cmd := exec.Command(bin, "secret", "claude", "upload",
+		"--from-file", "/nonexistent/creds.json",
+		"--name", "Missing")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error, got success\noutput:\n%s", out)
+	}
+	if !strings.Contains(string(out), "reading credentials file") {
+		t.Fatalf("expected file read error, got:\n%s", out)
+	}
+}
+
+func TestSecretClaudeList_NoAuth(t *testing.T) {
+	bin := buildAmika(t)
+
+	// Without auth, should fail with auth error, not crash.
+	cmd := exec.Command(bin, "secret", "claude", "list")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	}
+	// Should not panic or give unexpected errors.
+	text := string(out)
+	if strings.Contains(text, "panic") {
+		t.Fatalf("unexpected panic:\n%s", text)
+	}
+}
+
+func TestSecretClaudeDelete_NoArgs(t *testing.T) {
+	bin := buildAmika(t)
+
+	cmd := exec.Command(bin, "secret", "claude", "delete")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error, got success\noutput:\n%s", out)
+	}
+	if !strings.Contains(string(out), "accepts 1 arg(s)") {
+		t.Fatalf("expected args error, got:\n%s", out)
+	}
+}
+
+func TestSecretClaudePluralAlias(t *testing.T) {
+	bin := buildAmika(t)
+
+	// "secrets claude list" should also work.
+	cmd := exec.Command(bin, "secrets", "claude", "list")
+	out, err := cmd.CombinedOutput()
+	// Will fail with auth error, but the command should be recognized.
+	if err == nil {
+		return // surprisingly succeeded, that's fine
+	}
+	text := string(out)
+	if strings.Contains(text, "unknown command") {
+		t.Fatalf("secrets plural alias not working:\n%s", text)
+	}
+}
+
 func writeJSONFixture(t *testing.T, path string, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -34,16 +34,17 @@ func NewClientWithTokenSource(baseURL string, ts TokenSource) *Client {
 
 // CreateSandboxRequest is the request body for POST /api/sandboxes.
 type CreateSandboxRequest struct {
-	Name               string            `json:"name,omitempty"`
-	Provider           string            `json:"provider,omitempty"`
-	GitHubURL          string            `json:"github_url,omitempty"`
-	AutoStopInterval   *int              `json:"auto_stop_interval,omitempty"`
-	AutoDeleteInterval *int              `json:"auto_delete_interval,omitempty"`
-	EnvVars            map[string]string `json:"env_vars,omitempty"`
-	SecretEnvVars      map[string]string `json:"secret_env_vars,omitempty"`
-	Preset             string            `json:"preset,omitempty"`
-	Size               string            `json:"size,omitempty"`
-	SetupScriptText    string            `json:"setup_script_text,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Provider             string            `json:"provider,omitempty"`
+	GitHubURL            string            `json:"github_url,omitempty"`
+	AutoStopInterval     *int              `json:"auto_stop_interval,omitempty"`
+	AutoDeleteInterval   *int              `json:"auto_delete_interval,omitempty"`
+	EnvVars              map[string]string `json:"env_vars,omitempty"`
+	SecretEnvVars        map[string]string `json:"secret_env_vars,omitempty"`
+	Preset               string            `json:"preset,omitempty"`
+	Size                 string            `json:"size,omitempty"`
+	SetupScriptText      string            `json:"setup_script_text,omitempty"`
+	ClaudeCredentialName string            `json:"claude_credential_name,omitempty"`
 }
 
 // RemoteSandbox represents a sandbox returned by the remote API.
@@ -198,6 +199,53 @@ func (c *Client) CreateSecret(req CreateSecretRequest) error {
 func (c *Client) UpdateSecret(id string, req UpdateSecretRequest) error {
 	if err := c.doJSON("PUT", "/api/secrets/"+id, req, nil); err != nil {
 		return fmt.Errorf("remote update secret: %w", err)
+	}
+	return nil
+}
+
+// CreateClaudeSecretRequest is the request body for POST /api/secrets/claude.
+type CreateClaudeSecretRequest struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Type  string `json:"type,omitempty"` // "oauth" (default) or "api_key"
+}
+
+// ClaudeSecretSummary is the response from POST /api/secrets/claude.
+type ClaudeSecretSummary struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Scope string `json:"scope"`
+}
+
+// ClaudeSecretListItem is an item in the GET /api/secrets/claude response.
+type ClaudeSecretListItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// CreateClaudeSecret uploads Claude Code credentials to the remote API.
+func (c *Client) CreateClaudeSecret(req CreateClaudeSecretRequest) (*ClaudeSecretSummary, error) {
+	var result ClaudeSecretSummary
+	if err := c.doJSON("POST", "/api/secrets/claude", req, &result); err != nil {
+		return nil, fmt.Errorf("remote create claude secret: %w", err)
+	}
+	return &result, nil
+}
+
+// ListClaudeSecrets lists Claude credentials for the current user.
+func (c *Client) ListClaudeSecrets() ([]ClaudeSecretListItem, error) {
+	var result []ClaudeSecretListItem
+	if err := c.doJSON("GET", "/api/secrets/claude", nil, &result); err != nil {
+		return nil, fmt.Errorf("remote list claude secrets: %w", err)
+	}
+	return result, nil
+}
+
+// DeleteClaudeSecret deletes a credential by ID.
+func (c *Client) DeleteClaudeSecret(id string) error {
+	if err := c.doJSON("DELETE", "/api/secrets/"+id, nil, nil); err != nil {
+		return fmt.Errorf("remote delete secret: %w", err)
 	}
 	return nil
 }

--- a/internal/auth/discovery.go
+++ b/internal/auth/discovery.go
@@ -567,6 +567,88 @@ func parseEpochMillis(raw any) (int64, error) {
 	}
 }
 
+// ClaudeCredential represents a single discovered Claude credential with its
+// type and source preserved, suitable for interactive selection.
+type ClaudeCredential struct {
+	// Type is a human-readable label: "API Key" or "OAuth".
+	Type string
+	// Source describes where the credential was found (e.g. file path or "macOS Keychain").
+	Source string
+	// Value is the raw credential data to upload: the API key string or the full OAuth JSON.
+	Value string
+}
+
+// DiscoverClaudeCredentials scans local credential sources and returns all
+// Claude-specific credentials found, preserving their type and source.
+func DiscoverClaudeCredentials(homeDir string) ([]ClaudeCredential, error) {
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get home directory: %w", err)
+		}
+	}
+
+	var creds []ClaudeCredential
+
+	// Check for API keys in Claude config files.
+	apiKeyPaths := []string{
+		filepath.Join(homeDir, ".claude.json.api"),
+		filepath.Join(homeDir, ".claude.json"),
+	}
+	apiKeyFields := []string{"primaryApiKey", "apiKey", "anthropicApiKey", "customApiKey"}
+
+	for _, path := range apiKeyPaths {
+		obj, found, err := readJSONObjectIfExists(path)
+		if err != nil || !found {
+			continue
+		}
+		for _, field := range apiKeyFields {
+			value, exists, err := getStringPath(obj, field)
+			if err != nil || !exists || value == "" {
+				continue
+			}
+			if strings.HasPrefix(value, "sk-ant-") {
+				creds = append(creds, ClaudeCredential{
+					Type:   "API Key",
+					Source: path,
+					Value:  value,
+				})
+				break // one API key per file is enough
+			}
+		}
+	}
+
+	// Check for OAuth credentials in files.
+	oauthPaths := []string{
+		filepath.Join(homeDir, ".claude", ".credentials.json"),
+		filepath.Join(homeDir, ".claude-oauth-credentials.json"),
+	}
+	for _, path := range oauthPaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		raw := strings.TrimSpace(string(data))
+		// Verify it has claudeAiOauth.accessToken.
+		obj, found, err := readJSONObjectIfExists(path)
+		if err != nil || !found {
+			continue
+		}
+		token, exists, _ := getStringPath(obj, "claudeAiOauth.accessToken")
+		if !exists || token == "" {
+			continue
+		}
+		creds = append(creds, ClaudeCredential{
+			Type:   "OAuth",
+			Source: path,
+			Value:  raw,
+		})
+	}
+
+	return creds, nil
+}
+
 // ClaudeCredentialPaths returns the home-relative paths where Claude Code
 // stores credentials. Callers should join each with a home directory.
 func ClaudeCredentialPaths() []string {

--- a/internal/auth/discovery_test.go
+++ b/internal/auth/discovery_test.go
@@ -374,6 +374,122 @@ func TestOpenCodeCredentialPaths(t *testing.T) {
 	}
 }
 
+func TestDiscoverClaudeCredentials_APIKeyOnly(t *testing.T) {
+	home := t.TempDir()
+	writeDiscoveryFixture(t, filepath.Join(home, ".claude.json"), `{"apiKey":"sk-ant-test-key"}`)
+
+	creds, err := DiscoverClaudeCredentials(home)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeCredentials() error: %v", err)
+	}
+	if len(creds) != 1 {
+		t.Fatalf("got %d credentials, want 1", len(creds))
+	}
+	if creds[0].Type != "API Key" {
+		t.Fatalf("Type = %q, want %q", creds[0].Type, "API Key")
+	}
+	if creds[0].Value != "sk-ant-test-key" {
+		t.Fatalf("Value = %q, want %q", creds[0].Value, "sk-ant-test-key")
+	}
+}
+
+func TestDiscoverClaudeCredentials_OAuthOnly(t *testing.T) {
+	home := t.TempDir()
+	oauthJSON := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-xxx","refreshToken":"sk-ant-ort01-xxx","expiresAt":9999999999999}}`
+	writeDiscoveryFixture(t, filepath.Join(home, ".claude", ".credentials.json"), oauthJSON)
+
+	creds, err := DiscoverClaudeCredentials(home)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeCredentials() error: %v", err)
+	}
+	if len(creds) != 1 {
+		t.Fatalf("got %d credentials, want 1", len(creds))
+	}
+	if creds[0].Type != "OAuth" {
+		t.Fatalf("Type = %q, want %q", creds[0].Type, "OAuth")
+	}
+	if creds[0].Value != oauthJSON {
+		t.Fatalf("Value = %q, want %q", creds[0].Value, oauthJSON)
+	}
+	if creds[0].Source != filepath.Join(home, ".claude", ".credentials.json") {
+		t.Fatalf("Source = %q, want path ending in .claude/.credentials.json", creds[0].Source)
+	}
+}
+
+func TestDiscoverClaudeCredentials_BothAPIKeyAndOAuth(t *testing.T) {
+	home := t.TempDir()
+	writeDiscoveryFixture(t, filepath.Join(home, ".claude.json"), `{"apiKey":"sk-ant-api-key"}`)
+	writeDiscoveryFixture(t, filepath.Join(home, ".claude", ".credentials.json"), `{"claudeAiOauth":{"accessToken":"oauth-token"}}`)
+
+	creds, err := DiscoverClaudeCredentials(home)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeCredentials() error: %v", err)
+	}
+	if len(creds) != 2 {
+		t.Fatalf("got %d credentials, want 2", len(creds))
+	}
+
+	var types []string
+	for _, c := range creds {
+		types = append(types, c.Type)
+	}
+	if types[0] != "API Key" || types[1] != "OAuth" {
+		t.Fatalf("types = %v, want [API Key, OAuth]", types)
+	}
+}
+
+func TestDiscoverClaudeCredentials_EmptyHome(t *testing.T) {
+	home := t.TempDir()
+
+	creds, err := DiscoverClaudeCredentials(home)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeCredentials() error: %v", err)
+	}
+	if len(creds) != 0 {
+		t.Fatalf("got %d credentials, want 0", len(creds))
+	}
+}
+
+func TestDiscoverClaudeCredentials_SkipsNonAnthropicKeys(t *testing.T) {
+	home := t.TempDir()
+	writeDiscoveryFixture(t, filepath.Join(home, ".claude.json"), `{"apiKey":"not-an-anthropic-key"}`)
+
+	creds, err := DiscoverClaudeCredentials(home)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeCredentials() error: %v", err)
+	}
+	if len(creds) != 0 {
+		t.Fatalf("got %d credentials, want 0 (non sk-ant- key should be skipped)", len(creds))
+	}
+}
+
+func TestDiscoverClaudeCredentials_SkipsOAuthWithoutAccessToken(t *testing.T) {
+	home := t.TempDir()
+	writeDiscoveryFixture(t, filepath.Join(home, ".claude", ".credentials.json"), `{"claudeAiOauth":{"refreshToken":"rt"}}`)
+
+	creds, err := DiscoverClaudeCredentials(home)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeCredentials() error: %v", err)
+	}
+	if len(creds) != 0 {
+		t.Fatalf("got %d credentials, want 0 (missing accessToken should be skipped)", len(creds))
+	}
+}
+
+func TestDiscoverClaudeCredentials_BothOAuthPaths(t *testing.T) {
+	home := t.TempDir()
+	writeDiscoveryFixture(t, filepath.Join(home, ".claude", ".credentials.json"), `{"claudeAiOauth":{"accessToken":"token-1"}}`)
+	writeDiscoveryFixture(t, filepath.Join(home, ".claude-oauth-credentials.json"), `{"claudeAiOauth":{"accessToken":"token-2"}}`)
+
+	creds, err := DiscoverClaudeCredentials(home)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeCredentials() error: %v", err)
+	}
+	if len(creds) != 2 {
+		t.Fatalf("got %d credentials, want 2", len(creds))
+	}
+}
+
 func writeDiscoveryFixture(t *testing.T, path string, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {


### PR DESCRIPTION
Add CLI commands to manage Claude Code credentials for sandbox authentication:

- `secret claude upload`: Interactive discovery of local credentials (API keys from config files, OAuth from credential files and macOS Keychain). Users see what's available, pick one, and confirm before uploading. Supports --type api_key (reads ANTHROPIC_API_KEY env var) and --type oauth (reads keychain on macOS, credential files on Linux). Also accepts --value and --from-file for direct input.

- `secret claude list`: Lists uploaded credentials with ID, name, and type.

- `secret claude delete <id>`: Deletes a credential by ID.

Sandbox creation now auto-selects the Claude credential by name when exactly one exists, passing claude_credential_name in the create request.

API client additions:
- POST /api/secrets/claude (name required, unique per user, type: oauth|api_key)
- GET /api/secrets/claude
- DELETE /api/secrets/:id
- ClaudeCredentialName field on CreateSandboxRequest

Auth package additions:
- DiscoverClaudeCredentials() returns all local Claude credentials with their type and source preserved for interactive selection.