### PR TITLE
feat: add codex support to agent-send command

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -2017,14 +2017,31 @@ Examples:
 
 // agentConfig describes how to invoke an agent CLI in non-interactive mode.
 type agentConfig struct {
-	Binary    string   // CLI binary name
-	PrintArg  string   // flag for non-interactive print mode
-	ExtraArgs []string // additional flags passed on every invocation
+	Binary         string   // CLI binary name
+	SubCmd         []string // subcommand for non-interactive mode (e.g., ["exec"] for codex)
+	PrintArg       string   // flag for non-interactive print mode (empty = positional)
+	ExtraArgs      []string // additional flags passed on every invocation
+	ResumeSubCmd   []string // subcommand inserted for session resume (e.g., ["resume"] for codex)
+	ResumeFlag     string   // flag for session resume (e.g., "--resume" for claude; empty = positional)
+	JSONOutputArgs []string // flags to enable JSON output
 }
 
 // knownAgents maps agent names to their CLI configuration.
 var knownAgents = map[string]agentConfig{
-	"claude": {Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}},
+	"claude": {
+		Binary:         "claude",
+		PrintArg:       "-p",
+		ExtraArgs:      []string{"--dangerously-skip-permissions"},
+		ResumeFlag:     "--resume",
+		JSONOutputArgs: []string{"--output-format", "json"},
+	},
+	"codex": {
+		Binary:         "codex",
+		SubCmd:         []string{"exec"},
+		ExtraArgs:      []string{"--dangerously-bypass-approvals-and-sandbox"},
+		ResumeSubCmd:   []string{"resume"},
+		JSONOutputArgs: []string{"--json"},
+	},
 }
 
 // resolveAgentConfig returns the agent configuration for the given name.
