### PR TITLE
feat: add `--branch` flag to sandbox create for git branch support

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -163,9 +163,11 @@ var sandboxCreateCmd = &cobra.Command{
 		}
 		image = resolvedImage.Image
 
+		branchFlag, _ := cmd.Flags().GetString("branch")
 		collected, err := collectMounts(mountStrs, volumeStrs, portStrs, portHostIP,
 			gitPath, gitFlagChanged, noClean,
-			setupScript, cmd.Flags().Changed("setup-script"))
+			setupScript, cmd.Flags().Changed("setup-script"),
+			branchFlag)
 		if err != nil {
 			return err
 		}
@@ -294,6 +296,7 @@ var sandboxCreateCmd = &cobra.Command{
 			return err
 		}
 
+		branch, _ := cmd.Flags().GetString("branch")
 		info := sandbox.Info{
 			Name:        name,
 			Provider:    provider,
@@ -305,6 +308,7 @@ var sandboxCreateCmd = &cobra.Command{
 			Env:         envStrs,
 			Ports:       publishedPorts,
 			Services:    collected.Services,
+			Branch:      branch,
 		}
 		if err := store.Save(info); err != nil {
 			return fmt.Errorf("sandbox created but failed to save state: %w", err)
@@ -679,6 +683,7 @@ var sandboxListCmd = &cobra.Command{
 					Provider:  rs.Provider,
 					CreatedAt: rs.CreatedAt,
 					Location:  "remote",
+					Branch:    rs.Branch,
 				})
 			}
 		}
@@ -689,9 +694,9 @@ var sandboxListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tPROVIDER\tIMAGE\tPORTS\tCREATED")
+		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tPROVIDER\tIMAGE\tBRANCH\tPORTS\tCREATED")
 		for _, sb := range allItems {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Provider, sb.Image, formatPortBindings(sb.Ports), sb.CreatedAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Provider, sb.Image, sb.Branch, formatPortBindings(sb.Ports), sb.CreatedAt)
 		}
 		w.Flush()
 		return nil
@@ -1035,7 +1040,7 @@ type gitMountInfo struct {
 	Mount    sandbox.MountBinding
 }
 
