### PR TITLE
fix: resolve two test-expensive failures

### DIFF
--- a/internal/sandbox/presets/pre-setup.sh
+++ b/internal/sandbox/presets/pre-setup.sh
@@ -71,8 +71,12 @@ if [[ -f /usr/local/etc/amika/dind-enabled ]]; then
 fi
 
 # Configure pnpm global bin directory so setup.sh can run `pnpm add -g`.
+# Create as root first because Docker bind-mounts (e.g. agent credential files
+# under ~/.local/) can leave intermediate directories root-owned, preventing
+# the amika user from creating subdirectories.
 PNPM_HOME="/home/amika/.local/share/pnpm"
-sudo -H -u amika mkdir -p "$PNPM_HOME"
+mkdir -p "$PNPM_HOME"
+chown -R amika:amika /home/amika/.local
 cat > /usr/local/etc/amikad/setup/env.sh <<'ENVEOF'
 export PNPM_HOME="$HOME/.local/share/pnpm"
 export PATH="$PNPM_HOME:$PATH"

--- a/test/integration/cli/sandbox_lifecycle_test.go
+++ b/test/integration/cli/sandbox_lifecycle_test.go
@@ -14,7 +14,7 @@ func TestSandboxLifecycle(t *testing.T) {
 	name := testutil.NewSandboxName("amika-int")
 
 	t.Cleanup(func() {
-		_ = exec.Command(bin, "sandbox", "delete", "--local", name, "--keep-volumes").Run()
+		_ = exec.Command(bin, "sandbox", "delete", "--local", "--force", name, "--keep-volumes").Run()
 	})
 
 	create := exec.Command(bin, "sandbox", "create", "--local", "--name", name, "--image", "ubuntu:latest", "--yes")
@@ -32,7 +32,7 @@ func TestSandboxLifecycle(t *testing.T) {
 		t.Fatalf("expected sandbox list output to contain %q, got:\n%s", name, string(listOut))
 	}
 
-	deleteCmd := exec.Command(bin, "sandbox", "delete", "--local", name, "--keep-volumes")
+	deleteCmd := exec.Command(bin, "sandbox", "delete", "--local", "--force", name, "--keep-volumes")
 	deleteOut, err := deleteCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("sandbox delete failed: %v\n%s", err, string(deleteOut))


### PR DESCRIPTION
Fix pre-setup.sh pnpm directory creation failing when Docker bind-mounts (e.g. agent credential files under ~/.local/) leave intermediate directories root-owned. Create as root then chown instead of running mkdir as the amika user.

Fix sandbox lifecycle integration test failing because sandbox delete prompts for confirmation and receives EOF. Pass --force to skip the prompt.