### PR TITLE
feat: poll for status after remote sandbox start/stop

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -350,6 +350,11 @@ var sandboxStartCmd = &cobra.Command{
 			for _, name := range args {
 				if remoteErr := remoteClient.StartSandbox(name); remoteErr != nil {
 					errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
+					continue
+				}
+				fmt.Printf("Sandbox %q starting...\n", name)
+				if _, remoteErr := remoteClient.WaitForSandboxStart(name); remoteErr != nil {
+					errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
 				} else {
 					fmt.Printf("Sandbox %q started (remote)\n", name)
 				}
@@ -408,6 +413,11 @@ var sandboxStopCmd = &cobra.Command{
 			}
 			for _, name := range args {
 				if remoteErr := remoteClient.StopSandbox(name); remoteErr != nil {
+					errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
+					continue
+				}
+				fmt.Printf("Sandbox %q stopping...\n", name)
+				if _, remoteErr := remoteClient.WaitForSandboxStop(name); remoteErr != nil {
 					errs = append(errs, fmt.Sprintf("sandbox %q: %v", name, remoteErr))
 				} else {
 					fmt.Printf("Sandbox %q stopped (remote)\n", name)
@@ -2414,7 +2424,6 @@ func init() {
 	sandboxCmd.AddCommand(sandboxCreateCmd)
 	sandboxCmd.AddCommand(sandboxStartCmd)
 	sandboxCmd.AddCommand(sandboxStopCmd)
-	sandboxCmd.AddCommand(sandboxStartCmd)
 	sandboxCmd.AddCommand(sandboxDeleteCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxConnectCmd)

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -88,22 +88,30 @@ func (c *Client) GetSandbox(name string) (*RemoteSandbox, error) {
 	return &result, nil
 }
 
-// WaitForSandbox polls GET /api/sandboxes/{name} until the sandbox reaches
-// a ready or terminal state. It polls every 3 seconds.
-func (c *Client) WaitForSandbox(name string) (*RemoteSandbox, error) {
+// waitForSandboxState polls GET /api/sandboxes/{name} every 3 seconds until
+// the sandbox state matches one of readyStates or "failed".
+func (c *Client) waitForSandboxState(name string, readyStates []string, failMsg string) (*RemoteSandbox, error) {
 	for {
 		sb, err := c.GetSandbox(name)
 		if err != nil {
 			return nil, err
 		}
-		switch sb.State {
-		case "active", "running", "started":
-			return sb, nil
-		case "failed":
-			return sb, fmt.Errorf("sandbox provisioning failed")
+		if sb.State == "failed" {
+			return sb, fmt.Errorf("%s", failMsg)
+		}
+		for _, s := range readyStates {
+			if sb.State == s {
+				return sb, nil
+			}
 		}
 		time.Sleep(3 * time.Second)
 	}
+}
+
+// WaitForSandbox polls GET /api/sandboxes/{name} until the sandbox reaches
+// a ready or terminal state. It polls every 3 seconds.
+func (c *Client) WaitForSandbox(name string) (*RemoteSandbox, error) {
+	return c.waitForSandboxState(name, []string{"active", "running", "started"}, "sandbox provisioning failed")
 }
 
 // SSHInfo contains SSH connection details for a remote sandbox.
@@ -150,19 +158,7 @@ func (c *Client) StartSandbox(name string) error {
 // WaitForSandboxStart polls GET /api/sandboxes/{name} until the sandbox
 // transitions out of "initializing" state. It polls every 3 seconds.
 func (c *Client) WaitForSandboxStart(name string) (*RemoteSandbox, error) {
-	for {
-		sb, err := c.GetSandbox(name)
-		if err != nil {
-			return nil, err
-		}
-		switch sb.State {
-		case "active", "running", "started":
-			return sb, nil
-		case "failed":
-			return sb, fmt.Errorf("sandbox start failed")
-		}
-		time.Sleep(3 * time.Second)
-	}
+	return c.waitForSandboxState(name, []string{"active", "running", "started"}, "sandbox start failed")
 }
 
 // StopSandbox stops a sandbox on the remote API.
@@ -178,19 +174,7 @@ func (c *Client) StopSandbox(name string) error {
 // WaitForSandboxStop polls GET /api/sandboxes/{name} until the sandbox
 // transitions out of "stopping" state. It polls every 3 seconds.
 func (c *Client) WaitForSandboxStop(name string) (*RemoteSandbox, error) {
-	for {
-		sb, err := c.GetSandbox(name)
-		if err != nil {
-			return nil, err
-		}
-		switch sb.State {
-		case "stopped":
-			return sb, nil
-		case "failed":
-			return sb, fmt.Errorf("sandbox stop failed")
-		}
-		time.Sleep(3 * time.Second)
-	}
+	return c.waitForSandboxState(name, []string{"stopped"}, "sandbox stop failed")
 }
 
 // DeleteSandbox deletes a sandbox on the remote API.

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -138,6 +138,8 @@ func (c *Client) RevokeSSH(name, token string) error {
 }
 
 // StartSandbox starts (resumes) a sandbox on the remote API.
+// The endpoint returns 202 Accepted with the sandbox in "initializing" state.
+// Use WaitForSandboxStart to poll until the sandbox is active.
 func (c *Client) StartSandbox(name string) error {
 	if err := c.doJSON("POST", "/api/sandboxes/"+name+"/start", nil, nil); err != nil {
 		return fmt.Errorf("remote start sandbox: %w", err)
@@ -145,12 +147,50 @@ func (c *Client) StartSandbox(name string) error {
 	return nil
 }
 
+// WaitForSandboxStart polls GET /api/sandboxes/{name} until the sandbox
+// transitions out of "initializing" state. It polls every 3 seconds.
+func (c *Client) WaitForSandboxStart(name string) (*RemoteSandbox, error) {
+	for {
+		sb, err := c.GetSandbox(name)
+		if err != nil {
+			return nil, err
+		}
+		switch sb.State {
+		case "active", "running", "started":
+			return sb, nil
+		case "failed":
+			return sb, fmt.Errorf("sandbox start failed")
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
 // StopSandbox stops a sandbox on the remote API.
+// The endpoint returns 202 Accepted with the sandbox in "stopping" state.
+// Use WaitForSandboxStop to poll until the sandbox is stopped.
 func (c *Client) StopSandbox(name string) error {
 	if err := c.doJSON("POST", "/api/sandboxes/"+name+"/stop", nil, nil); err != nil {
 		return fmt.Errorf("remote stop sandbox: %w", err)
 	}
 	return nil
+}
+
+// WaitForSandboxStop polls GET /api/sandboxes/{name} until the sandbox
+// transitions out of "stopping" state. It polls every 3 seconds.
+func (c *Client) WaitForSandboxStop(name string) (*RemoteSandbox, error) {
+	for {
+		sb, err := c.GetSandbox(name)
+		if err != nil {
+			return nil, err
+		}
+		switch sb.State {
+		case "stopped":
+			return sb, nil
+		case "failed":
+			return sb, fmt.Errorf("sandbox stop failed")
+		}
+		time.Sleep(3 * time.Second)
+	}
 }
 
 // DeleteSandbox deletes a sandbox on the remote API.


### PR DESCRIPTION
The API now returns 202 for start/stop and transitions through intermediate states. Add WaitForSandboxStart/WaitForSandboxStop polling methods and wire them into the CLI commands to match the create-command pattern. Also remove duplicate sandboxStartCmd registration.