### PR TITLE
feat: add `sandbox agent-send` command for sending messages to sandbox agents

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -2009,15 +2009,19 @@ var knownAgents = map[string]agentConfig{
 }
 
 // resolveAgentConfig returns the agent configuration for the given name.
-// Unknown agents use the name as the binary with "-p" as the default flag.
-func resolveAgentConfig(name string) agentConfig {
+// Returns an error if the agent is not in the knownAgents map.
+func resolveAgentConfig(name string) (agentConfig, error) {
 	if cfg, ok := knownAgents[name]; ok {
-		return cfg
+		return cfg, nil
 	}
-	return agentConfig{Binary: name, PrintArg: "-p"}
+	known := make([]string, 0, len(knownAgents))
+	for k := range knownAgents {
+		known = append(known, fmt.Sprintf("%q", k))
+	}
+	return agentConfig{}, fmt.Errorf("unknown agent %q; supported agents: %s", name, strings.Join(known, ", "))
 }
 
-var runSandboxAgentSend = func(name, message string, noWait bool, workdir string, agent agentConfig, stdout, stderr io.Writer) error {
+func runDockerSandboxAgentSend(name, message string, noWait bool, workdir string, agent agentConfig, stdout, stderr io.Writer) error {
 	dockerArgs := buildSandboxAgentSendArgs(name, message, noWait, workdir, agent)
 	dockerCmd := exec.Command("docker", dockerArgs...)
 	if !noWait {
@@ -2088,24 +2092,27 @@ Use --no-wait to send the message and return immediately.`,
 		noWait, _ := cmd.Flags().GetBool("no-wait")
 		workdir, _ := cmd.Flags().GetString("workdir")
 		agentName, _ := cmd.Flags().GetString("agent")
-		agent := resolveAgentConfig(agentName)
+		agent, err := resolveAgentConfig(agentName)
+		if err != nil {
+			return err
+		}
 
 		// Try local sandbox first.
-		sandboxesFile, err := config.SandboxesStateFile()
-		if err == nil {
+		sandboxesFile, sErr := config.SandboxesStateFile()
+		if sErr == nil {
 			store := sandbox.NewStore(sandboxesFile)
-			if info, err := store.Get(name); err == nil {
+			if info, gErr := store.Get(name); gErr == nil {
 				if info.Provider != "docker" {
 					return fmt.Errorf("unsupported local provider %q: only \"docker\" is supported", info.Provider)
 				}
-				if err := runSandboxAgentSend(name, message, noWait, workdir, agent, os.Stdout, os.Stderr); err != nil {
+				if err := runDockerSandboxAgentSend(name, message, noWait, workdir, agent, os.Stdout, os.Stderr); err != nil {
 					if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 127 {
 						return fmt.Errorf("%s CLI not found in sandbox %q; was it created with the right preset?", agent.Binary, name)
 					}
-					return fmt.Errorf("instruct failed for sandbox %q: %w", name, err)
+					return fmt.Errorf("agent-send failed for sandbox %q: %w", name, err)
 				}
 				if noWait {
-					fmt.Fprintf(os.Stderr, "Instruction sent to %s in sandbox %q\n", agent.Binary, name)
+					fmt.Fprintf(os.Stderr, "Message sent to %s in sandbox %q\n", agent.Binary, name)
 				}
 				return nil
 			}
@@ -2121,22 +2128,19 @@ Use --no-wait to send the message and return immediately.`,
 			return err
 		}
 
+		// Build the remote command as a single shell string so multi-word
+		// messages and tmux commands are preserved through SSH.
 		agentStr := strings.Join(agentCmdParts(agent, fmt.Sprintf("%q", message)), " ")
 
 		if noWait {
-			// Run in a detached tmux session so the agent survives SSH disconnect.
-			// Pass as a single string so the remote shell keeps the tmux command intact.
 			sessionName := fmt.Sprintf("amika-agent-send-%d", time.Now().UnixNano())
 			shellCmd := fmt.Sprintf("tmux new-session -d -s '%s' 'cd %s && %s'",
 				sessionName, workdir, agentStr)
-			remoteCmd := []string{shellCmd}
-			return execSSH(client, name, false, remoteCmd)
+			return execSSH(client, name, false, []string{shellCmd})
 		}
 
-		// Quote the message so the remote shell keeps it as a single argument.
-		remoteCmd := []string{"cd", workdir, "&&"}
-		remoteCmd = append(remoteCmd, agentCmdParts(agent, fmt.Sprintf("%q", message))...)
-		return execSSH(client, name, false, remoteCmd)
+		remoteCmd := fmt.Sprintf("cd %s && %s", workdir, agentStr)
+		return execSSH(client, name, false, []string{remoteCmd})
 	},
 }
 
@@ -2280,6 +2284,6 @@ func init() {
 	sandboxSSHCmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
 	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor to open (currently only \"cursor\" is supported)")
 	sandboxAgentSendCmd.Flags().Bool("no-wait", false, "Send the instruction and return immediately without waiting for a response")
-	sandboxAgentSendCmd.Flags().String("workdir", sandboxConnectWorkdir, "Working directory inside the container")
+	sandboxAgentSendCmd.Flags().String("workdir", "$AMIKA_AGENT_CWD", "Working directory inside the container (default: $AMIKA_AGENT_CWD)")
 	sandboxAgentSendCmd.Flags().String("agent", "claude", "Agent CLI to use (default \"claude\")")
 }

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1996,6 +1996,150 @@ Examples:
 	},
 }
 
