### PR TITLE
feat: add session management to `sandbox agent-send` for remote sandboxes

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -2039,10 +2041,43 @@ func runDockerSandboxAgentSend(name, message string, noWait bool, workdir string
 	return dockerCmd.Run()
 }
 
+// agentRunOpts holds per-invocation options for an agent command.
+type agentRunOpts struct {
+	SessionID  string // resume an existing session
+	Resume     bool   // resume the most recent session
+	NewSession bool   // start a new session (do not resume)
+}
+
 // agentCmdParts returns the agent binary, flags, and message as a flat list.
 func agentCmdParts(agent agentConfig, message string) []string {
 	parts := []string{agent.Binary}
 	parts = append(parts, agent.ExtraArgs...)
+	parts = append(parts, agent.PrintArg, message)
+	return parts
+}
+
+// agentCmdPartsWithOpts returns the agent binary, flags, session options, and
+// message as a flat list. When jsonOutput is true, --output-format json is
+// appended so the caller can extract the session ID from Claude's output.
+//
+// Flag mapping (amika → Claude CLI):
+//
+//	SessionID → --resume <id>   (resume a specific session)
+//	Resume    → --continue      (continue the most recent session)
+//	NewSession → (no flag)      (Claude's default is a new session)
+func agentCmdPartsWithOpts(agent agentConfig, message string, opts agentRunOpts, jsonOutput bool) []string {
+	parts := []string{agent.Binary}
+	parts = append(parts, agent.ExtraArgs...)
+	if opts.SessionID != "" {
+		parts = append(parts, "--resume", opts.SessionID)
+	}
+	if opts.Resume {
+		parts = append(parts, "--continue")
+	}
+	// NewSession: no flag needed — Claude starts a new session by default.
+	if jsonOutput {
+		parts = append(parts, "--output-format", "json")
+	}
 	parts = append(parts, agent.PrintArg, message)
 	return parts
 }
@@ -2058,6 +2093,116 @@ func buildAgentShellCmd(message string, noWait bool, workdir string, agent agent
 		return fmt.Sprintf("tmux new-session -d -s '%s' '%s'", sessionName, cmd)
 	}
 	return cmd
