### PR TITLE
fix: sort sandbox list by creation time in public package

### DIFF
--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -255,7 +255,7 @@ func (s *serviceImpl) ListSandboxes(context.Context, ListSandboxesRequest) (List
 			Services:    toPublicServiceInfos(it.Services),
 		})
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt > out[j].CreatedAt })
 	return ListSandboxesResult{Items: out}, nil
 }
 


### PR DESCRIPTION
The internal service was updated in be01b0a to sort by CreatedAt descending, but the public pkg/amika API still sorted alphabetically by Name. Align both implementations.