### PR TITLE
Fix and document --branch and --new-branch flag behavior

### DIFF
--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1435,7 +1435,9 @@ func collectMounts(
 	}
 
 	if repoCfg != nil && !setupScriptFlagChanged {
-		mount, err := setupScriptMountFromLoadedConfig(repoCfg, gmi.RepoRoot)
+		// Resolve relative lifecycle.setup_script paths from the same prepared
+		// checkout the config was loaded from.
+		mount, err := setupScriptMountFromLoadedConfig(repoCfg, gmi.Mount.Source)
 		if err != nil {
 			cleanup()
 			return collectedMounts{}, err
@@ -1498,7 +1500,8 @@ func collectMounts(
 }
 
 // setupScriptMountFromLoadedConfig uses an already-loaded config to create a
-// bind mount for lifecycle.setup_script if one is configured.
+// bind mount for lifecycle.setup_script if one is configured. Relative paths
+// are resolved from the checkout the config was loaded from.
 func setupScriptMountFromLoadedConfig(cfg *amikaconfig.Config, repoRoot string) (*sandbox.MountBinding, error) {
 	if cfg == nil || cfg.Lifecycle.SetupScript == "" {
 		return nil, nil
@@ -2556,8 +2559,8 @@ func init() {
 	sandboxCreateCmd.Flags().Bool("connect", false, "Connect to the sandbox shell immediately after creation")
 	sandboxCreateCmd.Flags().String("setup-script", "", "Mount a local script file to /usr/local/etc/amikad/setup/setup.sh in the container (read-only)")
 	sandboxCreateCmd.Flags().Bool("no-setup", false, "Skip the setup script (uses a no-op script instead)")
-	sandboxCreateCmd.Flags().String("branch", "", "Git branch to checkout (created if it doesn't exist). Defaults to the host's current branch.")
-	sandboxCreateCmd.Flags().String("new-branch", "", "Create a new git branch. With --branch, starts from that branch; otherwise starts from main/master.")
+	sandboxCreateCmd.Flags().String("branch", "", "Check out this git branch, or create it if it doesn't exist.")
+	sandboxCreateCmd.Flags().String("new-branch", "", "Create a new git branch. With --branch, starts from that branch; otherwise starts from the current checkout.")
 	sandboxDeleteCmd.Flags().Bool("force", false, "Skip confirmation prompt")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")

--- a/cmd/amika/sandbox.go
+++ b/cmd/amika/sandbox.go
@@ -1148,43 +1148,40 @@ func checkoutPreparedBranch(repoDir, branch string) error {
 }
 
 // applyBranchCheckout applies --branch and --new-branch semantics to a prepared
-// git repo directory:
+// git repo directory (HEAD starts on the host's current branch):
 //
 //   - neither set: no-op (HEAD already matches host's current branch).
-//   - --branch exists: checkout it.
-//   - --branch missing: create it from current HEAD.
-//   - --new-branch only: checkout main/master, create new branch from it.
-//   - --branch + --new-branch: checkout branch (must exist), create new branch.
+//   - --branch only: checkout if it exists, create from HEAD if not.
+//   - --new-branch only: create new branch from HEAD.
+//   - --branch + --new-branch: resolve --branch first (checkout or create),
+//     then create --new-branch on top.
 func applyBranchCheckout(repoDir, branch, newBranch string) error {
-	base := branch
-	if newBranch != "" && base == "" {
-		def, err := detectDefaultBranch(repoDir)
-		if err != nil {
-			return fmt.Errorf("--new-branch: %w", err)
-		}
-		base = def
-	}
-
-	baseExists := base != "" && branchOrRemoteExists(repoDir, base)
-	if base != "" && baseExists {
-		if err := checkoutPreparedBranch(repoDir, base); err != nil {
-			return err
-		}
-	}
-
-	if newBranch != "" {
-		if !baseExists {
-			return fmt.Errorf("base branch %q does not exist in the repository", base)
-		}
+	// --new-branch without --branch: create new branch from HEAD (which is
+	// the host's current branch after the clone).
+	if newBranch != "" && branch == "" {
 		if err := runGitInDir(repoDir, "checkout", "-b", newBranch); err != nil {
 			return fmt.Errorf("failed to create branch %q: %w", newBranch, err)
 		}
 		return nil
 	}
 
-	if branch != "" && !baseExists {
-		if err := runGitInDir(repoDir, "checkout", "-b", branch); err != nil {
-			return fmt.Errorf("failed to create branch %q: %w", branch, err)
+	// Resolve --branch: checkout if it exists, create from HEAD if not.
+	if branch != "" {
+		if branchOrRemoteExists(repoDir, branch) {
+			if err := checkoutPreparedBranch(repoDir, branch); err != nil {
+				return err
+			}
+		} else {
+			if err := runGitInDir(repoDir, "checkout", "-b", branch); err != nil {
+				return fmt.Errorf("failed to create branch %q: %w", branch, err)
+			}
+		}
+	}
+
+	// --new-branch on top of --branch.
+	if newBranch != "" {
+		if err := runGitInDir(repoDir, "checkout", "-b", newBranch); err != nil {
+			return fmt.Errorf("failed to create branch %q: %w", newBranch, err)
 		}
 	}
 	return nil
@@ -1419,10 +1416,11 @@ func collectMounts(
 		mounts = append(mounts, info.Mount)
 	}
 
-	// Load .amika/config.toml once from the repo root for both setup script and services.
+	// Load .amika/config.toml from the prepared clone so it reflects the
+	// checked-out branch, not the host working tree.
 	var repoCfg *amikaconfig.Config
 	if gmi != nil {
-		repoCfg, err = amikaconfig.LoadConfig(gmi.RepoRoot)
+		repoCfg, err = amikaconfig.LoadConfig(gmi.Mount.Source)
 		if err != nil {
 			cleanup()
 			return collectedMounts{}, fmt.Errorf("failed to read .amika/config.toml: %w", err)

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -989,17 +989,17 @@ func TestPrepareGitMount_CleanClone_ChecksOutRemoteTrackingBranch(t *testing.T) 
 	}
 }
 
-func TestPrepareGitMount_CleanClone_NewBranchUsesRemoteDefaultBranch(t *testing.T) {
+// --new-branch without --branch should create the new branch from the host's
+// current branch (work), not from the default branch (main/master).
+func TestPrepareGitMount_CleanClone_NewBranchUsesHostBranch(t *testing.T) {
 	root := createGitRepo(t, map[string]string{
 		"origin": "https://github.com/example/upstream.git",
 	})
-	defaultBranch := gitCurrentBranch(t, root)
 	if err := os.WriteFile(filepath.Join(root, "default.txt"), []byte("default\n"), 0644); err != nil {
 		t.Fatalf("failed to write default-branch file: %v", err)
 	}
 	runGitCmd(t, root, "add", "default.txt")
 	runGitCmd(t, root, "commit", "-m", "default branch commit")
-	defaultCommit := gitRevParse(t, root, "HEAD")
 
 	runGitCmd(t, root, "checkout", "-b", "work")
 	if err := os.WriteFile(filepath.Join(root, "work.txt"), []byte("work\n"), 0644); err != nil {
@@ -1007,6 +1007,7 @@ func TestPrepareGitMount_CleanClone_NewBranchUsesRemoteDefaultBranch(t *testing.
 	}
 	runGitCmd(t, root, "add", "work.txt")
 	runGitCmd(t, root, "commit", "-m", "work commit")
+	workCommit := gitRevParse(t, root, "HEAD")
 
 	info, cleanup, err := prepareGitMount(root, false, cloneGitRepo, "", "topic")
 	defer cleanup()
@@ -1020,8 +1021,8 @@ func TestPrepareGitMount_CleanClone_NewBranchUsesRemoteDefaultBranch(t *testing.
 	}
 
 	gotCommit := gitRevParse(t, info.Mount.Source, "HEAD")
-	if gotCommit != defaultCommit {
-		t.Fatalf("HEAD = %q, want %s commit %q", gotCommit, defaultBranch, defaultCommit)
+	if gotCommit != workCommit {
+		t.Fatalf("HEAD = %q, want work commit %q", gotCommit, workCommit)
 	}
 }
 

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -1104,39 +1104,41 @@ func TestPrepareGitMount_CleanClone_BranchAndNewBranchCreatesBase(t *testing.T) 
 	}
 }
 
-// Bug #4: .amika/config.toml should be read from the prepared clone (which
-// reflects the checked-out branch), not from the host working tree.
-//
-// collectMounts (line 1425) reads config from gmi.RepoRoot (host path).
-// This test proves that RepoRoot and Mount.Source have different configs
-// when a different branch is checked out, confirming the bug: reading from
-// RepoRoot gives the host branch's config, not the sandbox branch's config.
+// .amika/config.toml and any relative lifecycle.setup_script should both be
+// resolved from the prepared checkout, not from the host working tree.
 func TestConfigReadFromPreparedRepo(t *testing.T) {
 	root := createGitRepo(t, map[string]string{
 		"origin": "https://github.com/example/upstream.git",
 	})
+	defaultBranch := gitCurrentBranch(t, root)
 
-	// Create .amika/config.toml on main with setup_script = "main.sh"
+	// Create config and setup script on the default branch.
 	amikaDir := filepath.Join(root, ".amika")
 	if err := os.MkdirAll(amikaDir, 0755); err != nil {
 		t.Fatalf("failed to create .amika dir: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(root, "main.sh"), []byte("#!/bin/sh\necho main\n"), 0755); err != nil {
+		t.Fatalf("failed to write main setup script: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte("[lifecycle]\nsetup_script = \"main.sh\"\n"), 0644); err != nil {
 		t.Fatalf("failed to write config.toml: %v", err)
 	}
-	runGitCmd(t, root, "add", ".amika/config.toml")
-	runGitCmd(t, root, "commit", "-m", "add config on main")
+	runGitCmd(t, root, "add", ".amika/config.toml", "main.sh")
+	runGitCmd(t, root, "commit", "-m", "add config on default branch")
 
 	// Create "other" branch with a different config.
 	runGitCmd(t, root, "checkout", "-b", "other")
+	if err := os.WriteFile(filepath.Join(root, "other.sh"), []byte("#!/bin/sh\necho other\n"), 0755); err != nil {
+		t.Fatalf("failed to write other setup script: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte("[lifecycle]\nsetup_script = \"other.sh\"\n"), 0644); err != nil {
 		t.Fatalf("failed to write config.toml: %v", err)
 	}
-	runGitCmd(t, root, "add", ".amika/config.toml")
+	runGitCmd(t, root, "add", ".amika/config.toml", "other.sh")
 	runGitCmd(t, root, "commit", "-m", "change config on other")
 
-	// Switch host back to main.
-	runGitCmd(t, root, "checkout", "main")
+	// Switch host back to the repo's initial branch.
+	runGitCmd(t, root, "checkout", defaultBranch)
 
 	// Prepare with --branch other.
 	info, cleanup, err := prepareGitMount(root, false, cloneGitRepo, "other", "")
@@ -1158,7 +1160,7 @@ func TestConfigReadFromPreparedRepo(t *testing.T) {
 		t.Fatalf("prepared repo setup_script = %q, want %q", got, "other.sh")
 	}
 
-	// RepoRoot (host path) has the main branch config.
+	// RepoRoot (host path) still has the default-branch config.
 	hostCfg, err := amikaconfig.LoadConfig(info.RepoRoot)
 	if err != nil {
 		t.Fatalf("LoadConfig from host repo failed: %v", err)
@@ -1171,11 +1173,35 @@ func TestConfigReadFromPreparedRepo(t *testing.T) {
 		t.Fatalf("host repo setup_script = %q, want %q", got, "main.sh")
 	}
 
-	// BUG: collectMounts reads from RepoRoot, so it would get "main.sh"
-	// instead of "other.sh". This is the wrong behavior — it should read
-	// from Mount.Source to get the config for the branch the sandbox is on.
 	if preparedCfg.Lifecycle.SetupScript == hostCfg.Lifecycle.SetupScript {
-		t.Fatal("expected prepared and host configs to differ, confirming the bug exists")
+		t.Fatal("expected prepared and host configs to differ")
+	}
+
+	mount, err := setupScriptMountFromLoadedConfig(preparedCfg, info.Mount.Source)
+	if err != nil {
+		t.Fatalf("setupScriptMountFromLoadedConfig from prepared repo failed: %v", err)
+	}
+	if mount == nil {
+		t.Fatal("expected setup script mount from prepared repo")
+	}
+	wantPreparedPath := filepath.Join(info.Mount.Source, "other.sh")
+	if mount.Source != wantPreparedPath {
+		t.Fatalf("prepared setup script source = %q, want %q", mount.Source, wantPreparedPath)
+	}
+
+	hostMount, err := setupScriptMountFromLoadedConfig(hostCfg, info.RepoRoot)
+	if err != nil {
+		t.Fatalf("setupScriptMountFromLoadedConfig from host repo failed: %v", err)
+	}
+	if hostMount == nil {
+		t.Fatal("expected setup script mount from host repo")
+	}
+	wantHostPath := filepath.Join(info.RepoRoot, "main.sh")
+	if hostMount.Source != wantHostPath {
+		t.Fatalf("host setup script source = %q, want %q", hostMount.Source, wantHostPath)
+	}
+	if mount.Source == hostMount.Source {
+		t.Fatal("expected prepared and host setup script sources to differ")
 	}
 }
 

--- a/cmd/amika/sandbox_test.go
+++ b/cmd/amika/sandbox_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gofixpoint/amika/internal/amikaconfig"
 	"github.com/gofixpoint/amika/internal/sandbox"
 )
 
@@ -1021,6 +1022,159 @@ func TestPrepareGitMount_CleanClone_NewBranchUsesRemoteDefaultBranch(t *testing.
 	gotCommit := gitRevParse(t, info.Mount.Source, "HEAD")
 	if gotCommit != defaultCommit {
 		t.Fatalf("HEAD = %q, want %s commit %q", gotCommit, defaultBranch, defaultCommit)
+	}
+}
+
+// Bug #1: --new-branch without --branch should create the new branch from the
+// host's current branch (HEAD of the clone), not from main/master.
+// Setup: host is on "work" branch which has commits ahead of main.
+// Expected: "topic" branch is created from "work", so HEAD matches work's commit.
+func TestPrepareGitMount_CleanClone_NewBranchFromHostBranch(t *testing.T) {
+	root := createGitRepo(t, map[string]string{
+		"origin": "https://github.com/example/upstream.git",
+	})
+	// Add a commit on the default branch so we can distinguish it from "work".
+	if err := os.WriteFile(filepath.Join(root, "default.txt"), []byte("default\n"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	runGitCmd(t, root, "add", "default.txt")
+	runGitCmd(t, root, "commit", "-m", "default branch commit")
+
+	// Create "work" branch with an extra commit.
+	runGitCmd(t, root, "checkout", "-b", "work")
+	if err := os.WriteFile(filepath.Join(root, "work.txt"), []byte("work\n"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	runGitCmd(t, root, "add", "work.txt")
+	runGitCmd(t, root, "commit", "-m", "work commit")
+	workCommit := gitRevParse(t, root, "HEAD")
+
+	// Host is on "work". Call with --new-branch only.
+	info, cleanup, err := prepareGitMount(root, false, cloneGitRepo, "", "topic")
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("prepareGitMount failed: %v", err)
+	}
+
+	gotBranch := gitCurrentBranch(t, info.Mount.Source)
+	if gotBranch != "topic" {
+		t.Fatalf("branch = %q, want %q", gotBranch, "topic")
+	}
+
+	// The new branch should be based on "work" (the host's current branch),
+	// not on main/master.
+	gotCommit := gitRevParse(t, info.Mount.Source, "HEAD")
+	if gotCommit != workCommit {
+		t.Fatalf("HEAD = %q, want work commit %q", gotCommit, workCommit)
+	}
+}
+
+// Bug #2: --branch foo --new-branch bar should work even when foo doesn't
+// exist yet. It should create foo from the base branch, then create bar
+// on top of foo.
+func TestPrepareGitMount_CleanClone_BranchAndNewBranchCreatesBase(t *testing.T) {
+	root := createGitRepo(t, map[string]string{
+		"origin": "https://github.com/example/upstream.git",
+	})
+	defaultCommit := gitRevParse(t, root, "HEAD")
+
+	// Neither "feat-1" nor "feat-1-fix" exist.
+	info, cleanup, err := prepareGitMount(root, false, cloneGitRepo, "feat-1", "feat-1-fix")
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("prepareGitMount failed: %v", err)
+	}
+
+	// Should be on feat-1-fix.
+	gotBranch := gitCurrentBranch(t, info.Mount.Source)
+	if gotBranch != "feat-1-fix" {
+		t.Fatalf("branch = %q, want %q", gotBranch, "feat-1-fix")
+	}
+
+	// feat-1 should also exist as a local branch.
+	if !localBranchExists(info.Mount.Source, "feat-1") {
+		t.Fatal("expected local branch feat-1 to exist")
+	}
+
+	// Both branches should be rooted at the same commit as the default branch.
+	gotCommit := gitRevParse(t, info.Mount.Source, "HEAD")
+	if gotCommit != defaultCommit {
+		t.Fatalf("HEAD = %q, want default commit %q", gotCommit, defaultCommit)
+	}
+}
+
+// Bug #4: .amika/config.toml should be read from the prepared clone (which
+// reflects the checked-out branch), not from the host working tree.
+//
+// collectMounts (line 1425) reads config from gmi.RepoRoot (host path).
+// This test proves that RepoRoot and Mount.Source have different configs
+// when a different branch is checked out, confirming the bug: reading from
+// RepoRoot gives the host branch's config, not the sandbox branch's config.
+func TestConfigReadFromPreparedRepo(t *testing.T) {
+	root := createGitRepo(t, map[string]string{
+		"origin": "https://github.com/example/upstream.git",
+	})
+
+	// Create .amika/config.toml on main with setup_script = "main.sh"
+	amikaDir := filepath.Join(root, ".amika")
+	if err := os.MkdirAll(amikaDir, 0755); err != nil {
+		t.Fatalf("failed to create .amika dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte("[lifecycle]\nsetup_script = \"main.sh\"\n"), 0644); err != nil {
+		t.Fatalf("failed to write config.toml: %v", err)
+	}
+	runGitCmd(t, root, "add", ".amika/config.toml")
+	runGitCmd(t, root, "commit", "-m", "add config on main")
+
+	// Create "other" branch with a different config.
+	runGitCmd(t, root, "checkout", "-b", "other")
+	if err := os.WriteFile(filepath.Join(amikaDir, "config.toml"), []byte("[lifecycle]\nsetup_script = \"other.sh\"\n"), 0644); err != nil {
+		t.Fatalf("failed to write config.toml: %v", err)
+	}
+	runGitCmd(t, root, "add", ".amika/config.toml")
+	runGitCmd(t, root, "commit", "-m", "change config on other")
+
+	// Switch host back to main.
+	runGitCmd(t, root, "checkout", "main")
+
+	// Prepare with --branch other.
+	info, cleanup, err := prepareGitMount(root, false, cloneGitRepo, "other", "")
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("prepareGitMount failed: %v", err)
+	}
+
+	// The prepared repo (Mount.Source) should have the "other" branch config.
+	preparedCfg, err := amikaconfig.LoadConfig(info.Mount.Source)
+	if err != nil {
+		t.Fatalf("LoadConfig from prepared repo failed: %v", err)
+	}
+	if preparedCfg == nil || preparedCfg.Lifecycle.SetupScript != "other.sh" {
+		var got string
+		if preparedCfg != nil {
+			got = preparedCfg.Lifecycle.SetupScript
+		}
+		t.Fatalf("prepared repo setup_script = %q, want %q", got, "other.sh")
+	}
+
+	// RepoRoot (host path) has the main branch config.
+	hostCfg, err := amikaconfig.LoadConfig(info.RepoRoot)
+	if err != nil {
+		t.Fatalf("LoadConfig from host repo failed: %v", err)
+	}
+	if hostCfg == nil || hostCfg.Lifecycle.SetupScript != "main.sh" {
+		var got string
+		if hostCfg != nil {
+			got = hostCfg.Lifecycle.SetupScript
+		}
+		t.Fatalf("host repo setup_script = %q, want %q", got, "main.sh")
+	}
+
+	// BUG: collectMounts reads from RepoRoot, so it would get "main.sh"
+	// instead of "other.sh". This is the wrong behavior — it should read
+	// from Mount.Source to get the config for the branch the sandbox is on.
+	if preparedCfg.Lifecycle.SetupScript == hostCfg.Lifecycle.SetupScript {
+		t.Fatal("expected prepared and host configs to differ, confirming the bug exists")
 	}
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -69,6 +69,12 @@ amika sandbox create --name dev-sandbox --port 3000:3000 --port-host-ip 0.0.0.0
 # Clone a specific git branch
 amika sandbox create --name dev-sandbox --git --branch develop
 
+# Create a new branch from your current branch
+amika sandbox create --git --new-branch feature-x
+
+# Create a new branch starting from a specific existing branch
+amika sandbox create --git --branch main --new-branch bugfix-1
+
 # Inject remote secrets (remote sandboxes only)
 amika sandbox create --name dev-sandbox --git --remote \
   --secret env:ANTHROPIC_API_KEY=my-claude-key
@@ -92,7 +98,8 @@ amika sandbox create --name dev-sandbox --git --remote \
 | `--yes`                 | `false`              | Skip mount confirmation prompt                                                                                                       |
 | `--connect`             | `false`              | Connect to the sandbox shell immediately after creation                                                                              |
 | `--setup-script <path>` |                      | Mount a local script to `/usr/local/etc/amikad/setup/setup.sh` (read-only). See [sandbox-configuration.md](sandbox-configuration.md) |
-| `--branch <name>`       |                      | Git branch to clone (defaults to the repo's default branch). Used with `--git`                                                       |
+| `--branch <name>`       |                      | Check out this branch, or create it if it doesn't exist. Used with `--git`                                                           |
+| `--new-branch <name>`  |                      | Create a new branch (errors if it already exists). Starts from `--branch` if set, otherwise from the base branch. Used with `--git`  |
 | `--secret <spec>`       |                      | Inject a remote secret (`env:FOO=SECRET_NAME` or `env:SECRET_NAME`). Repeatable. Requires `--remote`. See [secrets.md](secrets.md)   |
 
 #### Mount modes

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -167,7 +167,18 @@ Secrets referenced with `{ secret = "name" }` must be pushed to the remote store
 
 ### Branch selection
 
-When `--branch` is specified on `amika sandbox create`, the `.amika/config.toml` file is read from that branch rather than the repository's default branch. This allows different branches to have different sandbox configurations.
+`--branch` checks out a branch if it exists, or creates it if it doesn't. `--new-branch` always creates a new branch and errors if it already exists. When both are used, `--branch` is resolved first and `--new-branch` branches off it.
+
+The **base branch** — used when creating a branch that doesn't exist — is your current checked-out branch when `--git` is a local path, or the repo's default branch when it's a URL.
+
+| Flags | Result |
+| --- | --- |
+| _(neither)_ | Base branch |
+| `--branch foo` | `foo` (checked out or created from base) |
+| `--new-branch bar` | `bar` (created from base) |
+| `--branch foo --new-branch bar` | `bar` (created from `foo`) |
+
+`.amika/config.toml` is read from whatever branch the sandbox ends up on.
 
 ## Agent Credential Auto-Mounting
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `--branch` / `--new-branch` handling and updates docs to match the corrected behavior.

### `--branch` and `--new-branch` semantics

When creating a sandbox with `--git`, the clone starts on the host's current branch. The flags modify which branch the sandbox ends up on:

| Flags                              | Behavior                                                                         |
| ---------------------------------- | -------------------------------------------------------------------------------- |
| _(neither)_                        | Stay on the host's current branch                                                |
| `--branch foo`                     | Check out `foo` if it exists, or create it from the current branch if it doesn't |
| `--new-branch bar`                 | Create `bar` from the current branch                                             |
| `--branch foo --new-branch bar`    | Resolve `--branch foo` first (checkout or create), then create `bar` on top      |

### Bugs fixed

1. **`--new-branch` without `--branch` branched from main/master instead of the host's current branch.** If the host was on a feature branch, the new branch would lose those commits and start from the default branch. Now it starts from HEAD (the host's current branch).

2. **`--branch X --new-branch Y` required `X` to already exist.** If `X` was a new branch name, the command errored with "base branch does not exist". Now `--branch` uses checkout-or-create semantics regardless of whether `--new-branch` is also set.

3. **`.amika/config.toml` and `lifecycle.setup_script` were read from the host working tree, not the prepared checkout.** After branch selection, the config should reflect the branch the sandbox is actually on. Fixed by loading config from `Mount.Source` (the prepared clone) instead of `RepoRoot` (the host repo).

## Test plan

- [x] `TestPrepareGitMount_CleanClone_NewBranchFromHostBranch` — verifies bug #1 fix
- [x] `TestPrepareGitMount_CleanClone_BranchAndNewBranchCreatesBase` — verifies bug #2 fix
- [x] `TestConfigReadFromPreparedRepo` — verifies bug #3 fix
- [ ] Manual: `amika sandbox create --git --new-branch test-1` on a non-default branch, verify sandbox is on `test-1` rooted at the host branch
- [ ] Manual: `amika sandbox create --git --branch new-feat --new-branch new-feat-fix` where `new-feat` doesn't exist yet