### PR TITLE
fix: improve agent-send error message for authentication failures

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -4,6 +4,7 @@ package apiclient
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,18 @@ import (
 	"strings"
 	"time"
 )
+
+// HTTPError is returned by doJSON when the server responds with a non-2xx
+// status code. It carries the raw status and body so callers can inspect or
+// parse the response for structured error information.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
 
 // Client calls the remote Amika API with a bearer token.
 type Client struct {
@@ -301,9 +314,51 @@ func (c *Client) AgentSend(sandboxName string, req AgentSendRequest) (*AgentSend
 
 	var result AgentSendResponse
 	if err := c.doJSON("POST", "/api/sandboxes/"+sandboxName+"/agent-send", req, &result); err != nil {
+		if authErr := extractAgentAuthError(err); authErr != "" {
+			return nil, fmt.Errorf("remote agent-send: agent failed to authenticate with its AI provider: %s\n\nthe sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access", authErr)
+		}
 		return nil, fmt.Errorf("remote agent-send: %w", err)
 	}
 	return &result, nil
+}
+
+// extractAgentAuthError inspects an error returned by the agent-send endpoint
+// and returns a short description if the root cause is an authentication
+// failure in the agent's AI provider (e.g. Anthropic 401). Returns "" if the
+// error is not auth-related.
+func extractAgentAuthError(err error) string {
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		return ""
+	}
+
+	// The server wraps the agent result as {"error":"...","details":"<json>"}.
+	var envelope struct {
+		Error   string `json:"error"`
+		Details string `json:"details"`
+	}
+	if json.Unmarshal([]byte(httpErr.Body), &envelope) != nil || envelope.Details == "" {
+		return ""
+	}
+
+	// The details string is itself JSON with the agent run result.
+	var agentResult struct {
+		IsError bool   `json:"is_error"`
+		Result  string `json:"result"`
+	}
+	if json.Unmarshal([]byte(envelope.Details), &agentResult) != nil {
+		return ""
+	}
+
+	if !agentResult.IsError {
+		return ""
+	}
+
+	r := agentResult.Result
+	if strings.Contains(r, "authentication_error") || strings.Contains(r, "Invalid authentication credentials") || strings.Contains(r, "Failed to authenticate") {
+		return r
+	}
+	return ""
 }
 
 // Session represents an agent session on a remote sandbox.
