### PR TITLE
fix: set CWD to agent working directory before running setup.sh

### DIFF
--- a/cmd/amika/materialize_test.go
+++ b/cmd/amika/materialize_test.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
-)
 
-const runExpensiveTestsEnv = "AMIKA_RUN_EXPENSIVE_TESTS"
-const runDockerIntegrationTestsEnv = "AMIKA_RUN_DOCKER_INTEGRATION"
+	"github.com/gofixpoint/amika/test/testutil"
+)
 
 // buildAmika builds the amika binary for integration tests and returns its path.
 func buildAmika(t *testing.T) string {
@@ -46,7 +45,7 @@ func findModuleRoot(t *testing.T) string {
 }
 
 func TestTopMaterialize_CmdDefaultOutdir(t *testing.T) {
-	requireDockerIntegration(t)
+	testutil.RequireDockerIntegration(t)
 	bin := buildAmika(t)
 	destdir := t.TempDir()
 
@@ -69,7 +68,7 @@ func TestTopMaterialize_CmdDefaultOutdir(t *testing.T) {
 }
 
 func TestTopMaterialize_CmdAbsoluteOutdir(t *testing.T) {
-	requireDockerIntegration(t)
+	testutil.RequireDockerIntegration(t)
 	bin := buildAmika(t)
 	destdir := t.TempDir()
 
@@ -93,7 +92,7 @@ func TestTopMaterialize_CmdAbsoluteOutdir(t *testing.T) {
 }
 
 func TestTopMaterialize_CmdRelativeOutdir(t *testing.T) {
-	requireDockerIntegration(t)
+	testutil.RequireDockerIntegration(t)
 	bin := buildAmika(t)
 	destdir := t.TempDir()
 
@@ -117,7 +116,7 @@ func TestTopMaterialize_CmdRelativeOutdir(t *testing.T) {
 }
 
 func TestTopMaterialize_SandboxCleanup(t *testing.T) {
-	requireDockerIntegration(t)
+	testutil.RequireDockerIntegration(t)
 	bin := buildAmika(t)
 	destdir := t.TempDir()
 
@@ -144,7 +143,7 @@ func TestTopMaterialize_SandboxCleanup(t *testing.T) {
 }
 
 func TestTopMaterialize_Script(t *testing.T) {
-	requireDockerIntegration(t)
+	testutil.RequireDockerIntegration(t)
 	bin := buildAmika(t)
 	destdir := t.TempDir()
 	scriptDir := t.TempDir()
@@ -174,7 +173,7 @@ func TestTopMaterialize_Script(t *testing.T) {
 }
 
 func TestTopMaterialize_PresetAgentsAvailableOnPath(t *testing.T) {
-	requireExpensiveDockerTests(t)
+	testutil.RequireExpensiveDockerTests(t)
 
 	bin := buildAmika(t)
 	prefix := fmt.Sprintf("amika-test-%d", time.Now().UnixNano())
@@ -233,16 +232,6 @@ func TestTopMaterialize_PresetAgentsAvailableOnPath(t *testing.T) {
 	}
 }
 
-func requireExpensiveDockerTests(t *testing.T) {
-	t.Helper()
-
-	requireDockerIntegration(t)
-
-	if os.Getenv(runExpensiveTestsEnv) != "1" {
-		t.Skipf("set %s=1 to run expensive Docker rebuild tests", runExpensiveTestsEnv)
-	}
-}
-
 func withEnv(base []string, kvs ...string) []string {
 	env := append([]string(nil), base...)
 	for _, kv := range kvs {
@@ -262,23 +251,4 @@ func withEnv(base []string, kvs ...string) []string {
 		env = append(filtered, kv)
 	}
 	return env
-}
-
-func requireDockerIntegration(t *testing.T) {
-	t.Helper()
-
-	if os.Getenv(runDockerIntegrationTestsEnv) != "1" {
-		t.Skipf("set %s=1 to run docker-backed integration tests", runDockerIntegrationTestsEnv)
-	}
-
-	requireDocker(t)
-}
-
-func requireDocker(t *testing.T) {
-	t.Helper()
-
-	cmd := exec.Command("docker", "info")
-	if err := cmd.Run(); err != nil {
-		t.Skipf("docker unavailable: %v", err)
-	}
 }

--- a/internal/sandbox/pre_setup_test.go
+++ b/internal/sandbox/pre_setup_test.go
@@ -114,6 +114,7 @@ func TestPresetRunHook_UsesAmikaOnlyForSetupAndMirrorsItToAmikad(t *testing.T) {
 		`exec >>"$log_file" 2>&1`,
 		`sudo cp "$log_file" "$daemon_log_file"`,
 		`export BASH_ENV="/usr/lib/amikad/bash-error-prelude.sh"`,
+		`_amika_cwd_file="/var/lib/amikad/agent-cwd"`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("run-hook.sh missing %q", want)

--- a/internal/sandbox/presets/run-hook.sh
+++ b/internal/sandbox/presets/run-hook.sh
@@ -42,6 +42,14 @@ if [[ -f /usr/local/etc/amikad/setup/env.sh ]]; then
   source /usr/local/etc/amikad/setup/env.sh
 fi
 
+# Change to the agent working directory for the user-facing setup hook only.
+if [[ "$script_name" == "setup.sh" ]]; then
+  _amika_cwd_file="/var/lib/amikad/agent-cwd"
+  if [[ -f "$_amika_cwd_file" ]]; then
+    cd "$(cat "$_amika_cwd_file")"
+  fi
+fi
+
 set +e
 "$script_path"
 status=$?

--- a/test/integration/cli/sandbox_setup_test.go
+++ b/test/integration/cli/sandbox_setup_test.go
@@ -39,10 +39,7 @@ import (
 // records pwd and the env var to files. The materialize --cmd then copies
 // those files to the output directory where the test can read them.
 func TestSetupScript_CWDAndEnv(t *testing.T) {
-	testutil.RequireDockerIntegration(t)
-	if os.Getenv("AMIKA_RUN_EXPENSIVE_TESTS") != "1" {
-		t.Skip("set AMIKA_RUN_EXPENSIVE_TESTS=1 to run expensive Docker rebuild tests")
-	}
+	testutil.RequireExpensiveDockerTests(t)
 
 	bin := testutil.BuildAmikaBinary(t)
 

--- a/test/integration/cli/sandbox_setup_test.go
+++ b/test/integration/cli/sandbox_setup_test.go
@@ -1,0 +1,94 @@
+// sandbox_setup_test.go verifies that the container lifecycle correctly
+// configures the environment and working directory before running the
+// user-provided setup.sh hook.
+//
+// Background:
+// When a sandbox starts, the ENTRYPOINT runs three hooks in order:
+//   1. pre-setup.sh  — root-owned initialization; writes the agent working
+//      directory to /var/lib/amikad/agent-cwd.
+//   2. setup.sh      — user-provided hook; should see AMIKA_AGENT_CWD in the
+//      environment and should run with CWD set to that directory.
+//   3. post-setup.sh — root-owned cleanup.
+//
+// The CWD is set by run-hook.sh, which reads the agent-cwd file written by
+// pre-setup.sh and cd's into it before executing setup.sh. This test ensures
+// that both the environment variable and the working directory are correctly
+// propagated.
+//
+// These tests require preset Docker images (e.g. coder) and are gated behind
+// AMIKA_RUN_EXPENSIVE_TESTS=1 and AMIKA_RUN_DOCKER_INTEGRATION=1.
+
+package cli_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/amika/test/testutil"
+)
+
+// TestSetupScript_CWDAndEnv verifies that when AMIKA_AGENT_CWD is set, the
+// user-provided setup.sh runs with:
+//   - CWD equal to AMIKA_AGENT_CWD
+//   - AMIKA_AGENT_CWD available in the environment
+//
+// It uses amika materialize with --preset coder and a setup script that
+// records pwd and the env var to files. The materialize --cmd then copies
+// those files to the output directory where the test can read them.
+func TestSetupScript_CWDAndEnv(t *testing.T) {
+	testutil.RequireDockerIntegration(t)
+	if os.Getenv("AMIKA_RUN_EXPENSIVE_TESTS") != "1" {
+		t.Skip("set AMIKA_RUN_EXPENSIVE_TESTS=1 to run expensive Docker rebuild tests")
+	}
+
+	bin := testutil.BuildAmikaBinary(t)
+
+	// Write a temporary setup.sh that captures the CWD and env var.
+	setupScript := filepath.Join(t.TempDir(), "setup.sh")
+	err := os.WriteFile(setupScript, []byte("#!/bin/bash\npwd > /tmp/setup-cwd.txt\necho \"$AMIKA_AGENT_CWD\" > /tmp/setup-env.txt\n"), 0755)
+	if err != nil {
+		t.Fatalf("failed to write setup script: %v", err)
+	}
+
+	destdir := t.TempDir()
+	expectedCWD := "/home/amika/workspace"
+
+	// Run materialize with a preset image so the full lifecycle
+	// (pre-setup -> setup -> post-setup) executes via the ENTRYPOINT.
+	// AMIKA_OPENCODE_WEB=0 disables the opencode web server which
+	// would otherwise require OPENCODE_SERVER_PASSWORD.
+	cmd := exec.Command(bin,
+		"materialize",
+		"--preset", "coder",
+		"--setup-script", setupScript,
+		"--env", "AMIKA_AGENT_CWD="+expectedCWD,
+		"--env", "AMIKA_OPENCODE_WEB=0",
+		"--cmd", "cp /tmp/setup-cwd.txt . && cp /tmp/setup-env.txt .",
+		"--destdir", destdir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("materialize failed: %v\n%s", err, string(out))
+	}
+
+	// Verify that setup.sh ran with the correct CWD.
+	cwdData, err := os.ReadFile(filepath.Join(destdir, "setup-cwd.txt"))
+	if err != nil {
+		t.Fatalf("failed to read setup-cwd.txt: %v", err)
+	}
+	if got := strings.TrimSpace(string(cwdData)); got != expectedCWD {
+		t.Errorf("setup.sh CWD = %q, want %q", got, expectedCWD)
+	}
+
+	// Verify that AMIKA_AGENT_CWD was available in the environment.
+	envData, err := os.ReadFile(filepath.Join(destdir, "setup-env.txt"))
+	if err != nil {
+		t.Fatalf("failed to read setup-env.txt: %v", err)
+	}
+	if got := strings.TrimSpace(string(envData)); got != expectedCWD {
+		t.Errorf("AMIKA_AGENT_CWD = %q, want %q", got, expectedCWD)
+	}
+}

--- a/test/testutil/amika.go
+++ b/test/testutil/amika.go
@@ -13,6 +13,8 @@ import (
 const (
 	// RunDockerIntegrationTestsEnv gates Docker-backed integration tests.
 	RunDockerIntegrationTestsEnv = "AMIKA_RUN_DOCKER_INTEGRATION"
+	// RunExpensiveTestsEnv gates expensive tests that rebuild Docker images.
+	RunExpensiveTestsEnv = "AMIKA_RUN_EXPENSIVE_TESTS"
 )
 
 // BuildAmikaBinary builds amika and returns the path to the binary.
@@ -62,6 +64,17 @@ func RequireDockerIntegration(t *testing.T) {
 	cmd := exec.Command("docker", "info")
 	if err := cmd.Run(); err != nil {
 		t.Skipf("docker unavailable: %v", err)
+	}
+}
+
+// RequireExpensiveDockerTests skips unless both Docker integration and expensive tests are enabled.
+func RequireExpensiveDockerTests(t *testing.T) {
+	t.Helper()
+
+	RequireDockerIntegration(t)
+
+	if os.Getenv(RunExpensiveTestsEnv) != "1" {
+		t.Skipf("set %s=1 to run expensive Docker rebuild tests", RunExpensiveTestsEnv)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `run-hook.sh` now reads `/var/lib/amikad/agent-cwd` (written by `pre-setup.sh`) and `cd`s into it before executing `setup.sh`, so the user-provided setup hook runs from the project directory instead of `/home/amika`.
- Only `setup.sh` is affected — `pre-setup.sh` and `post-setup.sh` keep their existing CWD behavior.
- Extracts `RequireExpensiveDockerTests` into `test/testutil` to deduplicate the skip check across test packages.