@@ -2059,30 +2076,45 @@ type agentRunOpts struct {
 // agentCmdParts returns the agent binary, flags, and message as a flat list.
 func agentCmdParts(agent agentConfig, message string) []string {
 	parts := []string{agent.Binary}
+	parts = append(parts, agent.SubCmd...)
 	parts = append(parts, agent.ExtraArgs...)
-	parts = append(parts, agent.PrintArg, message)
+	if agent.PrintArg != "" {
+		parts = append(parts, agent.PrintArg)
+	}
+	parts = append(parts, message)
 	return parts
 }
 
 // agentCmdPartsWithOpts returns the agent binary, flags, session options, and
-// message as a flat list. When jsonOutput is true, --output-format json is
-// appended so the caller can extract the session ID from Claude's output.
+// message as a flat list. When jsonOutput is true, the agent's JSON output
+// flags are appended so the caller can extract the session ID from the output.
 //
-// Flag mapping (amika → Claude CLI):
+// Flag mapping (amika → agent CLI):
 //
-//	SessionID  → --resume <id>   (resume a specific session)
-//	NewSession → (no flag)       (Claude's default is a new session)
+//	Claude:  SessionID → --resume <id>
+//	Codex:   SessionID → exec resume <id> (subcommand + positional)
+//	NewSession → (no flag for either — both default to new session)
 func agentCmdPartsWithOpts(agent agentConfig, message string, opts agentRunOpts, jsonOutput bool) []string {
 	parts := []string{agent.Binary}
-	parts = append(parts, agent.ExtraArgs...)
+	parts = append(parts, agent.SubCmd...)
 	if opts.SessionID != "" {
-		parts = append(parts, "--resume", opts.SessionID)
+		parts = append(parts, agent.ResumeSubCmd...)
 	}
-	// NewSession: no flag needed — Claude starts a new session by default.
+	parts = append(parts, agent.ExtraArgs...)
+	if opts.SessionID != "" && agent.ResumeFlag != "" {
+		parts = append(parts, agent.ResumeFlag, opts.SessionID)
+	}
 	if jsonOutput {
-		parts = append(parts, "--output-format", "json")
+		parts = append(parts, agent.JSONOutputArgs...)
 	}
-	parts = append(parts, agent.PrintArg, message)
+	// Session ID as positional arg when no flag is used (e.g. Codex).
+	if opts.SessionID != "" && agent.ResumeFlag == "" {
+		parts = append(parts, opts.SessionID)
+	}
+	if agent.PrintArg != "" {
+		parts = append(parts, agent.PrintArg)
+	}
+	parts = append(parts, message)
 	return parts
 }
 
@@ -2128,6 +2160,7 @@ func runRemoteAgentSend(client *apiclient.Client, name, message string, noWait b
 		Message:    message,
 		NewSession: opts.NewSession,
 		SessionID:  opts.SessionID,
+		Agent:      agent.Binary,
 	}
 
 	resp, err := client.AgentSend(name, req)

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -568,10 +568,10 @@ func TestBuildSandboxConnectArgs(t *testing.T) {
 }
 
 func TestBuildAgentShellCmd(t *testing.T) {
-	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
+	claude := knownAgents["claude"]
 
 	t.Run("wait mode", func(t *testing.T) {
-		got := buildAgentShellCmd("hello world", false, "/home/amika", agent)
+		got := buildAgentShellCmd("hello world", false, "/home/amika", claude)
 		if !strings.Contains(got, "cd /home/amika") {
 			t.Fatalf("cmd = %q, want to contain 'cd /home/amika'", got)
 		}
@@ -587,7 +587,7 @@ func TestBuildAgentShellCmd(t *testing.T) {
 	})
 
 	t.Run("no-wait mode wraps in tmux", func(t *testing.T) {
-		got := buildAgentShellCmd("hello world", true, "/home/amika", agent)
+		got := buildAgentShellCmd("hello world", true, "/home/amika", claude)
 		if !strings.Contains(got, "tmux new-session -d") {
 			t.Fatalf("cmd = %q, want to contain 'tmux new-session -d'", got)
 		}
@@ -600,18 +600,32 @@ func TestBuildAgentShellCmd(t *testing.T) {
 	})
 
 	t.Run("custom workdir", func(t *testing.T) {
-		got := buildAgentShellCmd("test", false, "/workspace", agent)
+		got := buildAgentShellCmd("test", false, "/workspace", claude)
 		if !strings.Contains(got, "cd /workspace") {
 			t.Fatalf("cmd = %q, want to contain 'cd /workspace'", got)
+		}
+	})
+
+	t.Run("codex wait mode", func(t *testing.T) {
+		codex := knownAgents["codex"]
+		got := buildAgentShellCmd("hello world", false, "/home/amika", codex)
+		if !strings.Contains(got, "cd /home/amika") {
+			t.Fatalf("cmd = %q, want to contain 'cd /home/amika'", got)
+		}
+		if !strings.Contains(got, "codex exec") {
+			t.Fatalf("cmd = %q, want to contain 'codex exec'", got)
+		}
+		if !strings.Contains(got, "--dangerously-bypass-approvals-and-sandbox") {
+			t.Fatalf("cmd = %q, want to contain '--dangerously-bypass-approvals-and-sandbox'", got)
 		}
 	})
 }
 
 func TestBuildDockerAgentSendArgs(t *testing.T) {
-	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
+	claude := knownAgents["claude"]
 
 	t.Run("wraps in docker exec bash -c", func(t *testing.T) {
-		got := buildDockerAgentSendArgs("sb-1", "hello", false, "/home/amika", agent)
+		got := buildDockerAgentSendArgs("sb-1", "hello", false, "/home/amika", claude)
 		if got[0] != "exec" || got[1] != "sb-1" || got[2] != "bash" || got[3] != "-c" {
 			t.Fatalf("args prefix = %#v, want [exec sb-1 bash -c ...]", got[:4])
 		}
@@ -632,6 +646,22 @@ func TestResolveAgentConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("known agent codex", func(t *testing.T) {
+		cfg, err := resolveAgentConfig("codex")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Binary != "codex" {
+			t.Fatalf("Binary = %q, want %q", cfg.Binary, "codex")
+		}
+		if len(cfg.SubCmd) != 1 || cfg.SubCmd[0] != "exec" {
+			t.Fatalf("SubCmd = %v, want [exec]", cfg.SubCmd)
+		}
+		if len(cfg.ExtraArgs) != 1 || cfg.ExtraArgs[0] != "--dangerously-bypass-approvals-and-sandbox" {
+			t.Fatalf("ExtraArgs = %v, want [--dangerously-bypass-approvals-and-sandbox]", cfg.ExtraArgs)
+		}
+	})
+
 	t.Run("unknown agent returns error", func(t *testing.T) {
 		_, err := resolveAgentConfig("custom-agent")
 		if err == nil {
@@ -644,10 +674,10 @@ func TestResolveAgentConfig(t *testing.T) {
 }
 
 func TestAgentCmdPartsWithOpts(t *testing.T) {
-	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
+	claude := knownAgents["claude"]
 
 	t.Run("no opts no json", func(t *testing.T) {
-		got := agentCmdPartsWithOpts(agent, "hello", agentRunOpts{}, false)
+		got := agentCmdPartsWithOpts(claude, "hello", agentRunOpts{}, false)
 		want := []string{"claude", "--dangerously-skip-permissions", "-p", "hello"}
 		if strings.Join(got, " ") != strings.Join(want, " ") {
 			t.Fatalf("got %v, want %v", got, want)
@@ -655,7 +685,7 @@ func TestAgentCmdPartsWithOpts(t *testing.T) {
 	})
 
 	t.Run("with session id maps to --resume", func(t *testing.T) {
-		got := agentCmdPartsWithOpts(agent, "hello", agentRunOpts{SessionID: "abc-123"}, true)
+		got := agentCmdPartsWithOpts(claude, "hello", agentRunOpts{SessionID: "abc-123"}, true)
 		joined := strings.Join(got, " ")
 		if !strings.Contains(joined, "--resume abc-123") {
 			t.Fatalf("got %q, want --resume abc-123", joined)
@@ -666,7 +696,7 @@ func TestAgentCmdPartsWithOpts(t *testing.T) {
 	})
 
 	t.Run("new session passes no session flag", func(t *testing.T) {
-		got := agentCmdPartsWithOpts(agent, "hello", agentRunOpts{NewSession: true}, true)
+		got := agentCmdPartsWithOpts(claude, "hello", agentRunOpts{NewSession: true}, true)
 		joined := strings.Join(got, " ")
 		if strings.Contains(joined, "--new-session") {
 			t.Fatalf("got %q, should not contain --new-session", joined)
@@ -678,20 +708,47 @@ func TestAgentCmdPartsWithOpts(t *testing.T) {
 			t.Fatalf("got %q, should not contain --continue", joined)
 		}
 	})
+
+	codex := knownAgents["codex"]
+
+	t.Run("codex no opts no json", func(t *testing.T) {
+		got := agentCmdPartsWithOpts(codex, "hello", agentRunOpts{}, false)
+		want := []string{"codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "hello"}
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("codex with session id uses resume subcommand", func(t *testing.T) {
+		got := agentCmdPartsWithOpts(codex, "hello", agentRunOpts{SessionID: "abc-123"}, true)
+		joined := strings.Join(got, " ")
+		want := "codex exec resume --dangerously-bypass-approvals-and-sandbox --json abc-123 hello"
+		if joined != want {
+			t.Fatalf("got %q, want %q", joined, want)
+		}
+	})
+
+	t.Run("codex new session with json", func(t *testing.T) {
+		got := agentCmdPartsWithOpts(codex, "hello", agentRunOpts{NewSession: true}, true)
+		want := []string{"codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--json", "hello"}
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
 }
 
 func TestBuildRemoteAgentShellCmd(t *testing.T) {
-	agent := agentConfig{Binary: "claude", PrintArg: "-p", ExtraArgs: []string{"--dangerously-skip-permissions"}}
+	claude := knownAgents["claude"]
 
 	t.Run("wait mode includes json output", func(t *testing.T) {
-		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", agent, agentRunOpts{})
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", claude, agentRunOpts{})
 		if !strings.Contains(got, "--output-format json") {
 			t.Fatalf("cmd = %q, want --output-format json", got)
 		}
 	})
 
 	t.Run("no-wait mode has no json and wraps in tmux", func(t *testing.T) {
-		got := buildRemoteAgentShellCmd("hello", true, "/home/amika", agent, agentRunOpts{})
+		got := buildRemoteAgentShellCmd("hello", true, "/home/amika", claude, agentRunOpts{})
 		if strings.Contains(got, "--output-format") {
 			t.Fatalf("cmd = %q, should not contain --output-format in no-wait mode", got)
 		}
@@ -701,14 +758,14 @@ func TestBuildRemoteAgentShellCmd(t *testing.T) {
 	})
 
 	t.Run("session id maps to --resume", func(t *testing.T) {
-		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", agent, agentRunOpts{SessionID: "sess-42"})
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", claude, agentRunOpts{SessionID: "sess-42"})
 		if !strings.Contains(got, "--resume sess-42") {
 			t.Fatalf("cmd = %q, want --resume sess-42", got)
 		}
 	})
 
 	t.Run("new session passes no session flag to claude", func(t *testing.T) {
-		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", agent, agentRunOpts{NewSession: true})
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", claude, agentRunOpts{NewSession: true})
 		if strings.Contains(got, "--new-session") {
 			t.Fatalf("cmd = %q, should not contain --new-session", got)
 		}
@@ -718,6 +775,38 @@ func TestBuildRemoteAgentShellCmd(t *testing.T) {
 		// Should still have --output-format json for session capture.
 		if !strings.Contains(got, "--output-format json") {
 			t.Fatalf("cmd = %q, want --output-format json", got)
+		}
+	})
+
+	codex := knownAgents["codex"]
+
+	t.Run("codex wait mode includes --json", func(t *testing.T) {
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", codex, agentRunOpts{})
+		if !strings.Contains(got, "--json") {
+			t.Fatalf("cmd = %q, want --json", got)
+		}
+		if !strings.Contains(got, "codex exec") {
+			t.Fatalf("cmd = %q, want to contain 'codex exec'", got)
+		}
+	})
+
+	t.Run("codex no-wait wraps in tmux without json", func(t *testing.T) {
+		got := buildRemoteAgentShellCmd("hello", true, "/home/amika", codex, agentRunOpts{})
+		if strings.Contains(got, "--json") {
+			t.Fatalf("cmd = %q, should not contain --json in no-wait mode", got)
+		}
+		if !strings.Contains(got, "tmux new-session -d") {
+			t.Fatalf("cmd = %q, want tmux wrap", got)
+		}
+	})
+
+	t.Run("codex session id uses resume subcommand", func(t *testing.T) {
+		got := buildRemoteAgentShellCmd("hello", false, "/home/amika", codex, agentRunOpts{SessionID: "sess-42"})
+		if !strings.Contains(got, "codex exec resume") {
+			t.Fatalf("cmd = %q, want 'codex exec resume'", got)
+		}
+		if !strings.Contains(got, "sess-42") {
+			t.Fatalf("cmd = %q, want session ID 'sess-42'", got)
 		}
 	})
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -287,6 +287,7 @@ type AgentSendRequest struct {
 	Message    string `json:"message"`
 	NewSession bool   `json:"new_session,omitempty"`
 	SessionID  string `json:"session_id,omitempty"`
+	Agent      string `json:"agent,omitempty"`
 }
 
 // AgentSendResponse is the response from POST /api/sandboxes/{name}/agent-send.


### PR DESCRIPTION
Extend agentConfig to support agents with subcommand-based CLIs (like Codex's `exec` / `exec resume`) alongside flag-based CLIs (like Claude). Add "codex" to knownAgents so `--agent codex` works for agent-send.