@@ -417,7 +472,7 @@ func (c *Client) doJSON(method, path string, body interface{}, out interface{}) 
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+		return &HTTPError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	if out != nil && len(respBody) > 0 {

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -4,7 +4,6 @@ package apiclient
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,18 +11,6 @@ import (
 	"strings"
 	"time"
 )
-
-// HTTPError is returned by doJSON when the server responds with a non-2xx
-// status code. It carries the raw status and body so callers can inspect or
-// parse the response for structured error information.
-type HTTPError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *HTTPError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
 
 // Client calls the remote Amika API with a bearer token.
 type Client struct {
@@ -320,45 +307,6 @@ func (c *Client) AgentSend(sandboxName string, req AgentSendRequest) (*AgentSend
 		return nil, fmt.Errorf("remote agent-send: %w", err)
 	}
 	return &result, nil
-}
-
-// extractAgentAuthError inspects an error returned by the agent-send endpoint
-// and returns a short description if the root cause is an authentication
-// failure in the agent's AI provider (e.g. Anthropic 401). Returns "" if the
-// error is not auth-related.
-func extractAgentAuthError(err error) string {
-	var httpErr *HTTPError
-	if !errors.As(err, &httpErr) {
-		return ""
-	}
-
-	// The server wraps the agent result as {"error":"...","details":"<json>"}.
-	var envelope struct {
-		Error   string `json:"error"`
-		Details string `json:"details"`
-	}
-	if json.Unmarshal([]byte(httpErr.Body), &envelope) != nil || envelope.Details == "" {
-		return ""
-	}
-
-	// The details string is itself JSON with the agent run result.
-	var agentResult struct {
-		IsError bool   `json:"is_error"`
-		Result  string `json:"result"`
-	}
-	if json.Unmarshal([]byte(envelope.Details), &agentResult) != nil {
-		return ""
-	}
-
-	if !agentResult.IsError {
-		return ""
-	}
-
-	r := agentResult.Result
-	if strings.Contains(r, "authentication_error") || strings.Contains(r, "Invalid authentication credentials") || strings.Contains(r, "Failed to authenticate") {
-		return r
-	}
-	return ""
 }
 
 // Session represents an agent session on a remote sandbox.

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -2,8 +2,10 @@ package apiclient
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -86,4 +88,115 @@ func TestPathEscapesSandboxName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtractAgentAuthError(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantHit bool
+	}{
+		{
+			name:    "non-HTTPError is ignored",
+			err:     fmt.Errorf("some other error"),
+			wantHit: false,
+		},
+		{
+			name:    "HTTPError without JSON body",
+			err:     &HTTPError{StatusCode: 500, Body: "internal server error"},
+			wantHit: false,
+		},
+		{
+			name: "HTTPError with auth failure in agent result",
+			err: &HTTPError{StatusCode: 500, Body: mustJSON(t, map[string]interface{}{
+				"error": "Agent command failed",
+				"details": mustJSONString(t, map[string]interface{}{
+					"type":     "result",
+					"is_error": true,
+					"result":   `Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}`,
+				}),
+			})},
+			wantHit: true,
+		},
+		{
+			name: "HTTPError with non-auth agent error",
+			err: &HTTPError{StatusCode: 500, Body: mustJSON(t, map[string]interface{}{
+				"error": "Agent command failed",
+				"details": mustJSONString(t, map[string]interface{}{
+					"type":     "result",
+					"is_error": true,
+					"result":   "Some other agent error",
+				}),
+			})},
+			wantHit: false,
+		},
+		{
+			name: "HTTPError with is_error false",
+			err: &HTTPError{StatusCode: 500, Body: mustJSON(t, map[string]interface{}{
+				"error": "Agent command failed",
+				"details": mustJSONString(t, map[string]interface{}{
+					"type":     "result",
+					"is_error": false,
+					"result":   "Failed to authenticate. API Error: 401",
+				}),
+			})},
+			wantHit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAgentAuthError(tt.err)
+			if tt.wantHit && got == "" {
+				t.Error("expected auth error to be detected, got empty string")
+			}
+			if !tt.wantHit && got != "" {
+				t.Errorf("expected no auth error, got %q", got)
+			}
+		})
+	}
+}
+
+func TestAgentSendAuthErrorMessage(t *testing.T) {
+	details := mustJSONString(t, map[string]interface{}{
+		"type":     "result",
+		"is_error": true,
+		"result":   `Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}`,
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":   "Agent command failed",
+			"details": details,
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	_, err := c.AgentSend("test-sandbox", AgentSendRequest{Message: "hello"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to authenticate with its AI provider") {
+		t.Errorf("error should mention auth provider failure, got: %s", msg)
+	}
+	if !strings.Contains(msg, "expired or been revoked") { //nolint:dupword
+		t.Errorf("error should mention expired credentials, got: %s", msg)
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("mustJSON: %v", err)
+	}
+	return string(b)
+}
+
+func mustJSONString(t *testing.T, v interface{}) string {
+	t.Helper()
+	return mustJSON(t, v)
 }

--- a/internal/apiclient/errors.go
+++ b/internal/apiclient/errors.go
@@ -1,0 +1,59 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// HTTPError is returned by doJSON when the server responds with a non-2xx
+// status code. It carries the raw status and body so callers can inspect or
+// parse the response for structured error information.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// extractAgentAuthError inspects an error returned by the agent-send endpoint
+// and returns a short description if the root cause is an authentication
+// failure in the agent's AI provider (e.g. Anthropic 401). Returns "" if the
+// error is not auth-related.
+func extractAgentAuthError(err error) string {
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		return ""
+	}
+
+	// The server wraps the agent result as {"error":"...","details":"<json>"}.
+	var envelope struct {
+		Error   string `json:"error"`
+		Details string `json:"details"`
+	}
+	if json.Unmarshal([]byte(httpErr.Body), &envelope) != nil || envelope.Details == "" {
+		return ""
+	}
+
+	// The details string is itself JSON with the agent run result.
+	var agentResult struct {
+		IsError bool   `json:"is_error"`
+		Result  string `json:"result"`
+	}
+	if json.Unmarshal([]byte(envelope.Details), &agentResult) != nil {
+		return ""
+	}
+
+	if !agentResult.IsError {
+		return ""
+	}
+
+	r := agentResult.Result
+	if strings.Contains(r, "authentication_error") || strings.Contains(r, "Invalid authentication credentials") || strings.Contains(r, "Failed to authenticate") {
+		return r
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- When the sandbox agent fails to authenticate with its AI provider (e.g. Anthropic 401), the error was an opaque HTTP 500 with deeply nested JSON that was hard to read
- Now the client detects authentication failures in the agent result and returns a clear message: explains the agent failed to authenticate with its AI provider and that credentials may have expired or been revoked
- Introduces an `HTTPError` type in `apiclient` so callers can inspect HTTP status codes and response bodies from `doJSON` errors

**Before:**
```
agent-send failed for sandbox "amber-heron": remote agent-send: HTTP 500: {"error":"Agent command failed","details":"{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,...}"}
```

**After:**
```
agent-send failed for sandbox "amber-heron": remote agent-send: agent failed to authenticate with its AI provider: Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}

the sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access
```

## Test plan
- [x] Added unit tests for `extractAgentAuthError` covering: non-HTTP errors, non-JSON bodies, auth failures, non-auth agent errors, and `is_error=false`
- [x] Added integration-style test for `AgentSend` with a mock server returning a 500 auth failure
- [x] All existing tests pass
- [x] Lint, vet, fmt all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)