### PR TITLE
Fix shell prompt colors for light terminal backgrounds

### DIFF
--- a/internal/sandbox/presets/.bashrc
+++ b/internal/sandbox/presets/.bashrc
@@ -1,9 +1,9 @@
 # Set terminal type for proper rendering in tools like less, git, etc.
 export TERM=xterm
 
-# Set up the prompt (multi-line, similar to zsh adam1 theme)
+# Set up the prompt (works on both light and dark terminals)
 
-PS1='\u@\h\n\w\$ '
+PS1='\[\e[1;34m\]\u@\h\[\e[0m\]\n\[\e[1;35m\]\w\[\e[0m\]\$ '
 
 # History settings
 HISTCONTROL=ignoredups:erasedups

--- a/internal/sandbox/presets/.zshrc
+++ b/internal/sandbox/presets/.zshrc
@@ -1,11 +1,12 @@
 # Set terminal type for proper rendering in tools like less, git, etc.
 export TERM=xterm
 
-# Set up the prompt
+# Set up the prompt (works on both light and dark terminals)
 
-autoload -Uz promptinit
-promptinit
-prompt adam1
+autoload -Uz colors
+colors
+PROMPT='%B%F{blue}%n@%m%f%b
+%B%F{magenta}%~%f%b%# '
 
 setopt histignorealldups sharehistory
 


### PR DESCRIPTION
## Summary
- Replace zsh `prompt adam1` theme (uses cyan/green which are hard to read on light backgrounds) with a custom prompt using bold blue and bold magenta — readable on both light and dark terminals
- Add matching colored prompt to bash (previously had no colors at all)
- Both prompts keep the existing two-line layout: `user@host` on line 1, `path$` on line 2

## Test plan
- [x] Connect to a sandbox with zsh from a light-themed terminal and verify prompt is readable
- [x] Connect to a sandbox with zsh from a dark-themed terminal and verify prompt is readable
- [x] Connect to a sandbox with bash and verify the same on both terminal themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)