+// agentConfig describes how to invoke an agent CLI in non-interactive mode.
+type agentConfig struct {
+	Binary    string   // CLI binary name
+	PrintArg  string   // flag for non-interactive print mode
+	ExtraArgs []string // additional flags passed on every invocation
+}
+
+// knownAgents maps agent names to their CLI configuration.
+var knownAgents = map[string]agentConfig{
+	"claude": {Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}},
+}
+
+// resolveAgentConfig returns the agent configuration for the given name.
+// Unknown agents use the name as the binary with "-p" as the default flag.
+func resolveAgentConfig(name string) agentConfig {
+	if cfg, ok := knownAgents[name]; ok {
+		return cfg
+	}
+	return agentConfig{Binary: name, PrintArg: "-p"}
+}
+
+var runSandboxAgentSend = func(name, message string, noWait bool, workdir string, agent agentConfig, stdout, stderr io.Writer) error {
+	dockerArgs := buildSandboxAgentSendArgs(name, message, noWait, workdir, agent)
+	dockerCmd := exec.Command("docker", dockerArgs...)
+	if !noWait {
+		dockerCmd.Stdout = stdout
+		dockerCmd.Stderr = stderr
+	}
+	return dockerCmd.Run()
+}
+
+// agentCmdParts returns the agent binary, flags, and message as a flat list.
+func agentCmdParts(agent agentConfig, message string) []string {
+	parts := []string{agent.Binary}
+	parts = append(parts, agent.ExtraArgs...)
+	parts = append(parts, agent.PrintArg, message)
+	return parts
+}
+
+func buildSandboxAgentSendArgs(name, message string, noWait bool, workdir string, agent agentConfig) []string {
+	args := []string{"exec"}
+	if noWait {
+		// Run in a detached tmux session so the agent survives disconnect.
+		sessionName := fmt.Sprintf("amika-agent-send-%d", time.Now().UnixNano())
+		tmuxCmd := fmt.Sprintf("cd %s && %s", workdir, strings.Join(agentCmdParts(agent, fmt.Sprintf("%q", message)), " "))
+		args = append(args, name, "tmux", "new-session", "-d", "-s", sessionName, tmuxCmd)
+	} else {
+		args = append(args, "-w", workdir, name)
+		args = append(args, agentCmdParts(agent, message)...)
+	}
+	return args
+}
+
+func isStdinPiped() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) == 0
+}
+
+var sandboxAgentSendCmd = &cobra.Command{
+	Use:   "agent-send <name> [message]",
+	Short: "Send a message to an agent in a sandbox",
+	Long: `Send a prompt to an AI agent CLI running inside a sandbox container.
+The message can be provided as a positional argument or piped via stdin.
+By default the command waits for the agent to finish and streams the response.
+Use --no-wait to send the message and return immediately.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		name := args[0]
+
+		// Resolve message from args or stdin.
+		var message string
+		if len(args) > 1 {
+			message = strings.Join(args[1:], " ")
+		} else if isStdinPiped() {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("failed to read message from stdin: %w", err)
+			}
+			message = strings.TrimSpace(string(data))
+		}
+		if message == "" {
+			return fmt.Errorf("message is required as an argument or via stdin")
+		}
+
+		noWait, _ := cmd.Flags().GetBool("no-wait")
+		workdir, _ := cmd.Flags().GetString("workdir")
+		agentName, _ := cmd.Flags().GetString("agent")
+		agent := resolveAgentConfig(agentName)
+
+		// Try local sandbox first.
+		sandboxesFile, err := config.SandboxesStateFile()
+		if err == nil {
+			store := sandbox.NewStore(sandboxesFile)
+			if info, err := store.Get(name); err == nil {
+				if info.Provider != "docker" {
+					return fmt.Errorf("unsupported local provider %q: only \"docker\" is supported", info.Provider)
+				}
+				if err := runSandboxAgentSend(name, message, noWait, workdir, agent, os.Stdout, os.Stderr); err != nil {
+					if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 127 {
+						return fmt.Errorf("%s CLI not found in sandbox %q; was it created with the right preset?", agent.Binary, name)
+					}
+					return fmt.Errorf("instruct failed for sandbox %q: %w", name, err)
+				}
+				if noWait {
+					fmt.Fprintf(os.Stderr, "Instruction sent to %s in sandbox %q\n", agent.Binary, name)
+				}
+				return nil
+			}
+		}
+
+		// Not found locally — try remote via SSH.
+		target, err := getRemoteTarget(cmd)
+		if err != nil {
+			return err
+		}
+		client, err := getRemoteClient(target)
+		if err != nil {
+			return err
+		}
+
+		agentStr := strings.Join(agentCmdParts(agent, fmt.Sprintf("%q", message)), " ")
+
+		if noWait {
+			// Run in a detached tmux session so the agent survives SSH disconnect.
+			// Pass as a single string so the remote shell keeps the tmux command intact.
+			sessionName := fmt.Sprintf("amika-agent-send-%d", time.Now().UnixNano())
+			shellCmd := fmt.Sprintf("tmux new-session -d -s '%s' 'cd %s && %s'",
+				sessionName, workdir, agentStr)
+			remoteCmd := []string{shellCmd}
+			return execSSH(client, name, false, remoteCmd)
+		}
+
+		// Quote the message so the remote shell keeps it as a single argument.
+		remoteCmd := []string{"cd", workdir, "&&"}
+		remoteCmd = append(remoteCmd, agentCmdParts(agent, fmt.Sprintf("%q", message))...)
+		return execSSH(client, name, false, remoteCmd)
+	},
+}
+
 var sandboxCodeCmd = &cobra.Command{
 	Use:   "code <name>",
 	Short: "Open a remote sandbox in an editor via SSH",
@@ -2102,6 +2246,7 @@ func init() {
 	sandboxCmd.AddCommand(sandboxConnectCmd)
 	sandboxCmd.AddCommand(sandboxSSHCmd)
 	sandboxCmd.AddCommand(sandboxCodeCmd)
+	sandboxCmd.AddCommand(sandboxAgentSendCmd)
 
 	// Persistent flags for local/remote mode
 	sandboxCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
@@ -2134,4 +2279,7 @@ func init() {
 	sandboxSSHCmd.Flags().BoolP("t", "t", false, "Force pseudo-terminal allocation (like ssh -t)")
 	sandboxSSHCmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
 	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor to open (currently only \"cursor\" is supported)")
+	sandboxAgentSendCmd.Flags().Bool("no-wait", false, "Send the instruction and return immediately without waiting for a response")
+	sandboxAgentSendCmd.Flags().String("workdir", sandboxConnectWorkdir, "Working directory inside the container")
+	sandboxAgentSendCmd.Flags().String("agent", "claude", "Agent CLI to use (default \"claude\")")
 }

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -2022,7 +2022,7 @@ func resolveAgentConfig(name string) (agentConfig, error) {
 }
 
 func runDockerSandboxAgentSend(name, message string, noWait bool, workdir string, agent agentConfig, stdout, stderr io.Writer) error {
-	dockerArgs := buildSandboxAgentSendArgs(name, message, noWait, workdir, agent)
+	dockerArgs := buildDockerAgentSendArgs(name, message, noWait, workdir, agent)
 	dockerCmd := exec.Command("docker", dockerArgs...)
 	if !noWait {
 		dockerCmd.Stdout = stdout
@@ -2039,18 +2039,22 @@ func agentCmdParts(agent agentConfig, message string) []string {
 	return parts
 }
 
-func buildSandboxAgentSendArgs(name, message string, noWait bool, workdir string, agent agentConfig) []string {
-	args := []string{"exec"}
+// buildAgentShellCmd returns the shell command string to run the agent.
+// When noWait is true, the command is wrapped in a detached tmux session.
+// The message is shell-quoted so it survives interpretation as a single argument.
+func buildAgentShellCmd(message string, noWait bool, workdir string, agent agentConfig) string {
+	agentStr := strings.Join(agentCmdParts(agent, fmt.Sprintf("%q", message)), " ")
+	cmd := fmt.Sprintf("cd %s && %s", workdir, agentStr)
 	if noWait {
-		// Run in a detached tmux session so the agent survives disconnect.
 		sessionName := fmt.Sprintf("amika-agent-send-%d", time.Now().UnixNano())
-		tmuxCmd := fmt.Sprintf("cd %s && %s", workdir, strings.Join(agentCmdParts(agent, fmt.Sprintf("%q", message)), " "))
-		args = append(args, name, "tmux", "new-session", "-d", "-s", sessionName, tmuxCmd)
-	} else {
-		args = append(args, "-w", workdir, name)
-		args = append(args, agentCmdParts(agent, message)...)
+		return fmt.Sprintf("tmux new-session -d -s '%s' '%s'", sessionName, cmd)
 	}
-	return args
+	return cmd
+}
+
+func buildDockerAgentSendArgs(name, message string, noWait bool, workdir string, agent agentConfig) []string {
+	shellCmd := buildAgentShellCmd(message, noWait, workdir, agent)
+	return []string{"exec", name, "bash", "-c", shellCmd}
 }
 
 func isStdinPiped() bool {
@@ -2128,19 +2132,8 @@ Use --no-wait to send the message and return immediately.`,
 			return err
 		}
 
