### PR TITLE
Add .bashrc and set TERM=xterm in sandbox shell configs

### DIFF
--- a/internal/sandbox/presets/.bashrc
+++ b/internal/sandbox/presets/.bashrc
@@ -1,3 +1,6 @@
+# Set terminal type for proper rendering in tools like less, git, etc.
+export TERM=xterm
+
 # Set up the prompt (multi-line, similar to zsh adam1 theme)
 
 PS1='\u@\h\n\w\$ '

--- a/internal/sandbox/presets/.bashrc
+++ b/internal/sandbox/presets/.bashrc
@@ -1,0 +1,23 @@
+# Set up the prompt (multi-line, similar to zsh adam1 theme)
+
+PS1='\u@\h\n\w\$ '
+
+# History settings
+HISTCONTROL=ignoredups:erasedups
+HISTSIZE=1000
+HISTFILESIZE=1000
+HISTFILE=~/.bash_history
+
+# Enable color support for ls
+eval "$(dircolors -b)"
+alias ls='ls --color=auto'
+
+# Enable programmable completion if available
+if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+fi
+
+export PNPM_HOME="$HOME/.local/share/pnpm"
+export PATH="$PNPM_HOME:$PATH"

--- a/internal/sandbox/presets/.zshrc
+++ b/internal/sandbox/presets/.zshrc
@@ -1,3 +1,6 @@
+# Set terminal type for proper rendering in tools like less, git, etc.
+export TERM=xterm
+
 # Set up the prompt
 
 autoload -Uz promptinit

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -87,3 +87,4 @@ WORKDIR /home/amika
 RUN mkdir -p /home/amika/workspace
 
 COPY --chown=amika:amika .zshrc /home/amika/.zshrc
+COPY --chown=amika:amika .bashrc /home/amika/.bashrc

--- a/internal/sandbox/presets_test.go
+++ b/internal/sandbox/presets_test.go
@@ -175,6 +175,23 @@ func TestWritePresetBuildContext_ExtractsZshrc(t *testing.T) {
 	}
 }
 
+func TestWritePresetBuildContext_ExtractsBashrc(t *testing.T) {
+	contextDir, cleanup, err := WritePresetBuildContext("coder")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+
+	bashrcPath := filepath.Join(contextDir, ".bashrc")
+	data, err := os.ReadFile(bashrcPath)
+	if err != nil {
+		t.Fatalf("failed to read .bashrc from context dir: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty .bashrc")
+	}
+}
+
 func TestWritePresetBuildContext_UnknownPresetErrors(t *testing.T) {
 	_, _, err := WritePresetBuildContext("nonexistent")
 	if err == nil {


### PR DESCRIPTION
## Summary
- Add a `.bashrc` to sandbox containers that mirrors the existing `.zshrc` (prompt, history, completion, color, pnpm PATH)
- Set `export TERM=xterm` in both `.zshrc` and `.bashrc` so child processes (less, git, editors) render correctly
- Add build context extraction test for `.bashrc`

## Test plan
- [x] `TestWritePresetBuildContext_ExtractsBashrc` passes
- [x] `TestWritePresetBuildContext_ExtractsZshrc` still passes
- [x] `make fmt`, `make vet`, `make lint` all pass
- [x] Rebuild a preset image and verify bash/zsh sessions have the prompt, history, and `TERM=xterm`