### PR TITLE
auth: support WorkOS organization API key as a login credential

### DIFF
--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"time"
 
 	"github.com/gofixpoint/amika/internal/auth"
 	"github.com/gofixpoint/amika/internal/config"
@@ -17,21 +20,87 @@ var authCmd = &cobra.Command{
 
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Log in to Amika via WorkOS",
-	Long: `Authenticate with Amika using the WorkOS Device Authorization Flow.
-Opens a browser for you to authorize the CLI.`,
+	Short: "Log in to Amika",
+	Long: `Authenticate with Amika.
+
+By default runs the WorkOS Device Authorization Flow and opens a browser.
+
+Pass --api-key-file to skip the browser flow and store a WorkOS organization
+API key instead. Use "-" to read the key from stdin, which pairs well with
+secret managers in CI (for example: "vault kv get -field=key … | amika auth login --api-key-file -").`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
+
+		apiKeyFile, _ := cmd.Flags().GetString("api-key-file")
+
+		existingSession, sessionErr := auth.LoadSession()
+		existingKey, keyErr := auth.LoadAPIKey()
+
+		// I/O failures that aren't recoverable via logout (permission
+		// denied, invalid AMIKA_STATE_DIRECTORY, etc.) must surface
+		// directly — redirecting the user to `auth logout` would just
+		// fail with the same underlying error.
+		sessionCorrupt := sessionErr != nil && errors.Is(sessionErr, auth.ErrCorruptSession)
+		keyCorrupt := keyErr != nil && errors.Is(keyErr, auth.ErrCorruptAPIKey)
+		if sessionErr != nil && !sessionCorrupt {
+			return fmt.Errorf("reading stored session: %w", sessionErr)
+		}
+		if keyErr != nil && !keyCorrupt {
+			return fmt.Errorf("reading stored API key: %w", keyErr)
+		}
+
+		// A corrupt credential file counts as "something stored" —
+		// point the user at `auth logout`, which tolerates parse errors.
+		if existingSession != nil || existingKey != nil || sessionCorrupt || keyCorrupt {
+			who := "a credential"
+			switch {
+			case sessionCorrupt:
+				who = "an unreadable session file"
+			case keyCorrupt:
+				who = "an unreadable API key file"
+			case existingSession != nil:
+				who = fmt.Sprintf("session for %s", existingSession.Email)
+			case existingKey != nil:
+				who = "an API key"
+			}
+			return fmt.Errorf("already have %s stored, run `amika auth logout` first", who)
+		}
+
+		if apiKeyFile != "" {
+			return loginWithAPIKeyFile(cmd, apiKeyFile)
+		}
 
 		session, err := auth.DeviceLogin(config.WorkOSClientID())
 		if err != nil {
 			return err
 		}
-
 		fmt.Fprintf(cmd.OutOrStdout(), "Logged in as %s\n", session.Email)
 		return nil
 	},