-func prepareGitMount(startPath string, noClean bool, cloneFn func(src, dst string) error) (gitMountInfo, func(), error) {
+func prepareGitMount(startPath string, noClean bool, cloneFn func(src, dst, branch string) error, branch string) (gitMountInfo, func(), error) {
 	repoRoot, err := resolveGitRoot(startPath)
 	if err != nil {
 		return gitMountInfo{}, func() {}, err
@@ -1054,7 +1059,7 @@ func prepareGitMount(startPath string, noClean bool, cloneFn func(src, dst strin
 			return gitMountInfo{}, func() {}, err
 		}
 	} else {
-		if err := cloneFn(repoRoot, preparedRepo); err != nil {
+		if err := cloneFn(repoRoot, preparedRepo, branch); err != nil {
 			_ = os.RemoveAll(tmpDir)
 			return gitMountInfo{}, func() {}, err
 		}
@@ -1109,8 +1114,13 @@ func resolveGitRoot(startPath string) (string, error) {
 	return "", fmt.Errorf("no git repository root found from %q", absPath)
 }
 
-func cloneGitRepo(src, dst string) error {
-	cmd := exec.Command("git", "clone", "--local", "--no-hardlinks", src, dst)
+func cloneGitRepo(src, dst, branch string) error {
+	args := []string{"clone", "--local", "--no-hardlinks"}
+	if branch != "" {
+		args = append(args, "--branch", branch)
+	}
+	args = append(args, src, dst)
+	cmd := exec.Command("git", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to prepare clean git mount from %q: %s", src, strings.TrimSpace(string(out)))
@@ -1298,6 +1308,7 @@ func collectMounts(
 	noClean bool,
 	setupScript string,
 	setupScriptFlagChanged bool,
+	branch string,
 ) (collectedMounts, error) {
 	mounts, err := parseMountFlags(mountStrs)
 	if err != nil {
@@ -1315,7 +1326,7 @@ func collectMounts(
 	cleanup := func() {}
 	var gmi *gitMountInfo
 	if gitFlagChanged {
-		info, cleanupGitMount, err := prepareGitMount(gitPath, noClean, cloneGitRepo)
+		info, cleanupGitMount, err := prepareGitMount(gitPath, noClean, cloneGitRepo, branch)
 		if err != nil {
 			return collectedMounts{}, err
 		}
@@ -1773,6 +1784,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	preset, _ := cmd.Flags().GetString("preset")
 	size, _ := cmd.Flags().GetString("size")
 	setupScript, _ := cmd.Flags().GetString("setup-script")
+	branch, _ := cmd.Flags().GetString("branch")
 
 	if name == "" {
 		name = sandbox.GenerateName()
@@ -1824,6 +1836,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		Size:                 size,
 		SetupScriptText:      setupScriptText,
 		ClaudeCredentialName: claudeCredentialName,
+		Branch:               branch,
 	}
 
 	sb, err := client.CreateSandbox(req)
@@ -2269,6 +2282,7 @@ func init() {
 	sandboxCreateCmd.Flags().Bool("yes", false, "Skip mount confirmation prompt")
 	sandboxCreateCmd.Flags().Bool("connect", false, "Connect to the sandbox shell immediately after creation")
 	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /usr/local/etc/amikad/setup/setup.sh in the container (read-only)")
+	sandboxCreateCmd.Flags().String("branch", "", "Git branch to clone (defaults to repo's default branch)")
 	sandboxDeleteCmd.Flags().Bool("force", false, "Skip confirmation prompt")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -723,10 +723,10 @@ func TestPrepareGitMount_NoClean(t *testing.T) {
 		t.Fatalf("failed to create untracked file: %v", err)
 	}
 
-	info, cleanup, err := prepareGitMount(root, true, func(_, _ string) error {
+	info, cleanup, err := prepareGitMount(root, true, func(_, _, _ string) error {
 		t.Fatal("cloneFn should not be called in --no-clean mode")
 		return nil
-	})
+	}, "")
 	defer cleanup()
 	if err != nil {
 		t.Fatalf("prepareGitMount failed: %v", err)
@@ -754,16 +754,21 @@ func TestPrepareGitMount_CleanClone(t *testing.T) {
 	})
 
 	var clonedSrc, clonedDst string
-	info, cleanup, err := prepareGitMount(root, false, func(src, dst string) error {
+	info, cleanup, err := prepareGitMount(root, false, func(src, dst, branch string) error {
 		clonedSrc = src
 		clonedDst = dst
-		cmd := exec.Command("git", "clone", "--local", "--no-hardlinks", src, dst)
+		args := []string{"clone", "--local", "--no-hardlinks"}
+		if branch != "" {
+			args = append(args, "--branch", branch)
+		}
+		args = append(args, src, dst)
+		cmd := exec.Command("git", args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("clone failed: %s", out)
 		}
 		return nil
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("prepareGitMount failed: %v", err)
 	}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -45,6 +45,7 @@ type CreateSandboxRequest struct {
 	Size                 string            `json:"size,omitempty"`
 	SetupScriptText      string            `json:"setup_script_text,omitempty"`
 	ClaudeCredentialName string            `json:"claude_credential_name,omitempty"`
+	Branch               string            `json:"branch,omitempty"`
 }
 
 // RemoteSandbox represents a sandbox returned by the remote API.
@@ -55,6 +56,7 @@ type RemoteSandbox struct {
 	GitHubURL string `json:"github_url"`
 	State     string `json:"state"`
 	CreatedAt string `json:"created_at"`
+	Branch    string `json:"branch"`
 }
 
 // ListSandboxes fetches sandboxes from the remote API.

--- a/internal/sandbox/store.go
+++ b/internal/sandbox/store.go
@@ -53,6 +53,7 @@ type Info struct {
 	Env         []string       `json:"env,omitempty"`
 	Ports       []PortBinding  `json:"ports,omitempty"`
 	Services    []ServiceInfo  `json:"services,omitempty"`
+	Branch      string         `json:"branch,omitempty"`
 }
 
 // Store manages sandbox state persistence.

--- a/pkg/amika/requests.go
+++ b/pkg/amika/requests.go
@@ -32,6 +32,7 @@ type CreateSandboxRequest struct {
 	Ports           []PortBinding `json:"Ports,omitempty"`
 	SetupScript     string        `json:"SetupScript,omitempty"`
 	SetupScriptText string        `json:"SetupScriptText,omitempty"`
+	Branch          string        `json:"Branch,omitempty"`
 }
 
 // DeleteSandboxRequest describes sandbox deletion input.

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -10,6 +10,7 @@ type Sandbox struct {
 	CreatedAt   string
 	Preset      string
 	Location    string // "local" or "remote"
+	Branch      string
 	Mounts      []Mount
 	Env         []string
 	Ports       []PortBinding

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -113,7 +113,7 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	cleanupGitRepo := func() {}
 	var repoCfg *amikaconfig.Config
 	if req.GitRepo != "" {
-		gitResult, gitCleanup, err := s.resolveGitRepoMount(name, req.GitRepo)
+		gitResult, gitCleanup, err := s.resolveGitRepoMount(name, req.GitRepo, req.Branch)
 		if err != nil {
 			cleanupSetupScript()
 			return Sandbox{}, err
@@ -171,6 +171,7 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		Env:         req.Env,
 		Ports:       sandboxPorts,
 		Services:    serviceInfos,
+		Branch:      req.Branch,
 	}
 	if err := s.sandboxes.Save(info); err != nil {
 		return Sandbox{}, fmt.Errorf("%w: %v", ErrInternal, err)
@@ -182,6 +183,7 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		Image:       info.Image,
 		CreatedAt:   info.CreatedAt,
 		Preset:      info.Preset,
+		Branch:      info.Branch,
 		Mounts:      toMounts(info.Mounts),
 		Env:         info.Env,
 		Ports:       toPortBindings(info.Ports),
@@ -246,6 +248,7 @@ func (s *serviceImpl) ListSandboxes(context.Context, ListSandboxesRequest) (List
 			Image:       it.Image,
 			CreatedAt:   it.CreatedAt,
 			Preset:      it.Preset,
+			Branch:      it.Branch,
 			Mounts:      toMounts(it.Mounts),
 			Env:         it.Env,
 			Ports:       toPortBindings(it.Ports),
@@ -505,7 +508,7 @@ type gitRepoResult struct {
 // Docker volume, and returns a volume MountBinding targeting the sandbox
 // workspace. The returned cleanup func removes the volume on error; call it
 // only on failure paths. It also reads .amika/config.toml from the cloned repo.
-func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (gitRepoResult, func(), error) {
+func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo, branch string) (gitRepoResult, func(), error) {
 	repoName, err := parseGitRepoURL(gitRepo)
 	if err != nil {
 		return gitRepoResult{}, func() {}, err
@@ -522,7 +525,12 @@ func (s *serviceImpl) resolveGitRepoMount(sandboxName, gitRepo string) (gitRepoR
 		cloneURL = strings.TrimPrefix(gitRepo, "file://")
 	}
 
-	cmd := exec.Command("git", "clone", cloneURL, cloneDst)
+	cloneArgs := []string{"clone"}
+	if branch != "" {
+		cloneArgs = append(cloneArgs, "--branch", branch)
+	}
+	cloneArgs = append(cloneArgs, cloneURL, cloneDst)
+	cmd := exec.Command("git", cloneArgs...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		return gitRepoResult{}, func() {}, fmt.Errorf("%w: git clone %q failed: %s", ErrDependency, gitRepo, strings.TrimSpace(string(out)))


### PR DESCRIPTION
Pass a branch argument through the CLI, public service API, HTTP API, and remote API client so sandboxes can clone a specific git branch instead of the repo default. The branch is persisted in local sandbox state and displayed in `sandbox list`.