### PR TITLE
Add "ls" and "rm" aliases to list and delete subcommands

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -584,7 +584,7 @@ var sandboxListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "List all sandboxes",
-	Args:  cobra.NoArgs,
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		target, err := getRemoteTarget(cmd)
 		if err != nil {

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -581,8 +581,9 @@ var sandboxDeleteCmd = &cobra.Command{
 }
 
 var sandboxListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all sandboxes",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List all sandboxes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		target, err := getRemoteTarget(cmd)

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -675,8 +675,9 @@ func newSecretClaudeListCmd() *cobra.Command {
 
 func newSecretClaudeDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete <id>",
-		Short: "Delete a Claude credential by ID",
+		Use:     "delete <id>",
+		Aliases: []string{"rm"},
+		Short:   "Delete a Claude credential by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -641,8 +641,9 @@ func readClaudeCredentialFromKeychain() (string, error) {
 
 func newSecretClaudeListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "List pushed Claude credentials",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List pushed Claude credentials",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -678,7 +678,7 @@ func newSecretClaudeDeleteCmd() *cobra.Command {
 		Use:     "delete <id>",
 		Aliases: []string{"rm"},
 		Short:   "Delete a Claude credential by ID",
-		Args:  cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true

--- a/cmd/amika/service.go
+++ b/cmd/amika/service.go
@@ -20,7 +20,7 @@ var serviceListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "List services across sandboxes",
-	Args:  cobra.NoArgs,
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		sandboxName, _ := cmd.Flags().GetString("sandbox-name")
 

--- a/cmd/amika/service.go
+++ b/cmd/amika/service.go
@@ -17,8 +17,9 @@ var serviceCmd = &cobra.Command{
 }
 
 var serviceListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List services across sandboxes",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List services across sandboxes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		sandboxName, _ := cmd.Flags().GetString("sandbox-name")

--- a/cmd/amika/volume.go
+++ b/cmd/amika/volume.go
@@ -22,7 +22,7 @@ var volumeListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "List tracked volumes",
-	Args:  cobra.NoArgs,
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		volumesFile, err := config.VolumesStateFile()
 		if err != nil {

--- a/cmd/amika/volume.go
+++ b/cmd/amika/volume.go
@@ -19,8 +19,9 @@ var volumeCmd = &cobra.Command{
 }
 
 var volumeListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List tracked volumes",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List tracked volumes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		volumesFile, err := config.VolumesStateFile()


### PR DESCRIPTION
## Summary
- Add `ls` alias to all `list` subcommands (sandbox, volume, service, secret claude)
- Add `rm` alias to `secret claude delete` (sandbox delete and volume delete already had it)

## Test plan
- [x] `amika sandbox ls` works like `amika sandbox list`
- [x] `amika volume ls` works like `amika volume list`
- [x] `amika service ls` works like `amika service list`
- [x] `amika secret claude ls` works like `amika secret claude list`
- [x] `amika secret claude rm` works like `amika secret claude delete`