### PR TITLE
fix: match AgentSendResponse JSON tag to server field name

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -286,7 +286,7 @@ type AgentSendRequest struct {
 
 // AgentSendResponse is the response from POST /api/sandboxes/{name}/agent-send.
 type AgentSendResponse struct {
-	Result    string `json:"result"`
+	Result    string `json:"response"`
 	SessionID string `json:"session_id"`
 	IsError   bool   `json:"is_error"`
 }


### PR DESCRIPTION
The server returns the agent output as "response", not "result", causing the CLI to silently print empty output.