### PR TITLE
feat: restrict allowed presets to "coder" and "coder-dind"

### DIFF
--- a/cmd/amika/materialize.go
+++ b/cmd/amika/materialize.go
@@ -313,7 +313,7 @@ func init() {
 	topMaterializeCmd.Flags().String("outdir", "", "Container directory to copy from (default: workdir)")
 	topMaterializeCmd.Flags().String("destdir", "", "Host directory where output files are copied")
 	topMaterializeCmd.Flags().String("image", sandbox.DefaultCoderImage, "Docker image to use")
-	topMaterializeCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"coder\" or \"claude\")")
+	topMaterializeCmd.Flags().String("preset", "", `Use a preset environment ("coder" or "coder-dind")`)
 	topMaterializeCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
 	topMaterializeCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	topMaterializeCmd.Flags().BoolP("interactive", "i", false, "Run interactively with TTY (for programs like claude)")

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1782,6 +1782,9 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	secretFlags, _ := cmd.Flags().GetStringArray("secret")
 	envFlags, _ := cmd.Flags().GetStringArray("env")
 	preset, _ := cmd.Flags().GetString("preset")
+	if err := sandbox.ValidatePreset(preset); err != nil {
+		return err
+	}
 	size, _ := cmd.Flags().GetString("size")
 	setupScript, _ := cmd.Flags().GetString("setup-script")
 	branch, _ := cmd.Flags().GetString("branch")
@@ -2268,7 +2271,7 @@ func init() {
 	sandboxCreateCmd.Flags().String("provider", "docker", "Sandbox provider")
 	sandboxCreateCmd.Flags().String("name", "", "Name for the sandbox (auto-generated if not set)")
 	sandboxCreateCmd.Flags().String("image", sandbox.DefaultCoderImage, "Docker image to use")
-	sandboxCreateCmd.Flags().String("preset", "", "Use a preset environment (e.g. \"coder\" or \"claude\")")
+	sandboxCreateCmd.Flags().String("preset", "", `Use a preset environment ("coder" or "coder-dind")`)
 	sandboxCreateCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rwcopy)")
 	sandboxCreateCmd.Flags().StringArray("volume", nil, "Mount an existing named volume (name:target[:mode], mode defaults to rw)")
 	sandboxCreateCmd.Flags().StringArray("port", nil, "Publish a container port (hostPort:containerPort[/protocol], protocol defaults to tcp)")

--- a/internal/sandbox/image_resolution.go
+++ b/internal/sandbox/image_resolution.go
@@ -4,12 +4,29 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 const presetImagePrefixEnv = "AMIKA_PRESET_IMAGE_PREFIX"
 
 // DefaultCoderImage is the default Docker image used for the coder preset.
 const DefaultCoderImage = "amika/coder:latest"
+
+// AllowedPresets lists the preset names available for user selection via --preset.
+var AllowedPresets = []string{"coder", "coder-dind"}
+
+// ValidatePreset returns an error if preset is non-empty and not in AllowedPresets.
+func ValidatePreset(preset string) error {
+	if preset == "" {
+		return nil
+	}
+	for _, p := range AllowedPresets {
+		if preset == p {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown preset %q; allowed presets: %s", preset, strings.Join(AllowedPresets, ", "))
+}
 
 // PresetImageOptions controls how image/preset resolution and auto-build work.
 type PresetImageOptions struct {
@@ -34,6 +51,10 @@ var (
 
 // ResolveAndEnsureImage resolves image/preset behavior and auto-builds presets when needed.
 func ResolveAndEnsureImage(opts PresetImageOptions) (PresetImageResult, error) {
+	if err := ValidatePreset(opts.Preset); err != nil {
+		return PresetImageResult{}, err
+	}
+
 	result := PresetImageResult{
 		Image: opts.Image,
 	}

--- a/internal/sandbox/image_resolution_test.go
+++ b/internal/sandbox/image_resolution_test.go
@@ -18,7 +18,7 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherImageWins(t *testing.T) {
 
 	res, err := ResolveAndEnsureImage(PresetImageOptions{
 		Image:            "ubuntu:latest",
-		Preset:           "claude",
+		Preset:           "coder-dind",
 		ImageFlagChanged: true,
 	})
 	if err != nil {
@@ -27,8 +27,8 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherImageWins(t *testing.T) {
 	if res.Image != "ubuntu:latest" {
 		t.Fatalf("image = %q, want %q", res.Image, "ubuntu:latest")
 	}
-	if res.EffectivePreset != "claude" {
-		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "claude")
+	if res.EffectivePreset != "coder-dind" {
+		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder-dind")
 	}
 	if res.BuildPreset != "" {
 		t.Fatalf("build preset = %q, want empty", res.BuildPreset)
@@ -70,7 +70,7 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherNoAutoBuild(t *testing.T) {
 	}
 }
 
-func TestResolveAndEnsureImage_ExplicitClaudePresetBuildsWhenMissing(t *testing.T) {
+func TestResolveAndEnsureImage_ExplicitCoderDindPresetBuildsWhenMissing(t *testing.T) {
 	resetImageResolutionStubs(t)
 
 	var builtPreset string
@@ -86,24 +86,24 @@ func TestResolveAndEnsureImage_ExplicitClaudePresetBuildsWhenMissing(t *testing.
 	}
 
 	res, err := ResolveAndEnsureImage(PresetImageOptions{
-		Image:              "amika/claude:latest",
-		Preset:             "claude",
+		Image:              "amika/coder-dind:latest",
+		Preset:             "coder-dind",
 		DefaultBuildPreset: "coder",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Image != "amika/claude:latest" {
-		t.Fatalf("image = %q, want %q", res.Image, "amika/claude:latest")
+	if res.Image != "amika/coder-dind:latest" {
+		t.Fatalf("image = %q, want %q", res.Image, "amika/coder-dind:latest")
 	}
-	if res.EffectivePreset != "claude" {
-		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "claude")
+	if res.EffectivePreset != "coder-dind" {
+		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder-dind")
 	}
-	if res.BuildPreset != "claude" {
-		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "claude")
+	if res.BuildPreset != "coder-dind" {
+		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder-dind")
 	}
-	if builtPreset != "claude" {
-		t.Fatalf("built preset = %q, want %q", builtPreset, "claude")
+	if builtPreset != "coder-dind" {
+		t.Fatalf("built preset = %q, want %q", builtPreset, "coder-dind")
 	}
 	if builtContextDir != "/fake/context" {
 		t.Fatalf("context dir = %q, want %q", builtContextDir, "/fake/context")


### PR DESCRIPTION
Add ValidatePreset to reject unknown preset names early in both local and remote sandbox creation paths, and update --preset help text accordingly.