+}
+
+func loginWithAPIKeyFile(cmd *cobra.Command, path string) error {
+	var src io.Reader
+	if path == "-" {
+		src = cmd.InOrStdin()
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("opening api key file: %w", err)
+		}
+		defer f.Close()
+		src = f
+	}
+	key, err := auth.ReadAPIKeyFromReader(src)
+	if err != nil {
+		return err
+	}
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: key, StoredAt: time.Now().UTC()}); err != nil {
+		return fmt.Errorf("saving api key: %w", err)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Stored API key")
+	return nil
 }
 
 var authLogoutCmd = &cobra.Command{
@@ -41,12 +110,69 @@ var authLogoutCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 
-		if err := auth.DeleteSession(); err != nil {
-			return err
+		out := cmd.OutOrStdout()
+		clearedAny := false
+
+		// Parse errors must not block deletion: a corrupt credential file
+		// would otherwise trap the user, since `auth login` refuses to
+		// proceed while any stored credential is present.
+		apiKeyPath, _ := config.APIKeyFile()
+		if existingKey, loadErr := auth.LoadAPIKey(); loadErr != nil {
+			fmt.Fprintf(out, "Warning: stored API key file is unreadable (%v); removing %s\n", loadErr, apiKeyPath)
+			if err := auth.DeleteAPIKey(); err != nil {
+				return err
+			}
+			clearedAny = true
+		} else if existingKey != nil {
+			if err := auth.DeleteAPIKey(); err != nil {
+				return err
+			}
+			fmt.Fprintln(out, "Cleared stored API key")
+			clearedAny = true
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "Logged out")
+
+		sessionPath, _ := config.WorkOSAuthSessionFile()
+		if existingSession, loadErr := auth.LoadSession(); loadErr != nil {
+			fmt.Fprintf(out, "Warning: stored session file is unreadable (%v); removing %s\n", loadErr, sessionPath)
+			if err := auth.DeleteSession(); err != nil {
+				return err
+			}
+			clearedAny = true
+		} else if existingSession != nil {
+			if err := auth.DeleteSession(); err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Cleared logged-in session (%s)\n", existingSession.Email)
+			clearedAny = true
+		}
+
+		if !clearedAny {
+			fmt.Fprintln(out, "Already logged out")
+		}
 		return nil
 	},
+}
+
+func printAPIKeyAnnotation(out io.Writer, key *auth.APIKeyAuth, loadErr error, path string) {
+	switch {
+	case loadErr != nil:
+		fmt.Fprintf(out, "  ignoring unreadable API key file (%s: %v)\n", path, loadErr)
+	case key != nil:
+		fmt.Fprintf(out, "  shadows stored API key (%s)\n", path)
+	}
+}
+
+func printSessionAnnotation(out io.Writer, s *auth.WorkOSSession, loadErr error, path string) {
+	switch {
+	case loadErr != nil:
+		fmt.Fprintf(out, "  ignoring unreadable session file (%s: %v)\n", path, loadErr)
+	case s != nil:
+		fmt.Fprintf(out, "  shadows logged-in session: %s", s.Email)
+		if s.OrgID != "" {
+			fmt.Fprintf(out, " (org: %s)", s.OrgID)
+		}
+		fmt.Fprintln(out)
+	}
 }
 
 var authStatusCmd = &cobra.Command{
@@ -58,26 +184,48 @@ var authStatusCmd = &cobra.Command{
 
 		out := cmd.OutOrStdout()
 
-		// Check for API key auth.
-		if apiKey := os.Getenv("AMIKA_API_KEY"); apiKey != "" {
-			fmt.Fprintln(out, "Authenticated via AMIKA_API_KEY environment variable")
-			return nil
-		}
+		envKeySet := os.Getenv(config.EnvAPIKey) != ""
 
-		session, err := auth.LoadSession()
-		if err != nil {
-			return err
-		}
-		if session == nil {
-			fmt.Fprintln(out, "Not logged in")
-			return nil
-		}
+		// Lower-priority parse failures must not mask a higher-priority
+		// credential that's still valid. Collect load errors and surface
+		// them as warnings against the winning source instead.
+		storedKey, keyErr := auth.LoadAPIKey()
+		session, sessErr := auth.LoadSession()
 
-		fmt.Fprintf(out, "Logged in as %s", session.Email)
-		if session.OrgID != "" {
-			fmt.Fprintf(out, " (org: %s)", session.OrgID)
+		apiKeyPath, _ := config.APIKeyFile()
+		sessionPath, _ := config.WorkOSAuthSessionFile()
+
+		switch {
+		case envKeySet:
+			fmt.Fprintf(out, "Authenticated via %s environment variable\n", config.EnvAPIKey)
+			printAPIKeyAnnotation(out, storedKey, keyErr, apiKeyPath)
+			printSessionAnnotation(out, session, sessErr, sessionPath)
+		case storedKey != nil:
+			fmt.Fprintf(out, "Authenticated via stored API key (%s)\n", apiKeyPath)
+			printSessionAnnotation(out, session, sessErr, sessionPath)
+		case session != nil:
+			fmt.Fprintf(out, "Logged in as %s", session.Email)
+			if session.OrgID != "" {
+				fmt.Fprintf(out, " (org: %s)", session.OrgID)
+			}
+			fmt.Fprintln(out)
+			// The API key file is higher-priority; a corrupt one is
+			// being skipped, not shadowed. Surface it so the user
+			// knows to clean up.
+			printAPIKeyAnnotation(out, storedKey, keyErr, apiKeyPath)
+		default:
+			// No usable credential. If something's on disk but unreadable,
+			// point the user at the recovery path.
+			if keyErr != nil {
+				fmt.Fprintf(out, "Stored API key file is unreadable (%v); run `amika auth logout` to clear it\n", keyErr)
+			}
+			if sessErr != nil {
+				fmt.Fprintf(out, "Stored session file is unreadable (%v); run `amika auth logout` to clear it\n", sessErr)
+			}
+			if keyErr == nil && sessErr == nil {
+				fmt.Fprintln(out, "Not logged in")
+			}
 		}
-		fmt.Fprintln(out)
 		return nil
 	},
 }
@@ -88,4 +236,5 @@ func init() {
 	authCmd.AddCommand(authLogoutCmd)
 	authCmd.AddCommand(authStatusCmd)
 
+	authLoginCmd.Flags().String("api-key-file", "", `Read a WorkOS organization API key from this path instead of running the device flow ("-" for stdin)`)
 }

--- a/cmd/amika/auth_test.go
+++ b/cmd/amika/auth_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofixpoint/amika/internal/auth"
+)
+
+func TestAuthLogin_APIKeyFile(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_abc\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "login", "--api-key-file", keyPath)
+	if err != nil {
+		t.Fatalf("login: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "Stored API key") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+
+	loaded, err := auth.LoadAPIKey()
+	if err != nil {
+		t.Fatalf("LoadAPIKey: %v", err)
+	}
+	if loaded == nil || loaded.Key != "sk_abc" {
+		t.Fatalf("loaded = %+v, want sk_abc", loaded)
+	}
+}
+
+func TestAuthLogin_RefusesWhenAlreadyLoggedIn(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "existing"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_new\n"), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "login", "--api-key-file", keyPath)
+	if err == nil {
+		t.Fatalf("expected error, got output %q", out)
+	}
+	if !strings.Contains(err.Error(), "already have") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	loaded, _ := auth.LoadAPIKey()
+	if loaded == nil || loaded.Key != "existing" {
+		t.Fatalf("stored key should be unchanged: %+v", loaded)
+	}
+}
+
+func TestAuthLogout_RecoversFromCorruptFiles(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	// Write garbage where each credential file is expected. Logout must
+	// still succeed so the user can recover and log back in.
+	if err := os.WriteFile(filepath.Join(stateDir, "api-key.json"), []byte("not json"), 0600); err != nil {
+		t.Fatalf("write corrupt api key: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "workos-session.json"), []byte("{"), 0600); err != nil {
+		t.Fatalf("write corrupt session: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "logout")
+	if err != nil {
+		t.Fatalf("logout: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "stored API key file is unreadable") {
+		t.Fatalf("missing api key warning: %q", out)
+	}
+	if !strings.Contains(out, "stored session file is unreadable") {
+		t.Fatalf("missing session warning: %q", out)
+	}
+
+	for _, name := range []string{"api-key.json", "workos-session.json"} {
+		if _, err := os.Stat(filepath.Join(stateDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("%s still present after logout: err=%v", name, err)
+		}
+	}
+
+	// Subsequent login should succeed — recovery is complete.
+	keyPath := filepath.Join(t.TempDir(), "k")
+	if err := os.WriteFile(keyPath, []byte("sk_recovered\n"), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if _, err := runRootCommand("auth", "login", "--api-key-file", keyPath); err != nil {
+		t.Fatalf("login after recovery: %v", err)
+	}
+}
+
+func TestAuthLogin_SurfacesUnderlyingIOError(t *testing.T) {
+	// Point AMIKA_STATE_DIRECTORY at a path that exists as a file so
+	// ReadFile fails with ENOTDIR — a non-corruption error that
+	// `auth logout` cannot fix, so login must surface it directly
+	// instead of redirecting to logout.
+	notADir := filepath.Join(t.TempDir(), "state")
+	if err := os.WriteFile(notADir, []byte("not a dir"), 0600); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+	t.Setenv("AMIKA_STATE_DIRECTORY", notADir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	keyPath := filepath.Join(t.TempDir(), "k")
+	if err := os.WriteFile(keyPath, []byte("sk_x\n"), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	_, err := runRootCommand("auth", "login", "--api-key-file", keyPath)
+	if err == nil {
+		t.Fatal("expected I/O error")
+	}
+	if strings.Contains(err.Error(), "amika auth logout") {
+		t.Fatalf("should not redirect to logout for I/O error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "reading stored") {
+		t.Fatalf("error should name the failing operation: %v", err)
+	}
+}
+
+func TestAuthLogin_RedirectsToLogoutOnCorruptFile(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := os.WriteFile(filepath.Join(stateDir, "api-key.json"), []byte("garbage"), 0600); err != nil {
+		t.Fatalf("write corrupt api key: %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "k")
+	if err := os.WriteFile(keyPath, []byte("sk_new\n"), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	_, err := runRootCommand("auth", "login", "--api-key-file", keyPath)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "amika auth logout") {
+		t.Fatalf("error should point at logout: %v", err)
+	}
+}
+
+func TestAuthLogout_ClearsBoth(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "k"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "logout")
+	if err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	if !strings.Contains(out, "Cleared stored API key") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+
+	out, err = runRootCommand("auth", "logout")
+	if err != nil {
+		t.Fatalf("idempotent logout: %v", err)
+	}
+	if !strings.Contains(out, "Already logged out") {
+		t.Fatalf("second logout output: %q", out)
+	}
+}
+
+func TestAuthStatus_EnvShadowsStoredKey(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "env_key")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "stored"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "status")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !strings.Contains(out, "Authenticated via AMIKA_API_KEY") {
+		t.Fatalf("missing env line: %q", out)
+	}
+	if !strings.Contains(out, "shadows stored API key") {
+		t.Fatalf("missing shadow line: %q", out)
+	}
+}
+
+func TestAuthStatus_StoredKeyReported(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "stored"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "status")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !strings.Contains(out, "Authenticated via stored API key") {
+		t.Fatalf("unexpected status: %q", out)
+	}
+}
+
+func TestAuthStatus_EnvWinsWhenSessionCorrupt(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "env_key")
+
+	if err := os.WriteFile(filepath.Join(stateDir, "workos-session.json"), []byte("{"), 0600); err != nil {
+		t.Fatalf("write corrupt session: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "status")
+	if err != nil {
+		t.Fatalf("status: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "Authenticated via AMIKA_API_KEY") {
+		t.Fatalf("env winner line missing: %q", out)
+	}
+	if !strings.Contains(out, "ignoring unreadable session file") {
+		t.Fatalf("shadow warning missing: %q", out)
+	}
+}
+
+func TestAuthStatus_StoredKeyWinsWhenSessionCorrupt(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "stored"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "workos-session.json"), []byte("{"), 0600); err != nil {
+		t.Fatalf("write corrupt session: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "status")
+	if err != nil {
+		t.Fatalf("status: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "Authenticated via stored API key") {
+		t.Fatalf("stored key winner missing: %q", out)
+	}
+	if !strings.Contains(out, "ignoring unreadable session file") {
+		t.Fatalf("shadow warning missing: %q", out)
+	}
+}
+
+func TestAuthStatus_SessionWinsWithCorruptAPIKey(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := os.WriteFile(filepath.Join(stateDir, "api-key.json"), []byte("not json"), 0600); err != nil {
+		t.Fatalf("write corrupt api key: %v", err)
+	}
+	if err := auth.SaveSession(auth.WorkOSSession{
+		AccessToken: "tok",
+		Email:       "sess@example.com",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "status")
+	if err != nil {
+		t.Fatalf("status: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "Logged in as sess@example.com") {
+		t.Fatalf("session winner missing: %q", out)
+	}
+	if !strings.Contains(out, "ignoring unreadable API key file") {
+		t.Fatalf("api key warning missing: %q", out)
+	}
+}
+
+func TestAuthStatus_OnlyCorruptFile(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := os.WriteFile(filepath.Join(stateDir, "workos-session.json"), []byte("{"), 0600); err != nil {
+		t.Fatalf("write corrupt session: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "status")
+	if err != nil {
+		t.Fatalf("status: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "Stored session file is unreadable") {
+		t.Fatalf("expected unreadable warning: %q", out)
+	}
+	if !strings.Contains(out, "amika auth logout") {
+		t.Fatalf("expected recovery hint: %q", out)
+	}
+	if strings.Contains(out, "Not logged in") {
+		t.Fatalf("should not say 'Not logged in' when a corrupt file is present: %q", out)
+	}
+}
+
+func TestAuthStatus_NotLoggedIn(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	out, err := runRootCommand("auth", "status")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !strings.Contains(out, "Not logged in") {
+		t.Fatalf("unexpected status: %q", out)
+	}
+}

--- a/cmd/amika/sandbox/sandbox_local_remote.go
+++ b/cmd/amika/sandbox/sandbox_local_remote.go
@@ -15,8 +15,18 @@ import (
 // TODO: Parse env variables from an environment file (e.g. .amika/.env or ~/.config/amika/env)
 // so users don't need to export AMIKA_API_URL, AMIKA_WORKOS_CLIENT_ID, etc. in their shell profile.
 
-// defaultAuthChecker returns nil when a valid WorkOS session exists.
+// defaultAuthChecker returns nil when any credential source is present:
+// AMIKA_API_KEY env var, a stored API key, or a valid WorkOS session.
+// An unreadable API key file is skipped (matching the request-time
+// resolver) so a corrupt higher-priority file does not block a valid
+// lower-priority session.
 func defaultAuthChecker() error {
+	if os.Getenv(config.EnvAPIKey) != "" {
+		return nil
+	}
+	if stored, err := auth.LoadAPIKey(); err == nil && stored != nil {
+		return nil
+	}
 	_, err := auth.GetValidSession(config.WorkOSClientID())
 	return err
 }
@@ -32,11 +42,9 @@ func getRemoteTarget(cmd *cobra.Command) (string, error) {
 }
 
 // getRemoteClient returns an API client authenticated with the current session.
-// If AMIKA_API_KEY is set, it is used as a static bearer token instead of the WorkOS session.
+// Credentials are resolved per request in the order: AMIKA_API_KEY env var,
+// stored API key file, then WorkOS session.
 func getRemoteClient(target string) (*apiclient.Client, error) {
 	_ = target
-	if apiKey := os.Getenv("AMIKA_API_KEY"); apiKey != "" {
-		return apiclient.NewClient(config.APIURL(), apiKey), nil
-	}
-	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewWorkOSTokenSource(config.WorkOSClientID())), nil
+	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewResolvedTokenSource(config.WorkOSClientID())), nil
 }

--- a/cmd/amika/sandbox/sandbox_local_remote_test.go
+++ b/cmd/amika/sandbox/sandbox_local_remote_test.go
@@ -1,0 +1,76 @@
+package sandboxcmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gofixpoint/amika/internal/auth"
+)
+
+func TestDefaultAuthChecker_EnvKeySatisfies(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "env_key")
+
+	if err := defaultAuthChecker(); err != nil {
+		t.Fatalf("defaultAuthChecker: %v", err)
+	}
+}
+
+func TestDefaultAuthChecker_StoredAPIKeySatisfies(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "stored"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	if err := defaultAuthChecker(); err != nil {
+		t.Fatalf("defaultAuthChecker: %v", err)
+	}
+}
+
+func TestDefaultAuthChecker_SessionSatisfies(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := auth.SaveSession(auth.WorkOSSession{
+		AccessToken: "tok",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+	if err := defaultAuthChecker(); err != nil {
+		t.Fatalf("defaultAuthChecker: %v", err)
+	}
+}
+
+func TestDefaultAuthChecker_CorruptAPIKeyFallsThroughToSession(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	// Corrupt higher-priority API key file must not block a valid session.
+	if err := os.WriteFile(filepath.Join(stateDir, "api-key.json"), []byte("not json"), 0600); err != nil {
+		t.Fatalf("write corrupt api key: %v", err)
+	}
+	if err := auth.SaveSession(auth.WorkOSSession{
+		AccessToken: "tok",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	if err := defaultAuthChecker(); err != nil {
+		t.Fatalf("defaultAuthChecker should tolerate corrupt API key: %v", err)
+	}
+}
+
+func TestDefaultAuthChecker_NoCredentials(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := defaultAuthChecker(); err == nil {
+		t.Fatal("expected error when no credentials present")
+	}
+}

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -363,12 +363,10 @@ func pushSecret(client *apiclient.Client, existing map[string]apiclient.Secret, 
 }
 
 // getSecretsClient returns an API client for secrets operations.
-// If AMIKA_API_KEY is set, it is used as a static bearer token instead of the WorkOS session.
+// Credentials are resolved per request in the order: AMIKA_API_KEY env var,
+// stored API key file, then WorkOS session.
 func getSecretsClient() (*apiclient.Client, error) {
-	if apiKey := os.Getenv("AMIKA_API_KEY"); apiKey != "" {
-		return apiclient.NewClient(config.APIURL(), apiKey), nil
-	}
-	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewWorkOSTokenSource(config.WorkOSClientID())), nil
+	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewResolvedTokenSource(config.WorkOSClientID())), nil
 }
 
 // parseOnlyFilter splits a comma-separated list of secret names into a set.

--- a/internal/apiclient/token.go
+++ b/internal/apiclient/token.go
@@ -1,6 +1,12 @@
 package apiclient
 
-import "github.com/gofixpoint/amika/internal/auth"
+import (
+	"fmt"
+	"os"
+
+	"github.com/gofixpoint/amika/internal/auth"
+	"github.com/gofixpoint/amika/internal/config"
+)
 
 // TokenSource provides a bearer token for API requests.
 type TokenSource interface {
@@ -36,4 +42,39 @@ func (s *workosTokenSource) Token() (string, error) {
 		return "", err
 	}
 	return session.AccessToken, nil
+}
+
+type resolvedTokenSource struct {
+	clientID string
+}
+
+// NewResolvedTokenSource returns a TokenSource that resolves credentials fresh
+// on each Token() call using the precedence: AMIKA_API_KEY env var > stored
+// API key file > WorkOS session (with auto-refresh).
+func NewResolvedTokenSource(clientID string) TokenSource {
+	return &resolvedTokenSource{clientID: clientID}
+}
+
+func (s *resolvedTokenSource) Token() (string, error) {
+	if key := os.Getenv(config.EnvAPIKey); key != "" {
+		return key, nil
+	}
+	// An unreadable API key file must not block fall-through to the
+	// session: `auth status` already treats corrupt files as "skip,
+	// try the next source", so the resolver has to agree — otherwise
+	// status reports the user is authenticated while every request
+	// fails. The load error is combined with any downstream error so
+	// the final message still mentions the bad file.
+	stored, keyErr := auth.LoadAPIKey()
+	if keyErr == nil && stored != nil {
+		return stored.Key, nil
+	}
+	session, sessErr := auth.GetValidSession(s.clientID)
+	if sessErr == nil {
+		return session.AccessToken, nil
+	}
+	if keyErr != nil {
+		return "", fmt.Errorf("no usable credential: stored API key unreadable (%v); %w", keyErr, sessErr)
+	}
+	return "", sessErr
 }

--- a/internal/apiclient/token_test.go
+++ b/internal/apiclient/token_test.go
@@ -1,0 +1,147 @@
+package apiclient
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofixpoint/amika/internal/auth"
+)
+
+func TestResolvedTokenSource_PrecedenceEnvWins(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "env_key")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "file_key"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	tok, err := NewResolvedTokenSource("client").Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "env_key" {
+		t.Fatalf("got %q, want env_key", tok)
+	}
+}
+
+func TestResolvedTokenSource_PrecedenceFileOverSession(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "file_key"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	// Save a session that would otherwise be used; the file key should win.
+	if err := auth.SaveSession(auth.WorkOSSession{
+		AccessToken: "session_token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	tok, err := NewResolvedTokenSource("client").Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "file_key" {
+		t.Fatalf("got %q, want file_key", tok)
+	}
+}
+
+func TestResolvedTokenSource_FallsBackToSession(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := auth.SaveSession(auth.WorkOSSession{
+		AccessToken: "session_token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	tok, err := NewResolvedTokenSource("client").Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "session_token" {
+		t.Fatalf("got %q, want session_token", tok)
+	}
+}
+
+func TestResolvedTokenSource_CorruptAPIKeyFallsBackToSession(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	// Corrupt API key file — must not block fall-through to the session.
+	if err := os.WriteFile(filepath.Join(stateDir, "api-key.json"), []byte("not json"), 0600); err != nil {
+		t.Fatalf("write corrupt api key: %v", err)
+	}
+	if err := auth.SaveSession(auth.WorkOSSession{
+		AccessToken: "session_token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	tok, err := NewResolvedTokenSource("client").Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "session_token" {
+		t.Fatalf("got %q, want session_token", tok)
+	}
+}
+
+func TestResolvedTokenSource_CorruptAPIKeyNoSessionMentionsBoth(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if err := os.WriteFile(filepath.Join(stateDir, "api-key.json"), []byte("not json"), 0600); err != nil {
+		t.Fatalf("write corrupt api key: %v", err)
+	}
+
+	_, err := NewResolvedTokenSource("client").Token()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unreadable") {
+		t.Fatalf("error should mention unreadable API key: %v", err)
+	}
+}
+
+func TestResolvedTokenSource_NoCredentials(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	if _, err := NewResolvedTokenSource("client").Token(); err == nil {
+		t.Fatal("expected error when no credentials present")
+	}
+}
+
+func TestResolvedTokenSource_ReresolvesOnEachCall(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	src := NewResolvedTokenSource("client")
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "first"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	tok, err := src.Token()
+	if err != nil || tok != "first" {
+		t.Fatalf("first Token = (%q, %v), want (first, nil)", tok, err)
+	}
+
+	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: "second"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	tok, err = src.Token()
+	if err != nil || tok != "second" {
+		t.Fatalf("second Token = (%q, %v), want (second, nil)", tok, err)
+	}
+}

--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gofixpoint/amika/internal/config"
+)
+
+// ErrCorruptAPIKey is returned by LoadAPIKey when the file exists but
+// cannot be parsed or is missing the key value.
+var ErrCorruptAPIKey = errors.New("corrupt API key file")
+
+// APIKeyAuth holds a persisted WorkOS organization API key used as a static bearer token.
+type APIKeyAuth struct {
+	Key      string    `json:"key"`
+	StoredAt time.Time `json:"stored_at"`
+}
+
+// SaveAPIKey writes the API key to disk with restricted permissions.
+func SaveAPIKey(a APIKeyAuth) error {
+	path, err := config.APIKeyFile()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// LoadAPIKey reads the persisted API key. Returns nil, nil if no file exists.
+func LoadAPIKey() (*APIKeyAuth, error) {
+	path, err := config.APIKeyFile()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var a APIKeyAuth
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCorruptAPIKey, err)
+	}
+	if a.Key == "" {
+		return nil, fmt.Errorf("%w: empty key", ErrCorruptAPIKey)
+	}
+	return &a, nil
+}
+
+// DeleteAPIKey removes the persisted API key file.
+func DeleteAPIKey() error {
+	path, err := config.APIKeyFile()
+	if err != nil {
+		return err
+	}
+	err = os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// ReadAPIKeyFromReader reads an API key from r, trimming surrounding whitespace.
+// Returns an error when the result is empty.
+func ReadAPIKeyFromReader(r io.Reader) (string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	key := strings.TrimSpace(string(data))
+	if key == "" {
+		return "", fmt.Errorf("API key is empty")
+	}
+	return key, nil
+}

--- a/internal/auth/apikey_test.go
+++ b/internal/auth/apikey_test.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAPIKey_SaveLoadDelete(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+
+	if got, err := LoadAPIKey(); err != nil || got != nil {
+		t.Fatalf("LoadAPIKey before save = (%v, %v), want (nil, nil)", got, err)
+	}
+
+	if err := SaveAPIKey(APIKeyAuth{Key: "sk_test_123"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	loaded, err := LoadAPIKey()
+	if err != nil {
+		t.Fatalf("LoadAPIKey: %v", err)
+	}
+	if loaded == nil || loaded.Key != "sk_test_123" {
+		t.Fatalf("loaded = %+v, want key sk_test_123", loaded)
+	}
+
+	if err := DeleteAPIKey(); err != nil {
+		t.Fatalf("DeleteAPIKey: %v", err)
+	}
+	if got, err := LoadAPIKey(); err != nil || got != nil {
+		t.Fatalf("LoadAPIKey after delete = (%v, %v), want (nil, nil)", got, err)
+	}
+
+	// Delete is idempotent.
+	if err := DeleteAPIKey(); err != nil {
+		t.Fatalf("DeleteAPIKey idempotent: %v", err)
+	}
+}
+
+func TestAPIKey_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", dir)
+
+	if err := SaveAPIKey(APIKeyAuth{Key: "sk_test_perm"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var found bool
+	for _, e := range entries {
+		if e.Name() != "api-key.json" {
+			continue
+		}
+		found = true
+		info, err := e.Info()
+		if err != nil {
+			t.Fatalf("Info: %v", err)
+		}
+		if mode := info.Mode().Perm(); mode != 0600 {
+			t.Fatalf("api-key.json perms = %o, want 0600", mode)
+		}
+	}
+	if !found {
+		t.Fatalf("api-key.json not created in %s", dir)
+	}
+}
+
+func TestReadAPIKeyFromReader(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "trimmed", input: "  sk_abc  \n", want: "sk_abc"},
+		{name: "newline only", input: "\n\n\n", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+		{name: "embedded whitespace preserved", input: "sk_a b\n", want: "sk_a b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReadAPIKeyFromReader(strings.NewReader(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got key %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIKey_CorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", dir)
+
+	// Write a file with empty key.
+	if err := SaveAPIKey(APIKeyAuth{Key: "sk_x"}); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	if err := os.WriteFile(dir+"/api-key.json", []byte(`{"key":""}`), 0600); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if _, err := LoadAPIKey(); err == nil {
+		t.Fatal("expected error for empty key")
+	}
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,12 @@ import (
 
 	"github.com/gofixpoint/amika/internal/config"
 )
+
+// ErrCorruptSession is returned by LoadSession when the session file exists
+// but cannot be parsed. Distinguishing corruption from other I/O errors lets
+// callers route the user to `amika auth logout` only when logout can actually
+// resolve the problem.
+var ErrCorruptSession = errors.New("corrupt session file")
 
 // WorkOSSession holds the persisted WorkOS authentication state.
 type WorkOSSession struct {
@@ -53,7 +60,7 @@ func LoadSession() (*WorkOSSession, error) {
 	}
 	var session WorkOSSession
 	if err := json.Unmarshal(data, &session); err != nil {
-		return nil, fmt.Errorf("corrupt session file: %w", err)
+		return nil, fmt.Errorf("%w: %v", ErrCorruptSession, err)
 	}
 	return &session, nil
 }

--- a/internal/basedir/basedir.go
+++ b/internal/basedir/basedir.go
@@ -18,6 +18,7 @@ const (
 	fileMountsStateFile = "rwcopy-mounts.jsonl"
 	fileMountsDir       = "rwcopy-mounts.d"
 	workosSessionFile   = "workos-session.json"
+	apiKeyFile          = "api-key.json"
 	envXDGConfigHome    = "XDG_CONFIG_HOME"
 	envXDGDataHome      = "XDG_DATA_HOME"
 	envXDGCacheHome     = "XDG_CACHE_HOME"
@@ -46,6 +47,7 @@ type Paths interface {
 	FileMountsStateFile() (string, error)
 	FileMountsDir() (string, error)
 	WorkOSAuthSessionFile() (string, error)
+	APIKeyFile() (string, error)
 }
 
 type xdgPaths struct {
@@ -217,6 +219,14 @@ func (p *xdgPaths) WorkOSAuthSessionFile() (string, error) {
 	return WorkOSAuthSessionFileIn(dir), nil
 }
 
+func (p *xdgPaths) APIKeyFile() (string, error) {
+	dir, err := p.AmikaStateDir()
+	if err != nil {
+		return "", err
+	}
+	return APIKeyFileIn(dir), nil
+}
+
 // MountsStateFileIn returns the mounts state file path under the given state directory.
 func MountsStateFileIn(stateDir string) string {
 	return filepath.Join(stateDir, mountsStateFile)
@@ -245,4 +255,9 @@ func FileMountsDirIn(stateDir string) string {
 // WorkOSAuthSessionFileIn returns the WorkOS auth session file path under the given state directory.
 func WorkOSAuthSessionFileIn(stateDir string) string {
 	return filepath.Join(stateDir, workosSessionFile)
+}
+
+// APIKeyFileIn returns the stored API key file path under the given state directory.
+func APIKeyFileIn(stateDir string) string {
+	return filepath.Join(stateDir, apiKeyFile)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,9 @@ const (
 	EnvAPIURL = "AMIKA_API_URL"
 	// EnvWorkOSClientID is the environment variable that overrides the default WorkOS client ID.
 	EnvWorkOSClientID = "AMIKA_WORKOS_CLIENT_ID"
+	// EnvAPIKey is the environment variable that provides a WorkOS organization API key
+	// for bearer-token authentication. When set, it takes precedence over stored credentials.
+	EnvAPIKey = "AMIKA_API_KEY"
 
 	// DefaultAPIURL is the default remote API base URL.
 	DefaultAPIURL = "https://app.amika.dev"
@@ -93,4 +96,12 @@ func WorkOSAuthSessionFile() (string, error) {
 		return basedir.WorkOSAuthSessionFileIn(dir), nil
 	}
 	return basedir.New("").WorkOSAuthSessionFile()
+}
+
+// APIKeyFile returns the resolved stored API key file path.
+func APIKeyFile() (string, error) {
+	if dir := os.Getenv(EnvStateDirectory); dir != "" {
+		return basedir.APIKeyFileIn(dir), nil
+	}
+	return basedir.New("").APIKeyFile()
 }


### PR DESCRIPTION
Add `amika auth login --api-key-file <path>` (and `-` for stdin) so CI and headless environments can authenticate without the interactive WorkOS device flow. The key is persisted at `~/.local/state/amika/api-key.json` (0600) alongside the existing session file.

Credential precedence is now resolved in one place via `apiclient.NewResolvedTokenSource`, re-evaluated on every request:

  1. AMIKA_API_KEY environment variable
  2. Stored API key file
  3. WorkOS session (with auto-refresh)

`amika auth login` refuses to stack credentials — callers must `amika auth logout` first. `amika auth logout` now clears both the stored API key and the WorkOS session. `amika auth status` reports the winning source and explicitly calls out shadowed sources.