### PR TITLE
feat: add amika secret codex push/list/delete commands

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1873,11 +1873,11 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 // the first API key. The chosen credential is printed to stderr. Returns empty
 // string on any error or if no credentials are uploaded.
 func autoSelectClaudeCredential(cmd *cobra.Command, client *apiclient.Client) string {
-	creds, err := client.ListClaudeSecrets()
+	creds, err := client.ListProviderSecrets("claude")
 	if err != nil || len(creds) == 0 {
 		return ""
 	}
-	var selected apiclient.ClaudeSecretListItem
+	var selected apiclient.ProviderSecretListItem
 	for _, c := range creds {
 		if c.Type == "oauth" {
 			selected = c

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -403,17 +403,46 @@ func maskValue(value string) string {
 	return value[:4] + strings.Repeat("*", len(value)-8) + value[len(value)-4:]
 }
 
-var secretClaudeCmd = &cobra.Command{
-	Use:   "claude",
-	Short: "Manage Claude Code credentials",
-	Long:  `Push and list Claude Code credentials for sandbox authentication.`,
+// discoveredCredential is a credential found on the local system, normalized
+// across providers for display and interactive selection.
+type discoveredCredential struct {
+	// Type is a human-readable label: "API Key" or "OAuth".
+	Type string
+	// Source describes where the credential was found (e.g. file path).
+	Source string
+	// Value is the raw credential data to upload.
+	Value string
 }
 
-func newSecretClaudePushCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "push",
-		Short: "Push Claude Code credentials to the remote secrets store",
-		Long: `Push Claude Code credentials to the remote Amika secrets store.
+// providerConfig captures the per-provider configuration driving the generic
+// push/list/delete commands for provider-scoped credentials (Claude, Codex).
+type providerConfig struct {
+	// Use is the cobra subcommand name ("claude", "codex").
+	Use string
+	// DisplayName is the user-facing provider name shown in help text
+	// ("Claude Code", "Codex").
+	DisplayName string
+	// ShortName is the prefix used for default credential labels and
+	// terse messages ("Claude", "Codex").
+	ShortName string
+	// APIPath is the provider segment of the API endpoint used to build
+	// /api/secrets/<APIPath>.
+	APIPath string
+	// PushLongHelp is the "Long" description for the push command.
+	PushLongHelp string
+	// Discover scans local credential sources for this provider.
+	Discover func() ([]discoveredCredential, error)
+	// AutoResolve resolves a credential value for a given credType
+	// ("oauth" or "api_key") without interactive prompts.
+	AutoResolve func(credType string) (string, error)
+}
+
+var claudeProvider = providerConfig{
+	Use:         "claude",
+	DisplayName: "Claude Code",
+	ShortName:   "Claude",
+	APIPath:     "claude",
+	PushLongHelp: `Push Claude Code credentials to the remote Amika secrets store.
 
 Scans your system for Claude credentials (API keys and OAuth tokens) and
 lets you choose which one to push. On macOS, the keychain is also checked.
@@ -437,16 +466,62 @@ Examples:
   amika secret claude push --name "Claude OAuth (Work Laptop)"
   amika secret claude push --from-file ~/.claude/.credentials.json
   amika secret claude push --value '{"claudeAiOauth":{...}}'`,
+	Discover:    discoverClaudeCredentials,
+	AutoResolve: autoResolveClaudeCredential,
+}
+
+var codexProvider = providerConfig{
+	Use:         "codex",
+	DisplayName: "Codex",
+	ShortName:   "Codex",
+	APIPath:     "codex",
+	PushLongHelp: `Push Codex credentials to the remote Amika secrets store.
+
+Scans ~/.codex/auth.json for credentials (API keys and OAuth tokens) and
+lets you choose which one to push.
+
+You can also provide credentials directly via --value or from a file via --from-file.
+
+When using --type to auto-resolve credentials:
+  --type api_key  Reads the OPENAI_API_KEY environment variable, then falls
+                  back to the OPENAI_API_KEY field in ~/.codex/auth.json.
+  --type oauth    Reads the full contents of ~/.codex/auth.json.
+
+Examples:
+  amika secret codex push
+  amika secret codex push --type oauth --name "Codex OAuth"
+  amika secret codex push --type api_key --name "Codex API Key"
+  amika secret codex push --from-file ~/.codex/auth.json
+  amika secret codex push --value '{"tokens":{"access_token":"..."}}'`,
+	Discover:    discoverCodexCredentials,
+	AutoResolve: autoResolveCodexCredential,
+}
+
+// newProviderCmd builds the parent subcommand for a provider
+// (e.g. "amika secret claude").
+func newProviderCmd(p providerConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:   p.Use,
+		Short: fmt.Sprintf("Manage %s credentials", p.DisplayName),
+		Long:  fmt.Sprintf("Push and list %s credentials for sandbox authentication.", p.DisplayName),
+	}
+}
+
+func newProviderPushCmd(p providerConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: fmt.Sprintf("Push %s credentials to the remote secrets store", p.DisplayName),
+		Long:  p.PushLongHelp,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 
-			credValue, credType, err := parseClaudeCreds(cmd)
+			credValue, credType, err := parseProviderCreds(cmd, p)
 			if err != nil {
 				return err
 			}
 
-			name, err := parseClaudeName(cmd, credType)
+			name, err := parseProviderName(cmd, p, credType)
 			if err != nil {
 				return err
 			}
@@ -456,7 +531,7 @@ Examples:
 				return fmt.Errorf("authenticating with remote API: %w", err)
 			}
 
-			summary, err := client.CreateClaudeSecret(apiclient.CreateClaudeSecretRequest{
+			summary, err := client.CreateProviderSecret(p.APIPath, apiclient.CreateProviderSecretRequest{
 				Name:  name,
 				Value: credValue,
 				Type:  credType,
@@ -465,7 +540,7 @@ Examples:
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Created Claude credential %q\n", summary.Name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Created %s credential %q\n", p.ShortName, summary.Name)
 			return nil
 		},
 	}
@@ -478,10 +553,70 @@ Examples:
 	return cmd
 }
 
-// parseClaudeCreds resolves the credential value and type from command flags.
-// credType is "oauth" or "api_key". Returns an error if mutually exclusive
-// flags --value and --from-file are both provided.
-func parseClaudeCreds(cmd *cobra.Command) (credValue string, credType string, err error) {
+func newProviderListCmd(p providerConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   fmt.Sprintf("List pushed %s credentials", p.DisplayName),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			client, err := getSecretsClient()
+			if err != nil {
+				return fmt.Errorf("authenticating with remote API: %w", err)
+			}
+
+			items, err := client.ListProviderSecrets(p.APIPath)
+			if err != nil {
+				return err
+			}
+
+			if len(items) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "No %s credentials found.\n", p.ShortName)
+				return nil
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tNAME\tTYPE")
+			for _, item := range items {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", item.ID, item.Name, item.Type)
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func newProviderDeleteCmd(p providerConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <id>",
+		Aliases: []string{"rm"},
+		Short:   fmt.Sprintf("Delete a %s credential by ID", p.DisplayName),
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			client, err := getSecretsClient()
+			if err != nil {
+				return fmt.Errorf("authenticating with remote API: %w", err)
+			}
+
+			if err := client.DeleteProviderSecret(args[0]); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted credential %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+// parseProviderCreds resolves the credential value and type from command
+// flags, using the provider's hooks for auto-resolution and interactive
+// discovery when needed. credType is "oauth" or "api_key". Returns an error
+// if mutually exclusive flags --value and --from-file are both provided.
+func parseProviderCreds(cmd *cobra.Command, p providerConfig) (credValue string, credType string, err error) {
 	value, _ := cmd.Flags().GetString("value")
 	fromFile, _ := cmd.Flags().GetString("from-file")
 	typeFlag, _ := cmd.Flags().GetString("type")
@@ -504,7 +639,7 @@ func parseClaudeCreds(cmd *cobra.Command) (credValue string, credType string, er
 	case cmd.Flags().Changed("type"):
 		// --type was set explicitly without --value/--from-file;
 		// auto-resolve based on the requested type.
-		resolved, err := autoResolveClaudeCredential(typeFlag)
+		resolved, err := p.AutoResolve(typeFlag)
 		if err != nil {
 			return "", "", err
 		}
@@ -512,12 +647,12 @@ func parseClaudeCreds(cmd *cobra.Command) (credValue string, credType string, er
 		credType = typeFlag
 	default:
 		// Interactive discovery — show all found credentials.
-		cred, err := discoverAndPickClaudeCredential(cmd)
+		cred, err := discoverAndPickCredential(cmd, p)
 		if err != nil {
 			return "", "", err
 		}
 		credValue = cred.Value
-		credType = claudeCredentialTypeToAPI(cred.Type)
+		credType = credentialTypeToAPI(cred.Type)
 	}
 
 	// Validate: OAuth credentials must be valid JSON.
@@ -528,18 +663,18 @@ func parseClaudeCreds(cmd *cobra.Command) (credValue string, credType string, er
 	return credValue, credType, nil
 }
 
-// parseClaudeName resolves the credential name from the --name flag or by
+// parseProviderName resolves the credential name from the --name flag or by
 // prompting the user interactively with a type-appropriate default.
-func parseClaudeName(cmd *cobra.Command, credType string) (string, error) {
+func parseProviderName(cmd *cobra.Command, p providerConfig, credType string) (string, error) {
 	name, _ := cmd.Flags().GetString("name")
 	if name != "" {
 		return name, nil
 	}
 
 	reader := bufio.NewReader(cmd.InOrStdin())
-	defaultName := "Claude OAuth"
+	defaultName := p.ShortName + " OAuth"
 	if credType == "api_key" {
-		defaultName = "Claude API Key"
+		defaultName = p.ShortName + " API Key"
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Name for this credential [%s]: ", defaultName)
 	input, err := reader.ReadString('\n')
@@ -553,29 +688,25 @@ func parseClaudeName(cmd *cobra.Command, credType string) (string, error) {
 	return name, nil
 }
 
-// discoverAndPickClaudeCredential scans the local system for Claude credentials,
-// displays them, and lets the user pick one to push.
-func discoverAndPickClaudeCredential(cmd *cobra.Command) (auth.ClaudeCredential, error) {
-	// Also check macOS keychain if on darwin.
-	creds, err := discoverAllClaudeCredentials()
+// discoverAndPickCredential scans for local credentials via the provider's
+// Discover hook, displays them, and lets the user pick one to push.
+func discoverAndPickCredential(cmd *cobra.Command, p providerConfig) (discoveredCredential, error) {
+	creds, err := p.Discover()
 	if err != nil {
-		return auth.ClaudeCredential{}, err
+		return discoveredCredential{}, err
 	}
 
 	if len(creds) == 0 {
-		return auth.ClaudeCredential{}, fmt.Errorf("no Claude credentials found on this system\n\nUse --value or --from-file to provide credentials manually")
+		return discoveredCredential{}, fmt.Errorf("no %s credentials found on this system\n\nUse --value or --from-file to provide credentials manually", p.ShortName)
 	}
 
-	// Display discovered credentials.
-	fmt.Fprintln(cmd.OutOrStdout(), "Discovered Claude credentials:")
-	fmt.Fprintln(cmd.OutOrStdout())
+	fmt.Fprintf(cmd.OutOrStdout(), "Discovered %s credentials:\n\n", p.ShortName)
 	for i, c := range creds {
 		fmt.Fprintf(cmd.OutOrStdout(), "  [%d] %s  (%s)\n", i+1, c.Type, c.Source)
 	}
 	fmt.Fprintln(cmd.OutOrStdout())
 
-	// If only one, ask for confirmation directly.
-	var selected auth.ClaudeCredential
+	var selected discoveredCredential
 	reader := bufio.NewReader(cmd.InOrStdin())
 	if len(creds) == 1 {
 		selected = creds[0]
@@ -584,12 +715,12 @@ func discoverAndPickClaudeCredential(cmd *cobra.Command) (auth.ClaudeCredential,
 		fmt.Fprintf(cmd.OutOrStdout(), "Select credential to push [1-%d]: ", len(creds))
 		input, err := reader.ReadString('\n')
 		if err != nil {
-			return auth.ClaudeCredential{}, fmt.Errorf("reading selection: %w", err)
+			return discoveredCredential{}, fmt.Errorf("reading selection: %w", err)
 		}
 		input = strings.TrimSpace(input)
 		choice, err := strconv.Atoi(input)
 		if err != nil || choice < 1 || choice > len(creds) {
-			return auth.ClaudeCredential{}, fmt.Errorf("invalid selection: %q", input)
+			return discoveredCredential{}, fmt.Errorf("invalid selection: %q", input)
 		}
 		selected = creds[choice-1]
 
@@ -598,31 +729,46 @@ func discoverAndPickClaudeCredential(cmd *cobra.Command) (auth.ClaudeCredential,
 
 	answer, err := reader.ReadString('\n')
 	if err != nil {
-		return auth.ClaudeCredential{}, fmt.Errorf("reading confirmation: %w", err)
+		return discoveredCredential{}, fmt.Errorf("reading confirmation: %w", err)
 	}
 	answer = strings.TrimSpace(strings.ToLower(answer))
 	if answer != "y" && answer != "yes" {
-		return auth.ClaudeCredential{}, fmt.Errorf("aborted")
+		return discoveredCredential{}, fmt.Errorf("aborted")
 	}
 
 	return selected, nil
 }
 
-// discoverAllClaudeCredentials finds Claude credentials from files and (on macOS) keychain.
-func discoverAllClaudeCredentials() ([]auth.ClaudeCredential, error) {
-	creds, err := auth.DiscoverClaudeCredentials("")
+// credentialTypeToAPI maps a discovery type label ("API Key" / "OAuth") to
+// the API type field ("api_key" / "oauth").
+func credentialTypeToAPI(discoveryType string) string {
+	switch discoveryType {
+	case "API Key":
+		return "api_key"
+	default:
+		return "oauth"
+	}
+}
+
+// discoverClaudeCredentials returns Claude credentials from files plus
+// (on macOS) the keychain.
+func discoverClaudeCredentials() ([]discoveredCredential, error) {
+	raw, err := auth.DiscoverClaudeCredentials("")
 	if err != nil {
 		return nil, err
 	}
 
-	// On macOS, also try the keychain.
+	creds := make([]discoveredCredential, 0, len(raw)+1)
+	for _, c := range raw {
+		creds = append(creds, discoveredCredential{Type: c.Type, Source: c.Source, Value: c.Value})
+	}
+
 	if arch.IsMacOS() {
-		keychainValue, err := readClaudeCredentialFromKeychain()
-		if err == nil && keychainValue != "" && json.Valid([]byte(keychainValue)) {
-			creds = append(creds, auth.ClaudeCredential{
+		if v, err := readClaudeCredentialFromKeychain(); err == nil && v != "" && json.Valid([]byte(v)) {
+			creds = append(creds, discoveredCredential{
 				Type:   "OAuth",
 				Source: "macOS Keychain",
-				Value:  keychainValue,
+				Value:  v,
 			})
 		}
 	}
@@ -630,7 +776,8 @@ func discoverAllClaudeCredentials() ([]auth.ClaudeCredential, error) {
 	return creds, nil
 }
 
-// readClaudeCredentialFromKeychain reads Claude Code credentials from the macOS keychain.
+// readClaudeCredentialFromKeychain reads Claude Code credentials from the
+// macOS keychain.
 func readClaudeCredentialFromKeychain() (string, error) {
 	out, err := exec.Command("security", "find-generic-password", "-s", "Claude Code-credentials", "-w").Output()
 	if err != nil {
@@ -639,69 +786,10 @@ func readClaudeCredentialFromKeychain() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func newSecretClaudeListCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "List pushed Claude credentials",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
-
-			client, err := getSecretsClient()
-			if err != nil {
-				return fmt.Errorf("authenticating with remote API: %w", err)
-			}
-
-			items, err := client.ListClaudeSecrets()
-			if err != nil {
-				return err
-			}
-
-			if len(items) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "No Claude credentials found.")
-				return nil
-			}
-
-			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "ID\tNAME\tTYPE")
-			for _, item := range items {
-				fmt.Fprintf(w, "%s\t%s\t%s\n", item.ID, item.Name, item.Type)
-			}
-			return w.Flush()
-		},
-	}
-}
-
-func newSecretClaudeDeleteCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "delete <id>",
-		Aliases: []string{"rm"},
-		Short:   "Delete a Claude credential by ID",
-		Args:    cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
-
-			client, err := getSecretsClient()
-			if err != nil {
-				return fmt.Errorf("authenticating with remote API: %w", err)
-			}
-
-			if err := client.DeleteClaudeSecret(args[0]); err != nil {
-				return err
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Deleted credential %s\n", args[0])
-			return nil
-		},
-	}
-}
-
-// autoResolveClaudeCredential resolves a credential value automatically based
-// on the requested type, without interactive prompts.
+// autoResolveClaudeCredential resolves a Claude credential value automatically
+// based on the requested type, without interactive prompts.
 //   - "api_key": reads the ANTHROPIC_API_KEY environment variable.
-//   - "oauth": on macOS reads from the keychain, otherwise from credential files.
+//   - "oauth": on macOS reads from the keychain first, then from credential files.
 func autoResolveClaudeCredential(credType string) (string, error) {
 	if credType == "api_key" {
 		key := os.Getenv("ANTHROPIC_API_KEY")
@@ -724,56 +812,129 @@ func autoResolveClaudeCredential(credType string) (string, error) {
 		return "", fmt.Errorf("determining home directory: %w", err)
 	}
 
-	oauthPaths := make([]string, len(auth.ClaudeOAuthPaths()))
-	for i, p := range auth.ClaudeOAuthPaths() {
-		oauthPaths[i] = filepath.Join(homeDir, p)
-	}
-	for _, path := range oauthPaths {
+	for _, rel := range auth.ClaudeOAuthPaths() {
+		path := filepath.Join(homeDir, rel)
 		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}
 		value := strings.TrimSpace(string(data))
-		if json.Valid([]byte(value)) {
-			return value, nil
+		if !json.Valid([]byte(value)) {
+			continue
 		}
+		// Verify OAuth-specific field: claudeAiOauth.accessToken must be
+		// present, matching the check in DiscoverClaudeCredentials.
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(value), &obj); err != nil {
+			continue
+		}
+		oauth, ok := obj["claudeAiOauth"].(map[string]any)
+		if !ok {
+			continue
+		}
+		at, ok := oauth["accessToken"].(string)
+		if !ok || at == "" {
+			continue
+		}
+		return value, nil
 	}
 
 	return "", fmt.Errorf("no OAuth credentials found; on macOS check keychain, or provide --value or --from-file")
 }
 
-// claudeCredentialTypeToAPI maps the discovery type label to the API type field.
-func claudeCredentialTypeToAPI(discoveryType string) string {
-	switch discoveryType {
-	case "API Key":
-		return "api_key"
-	default:
-		return "oauth"
+// discoverCodexCredentials returns Codex credentials from ~/.codex/auth.json.
+func discoverCodexCredentials() ([]discoveredCredential, error) {
+	raw, err := auth.DiscoverCodexCredentials("")
+	if err != nil {
+		return nil, err
 	}
+	creds := make([]discoveredCredential, 0, len(raw))
+	for _, c := range raw {
+		creds = append(creds, discoveredCredential{Type: c.Type, Source: c.Source, Value: c.Value})
+	}
+	return creds, nil
+}
+
+// autoResolveCodexCredential resolves a Codex credential value automatically
+// based on the requested type, without interactive prompts.
+//   - "api_key": reads OPENAI_API_KEY from the environment, falling back to
+//     the OPENAI_API_KEY field in ~/.codex/auth.json.
+//   - "oauth": reads the full contents of ~/.codex/auth.json.
+func autoResolveCodexCredential(credType string) (string, error) {
+	if credType == "api_key" {
+		if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+			return key, nil
+		}
+		// Fall back to the API key field inside auth.json.
+		creds, err := auth.DiscoverCodexCredentials("")
+		if err != nil {
+			return "", err
+		}
+		for _, c := range creds {
+			if c.Type == "API Key" {
+				return c.Value, nil
+			}
+		}
+		return "", fmt.Errorf("OPENAI_API_KEY environment variable is not set and no API key found in ~/.codex/auth.json")
+	}
+
+	// OAuth: read the auth.json file contents directly.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+	for _, rel := range auth.CodexCredentialPaths() {
+		path := filepath.Join(homeDir, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		value := strings.TrimSpace(string(data))
+		if !json.Valid([]byte(value)) {
+			continue
+		}
+		// Verify OAuth-specific field: tokens.access_token must be present,
+		// matching the check in DiscoverCodexCredentials.
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(value), &obj); err != nil {
+			continue
+		}
+		tokens, ok := obj["tokens"].(map[string]any)
+		if !ok {
+			continue
+		}
+		at, ok := tokens["access_token"].(string)
+		if !ok || at == "" {
+			continue
+		}
+		return value, nil
+	}
+
+	return "", fmt.Errorf("no OAuth credentials found in ~/.codex/auth.json (missing tokens.access_token); provide --value or --from-file")
+}
+
+// addProviderCommands attaches the push/list/delete subcommands for a
+// provider under a shared parent on `parent`. When hidden is true, the
+// provider's own subcommand is hidden (used under the `secrets` alias).
+func addProviderCommands(parent *cobra.Command, p providerConfig, hidden bool) {
+	cmd := newProviderCmd(p)
+	cmd.Hidden = hidden
+	cmd.AddCommand(newProviderPushCmd(p))
+	cmd.AddCommand(newProviderListCmd(p))
+	cmd.AddCommand(newProviderDeleteCmd(p))
+	parent.AddCommand(cmd)
 }
 
 func init() {
 	rootCmd.AddCommand(secretCmd)
 	secretCmd.AddCommand(newSecretExtractCmd())
 	secretCmd.AddCommand(newSecretPushCmd())
-	secretCmd.AddCommand(secretClaudeCmd)
-	secretClaudeCmd.AddCommand(newSecretClaudePushCmd())
-	secretClaudeCmd.AddCommand(newSecretClaudeListCmd())
-	secretClaudeCmd.AddCommand(newSecretClaudeDeleteCmd())
+	addProviderCommands(secretCmd, claudeProvider, false)
+	addProviderCommands(secretCmd, codexProvider, false)
 
 	rootCmd.AddCommand(secretsAliasCmd)
 	secretsAliasCmd.AddCommand(newSecretExtractCmd())
 	secretsAliasCmd.AddCommand(newSecretPushCmd())
-
-	// Add claude subcommand to the alias too.
-	secretsClaudeAlias := &cobra.Command{
-		Use:    "claude",
-		Short:  "Manage Claude Code credentials",
-		Long:   `Push and list Claude Code credentials for sandbox authentication.`,
-		Hidden: true,
-	}
-	secretsAliasCmd.AddCommand(secretsClaudeAlias)
-	secretsClaudeAlias.AddCommand(newSecretClaudePushCmd())
-	secretsClaudeAlias.AddCommand(newSecretClaudeListCmd())
-	secretsClaudeAlias.AddCommand(newSecretClaudeDeleteCmd())
+	addProviderCommands(secretsAliasCmd, claudeProvider, true)
+	addProviderCommands(secretsAliasCmd, codexProvider, true)
 }

--- a/cmd/amika/secrets_test.go
+++ b/cmd/amika/secrets_test.go
@@ -383,7 +383,7 @@ func TestMaskValue(t *testing.T) {
 	}
 }
 
-func TestClaudeCredentialTypeToAPI(t *testing.T) {
+func TestCredentialTypeToAPI(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
@@ -394,9 +394,9 @@ func TestClaudeCredentialTypeToAPI(t *testing.T) {
 		{"", "oauth"},
 	}
 	for _, tt := range tests {
-		got := claudeCredentialTypeToAPI(tt.input)
+		got := credentialTypeToAPI(tt.input)
 		if got != tt.want {
-			t.Errorf("claudeCredentialTypeToAPI(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("credentialTypeToAPI(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -230,47 +230,52 @@ func (c *Client) UpdateSecret(id string, req UpdateSecretRequest) error {
 	return nil
 }
 
-// CreateClaudeSecretRequest is the request body for POST /api/secrets/claude.
-type CreateClaudeSecretRequest struct {
+// CreateProviderSecretRequest is the request body for
+// POST /api/secrets/<provider>. Shared by provider-scoped credential
+// endpoints (e.g. Claude, Codex).
+type CreateProviderSecretRequest struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 	Type  string `json:"type"` // "oauth" or "api_key" — required by the server
 }
 
-// ClaudeSecretSummary is the response from POST /api/secrets/claude.
-type ClaudeSecretSummary struct {
+// ProviderSecretSummary is the response from POST /api/secrets/<provider>.
+type ProviderSecretSummary struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Scope string `json:"scope"`
 }
 
-// ClaudeSecretListItem is an item in the GET /api/secrets/claude response.
-type ClaudeSecretListItem struct {
+// ProviderSecretListItem is an item in the GET /api/secrets/<provider>
+// response.
+type ProviderSecretListItem struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
-// CreateClaudeSecret uploads Claude Code credentials to the remote API.
-func (c *Client) CreateClaudeSecret(req CreateClaudeSecretRequest) (*ClaudeSecretSummary, error) {
-	var result ClaudeSecretSummary
-	if err := c.doJSON("POST", "/api/secrets/claude", req, &result); err != nil {
-		return nil, fmt.Errorf("remote create claude secret: %w", err)
+// CreateProviderSecret uploads provider-scoped credentials (e.g. Claude,
+// Codex) to the remote API. provider is the URL segment
+// ("claude", "codex").
+func (c *Client) CreateProviderSecret(provider string, req CreateProviderSecretRequest) (*ProviderSecretSummary, error) {
+	var result ProviderSecretSummary
+	if err := c.doJSON("POST", "/api/secrets/"+provider, req, &result); err != nil {
+		return nil, fmt.Errorf("remote create %s secret: %w", provider, err)
 	}
 	return &result, nil
 }
 
-// ListClaudeSecrets lists Claude credentials for the current user.
-func (c *Client) ListClaudeSecrets() ([]ClaudeSecretListItem, error) {
-	var result []ClaudeSecretListItem
-	if err := c.doJSON("GET", "/api/secrets/claude", nil, &result); err != nil {
-		return nil, fmt.Errorf("remote list claude secrets: %w", err)
+// ListProviderSecrets lists provider-scoped credentials for the current user.
+func (c *Client) ListProviderSecrets(provider string) ([]ProviderSecretListItem, error) {
+	var result []ProviderSecretListItem
+	if err := c.doJSON("GET", "/api/secrets/"+provider, nil, &result); err != nil {
+		return nil, fmt.Errorf("remote list %s secrets: %w", provider, err)
 	}
 	return result, nil
 }
 
-// DeleteClaudeSecret deletes a credential by ID.
-func (c *Client) DeleteClaudeSecret(id string) error {
+// DeleteProviderSecret deletes a provider-scoped credential by ID.
+func (c *Client) DeleteProviderSecret(id string) error {
 	if err := c.doJSON("DELETE", "/api/secrets/"+id, nil, nil); err != nil {
 		return fmt.Errorf("remote delete secret: %w", err)
 	}

--- a/internal/auth/discovery.go
+++ b/internal/auth/discovery.go
@@ -651,6 +651,71 @@ func DiscoverClaudeCredentials(homeDir string) ([]ClaudeCredential, error) {
 	return creds, nil
 }
 
+// CodexCredential represents a single discovered Codex credential with its
+// type and source preserved, suitable for interactive selection.
+type CodexCredential struct {
+	// Type is a human-readable label: "API Key" or "OAuth".
+	Type string
+	// Source describes where the credential was found (e.g. file path).
+	Source string
+	// Value is the raw credential data to upload: the API key string or the
+	// full auth.json contents for OAuth.
+	Value string
+}
+
+// DiscoverCodexCredentials scans local credential sources and returns all
+// Codex-specific credentials found, preserving their type and source. If
+// homeDir is empty, the user's home directory is obtained from the operating
+// system (e.g. the HOME environment variable or OS-level user database).
+func DiscoverCodexCredentials(homeDir string) ([]CodexCredential, error) {
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get home directory: %w", err)
+		}
+	}
+
+	var creds []CodexCredential
+
+	for _, rel := range CodexCredentialPaths() {
+		path := filepath.Join(homeDir, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		raw := strings.TrimSpace(string(data))
+
+		obj, found, err := readJSONObjectIfExists(path)
+		if err != nil || !found {
+			continue
+		}
+
+		// API key takes precedence when present and non-empty.
+		apiKey, exists, err := getStringPath(obj, "OPENAI_API_KEY")
+		if err == nil && exists && apiKey != "" {
+			creds = append(creds, CodexCredential{
+				Type:   "API Key",
+				Source: path,
+				Value:  apiKey,
+			})
+		}
+
+		// OAuth credentials are identified by tokens.access_token; the value
+		// uploaded is the entire auth.json file so refresh tokens are preserved.
+		token, exists, err := getStringPath(obj, "tokens.access_token")
+		if err == nil && exists && token != "" {
+			creds = append(creds, CodexCredential{
+				Type:   "OAuth",
+				Source: path,
+				Value:  raw,
+			})
+		}
+	}
+
+	return creds, nil
+}
+
 // ClaudeAPIKeyPaths returns the home-relative paths where Claude Code stores
 // API key configuration. Callers should join each with a home directory.
 func ClaudeAPIKeyPaths() []string {


### PR DESCRIPTION
Adds Codex credential management (push/list/delete) using a generic providerConfig abstraction shared with Claude commands, eliminating duplication. Collapses Claude/Codex-specific apiclient types into parameterized ProviderSecret* types and methods.