### PR TITLE
Address PR #119 code review feedback

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1848,10 +1848,6 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	return nil
 }
 
-// resolveGitURL takes the --git flag value and returns a git URL suitable for
-// remote sandbox creation. If the value is already an HTTP(S) or SSH URL, it is
-// returned directly. Otherwise it is treated as a local path and the origin
-// remote URL is extracted.
 // autoSelectClaudeCredential returns the name of the user's Claude credential
 // if exactly one exists on the remote. Returns empty string on any error or
 // if no credentials are uploaded.
@@ -1863,6 +1859,10 @@ func autoSelectClaudeCredential(client *apiclient.Client) string {
 	return creds[0].Name
 }
 
+// resolveGitURL takes the --git flag value and returns a git URL suitable for
+// remote sandbox creation. If the value is already an HTTP(S) or SSH URL, it is
+// returned directly. Otherwise it is treated as a local path and the origin
+// remote URL is extracted.
 func resolveGitURL(value string) (string, error) {
 	// Already a URL — use as-is.
 	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "git@") {

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -619,7 +619,7 @@ func discoverAllClaudeCredentials() ([]auth.ClaudeCredential, error) {
 	}
 
 	// On macOS, also try the keychain.
-	if runtime.GOOS == "darwin" {
+	if isMacOS() {
 		keychainValue, err := readClaudeCredentialFromKeychain()
 		if err == nil && keychainValue != "" && json.Valid([]byte(keychainValue)) {
 			creds = append(creds, auth.ClaudeCredential{
@@ -713,7 +713,7 @@ func autoResolveClaudeCredential(credType string) (string, error) {
 	}
 
 	// OAuth: try keychain on macOS, then credential files.
-	if runtime.GOOS == "darwin" {
+	if isMacOS() {
 		value, err := readClaudeCredentialFromKeychain()
 		if err == nil && value != "" {
 			return value, nil
@@ -741,6 +741,11 @@ func autoResolveClaudeCredential(credType string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no OAuth credentials found; on macOS check keychain, or provide --value or --from-file")
+}
+
+// isMacOS reports whether the current operating system is macOS.
+func isMacOS() bool {
+	return runtime.GOOS == "darwin"
 }
 
 // claudeCredentialTypeToAPI maps the discovery type label to the API type field.

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -725,9 +725,9 @@ func autoResolveClaudeCredential(credType string) (string, error) {
 		return "", fmt.Errorf("determining home directory: %w", err)
 	}
 
-	oauthPaths := []string{
-		filepath.Join(homeDir, ".claude", ".credentials.json"),
-		filepath.Join(homeDir, ".claude-oauth-credentials.json"),
+	oauthPaths := make([]string, len(auth.ClaudeOAuthPaths()))
+	for i, p := range auth.ClaudeOAuthPaths() {
+		oauthPaths[i] = filepath.Join(homeDir, p)
 	}
 	for _, path := range oauthPaths {
 		data, err := os.ReadFile(path)

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -441,66 +441,14 @@ Examples:
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 
-			nameFlag, _ := cmd.Flags().GetString("name")
-			value, _ := cmd.Flags().GetString("value")
-			fromFile, _ := cmd.Flags().GetString("from-file")
-			typeFlag, _ := cmd.Flags().GetString("type")
-
-			var credValue string
-			var credType string // "oauth" or "api_key"
-
-			switch {
-			case value != "":
-				credValue = value
-				credType = typeFlag
-			case fromFile != "":
-				data, err := os.ReadFile(fromFile)
-				if err != nil {
-					return fmt.Errorf("reading credentials file: %w", err)
-				}
-				credValue = strings.TrimSpace(string(data))
-				credType = typeFlag
-			case cmd.Flags().Changed("type"):
-				// --type was set explicitly without --value/--from-file;
-				// auto-resolve based on the requested type.
-				resolved, err := autoResolveClaudeCredential(typeFlag)
-				if err != nil {
-					return err
-				}
-				credValue = resolved
-				credType = typeFlag
-			default:
-				// Interactive discovery — show all found credentials.
-				cred, err := discoverAndPickClaudeCredential(cmd)
-				if err != nil {
-					return err
-				}
-				credValue = cred.Value
-				credType = claudeCredentialTypeToAPI(cred.Type)
+			credValue, credType, err := parseClaudeCreds(cmd)
+			if err != nil {
+				return err
 			}
 
-			// Validate: OAuth credentials must be valid JSON.
-			if credType == "oauth" && !json.Valid([]byte(credValue)) {
-				return fmt.Errorf("OAuth credentials must be valid JSON")
-			}
-
-			// Name is required.
-			name := nameFlag
-			if name == "" {
-				reader := bufio.NewReader(cmd.InOrStdin())
-				defaultName := "Claude OAuth"
-				if credType == "api_key" {
-					defaultName = "Claude API Key"
-				}
-				fmt.Fprintf(cmd.OutOrStdout(), "Name for this credential [%s]: ", defaultName)
-				input, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("reading name: %w", err)
-				}
-				name = strings.TrimSpace(input)
-				if name == "" {
-					name = defaultName
-				}
+			name, err := parseClaudeName(cmd, credType)
+			if err != nil {
+				return err
 			}
 
 			client, err := getSecretsClient()
@@ -528,6 +476,84 @@ Examples:
 	cmd.Flags().String("type", "oauth", "Credential type: \"oauth\" (default) or \"api_key\"")
 
 	return cmd
+}
+
+// parseClaudeCreds resolves the credential value and type from command flags.
+// It returns an error if mutually exclusive flags --value and --from-file are
+// both provided.
+func parseClaudeCreds(cmd *cobra.Command) (string, string, error) {
+	value, _ := cmd.Flags().GetString("value")
+	fromFile, _ := cmd.Flags().GetString("from-file")
+	typeFlag, _ := cmd.Flags().GetString("type")
+
+	if value != "" && fromFile != "" {
+		return "", "", fmt.Errorf("--value and --from-file are mutually exclusive")
+	}
+
+	var credValue string
+	var credType string // "oauth" or "api_key"
+
+	switch {
+	case value != "":
+		credValue = value
+		credType = typeFlag
+	case fromFile != "":
+		data, err := os.ReadFile(fromFile)
+		if err != nil {
+			return "", "", fmt.Errorf("reading credentials file: %w", err)
+		}
+		credValue = strings.TrimSpace(string(data))
+		credType = typeFlag
+	case cmd.Flags().Changed("type"):
+		// --type was set explicitly without --value/--from-file;
+		// auto-resolve based on the requested type.
+		resolved, err := autoResolveClaudeCredential(typeFlag)
+		if err != nil {
+			return "", "", err
+		}
+		credValue = resolved
+		credType = typeFlag
+	default:
+		// Interactive discovery — show all found credentials.
+		cred, err := discoverAndPickClaudeCredential(cmd)
+		if err != nil {
+			return "", "", err
+		}
+		credValue = cred.Value
+		credType = claudeCredentialTypeToAPI(cred.Type)
+	}
+
+	// Validate: OAuth credentials must be valid JSON.
+	if credType == "oauth" && !json.Valid([]byte(credValue)) {
+		return "", "", fmt.Errorf("OAuth credentials must be valid JSON")
+	}
+
+	return credValue, credType, nil
+}
+
+// parseClaudeName resolves the credential name from the --name flag or by
+// prompting the user interactively with a type-appropriate default.
+func parseClaudeName(cmd *cobra.Command, credType string) (string, error) {
+	name, _ := cmd.Flags().GetString("name")
+	if name != "" {
+		return name, nil
+	}
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+	defaultName := "Claude OAuth"
+	if credType == "api_key" {
+		defaultName = "Claude API Key"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Name for this credential [%s]: ", defaultName)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("reading name: %w", err)
+	}
+	name = strings.TrimSpace(input)
+	if name == "" {
+		name = defaultName
+	}
+	return name, nil
 }
 
 // discoverAndPickClaudeCredential scans the local system for Claude credentials,

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/gofixpoint/amika/internal/apiclient"
+	"github.com/gofixpoint/amika/internal/arch"
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/gofixpoint/amika/internal/config"
 	"github.com/spf13/cobra"
@@ -479,9 +479,9 @@ Examples:
 }
 
 // parseClaudeCreds resolves the credential value and type from command flags.
-// It returns an error if mutually exclusive flags --value and --from-file are
-// both provided.
-func parseClaudeCreds(cmd *cobra.Command) (string, string, error) {
+// credType is "oauth" or "api_key". Returns an error if mutually exclusive
+// flags --value and --from-file are both provided.
+func parseClaudeCreds(cmd *cobra.Command) (credValue string, credType string, err error) {
 	value, _ := cmd.Flags().GetString("value")
 	fromFile, _ := cmd.Flags().GetString("from-file")
 	typeFlag, _ := cmd.Flags().GetString("type")
@@ -489,9 +489,6 @@ func parseClaudeCreds(cmd *cobra.Command) (string, string, error) {
 	if value != "" && fromFile != "" {
 		return "", "", fmt.Errorf("--value and --from-file are mutually exclusive")
 	}
-
-	var credValue string
-	var credType string // "oauth" or "api_key"
 
 	switch {
 	case value != "":
@@ -619,7 +616,7 @@ func discoverAllClaudeCredentials() ([]auth.ClaudeCredential, error) {
 	}
 
 	// On macOS, also try the keychain.
-	if isMacOS() {
+	if arch.IsMacOS() {
 		keychainValue, err := readClaudeCredentialFromKeychain()
 		if err == nil && keychainValue != "" && json.Valid([]byte(keychainValue)) {
 			creds = append(creds, auth.ClaudeCredential{
@@ -713,7 +710,7 @@ func autoResolveClaudeCredential(credType string) (string, error) {
 	}
 
 	// OAuth: try keychain on macOS, then credential files.
-	if isMacOS() {
+	if arch.IsMacOS() {
 		value, err := readClaudeCredentialFromKeychain()
 		if err == nil && value != "" {
 			return value, nil
@@ -741,11 +738,6 @@ func autoResolveClaudeCredential(credType string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no OAuth credentials found; on macOS check keychain, or provide --value or --from-file")
-}
-
-// isMacOS reports whether the current operating system is macOS.
-func isMacOS() bool {
-	return runtime.GOOS == "darwin"
 }
 
 // claudeCredentialTypeToAPI maps the discovery type label to the API type field.

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -406,25 +406,37 @@ func maskValue(value string) string {
 var secretClaudeCmd = &cobra.Command{
 	Use:   "claude",
 	Short: "Manage Claude Code credentials",
-	Long:  `Upload and list Claude Code credentials for sandbox authentication.`,
+	Long:  `Push and list Claude Code credentials for sandbox authentication.`,
 }
 
-func newSecretClaudeUploadCmd() *cobra.Command {
+func newSecretClaudePushCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "upload",
-		Short: "Upload Claude Code credentials to the remote secrets store",
-		Long: `Upload Claude Code credentials to the remote Amika secrets store.
+		Use:   "push",
+		Short: "Push Claude Code credentials to the remote secrets store",
+		Long: `Push Claude Code credentials to the remote Amika secrets store.
 
 Scans your system for Claude credentials (API keys and OAuth tokens) and
-lets you choose which one to upload. On macOS, the keychain is also checked.
+lets you choose which one to push. On macOS, the keychain is also checked.
 
 You can also provide credentials directly via --value or from a file via --from-file.
 
+When using --type to auto-resolve credentials:
+  --type api_key  Reads the ANTHROPIC_API_KEY environment variable.
+  --type oauth    On macOS, reads from the macOS Keychain first, then falls
+                  back to ~/.claude/.credentials.json and
+                  ~/.claude-oauth-credentials.json.
+
+When run interactively (no flags), scans all known credential sources:
+  API keys:  ~/.claude.json.api, ~/.claude.json (fields: primaryApiKey,
+             apiKey, anthropicApiKey, customApiKey with sk-ant- prefix)
+  OAuth:     ~/.claude/.credentials.json, ~/.claude-oauth-credentials.json,
+             and macOS Keychain (on macOS)
+
 Examples:
-  amika secret claude upload
-  amika secret claude upload --name "Claude OAuth (Work Laptop)"
-  amika secret claude upload --from-file ~/.claude/.credentials.json
-  amika secret claude upload --value '{"claudeAiOauth":{...}}'`,
+  amika secret claude push
+  amika secret claude push --name "Claude OAuth (Work Laptop)"
+  amika secret claude push --from-file ~/.claude/.credentials.json
+  amika secret claude push --value '{"claudeAiOauth":{...}}'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
@@ -519,7 +531,7 @@ Examples:
 }
 
 // discoverAndPickClaudeCredential scans the local system for Claude credentials,
-// displays them, and lets the user pick one to upload.
+// displays them, and lets the user pick one to push.
 func discoverAndPickClaudeCredential(cmd *cobra.Command) (auth.ClaudeCredential, error) {
 	// Also check macOS keychain if on darwin.
 	creds, err := discoverAllClaudeCredentials()
@@ -544,9 +556,9 @@ func discoverAndPickClaudeCredential(cmd *cobra.Command) (auth.ClaudeCredential,
 	reader := bufio.NewReader(cmd.InOrStdin())
 	if len(creds) == 1 {
 		selected = creds[0]
-		fmt.Fprintf(cmd.OutOrStdout(), "Upload this credential? [y/N] ")
+		fmt.Fprintf(cmd.OutOrStdout(), "Push this credential? [y/N] ")
 	} else {
-		fmt.Fprintf(cmd.OutOrStdout(), "Select credential to upload [1-%d]: ", len(creds))
+		fmt.Fprintf(cmd.OutOrStdout(), "Select credential to push [1-%d]: ", len(creds))
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			return auth.ClaudeCredential{}, fmt.Errorf("reading selection: %w", err)
@@ -558,7 +570,7 @@ func discoverAndPickClaudeCredential(cmd *cobra.Command) (auth.ClaudeCredential,
 		}
 		selected = creds[choice-1]
 
-		fmt.Fprintf(cmd.OutOrStdout(), "\nUpload %s from %s? [y/N] ", selected.Type, selected.Source)
+		fmt.Fprintf(cmd.OutOrStdout(), "\nPush %s from %s? [y/N] ", selected.Type, selected.Source)
 	}
 
 	answer, err := reader.ReadString('\n')
@@ -607,7 +619,7 @@ func readClaudeCredentialFromKeychain() (string, error) {
 func newSecretClaudeListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List uploaded Claude credentials",
+		Short: "List pushed Claude credentials",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
@@ -720,7 +732,7 @@ func init() {
 	secretCmd.AddCommand(newSecretExtractCmd())
 	secretCmd.AddCommand(newSecretPushCmd())
 	secretCmd.AddCommand(secretClaudeCmd)
-	secretClaudeCmd.AddCommand(newSecretClaudeUploadCmd())
+	secretClaudeCmd.AddCommand(newSecretClaudePushCmd())
 	secretClaudeCmd.AddCommand(newSecretClaudeListCmd())
 	secretClaudeCmd.AddCommand(newSecretClaudeDeleteCmd())
 
@@ -732,11 +744,11 @@ func init() {
 	secretsClaudeAlias := &cobra.Command{
 		Use:    "claude",
 		Short:  "Manage Claude Code credentials",
-		Long:   `Upload and list Claude Code credentials for sandbox authentication.`,
+		Long:   `Push and list Claude Code credentials for sandbox authentication.`,
 		Hidden: true,
 	}
 	secretsAliasCmd.AddCommand(secretsClaudeAlias)
-	secretsClaudeAlias.AddCommand(newSecretClaudeUploadCmd())
+	secretsClaudeAlias.AddCommand(newSecretClaudePushCmd())
 	secretsClaudeAlias.AddCommand(newSecretClaudeListCmd())
 	secretsClaudeAlias.AddCommand(newSecretClaudeDeleteCmd())
 }

--- a/cmd/amika/secrets_test.go
+++ b/cmd/amika/secrets_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -400,20 +403,20 @@ func TestClaudeCredentialTypeToAPI(t *testing.T) {
 
 func TestSecretClaudePush_ValueFlag(t *testing.T) {
 	bin := buildAmika(t)
+	srv := newMockClaudeAPI(t)
+	defer srv.Close()
 
-	// With --value and --name, the command will try to hit the API and fail,
-	// but we can verify it gets past validation.
 	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--value", `{"claudeAiOauth":{"accessToken":"test"}}`,
 		"--name", "Test OAuth")
+	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
 	out, err := cmd.CombinedOutput()
-	// Expect failure due to no auth, but NOT a validation error.
-	if err == nil {
-		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	if err != nil {
+		t.Fatalf("unexpected error:\n%s", out)
 	}
 	text := string(out)
-	if strings.Contains(text, "must be valid JSON") {
-		t.Fatalf("unexpected validation error for valid JSON:\n%s", text)
+	if !strings.Contains(text, "Created Claude credential") {
+		t.Fatalf("expected success message, got:\n%s", text)
 	}
 }
 
@@ -435,16 +438,18 @@ func TestSecretClaudePush_InvalidOAuthJSON(t *testing.T) {
 
 func TestSecretClaudePush_APIKeyNoJSONValidation(t *testing.T) {
 	bin := buildAmika(t)
+	srv := newMockClaudeAPI(t)
+	defer srv.Close()
 
-	// api_key type should NOT require valid JSON — it should get past validation
-	// and fail at the auth step.
+	// api_key type should NOT require valid JSON — it should succeed.
 	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--value", "sk-ant-api03-plaintext",
 		"--type", "api_key",
 		"--name", "My Key")
+	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
 	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	if err != nil {
+		t.Fatalf("unexpected error:\n%s", out)
 	}
 	text := string(out)
 	if strings.Contains(text, "must be valid JSON") {
@@ -481,26 +486,29 @@ func TestSecretClaudePush_TypeAPIKeyReadsEnv(t *testing.T) {
 
 func TestSecretClaudePush_TypeAPIKeyWithEnvSet(t *testing.T) {
 	bin := buildAmika(t)
+	srv := newMockClaudeAPI(t)
+	defer srv.Close()
 
-	// With ANTHROPIC_API_KEY set, it should get past resolution and fail at auth.
+	// With ANTHROPIC_API_KEY set, it should resolve the key and push successfully.
 	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--type", "api_key",
 		"--name", "Key From Env")
-	cmd.Env = withEnv(os.Environ(), "ANTHROPIC_API_KEY=sk-ant-api03-test")
+	cmd.Env = withEnv(os.Environ(), append(mockAPIEnv(srv.URL), "ANTHROPIC_API_KEY=sk-ant-api03-test")...)
 
 	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	if err != nil {
+		t.Fatalf("unexpected error:\n%s", out)
 	}
 	text := string(out)
-	// Should NOT be a resolution error.
-	if strings.Contains(text, "ANTHROPIC_API_KEY environment variable is not set") {
-		t.Fatalf("unexpected resolution error when env var is set:\n%s", text)
+	if !strings.Contains(text, "Created Claude credential") {
+		t.Fatalf("expected success message, got:\n%s", text)
 	}
 }
 
 func TestSecretClaudePush_FromFile(t *testing.T) {
 	bin := buildAmika(t)
+	srv := newMockClaudeAPI(t)
+	defer srv.Close()
 
 	credFile := filepath.Join(t.TempDir(), "creds.json")
 	if err := os.WriteFile(credFile, []byte(`{"claudeAiOauth":{"accessToken":"test"}}`), 0644); err != nil {
@@ -510,17 +518,14 @@ func TestSecretClaudePush_FromFile(t *testing.T) {
 	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--from-file", credFile,
 		"--name", "From File")
+	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
 	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	if err != nil {
+		t.Fatalf("unexpected error:\n%s", out)
 	}
 	text := string(out)
-	// Should get past file reading and validation.
-	if strings.Contains(text, "reading credentials file") {
-		t.Fatalf("unexpected file read error:\n%s", text)
-	}
-	if strings.Contains(text, "must be valid JSON") {
-		t.Fatalf("unexpected validation error:\n%s", text)
+	if !strings.Contains(text, "Created Claude credential") {
+		t.Fatalf("expected success message, got:\n%s", text)
 	}
 }
 
@@ -539,14 +544,16 @@ func TestSecretClaudePush_FromFileMissing(t *testing.T) {
 	}
 }
 
-func TestSecretClaudeList_NoAuth(t *testing.T) {
+func TestSecretClaudeList_WithMock(t *testing.T) {
 	bin := buildAmika(t)
+	srv := newMockClaudeAPI(t)
+	defer srv.Close()
 
-	// Without auth, should fail with auth error, not crash.
 	cmd := exec.Command(bin, "secret", "claude", "list")
+	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
 	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected error (no auth), got success\noutput:\n%s", out)
+	if err != nil {
+		t.Fatalf("unexpected error:\n%s", out)
 	}
 	// Should not panic or give unexpected errors.
 	text := string(out)
@@ -570,13 +577,15 @@ func TestSecretClaudeDelete_NoArgs(t *testing.T) {
 
 func TestSecretClaudePluralAlias(t *testing.T) {
 	bin := buildAmika(t)
+	srv := newMockClaudeAPI(t)
+	defer srv.Close()
 
 	// "secrets claude list" should also work.
 	cmd := exec.Command(bin, "secrets", "claude", "list")
+	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
 	out, err := cmd.CombinedOutput()
-	// Will fail with auth error, but the command should be recognized.
-	if err == nil {
-		return // surprisingly succeeded, that's fine
+	if err != nil {
+		t.Fatalf("unexpected error:\n%s", out)
 	}
 	text := string(out)
 	if strings.Contains(text, "unknown command") {
@@ -591,6 +600,38 @@ func writeJSONFixture(t *testing.T, path string, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("failed to write fixture %s: %v", path, err)
+	}
+}
+
+// newMockClaudeAPI starts an httptest server that handles Claude secret API
+// endpoints and returns it. The caller should defer server.Close().
+func newMockClaudeAPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/api/secrets/claude":
+			json.NewEncoder(w).Encode(map[string]string{
+				"id":    "cred-test-123",
+				"name":  "Test",
+				"scope": "user",
+			})
+		case r.Method == "GET" && r.URL.Path == "/api/secrets/claude":
+			json.NewEncoder(w).Encode([]interface{}{})
+		case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/api/secrets/"):
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// mockAPIEnv returns environment variables that point the CLI at the given
+// mock server instead of the production API.
+func mockAPIEnv(serverURL string) []string {
+	return []string{
+		"AMIKA_API_URL=" + serverURL,
+		"AMIKA_API_KEY=test-bearer-token",
 	}
 }
 

--- a/cmd/amika/secrets_test.go
+++ b/cmd/amika/secrets_test.go
@@ -398,12 +398,12 @@ func TestClaudeCredentialTypeToAPI(t *testing.T) {
 	}
 }
 
-func TestSecretClaudeUpload_ValueFlag(t *testing.T) {
+func TestSecretClaudePush_ValueFlag(t *testing.T) {
 	bin := buildAmika(t)
 
 	// With --value and --name, the command will try to hit the API and fail,
 	// but we can verify it gets past validation.
-	cmd := exec.Command(bin, "secret", "claude", "upload",
+	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--value", `{"claudeAiOauth":{"accessToken":"test"}}`,
 		"--name", "Test OAuth")
 	out, err := cmd.CombinedOutput()
@@ -417,10 +417,10 @@ func TestSecretClaudeUpload_ValueFlag(t *testing.T) {
 	}
 }
 
-func TestSecretClaudeUpload_InvalidOAuthJSON(t *testing.T) {
+func TestSecretClaudePush_InvalidOAuthJSON(t *testing.T) {
 	bin := buildAmika(t)
 
-	cmd := exec.Command(bin, "secret", "claude", "upload",
+	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--value", "not-json",
 		"--type", "oauth",
 		"--name", "Bad")
@@ -433,12 +433,12 @@ func TestSecretClaudeUpload_InvalidOAuthJSON(t *testing.T) {
 	}
 }
 
-func TestSecretClaudeUpload_APIKeyNoJSONValidation(t *testing.T) {
+func TestSecretClaudePush_APIKeyNoJSONValidation(t *testing.T) {
 	bin := buildAmika(t)
 
 	// api_key type should NOT require valid JSON — it should get past validation
 	// and fail at the auth step.
-	cmd := exec.Command(bin, "secret", "claude", "upload",
+	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--value", "sk-ant-api03-plaintext",
 		"--type", "api_key",
 		"--name", "My Key")
@@ -452,12 +452,12 @@ func TestSecretClaudeUpload_APIKeyNoJSONValidation(t *testing.T) {
 	}
 }
 
-func TestSecretClaudeUpload_TypeAPIKeyReadsEnv(t *testing.T) {
+func TestSecretClaudePush_TypeAPIKeyReadsEnv(t *testing.T) {
 	bin := buildAmika(t)
 
 	// --type api_key without --value should read ANTHROPIC_API_KEY.
 	// With the env var unset, it should produce an error.
-	cmd := exec.Command(bin, "secret", "claude", "upload",
+	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--type", "api_key",
 		"--name", "Key")
 	cmd.Env = withEnv(os.Environ(), "ANTHROPIC_API_KEY=")
@@ -479,11 +479,11 @@ func TestSecretClaudeUpload_TypeAPIKeyReadsEnv(t *testing.T) {
 	}
 }
 
-func TestSecretClaudeUpload_TypeAPIKeyWithEnvSet(t *testing.T) {
+func TestSecretClaudePush_TypeAPIKeyWithEnvSet(t *testing.T) {
 	bin := buildAmika(t)
 
 	// With ANTHROPIC_API_KEY set, it should get past resolution and fail at auth.
-	cmd := exec.Command(bin, "secret", "claude", "upload",
+	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--type", "api_key",
 		"--name", "Key From Env")
 	cmd.Env = withEnv(os.Environ(), "ANTHROPIC_API_KEY=sk-ant-api03-test")
@@ -499,7 +499,7 @@ func TestSecretClaudeUpload_TypeAPIKeyWithEnvSet(t *testing.T) {
 	}
 }
 
-func TestSecretClaudeUpload_FromFile(t *testing.T) {
+func TestSecretClaudePush_FromFile(t *testing.T) {
 	bin := buildAmika(t)
 
 	credFile := filepath.Join(t.TempDir(), "creds.json")
@@ -507,7 +507,7 @@ func TestSecretClaudeUpload_FromFile(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	cmd := exec.Command(bin, "secret", "claude", "upload",
+	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--from-file", credFile,
 		"--name", "From File")
 	out, err := cmd.CombinedOutput()
@@ -524,10 +524,10 @@ func TestSecretClaudeUpload_FromFile(t *testing.T) {
 	}
 }
 
-func TestSecretClaudeUpload_FromFileMissing(t *testing.T) {
+func TestSecretClaudePush_FromFileMissing(t *testing.T) {
 	bin := buildAmika(t)
 
-	cmd := exec.Command(bin, "secret", "claude", "upload",
+	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--from-file", "/nonexistent/creds.json",
 		"--name", "Missing")
 	out, err := cmd.CombinedOutput()

--- a/cmd/amika/secrets_test.go
+++ b/cmd/amika/secrets_test.go
@@ -403,20 +403,19 @@ func TestClaudeCredentialTypeToAPI(t *testing.T) {
 
 func TestSecretClaudePush_ValueFlag(t *testing.T) {
 	bin := buildAmika(t)
-	srv := newMockClaudeAPI(t)
-	defer srv.Close()
+	mockEnv := setupMockClaudeAPI(t)
 
 	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--value", `{"claudeAiOauth":{"accessToken":"test"}}`,
 		"--name", "Test OAuth")
-	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
+	cmd.Env = mockEnv
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected error:\n%s", out)
+		t.Fatalf("expected success, got error: %v\n%s", err, out)
 	}
 	text := string(out)
-	if !strings.Contains(text, "Created Claude credential") {
-		t.Fatalf("expected success message, got:\n%s", text)
+	if strings.Contains(text, "must be valid JSON") {
+		t.Fatalf("unexpected validation error for valid JSON:\n%s", text)
 	}
 }
 
@@ -438,18 +437,17 @@ func TestSecretClaudePush_InvalidOAuthJSON(t *testing.T) {
 
 func TestSecretClaudePush_APIKeyNoJSONValidation(t *testing.T) {
 	bin := buildAmika(t)
-	srv := newMockClaudeAPI(t)
-	defer srv.Close()
+	mockEnv := setupMockClaudeAPI(t)
 
 	// api_key type should NOT require valid JSON — it should succeed.
 	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--value", "sk-ant-api03-plaintext",
 		"--type", "api_key",
 		"--name", "My Key")
-	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
+	cmd.Env = mockEnv
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected error:\n%s", out)
+		t.Fatalf("expected success, got error: %v\n%s", err, out)
 	}
 	text := string(out)
 	if strings.Contains(text, "must be valid JSON") {
@@ -486,29 +484,28 @@ func TestSecretClaudePush_TypeAPIKeyReadsEnv(t *testing.T) {
 
 func TestSecretClaudePush_TypeAPIKeyWithEnvSet(t *testing.T) {
 	bin := buildAmika(t)
-	srv := newMockClaudeAPI(t)
-	defer srv.Close()
+	mockEnv := setupMockClaudeAPI(t)
 
 	// With ANTHROPIC_API_KEY set, it should resolve the key and push successfully.
 	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--type", "api_key",
 		"--name", "Key From Env")
-	cmd.Env = withEnv(os.Environ(), append(mockAPIEnv(srv.URL), "ANTHROPIC_API_KEY=sk-ant-api03-test")...)
+	cmd.Env = withEnv(mockEnv, "ANTHROPIC_API_KEY=sk-ant-api03-test")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected error:\n%s", out)
+		t.Fatalf("expected success, got error: %v\n%s", err, out)
 	}
 	text := string(out)
-	if !strings.Contains(text, "Created Claude credential") {
-		t.Fatalf("expected success message, got:\n%s", text)
+	// Should NOT be a resolution error.
+	if strings.Contains(text, "ANTHROPIC_API_KEY environment variable is not set") {
+		t.Fatalf("unexpected resolution error when env var is set:\n%s", text)
 	}
 }
 
 func TestSecretClaudePush_FromFile(t *testing.T) {
 	bin := buildAmika(t)
-	srv := newMockClaudeAPI(t)
-	defer srv.Close()
+	mockEnv := setupMockClaudeAPI(t)
 
 	credFile := filepath.Join(t.TempDir(), "creds.json")
 	if err := os.WriteFile(credFile, []byte(`{"claudeAiOauth":{"accessToken":"test"}}`), 0644); err != nil {
@@ -518,14 +515,18 @@ func TestSecretClaudePush_FromFile(t *testing.T) {
 	cmd := exec.Command(bin, "secret", "claude", "push",
 		"--from-file", credFile,
 		"--name", "From File")
-	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
+	cmd.Env = mockEnv
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected error:\n%s", out)
+		t.Fatalf("expected success, got error: %v\n%s", err, out)
 	}
 	text := string(out)
-	if !strings.Contains(text, "Created Claude credential") {
-		t.Fatalf("expected success message, got:\n%s", text)
+	// Should get past file reading and validation.
+	if strings.Contains(text, "reading credentials file") {
+		t.Fatalf("unexpected file read error:\n%s", text)
+	}
+	if strings.Contains(text, "must be valid JSON") {
+		t.Fatalf("unexpected validation error:\n%s", text)
 	}
 }
 
@@ -546,11 +547,10 @@ func TestSecretClaudePush_FromFileMissing(t *testing.T) {
 
 func TestSecretClaudeList_WithMock(t *testing.T) {
 	bin := buildAmika(t)
-	srv := newMockClaudeAPI(t)
-	defer srv.Close()
+	mockEnv := setupMockClaudeAPI(t)
 
 	cmd := exec.Command(bin, "secret", "claude", "list")
-	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
+	cmd.Env = mockEnv
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("unexpected error:\n%s", out)
@@ -577,12 +577,11 @@ func TestSecretClaudeDelete_NoArgs(t *testing.T) {
 
 func TestSecretClaudePluralAlias(t *testing.T) {
 	bin := buildAmika(t)
-	srv := newMockClaudeAPI(t)
-	defer srv.Close()
+	mockEnv := setupMockClaudeAPI(t)
 
 	// "secrets claude list" should also work.
 	cmd := exec.Command(bin, "secrets", "claude", "list")
-	cmd.Env = withEnv(os.Environ(), mockAPIEnv(srv.URL)...)
+	cmd.Env = mockEnv
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("unexpected error:\n%s", out)
@@ -603,11 +602,14 @@ func writeJSONFixture(t *testing.T, path string, content string) {
 	}
 }
 
-// newMockClaudeAPI starts an httptest server that handles Claude secret API
-// endpoints and returns it. The caller should defer server.Close().
-func newMockClaudeAPI(t *testing.T) *httptest.Server {
+// setupMockClaudeAPI starts a mock API server for Claude secret endpoints
+// and returns an environment slice (based on os.Environ) that directs the
+// CLI at the mock. The server is closed automatically when the test ends.
+//
+// TODO: extract mock API server helpers to a shared test package (e.g. test/testutil).
+func setupMockClaudeAPI(t *testing.T) []string {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == "POST" && r.URL.Path == "/api/secrets/claude":
@@ -624,15 +626,11 @@ func newMockClaudeAPI(t *testing.T) *httptest.Server {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-}
-
-// mockAPIEnv returns environment variables that point the CLI at the given
-// mock server instead of the production API.
-func mockAPIEnv(serverURL string) []string {
-	return []string{
-		"AMIKA_API_URL=" + serverURL,
+	t.Cleanup(srv.Close)
+	return withEnv(os.Environ(),
+		"AMIKA_API_URL="+srv.URL,
 		"AMIKA_API_KEY=test-bearer-token",
-	}
+	)
 }
 
 func withXDGEnv(home string) []string {

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -207,7 +207,7 @@ func (c *Client) UpdateSecret(id string, req UpdateSecretRequest) error {
 type CreateClaudeSecretRequest struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
-	Type  string `json:"type,omitempty"` // "oauth" (default) or "api_key"
+	Type  string `json:"type"` // "oauth" or "api_key" — required by the server
 }
 
 // ClaudeSecretSummary is the response from POST /api/secrets/claude.

--- a/internal/arch/arch.go
+++ b/internal/arch/arch.go
@@ -1,0 +1,9 @@
+// Package arch provides platform detection helpers.
+package arch
+
+import "runtime"
+
+// IsMacOS reports whether the current operating system is macOS.
+func IsMacOS() bool {
+	return runtime.GOOS == "darwin"
+}

--- a/internal/auth/discovery.go
+++ b/internal/auth/discovery.go
@@ -106,9 +106,9 @@ func configuredSources() []sourceDef {
 }
 
 func parseClaudeAPI(homeDir string, _ bool, _ time.Time, _ basedir.Paths) (map[string]string, error) {
-	paths := []string{
-		filepath.Join(homeDir, ".claude.json.api"),
-		filepath.Join(homeDir, ".claude.json"),
+	paths := make([]string, len(ClaudeAPIKeyPaths()))
+	for i, p := range ClaudeAPIKeyPaths() {
+		paths[i] = filepath.Join(homeDir, p)
 	}
 	fields := []string{"primaryApiKey", "apiKey", "anthropicApiKey", "customApiKey"}
 
@@ -143,9 +143,9 @@ func parseClaudeOAuth(homeDir string, includeOAuth bool, now time.Time, _ basedi
 		return nil, nil
 	}
 
-	paths := []string{
-		filepath.Join(homeDir, ".claude", ".credentials.json"),
-		filepath.Join(homeDir, ".claude-oauth-credentials.json"),
+	paths := make([]string, len(ClaudeOAuthPaths()))
+	for i, p := range ClaudeOAuthPaths() {
+		paths[i] = filepath.Join(homeDir, p)
 	}
 
 	for _, path := range paths {
@@ -579,7 +579,9 @@ type ClaudeCredential struct {
 }
 
 // DiscoverClaudeCredentials scans local credential sources and returns all
-// Claude-specific credentials found, preserving their type and source.
+// Claude-specific credentials found, preserving their type and source. If
+// homeDir is empty, the user's home directory is obtained from the operating
+// system (e.g. the HOME environment variable or OS-level user database).
 func DiscoverClaudeCredentials(homeDir string) ([]ClaudeCredential, error) {
 	if homeDir == "" {
 		var err error
@@ -592,9 +594,9 @@ func DiscoverClaudeCredentials(homeDir string) ([]ClaudeCredential, error) {
 	var creds []ClaudeCredential
 
 	// Check for API keys in Claude config files.
-	apiKeyPaths := []string{
-		filepath.Join(homeDir, ".claude.json.api"),
-		filepath.Join(homeDir, ".claude.json"),
+	apiKeyPaths := make([]string, len(ClaudeAPIKeyPaths()))
+	for i, p := range ClaudeAPIKeyPaths() {
+		apiKeyPaths[i] = filepath.Join(homeDir, p)
 	}
 	apiKeyFields := []string{"primaryApiKey", "apiKey", "anthropicApiKey", "customApiKey"}
 
@@ -620,9 +622,9 @@ func DiscoverClaudeCredentials(homeDir string) ([]ClaudeCredential, error) {
 	}
 
 	// Check for OAuth credentials in files.
-	oauthPaths := []string{
-		filepath.Join(homeDir, ".claude", ".credentials.json"),
-		filepath.Join(homeDir, ".claude-oauth-credentials.json"),
+	oauthPaths := make([]string, len(ClaudeOAuthPaths()))
+	for i, p := range ClaudeOAuthPaths() {
+		oauthPaths[i] = filepath.Join(homeDir, p)
 	}
 	for _, path := range oauthPaths {
 		data, err := os.ReadFile(path)
@@ -649,15 +651,28 @@ func DiscoverClaudeCredentials(homeDir string) ([]ClaudeCredential, error) {
 	return creds, nil
 }
 
-// ClaudeCredentialPaths returns the home-relative paths where Claude Code
-// stores credentials. Callers should join each with a home directory.
-func ClaudeCredentialPaths() []string {
+// ClaudeAPIKeyPaths returns the home-relative paths where Claude Code stores
+// API key configuration. Callers should join each with a home directory.
+func ClaudeAPIKeyPaths() []string {
 	return []string{
 		".claude.json.api",
 		".claude.json",
+	}
+}
+
+// ClaudeOAuthPaths returns the home-relative paths where Claude Code stores
+// OAuth credentials. Callers should join each with a home directory.
+func ClaudeOAuthPaths() []string {
+	return []string{
 		filepath.Join(".claude", ".credentials.json"),
 		".claude-oauth-credentials.json",
 	}
+}
+
+// ClaudeCredentialPaths returns the home-relative paths where Claude Code
+// stores credentials. Callers should join each with a home directory.
+func ClaudeCredentialPaths() []string {
+	return append(ClaudeAPIKeyPaths(), ClaudeOAuthPaths()...)
 }
 
 // CodexCredentialPaths returns the home-relative paths where Codex stores


### PR DESCRIPTION
## Summary

- Rename `secret claude upload` to `secret claude push` for consistency with `amika secret push`
- Fix misplaced doc comments (`resolveGitURL` comment was above `autoSelectClaudeCredential`)
- Expand push command help text to document credential auto-resolution sources
- Extract `parseClaudeCreds` and `parseClaudeName` functions with explicit mutual exclusivity check for `--value`/`--from-file`
- Consolidate hardcoded Claude credential file paths into shared `ClaudeAPIKeyPaths()` and `ClaudeOAuthPaths()` helpers in `internal/auth`
- Add `isMacOS()` helper to replace inline `runtime.GOOS == "darwin"` checks
- Replace tests that relied on auth failures (hitting production) with `httptest` mock server