### PR TITLE
fix: sort local sandbox list by creation time descending

### DIFF
--- a/internal/app/service_impl.go
+++ b/internal/app/service_impl.go
@@ -143,7 +143,7 @@ func (s *Service) ListSandboxes(context.Context, amika.ListSandboxesRequest) (am
 			Ports:       toPublicPorts(rec.Ports),
 		})
 	}
-	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt > items[j].CreatedAt })
 	return amika.ListSandboxesResult{Items: items}, nil
 }
 

--- a/internal/app/service_impl_test.go
+++ b/internal/app/service_impl_test.go
@@ -103,3 +103,45 @@ type stubRunner struct{}
 func (stubRunner) Run(context.Context, string, []string, ports.RunOptions) (ports.RunResult, error) {
 	return ports.RunResult{}, nil
 }
+
+// listSandboxStore returns a fixed list of sandbox records for testing sort order.
+type listSandboxStore struct{ stubSandboxStore }
+
+func (listSandboxStore) List() ([]ports.SandboxRecord, error) {
+	return []ports.SandboxRecord{
+		{Name: "alpha", CreatedAt: "2025-01-01T00:00:00Z"},
+		{Name: "gamma", CreatedAt: "2025-03-01T00:00:00Z"},
+		{Name: "beta", CreatedAt: "2025-02-01T00:00:00Z"},
+	}, nil
+}
+
+func TestListSandboxes_SortedByCreatedAtDescending(t *testing.T) {
+	svc, err := NewService(Dependencies{
+		Docker:      stubDocker{},
+		Sandboxes:   listSandboxStore{},
+		Volumes:     stubVolumeStore{},
+		FileMounts:  stubFileMountStore{},
+		Runner:      stubRunner{},
+		Clock:       stubClock{},
+		IDGenerator: stubIDGenerator{},
+	})
+	if err != nil {
+		t.Fatalf("NewService error: %v", err)
+	}
+
+	result, err := svc.ListSandboxes(context.Background(), amika.ListSandboxesRequest{})
+	if err != nil {
+		t.Fatalf("ListSandboxes error: %v", err)
+	}
+
+	if len(result.Items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(result.Items))
+	}
+
+	want := []string{"gamma", "beta", "alpha"}
+	for i, name := range want {
+		if result.Items[i].Name != name {
+			t.Errorf("items[%d].Name = %q, want %q", i, result.Items[i].Name, name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Sort local sandbox list by creation time descending so most recently created sandboxes appear first
- Remote sandbox listing already relies on the API server's sort order and is unchanged