+}
+
+// buildRemoteAgentShellCmd builds a shell command for remote execution.
+// In wait mode, --output-format json is enabled so the caller can extract
+// the session ID. In no-wait mode, the command is wrapped in a detached
+// tmux session without JSON output.
+func buildRemoteAgentShellCmd(message string, noWait bool, workdir string, agent agentConfig, opts agentRunOpts) string {
+	agentStr := strings.Join(agentCmdPartsWithOpts(agent, fmt.Sprintf("%q", message), opts, !noWait), " ")
+	cmd := fmt.Sprintf("cd %s && %s", workdir, agentStr)
+	if noWait {
+		sessionName := fmt.Sprintf("amika-agent-send-%d", time.Now().UnixNano())
+		return fmt.Sprintf("tmux new-session -d -s '%s' '%s'", sessionName, cmd)
+	}
+	return cmd
+}
+
+// claudeJSONOutput is the subset of fields we parse from
+// `claude -p --output-format json` output.
+type claudeJSONOutput struct {
+	SessionID string `json:"session_id"`
+	Result    string `json:"result"`
+	IsError   bool   `json:"is_error"`
+}
+
+// runRemoteAgentSend runs an agent command on a remote sandbox via SSH,
+// captures the JSON output to extract the session ID, manages sessions
+// via the API, and prints the result text to stdout.
+func runRemoteAgentSend(client *apiclient.Client, name, message string, noWait bool, workdir string, agent agentConfig, opts agentRunOpts, stdout, stderr io.Writer) error {
+	// Resolve session for default behavior (no explicit session flags).
+	var existingSession *apiclient.Session
+	if !opts.NewSession && opts.SessionID == "" && !opts.Resume {
+		session, err := client.GetLatestSession(name)
+		if err != nil {
+			fmt.Fprintf(stderr, "Warning: could not look up latest session: %v\n", err)
+		} else if session != nil && session.Status == "active" {
+			if claudeID, ok := session.Metadata["claude_session_id"].(string); ok && claudeID != "" {
+				opts.SessionID = claudeID
+				existingSession = session
+			}
+		}
+	}
+
+	shellCmd := buildRemoteAgentShellCmd(message, noWait, workdir, agent, opts)
+
+	// For no-wait, use execSSH (no output capture needed).
+	if noWait {
+		return execSSH(client, name, false, []string{shellCmd})
+	}
+
+	// Get SSH connection info.
+	info, err := client.GetSSH(name)
+	if err != nil {
+		return err
+	}
+	if info.SSHDestination == "" {
+		return fmt.Errorf("server returned empty SSH destination")
+	}
+
+	// Run SSH via exec.Command so we can capture stdout.
+	sshArgs := strings.Fields(info.SSHDestination)
+	sshArgs = append(sshArgs, shellCmd)
+
+	sshCmd := exec.Command("ssh", sshArgs...)
+	var stdoutBuf bytes.Buffer
+	sshCmd.Stdout = &stdoutBuf
+	sshCmd.Stderr = stderr
+	runErr := sshCmd.Run()
+
+	// Try to parse JSON output regardless of exit code — Claude may
+	// have produced partial results before failing.
+	output := stdoutBuf.Bytes()
+	var parsed claudeJSONOutput
+	jsonOK := len(output) > 0 && json.Unmarshal(output, &parsed) == nil
+
+	if jsonOK {
+		// Print the result text to the caller.
+		fmt.Fprint(stdout, parsed.Result)
+		if parsed.Result != "" && !strings.HasSuffix(parsed.Result, "\n") {
+			fmt.Fprintln(stdout)
+		}
+
+		// Store session if this was a new session (no existing session being resumed).
+		if parsed.SessionID != "" && existingSession == nil {
+			if _, createErr := client.CreateSession(name, apiclient.CreateSessionRequest{
+				AgentName: agent.Binary,
+				Metadata: map[string]interface{}{
+					"claude_session_id": parsed.SessionID,
+				},
+			}); createErr != nil {
+				fmt.Fprintf(stderr, "Warning: failed to store session: %v\n", createErr)
+			}
+		}
+
+		// If we got valid, non-error JSON output, ignore SSH-level exit
+		// codes (e.g. 255 from connection teardown).
+		if !parsed.IsError {
+			return nil
+		}
+	} else if len(output) > 0 {
+		// Could not parse JSON — print raw output.
+		stdout.Write(output) //nolint:errcheck
+	}
+
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok && exitErr.ExitCode() == 127 {
+			return fmt.Errorf("%s CLI not found in sandbox %q; was it created with the right preset?", agent.Binary, name)
+		}
+		return fmt.Errorf("agent-send failed for sandbox %q: %w", name, runErr)
+	}
+	return nil
 }
 
 func buildDockerAgentSendArgs(name, message string, noWait bool, workdir string, agent agentConfig) []string {
@@ -2083,6 +2228,7 @@ Use --no-wait to send the message and return immediately.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 
 		name := args[0]
 
@@ -2148,8 +2294,19 @@ Use --no-wait to send the message and return immediately.`,
 		if err != nil {
 			return err
 		}
-		shellCmd := buildAgentShellCmd(message, noWait, workdir, agent)
-		return execSSH(client, name, false, []string{shellCmd})
+
+		sessionID, _ := cmd.Flags().GetString("session-id")
+		resume, _ := cmd.Flags().GetBool("resume")
+		newSession, _ := cmd.Flags().GetBool("new-session")
+		opts := agentRunOpts{SessionID: sessionID, Resume: resume, NewSession: newSession}
+
+		if err := runRemoteAgentSend(client, name, message, noWait, workdir, agent, opts, os.Stdout, os.Stderr); err != nil {
+			return err
+		}
+		if noWait {
+			fmt.Fprintf(os.Stderr, "Message sent to %s in sandbox %q\n", agent.Binary, name)
+		}
+		return nil
 	},
 }
 
@@ -2296,4 +2453,7 @@ func init() {
 	sandboxAgentSendCmd.Flags().Bool("no-wait", false, "Send the instruction and return immediately without waiting for a response")
 	sandboxAgentSendCmd.Flags().String("workdir", "$AMIKA_AGENT_CWD", "Working directory inside the container (default: $AMIKA_AGENT_CWD)")
 	sandboxAgentSendCmd.Flags().String("agent", "claude", "Agent CLI to use (default \"claude\")")
+	sandboxAgentSendCmd.Flags().String("session-id", "", "Resume an existing agent session by ID (remote sandboxes only)")
+	sandboxAgentSendCmd.Flags().Bool("resume", false, "Resume the most recent agent session (remote sandboxes only)")
+	sandboxAgentSendCmd.Flags().Bool("new-session", false, "Start a new agent session (remote sandboxes only)")
 }

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -2068,6 +2068,9 @@ func agentCmdParts(agent agentConfig, message string) []string {
 func agentCmdPartsWithOpts(agent agentConfig, message string, opts agentRunOpts, jsonOutput bool) []string {
 	parts := []string{agent.Binary}
 	parts = append(parts, agent.ExtraArgs...)
+	// TODO: SessionID is currently pulled from session.Metadata["claude_session_id"].
+	// Move internal keys like this to a separate SystemMetadata field so they don't
+	// collide with client-settable metadata.
 	if opts.SessionID != "" {
 		parts = append(parts, "--resume", opts.SessionID)
 	}
@@ -2192,8 +2195,10 @@ func runRemoteAgentSend(client *apiclient.Client, name, message string, noWait b
 			return nil
 		}
 	} else if len(output) > 0 {
-		// Could not parse JSON — print raw output.
+		// Expected JSON but got something else — dump it so the user can
+		// see what the agent returned, then report the parse failure.
 		stdout.Write(output) //nolint:errcheck
+		return fmt.Errorf("agent-send: unexpected non-JSON output from %s", agent.Binary)
 	}
 
 	if runErr != nil {

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -643,6 +643,103 @@ func TestResolveAgentConfig(t *testing.T) {
 	})
 }
 
+func TestAgentCmdPartsWithOpts(t *testing.T) {
+	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
+
+	t.Run("no opts no json", func(t *testing.T) {
+		got := agentCmdPartsWithOpts(agent, "hello", agentRunOpts{}, false)
+		want := []string{"claude", "--dangerously-skip-permissions", "-p", "hello"}
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("with session id maps to --resume", func(t *testing.T) {
+		got := agentCmdPartsWithOpts(agent, "hello", agentRunOpts{SessionID: "abc-123"}, true)
+		joined := strings.Join(got, " ")
+		if !strings.Contains(joined, "--resume abc-123") {
+			t.Fatalf("got %q, want --resume abc-123", joined)
+		}
+		if !strings.Contains(joined, "--output-format json") {
+			t.Fatalf("got %q, want --output-format json", joined)
+		}
+	})
+
+	t.Run("with resume maps to --continue", func(t *testing.T) {
+		got := agentCmdPartsWithOpts(agent, "hello", agentRunOpts{Resume: true}, true)
+		joined := strings.Join(got, " ")
+		if !strings.Contains(joined, "--continue") {
+			t.Fatalf("got %q, want --continue", joined)
+		}
+	})
+
+	t.Run("new session passes no session flag", func(t *testing.T) {
+		got := agentCmdPartsWithOpts(agent, "hello", agentRunOpts{NewSession: true}, true)
+		joined := strings.Join(got, " ")
+		if strings.Contains(joined, "--new-session") {
+			t.Fatalf("got %q, should not contain --new-session", joined)
+		}
+		if strings.Contains(joined, "--resume") {
+			t.Fatalf("got %q, should not contain --resume", joined)
+		}
+		if strings.Contains(joined, "--continue") {
+			t.Fatalf("got %q, should not contain --continue", joined)
+		}
+	})
+}
+
+func TestBuildRemoteAgentShellCmd(t *testing.T) {
+	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
+
+	t.Run("wait mode includes json output", func(t *testing.T) {
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", agent, agentRunOpts{})
+		if !strings.Contains(got, "--output-format json") {
+			t.Fatalf("cmd = %q, want --output-format json", got)
+		}
+	})
+
+	t.Run("no-wait mode has no json and wraps in tmux", func(t *testing.T) {
+		got := buildRemoteAgentShellCmd("hello", true, "/home/amika", agent, agentRunOpts{})
+		if strings.Contains(got, "--output-format") {
+			t.Fatalf("cmd = %q, should not contain --output-format in no-wait mode", got)
+		}
+		if !strings.Contains(got, "tmux new-session -d") {
+			t.Fatalf("cmd = %q, want tmux wrap", got)
+		}
+	})
+
+	t.Run("session id maps to --resume", func(t *testing.T) {
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", agent, agentRunOpts{SessionID: "sess-42"})
+		if !strings.Contains(got, "--resume sess-42") {
+			t.Fatalf("cmd = %q, want --resume sess-42", got)
+		}
+	})
+
+	t.Run("resume maps to --continue", func(t *testing.T) {
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", agent, agentRunOpts{Resume: true})
+		if !strings.Contains(got, "--continue") {
+			t.Fatalf("cmd = %q, want --continue", got)
+		}
+	})
+
+	t.Run("new session passes no session flag to claude", func(t *testing.T) {
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", agent, agentRunOpts{NewSession: true})
+		if strings.Contains(got, "--new-session") {
+			t.Fatalf("cmd = %q, should not contain --new-session", got)
+		}
+		if strings.Contains(got, "--resume") {
+			t.Fatalf("cmd = %q, should not contain --resume", got)
+		}
+		if strings.Contains(got, "--continue") {
+			t.Fatalf("cmd = %q, should not contain --continue", got)
+		}
+		// Should still have --output-format json for session capture.
+		if !strings.Contains(got, "--output-format json") {
+			t.Fatalf("cmd = %q, want --output-format json", got)
+		}
+	})
+}
+
 func TestResolveGitRoot(t *testing.T) {
 	t.Run("finds from nested directory", func(t *testing.T) {
 		root := t.TempDir()

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -252,6 +252,82 @@ func (c *Client) DeleteClaudeSecret(id string) error {
 	return nil
 }
 
+// Session represents an agent session on a remote sandbox.
+type Session struct {
+	ID        string                 `json:"id"`
+	SandboxID string                 `json:"sandbox_id"`
+	OrgID     string                 `json:"org_id"`
+	AgentName string                 `json:"agent_name"`
+	Status    string                 `json:"status"`
+	StartedAt string                 `json:"started_at"`
+	EndedAt   *string                `json:"ended_at"`
+	Metadata  map[string]interface{} `json:"metadata"`
+	CreatedAt string                 `json:"created_at"`
+	UpdatedAt string                 `json:"updated_at"`
+}
+
+// CreateSessionRequest is the request body for POST /api/sandboxes/{name}/sessions.
+type CreateSessionRequest struct {
+	AgentName string                 `json:"agent_name"`
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// UpdateSessionRequest is the request body for PATCH /api/sandboxes/{name}/sessions/{id}.
+type UpdateSessionRequest struct {
+	Status   string                 `json:"status,omitempty"`
+	EndedAt  string                 `json:"ended_at,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// CreateSession creates a new agent session on a remote sandbox.
+func (c *Client) CreateSession(sandboxName string, req CreateSessionRequest) (*Session, error) {
+	var result Session
+	if err := c.doJSON("POST", "/api/sandboxes/"+sandboxName+"/sessions", req, &result); err != nil {
+		return nil, fmt.Errorf("remote create session: %w", err)
+	}
+	return &result, nil
+}
+
+// ListSessions lists agent sessions for a remote sandbox.
+func (c *Client) ListSessions(sandboxName string) ([]Session, error) {
+	var result []Session
+	if err := c.doJSON("GET", "/api/sandboxes/"+sandboxName+"/sessions", nil, &result); err != nil {
+		return nil, fmt.Errorf("remote list sessions: %w", err)
+	}
+	return result, nil
+}
+
+// GetLatestSession returns the most recent session for a remote sandbox.
+// Returns nil, nil if no session exists (HTTP 404).
+func (c *Client) GetLatestSession(sandboxName string) (*Session, error) {
+	var result Session
+	if err := c.doJSON("GET", "/api/sandboxes/"+sandboxName+"/sessions/latest", nil, &result); err != nil {
+		if strings.Contains(err.Error(), "HTTP 404") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("remote get latest session: %w", err)
+	}
+	return &result, nil
+}
+
+// GetSession returns a specific session by ID.
+func (c *Client) GetSession(sandboxName, sessionID string) (*Session, error) {
+	var result Session
+	if err := c.doJSON("GET", "/api/sandboxes/"+sandboxName+"/sessions/"+sessionID, nil, &result); err != nil {
+		return nil, fmt.Errorf("remote get session: %w", err)
+	}
+	return &result, nil
+}
+
+// UpdateSession updates a session on a remote sandbox.
+func (c *Client) UpdateSession(sandboxName, sessionID string, req UpdateSessionRequest) (*Session, error) {
+	var result Session
+	if err := c.doJSON("PATCH", "/api/sandboxes/"+sandboxName+"/sessions/"+sessionID, req, &result); err != nil {
+		return nil, fmt.Errorf("remote update session: %w", err)
+	}
+	return &result, nil
+}
+
 func (c *Client) doJSON(method, path string, body interface{}, out interface{}) error {
 	var bodyReader io.Reader
 	if body != nil {


### PR DESCRIPTION
By default agent-send now resumes the latest active session so multi-turn conversations persist without manual session tracking. Use --new-session to start fresh, --session-id to resume a specific session, or --resume to continue the most recent one.

Key changes:
- Add session CRUD methods to apiclient (create, list, get, update)
- Replace syscall.Exec with exec.Command on the remote path so stdout can be captured and parsed for the Claude session ID
- Use --output-format json in wait mode; extract session_id from the response and store it via POST /api/sandboxes/:id/sessions
- Map amika flags to Claude CLI flags correctly (SessionID → --resume, Resume → --continue, NewSession → no flag)
- Ignore SSH exit 255 when valid JSON output was already received
- Silence duplicate Cobra error output on agent-send