### PR TITLE
URL-encode sandbox names in API client

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -82,7 +83,7 @@ func (c *Client) CreateSandbox(req CreateSandboxRequest) (*RemoteSandbox, error)
 // GetSandbox fetches a single sandbox by name from the remote API.
 func (c *Client) GetSandbox(name string) (*RemoteSandbox, error) {
 	var result RemoteSandbox
-	if err := c.doJSON("GET", "/api/sandboxes/"+name, nil, &result); err != nil {
+	if err := c.doJSON("GET", "/api/sandboxes/"+url.PathEscape(name), nil, &result); err != nil {
 		return nil, fmt.Errorf("remote get sandbox: %w", err)
 	}
 	return &result, nil
@@ -125,7 +126,7 @@ type SSHInfo struct {
 // GetSSH retrieves SSH connection details for a remote sandbox.
 func (c *Client) GetSSH(name string) (*SSHInfo, error) {
 	var result SSHInfo
-	if err := c.doJSON("POST", "/api/sandboxes/"+name+"/ssh", nil, &result); err != nil {
+	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(name)+"/ssh", nil, &result); err != nil {
 		return nil, fmt.Errorf("remote ssh: %w", err)
 	}
 	return &result, nil
@@ -139,7 +140,7 @@ type RevokeSSHRequest struct {
 // RevokeSSH revokes an SSH token for a remote sandbox.
 func (c *Client) RevokeSSH(name, token string) error {
 	req := RevokeSSHRequest{Token: token}
-	if err := c.doJSON("DELETE", "/api/sandboxes/"+name+"/ssh", req, nil); err != nil {
+	if err := c.doJSON("DELETE", "/api/sandboxes/"+url.PathEscape(name)+"/ssh", req, nil); err != nil {
 		return fmt.Errorf("remote revoke ssh: %w", err)
 	}
 	return nil
@@ -149,7 +150,7 @@ func (c *Client) RevokeSSH(name, token string) error {
 // The endpoint returns 202 Accepted with the sandbox in "initializing" state.
 // Use WaitForSandboxStart to poll until the sandbox is active.
 func (c *Client) StartSandbox(name string) error {
-	if err := c.doJSON("POST", "/api/sandboxes/"+name+"/start", nil, nil); err != nil {
+	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(name)+"/start", nil, nil); err != nil {
 		return fmt.Errorf("remote start sandbox: %w", err)
 	}
 	return nil
@@ -165,7 +166,7 @@ func (c *Client) WaitForSandboxStart(name string) (*RemoteSandbox, error) {
 // The endpoint returns 202 Accepted with the sandbox in "stopping" state.
 // Use WaitForSandboxStop to poll until the sandbox is stopped.
 func (c *Client) StopSandbox(name string) error {
-	if err := c.doJSON("POST", "/api/sandboxes/"+name+"/stop", nil, nil); err != nil {
+	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(name)+"/stop", nil, nil); err != nil {
 		return fmt.Errorf("remote stop sandbox: %w", err)
 	}
 	return nil
@@ -179,7 +180,7 @@ func (c *Client) WaitForSandboxStop(name string) (*RemoteSandbox, error) {
 
 // DeleteSandbox deletes a sandbox on the remote API.
 func (c *Client) DeleteSandbox(name string) error {
-	if err := c.doJSON("DELETE", "/api/sandboxes/"+name, nil, nil); err != nil {
+	if err := c.doJSON("DELETE", "/api/sandboxes/"+url.PathEscape(name), nil, nil); err != nil {
 		return fmt.Errorf("remote delete sandbox: %w", err)
 	}
 	return nil
@@ -306,7 +307,7 @@ type UpdateSessionRequest struct {
 // CreateSession creates a new agent session on a remote sandbox.
 func (c *Client) CreateSession(sandboxName string, req CreateSessionRequest) (*Session, error) {
 	var result Session
-	if err := c.doJSON("POST", "/api/sandboxes/"+sandboxName+"/sessions", req, &result); err != nil {
+	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions", req, &result); err != nil {
 		return nil, fmt.Errorf("remote create session: %w", err)
 	}
 	return &result, nil
@@ -315,7 +316,7 @@ func (c *Client) CreateSession(sandboxName string, req CreateSessionRequest) (*S
 // ListSessions lists agent sessions for a remote sandbox.
 func (c *Client) ListSessions(sandboxName string) ([]Session, error) {
 	var result []Session
-	if err := c.doJSON("GET", "/api/sandboxes/"+sandboxName+"/sessions", nil, &result); err != nil {
+	if err := c.doJSON("GET", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions", nil, &result); err != nil {
 		return nil, fmt.Errorf("remote list sessions: %w", err)
 	}
 	return result, nil
@@ -325,7 +326,7 @@ func (c *Client) ListSessions(sandboxName string) ([]Session, error) {
 // Returns nil, nil if no session exists (HTTP 404).
 func (c *Client) GetLatestSession(sandboxName string) (*Session, error) {
 	var result Session
-	if err := c.doJSON("GET", "/api/sandboxes/"+sandboxName+"/sessions/latest", nil, &result); err != nil {
+	if err := c.doJSON("GET", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/latest", nil, &result); err != nil {
 		if strings.Contains(err.Error(), "HTTP 404") {
 			return nil, nil
 		}
@@ -337,7 +338,7 @@ func (c *Client) GetLatestSession(sandboxName string) (*Session, error) {
 // GetSession returns a specific session by ID.
 func (c *Client) GetSession(sandboxName, sessionID string) (*Session, error) {
 	var result Session
-	if err := c.doJSON("GET", "/api/sandboxes/"+sandboxName+"/sessions/"+sessionID, nil, &result); err != nil {
+	if err := c.doJSON("GET", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), nil, &result); err != nil {
 		return nil, fmt.Errorf("remote get session: %w", err)
 	}
 	return &result, nil
@@ -346,7 +347,7 @@ func (c *Client) GetSession(sandboxName, sessionID string) (*Session, error) {
 // UpdateSession updates a session on a remote sandbox.
 func (c *Client) UpdateSession(sandboxName, sessionID string, req UpdateSessionRequest) (*Session, error) {
 	var result Session
-	if err := c.doJSON("PATCH", "/api/sandboxes/"+sandboxName+"/sessions/"+sessionID, req, &result); err != nil {
+	if err := c.doJSON("PATCH", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), req, &result); err != nil {
 		return nil, fmt.Errorf("remote update session: %w", err)
 	}
 	return &result, nil

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -1,0 +1,89 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPathEscapesSandboxName(t *testing.T) {
+	tests := []struct {
+		name       string
+		call       func(c *Client) error
+		wantMethod string
+		wantPath   string
+	}{
+		{
+			name:       "GetSandbox with slash",
+			call:       func(c *Client) error { _, err := c.GetSandbox("org/proj"); return err },
+			wantMethod: "GET",
+			wantPath:   "/api/sandboxes/org%2Fproj",
+		},
+		{
+			name:       "DeleteSandbox with slash",
+			call:       func(c *Client) error { return c.DeleteSandbox("org/proj") },
+			wantMethod: "DELETE",
+			wantPath:   "/api/sandboxes/org%2Fproj",
+		},
+		{
+			name:       "StartSandbox with slash",
+			call:       func(c *Client) error { return c.StartSandbox("a/b") },
+			wantMethod: "POST",
+			wantPath:   "/api/sandboxes/a%2Fb/start",
+		},
+		{
+			name:       "StopSandbox with slash",
+			call:       func(c *Client) error { return c.StopSandbox("a/b") },
+			wantMethod: "POST",
+			wantPath:   "/api/sandboxes/a%2Fb/stop",
+		},
+		{
+			name:       "GetSSH with slash",
+			call:       func(c *Client) error { _, err := c.GetSSH("a/b"); return err },
+			wantMethod: "POST",
+			wantPath:   "/api/sandboxes/a%2Fb/ssh",
+		},
+		{
+			name:       "RevokeSSH with slash",
+			call:       func(c *Client) error { return c.RevokeSSH("a/b", "tok") },
+			wantMethod: "DELETE",
+			wantPath:   "/api/sandboxes/a%2Fb/ssh",
+		},
+		{
+			name: "ListSessions with slash",
+			call: func(c *Client) error { _, err := c.ListSessions("a/b"); return err },
+			wantMethod: "GET",
+			wantPath:   "/api/sandboxes/a%2Fb/sessions",
+		},
+		{
+			name:       "GetSandbox without slash",
+			call:       func(c *Client) error { _, err := c.GetSandbox("simple-name"); return err },
+			wantMethod: "GET",
+			wantPath:   "/api/sandboxes/simple-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.RequestURI
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]string{"id": "1", "name": "test", "state": "active"})
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL, "test-token")
+			_ = tt.call(c)
+
+			if gotMethod != tt.wantMethod {
+				t.Errorf("method = %q, want %q", gotMethod, tt.wantMethod)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("path = %q, want %q", gotPath, tt.wantPath)
+			}
+		})
+	}
+}

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -51,8 +51,8 @@ func TestPathEscapesSandboxName(t *testing.T) {
 			wantPath:   "/api/sandboxes/a%2Fb/ssh",
 		},
 		{
-			name: "ListSessions with slash",
-			call: func(c *Client) error { _, err := c.ListSessions("a/b"); return err },
+			name:       "ListSessions with slash",
+			call:       func(c *Client) error { _, err := c.ListSessions("a/b"); return err },
 			wantMethod: "GET",
 			wantPath:   "/api/sandboxes/a%2Fb/sessions",
 		},


### PR DESCRIPTION
## Summary
- Add `url.PathEscape()` to all sandbox name and session ID interpolations in `internal/apiclient/client.go`
- Add unit tests verifying that names with slashes (e.g. `org/proj`) produce properly encoded paths (`org%2Fproj`)

Sandbox names containing `/` were being split into multiple URL path segments, causing 404 errors on get, delete, start, stop, SSH, and session operations.

## Test plan
- [x] `go test ./internal/apiclient/...` passes
- [x] Existing tests still pass
- [x] Manual: create sandbox with `/` in name, verify get/delete/start/stop work from CLI