-		// Build the remote command as a single shell string so multi-word
-		// messages and tmux commands are preserved through SSH.
-		agentStr := strings.Join(agentCmdParts(agent, fmt.Sprintf("%q", message)), " ")
-
-		if noWait {
-			sessionName := fmt.Sprintf("amika-agent-send-%d", time.Now().UnixNano())
-			shellCmd := fmt.Sprintf("tmux new-session -d -s '%s' 'cd %s && %s'",
-				sessionName, workdir, agentStr)
-			return execSSH(client, name, false, []string{shellCmd})
-		}
-
-		remoteCmd := fmt.Sprintf("cd %s && %s", workdir, agentStr)
-		return execSSH(client, name, false, []string{remoteCmd})
+		shellCmd := buildAgentShellCmd(message, noWait, workdir, agent)
+		return execSSH(client, name, false, []string{shellCmd})
 	},
 }
 

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -567,6 +567,68 @@ func TestBuildSandboxConnectArgs(t *testing.T) {
 	}
 }
 
+func TestBuildSandboxAgentSendArgs(t *testing.T) {
+	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
+
+	t.Run("wait mode", func(t *testing.T) {
+		got := buildSandboxAgentSendArgs("sb-1", "hello world", false, "/home/amika", agent)
+		want := []string{"exec", "-w", "/home/amika", "sb-1", "claude", "--dangerously-skip-permissions", "-p", "hello world"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("args = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("no-wait mode uses tmux", func(t *testing.T) {
+		got := buildSandboxAgentSendArgs("sb-1", "hello world", true, "/home/amika", agent)
+		// Should start with "exec sb-1 tmux new-session -d -s amika-agent-send-..."
+		if len(got) != 8 {
+			t.Fatalf("expected 8 args, got %d: %#v", len(got), got)
+		}
+		if got[0] != "exec" || got[1] != "sb-1" || got[2] != "tmux" || got[3] != "new-session" || got[4] != "-d" || got[5] != "-s" {
+			t.Fatalf("unexpected prefix: %#v", got[:6])
+		}
+		if !strings.HasPrefix(got[6], "amika-agent-send-") {
+			t.Fatalf("session name = %q, want amika-agent-send-* prefix", got[6])
+		}
+		if !strings.Contains(got[7], "--dangerously-skip-permissions") {
+			t.Fatalf("tmux command = %q, want to contain '--dangerously-skip-permissions'", got[7])
+		}
+	})
+
+	t.Run("custom workdir", func(t *testing.T) {
+		got := buildSandboxAgentSendArgs("sb-1", "test", false, "/workspace", agent)
+		want := []string{"exec", "-w", "/workspace", "sb-1", "claude", "--dangerously-skip-permissions", "-p", "test"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("args = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("custom agent without extra args", func(t *testing.T) {
+		custom := agentConfig{Binary: "my-agent", PrintArg: "--msg"}
+		got := buildSandboxAgentSendArgs("sb-1", "fix it", false, "/home/amika", custom)
+		want := []string{"exec", "-w", "/home/amika", "sb-1", "my-agent", "--msg", "fix it"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("args = %#v, want %#v", got, want)
+		}
+	})
+}
+
+func TestResolveAgentConfig(t *testing.T) {
+	t.Run("known agent claude", func(t *testing.T) {
+		cfg := resolveAgentConfig("claude")
+		if cfg.Binary != "claude" || cfg.PrintArg != "-p" || len(cfg.ExtraArgs) != 1 || cfg.ExtraArgs[0] != "--dangerously-skip-permissions" {
+			t.Fatalf("got %+v, want claude/-p/--dangerously-skip-permissions", cfg)
+		}
+	})
+
+	t.Run("unknown agent uses defaults", func(t *testing.T) {
+		cfg := resolveAgentConfig("custom-agent")
+		if cfg.Binary != "custom-agent" || cfg.PrintArg != "-p" {
+			t.Fatalf("got %+v, want custom-agent/-p", cfg)
+		}
+	})
+}
+
 func TestResolveGitRoot(t *testing.T) {
 	t.Run("finds from nested directory", func(t *testing.T) {
 		root := t.TempDir()

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -615,16 +615,22 @@ func TestBuildSandboxAgentSendArgs(t *testing.T) {
 
 func TestResolveAgentConfig(t *testing.T) {
 	t.Run("known agent claude", func(t *testing.T) {
-		cfg := resolveAgentConfig("claude")
+		cfg, err := resolveAgentConfig("claude")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if cfg.Binary != "claude" || cfg.PrintArg != "-p" || len(cfg.ExtraArgs) != 1 || cfg.ExtraArgs[0] != "--dangerously-skip-permissions" {
 			t.Fatalf("got %+v, want claude/-p/--dangerously-skip-permissions", cfg)
 		}
 	})
 
-	t.Run("unknown agent uses defaults", func(t *testing.T) {
-		cfg := resolveAgentConfig("custom-agent")
-		if cfg.Binary != "custom-agent" || cfg.PrintArg != "-p" {
-			t.Fatalf("got %+v, want custom-agent/-p", cfg)
+	t.Run("unknown agent returns error", func(t *testing.T) {
+		_, err := resolveAgentConfig("custom-agent")
+		if err == nil {
+			t.Fatal("expected error for unknown agent, got nil")
+		}
+		if !strings.Contains(err.Error(), "unknown agent") {
+			t.Fatalf("error = %q, want to contain 'unknown agent'", err.Error())
 		}
 	})
 }

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -567,48 +567,56 @@ func TestBuildSandboxConnectArgs(t *testing.T) {
 	}
 }
 
-func TestBuildSandboxAgentSendArgs(t *testing.T) {
+func TestBuildAgentShellCmd(t *testing.T) {
 	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
 
 	t.Run("wait mode", func(t *testing.T) {
-		got := buildSandboxAgentSendArgs("sb-1", "hello world", false, "/home/amika", agent)
-		want := []string{"exec", "-w", "/home/amika", "sb-1", "claude", "--dangerously-skip-permissions", "-p", "hello world"}
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("args = %#v, want %#v", got, want)
+		got := buildAgentShellCmd("hello world", false, "/home/amika", agent)
+		if !strings.Contains(got, "cd /home/amika") {
+			t.Fatalf("cmd = %q, want to contain 'cd /home/amika'", got)
+		}
+		if !strings.Contains(got, "--dangerously-skip-permissions") {
+			t.Fatalf("cmd = %q, want to contain '--dangerously-skip-permissions'", got)
+		}
+		if !strings.Contains(got, "claude") {
+			t.Fatalf("cmd = %q, want to contain 'claude'", got)
+		}
+		if strings.Contains(got, "tmux") {
+			t.Fatalf("cmd = %q, should not contain tmux in wait mode", got)
 		}
 	})
 
-	t.Run("no-wait mode uses tmux", func(t *testing.T) {
-		got := buildSandboxAgentSendArgs("sb-1", "hello world", true, "/home/amika", agent)
-		// Should start with "exec sb-1 tmux new-session -d -s amika-agent-send-..."
-		if len(got) != 8 {
-			t.Fatalf("expected 8 args, got %d: %#v", len(got), got)
+	t.Run("no-wait mode wraps in tmux", func(t *testing.T) {
+		got := buildAgentShellCmd("hello world", true, "/home/amika", agent)
+		if !strings.Contains(got, "tmux new-session -d") {
+			t.Fatalf("cmd = %q, want to contain 'tmux new-session -d'", got)
 		}
-		if got[0] != "exec" || got[1] != "sb-1" || got[2] != "tmux" || got[3] != "new-session" || got[4] != "-d" || got[5] != "-s" {
-			t.Fatalf("unexpected prefix: %#v", got[:6])
+		if !strings.Contains(got, "amika-agent-send-") {
+			t.Fatalf("cmd = %q, want to contain session name prefix", got)
 		}
-		if !strings.HasPrefix(got[6], "amika-agent-send-") {
-			t.Fatalf("session name = %q, want amika-agent-send-* prefix", got[6])
-		}
-		if !strings.Contains(got[7], "--dangerously-skip-permissions") {
-			t.Fatalf("tmux command = %q, want to contain '--dangerously-skip-permissions'", got[7])
+		if !strings.Contains(got, "--dangerously-skip-permissions") {
+			t.Fatalf("cmd = %q, want to contain '--dangerously-skip-permissions'", got)
 		}
 	})
 
 	t.Run("custom workdir", func(t *testing.T) {
-		got := buildSandboxAgentSendArgs("sb-1", "test", false, "/workspace", agent)
-		want := []string{"exec", "-w", "/workspace", "sb-1", "claude", "--dangerously-skip-permissions", "-p", "test"}
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("args = %#v, want %#v", got, want)
+		got := buildAgentShellCmd("test", false, "/workspace", agent)
+		if !strings.Contains(got, "cd /workspace") {
+			t.Fatalf("cmd = %q, want to contain 'cd /workspace'", got)
 		}
 	})
+}
 
-	t.Run("custom agent without extra args", func(t *testing.T) {
-		custom := agentConfig{Binary: "my-agent", PrintArg: "--msg"}
-		got := buildSandboxAgentSendArgs("sb-1", "fix it", false, "/home/amika", custom)
-		want := []string{"exec", "-w", "/home/amika", "sb-1", "my-agent", "--msg", "fix it"}
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("args = %#v, want %#v", got, want)
+func TestBuildDockerAgentSendArgs(t *testing.T) {
+	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
+
+	t.Run("wraps in docker exec bash -c", func(t *testing.T) {
+		got := buildDockerAgentSendArgs("sb-1", "hello", false, "/home/amika", agent)
+		if got[0] != "exec" || got[1] != "sb-1" || got[2] != "bash" || got[3] != "-c" {
+			t.Fatalf("args prefix = %#v, want [exec sb-1 bash -c ...]", got[:4])
+		}
+		if !strings.Contains(got[4], "claude") {
+			t.Fatalf("shell cmd = %q, want to contain 'claude'", got[4])
 		}
 	})
 }


### PR DESCRIPTION
Add a new `amika sandbox agent-send <name> [message]` CLI command that sends prompts to AI agent CLIs (Claude, Codex, etc.) running inside sandbox containers.

Two execution modes:
- **Wait (default):** Streams agent stdout/stderr in real-time via `docker exec` (local) or SSH (remote), blocking until the agent finishes.
- **No-wait (`--no-wait`):** Launches the agent in a detached tmux session so the process survives SSH/container disconnect, then returns immediately.

The command resolves messages from positional args or piped stdin, tries the local sandbox store first, and falls back to remote SSH — matching the existing `sandbox connect` pattern.

Agent CLI differences are handled via a config map (`knownAgents`) that maps agent names to their binary and non-interactive print flag (e.g. claude → `-p`, codex → `--prompt`). Unknown agents default to the name as-is with `-p`.

Flags: --no-wait, --agent (default "claude"), --workdir (default /home/amika)