### PR TITLE
CLI: improve error messages for unpushed git branches

### DIFF
--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -29,9 +29,6 @@ Pass --api-key-file to skip the browser flow and store a WorkOS organization
 API key instead. Use "-" to read the key from stdin, which pairs well with
 secret managers in CI (for example: "vault kv get -field=key … | amika auth login --api-key-file -").`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-
 		apiKeyFile, _ := cmd.Flags().GetString("api-key-file")
 
 		existingSession, sessionErr := auth.LoadSession()
@@ -107,9 +104,6 @@ var authLogoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Log out of Amika",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-
 		out := cmd.OutOrStdout()
 		clearedAny := false
 
@@ -179,9 +173,6 @@ var authStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show current authentication status",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-
 		out := cmd.OutOrStdout()
 
 		envKeySet := os.Getenv(config.EnvAPIKey) != ""

--- a/cmd/amika/main.go
+++ b/cmd/amika/main.go
@@ -14,6 +14,8 @@ var rootCmd = &cobra.Command{
 	Short:             "Amika - filesystem mounting and script execution",
 	Long:              `Amika provides filesystem mounting and script execution with output materialization.`,
 	CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
+	SilenceUsage:      true,
+	SilenceErrors:     true,
 }
 
 func init() {

--- a/cmd/amika/materialize.go
+++ b/cmd/amika/materialize.go
@@ -57,9 +57,6 @@ Examples:
   amika materialize -i --cmd claude --mount $(pwd):/workspace --env ANTHROPIC_API_KEY=...`,
 	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-
 		script, _ := cmd.Flags().GetString("script")
 		cmdStr, _ := cmd.Flags().GetString("cmd")
 		outdir, _ := cmd.Flags().GetString("outdir")

--- a/cmd/amika/sandbox/sandbox_agent.go
+++ b/cmd/amika/sandbox/sandbox_agent.go
@@ -175,9 +175,6 @@ By default the command waits for the agent to finish and streams the response.
 Use --no-wait to send the message and return immediately.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-
 		name := args[0]
 
 		var message string

--- a/cmd/amika/sandbox/sandbox_create.go
+++ b/cmd/amika/sandbox/sandbox_create.go
@@ -301,6 +301,21 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		}
 	}
 
+	// Warn if the auto-detected branch hasn't been pushed to the remote.
+	if branch != "" && newBranch == "" && gitValueIsLocalPath && !cmd.Flags().Changed("branch") {
+		if repoRoot, err := resolveGitRoot(gitValue); err == nil {
+			if !isBranchPushedToRemote(repoRoot, branch) {
+				return fmt.Errorf(
+					"current branch %q has not been pushed to the remote\n\n"+
+						"The sandbox will either start from an older version of this branch or\n"+
+						"create it fresh from the default branch.\n\n"+
+						"Push your branch first, or use --branch to specify your branch explicitly.",
+					branch,
+				)
+			}
+		}
+	}
+
 	secretEnvVars, err := parseSecretFlags(secretFlags)
 	if err != nil {
 		return err

--- a/cmd/amika/sandbox/sandbox_create.go
+++ b/cmd/amika/sandbox/sandbox_create.go
@@ -24,8 +24,6 @@ var sandboxCreateCmd = &cobra.Command{
 	Long:  `Create a new sandbox using the specified provider. Currently only "docker" is supported.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		cmd.SilenceUsage = true
-
 		noClean, _ := cmd.Flags().GetBool("no-clean")
 		noSetup, _ := cmd.Flags().GetBool("no-setup")
 		gitFlagChanged := cmd.Flags().Changed("git")

--- a/cmd/amika/sandbox/sandbox_create_git.go
+++ b/cmd/amika/sandbox/sandbox_create_git.go
@@ -211,17 +211,20 @@ func detectHostCurrentBranch(startPath string) (string, error) {
 
 // isBranchPushedToRemote checks whether the given branch has been pushed to
 // its upstream remote. Returns false if the branch has no upstream tracking
-// branch (never pushed) or if there are local commits not yet pushed.
+// branch and doesn't exist on origin, or if there are local commits not yet
+// pushed.
 func isBranchPushedToRemote(repoDir, branch string) bool {
 	// Check if the branch has an upstream tracking ref set.
 	upstreamCmd := exec.Command("git", "-C", repoDir, "rev-parse", "--abbrev-ref", branch+"@{upstream}")
 	upstreamOut, err := upstreamCmd.Output()
 	if err != nil {
-		return false // No upstream configured — branch was never pushed
+		// No upstream configured — could still be pushed without -u.
+		// Check the remote directly.
+		return remoteBranchExists(repoDir, branch)
 	}
 	upstream := strings.TrimSpace(string(upstreamOut))
 	if upstream == "" {
-		return false
+		return remoteBranchExists(repoDir, branch)
 	}
 
 	// Check if there are local commits ahead of the upstream.
@@ -231,6 +234,18 @@ func isBranchPushedToRemote(repoDir, branch string) bool {
 		return false
 	}
 	return strings.TrimSpace(string(countOut)) == "0"
+}
+
+// remoteBranchExists checks whether a branch exists on the "origin" remote
+// via git ls-remote. This is a network call but only used as a fallback when
+// no upstream tracking is configured.
+func remoteBranchExists(repoDir, branch string) bool {
+	cmd := exec.Command("git", "-C", repoDir, "ls-remote", "--heads", "origin", branch)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
 }
 
 func copyRepoWorkingTree(src, dst string) error {

--- a/cmd/amika/sandbox/sandbox_create_git.go
+++ b/cmd/amika/sandbox/sandbox_create_git.go
@@ -209,43 +209,28 @@ func detectHostCurrentBranch(startPath string) (string, error) {
 	return name, nil
 }
 
-// isBranchPushedToRemote checks whether the given branch has been pushed to
-// its upstream remote. Returns false if the branch has no upstream tracking
-// branch and doesn't exist on origin, or if there are local commits not yet
-// pushed.
+// isBranchPushedToRemote checks whether the local branch tip matches the
+// tip on the "origin" remote. Always checks against origin directly (not
+// the upstream tracking branch) because sandbox creation resolves the
+// origin URL regardless of what remote the branch tracks.
 func isBranchPushedToRemote(repoDir, branch string) bool {
-	// Check if the branch has an upstream tracking ref set.
-	upstreamCmd := exec.Command("git", "-C", repoDir, "rev-parse", "--abbrev-ref", branch+"@{upstream}")
-	upstreamOut, err := upstreamCmd.Output()
-	if err != nil {
-		// No upstream configured — could still be pushed without -u.
-		// Check the remote directly.
-		return remoteBranchExists(repoDir, branch)
+	// Get the remote tip SHA from origin.
+	lsCmd := exec.Command("git", "-C", repoDir, "ls-remote", "--heads", "origin", branch)
+	lsOut, err := lsCmd.Output()
+	if err != nil || strings.TrimSpace(string(lsOut)) == "" {
+		return false // branch doesn't exist on origin
 	}
-	upstream := strings.TrimSpace(string(upstreamOut))
-	if upstream == "" {
-		return remoteBranchExists(repoDir, branch)
-	}
+	remoteSHA := strings.Fields(strings.TrimSpace(string(lsOut)))[0]
 
-	// Check if there are local commits ahead of the upstream.
-	countCmd := exec.Command("git", "-C", repoDir, "rev-list", "--count", upstream+".."+branch)
-	countOut, err := countCmd.Output()
+	// Get the local branch tip SHA.
+	localCmd := exec.Command("git", "-C", repoDir, "rev-parse", branch)
+	localOut, err := localCmd.Output()
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(string(countOut)) == "0"
-}
+	localSHA := strings.TrimSpace(string(localOut))
 
-// remoteBranchExists checks whether a branch exists on the "origin" remote
-// via git ls-remote. This is a network call but only used as a fallback when
-// no upstream tracking is configured.
-func remoteBranchExists(repoDir, branch string) bool {
-	cmd := exec.Command("git", "-C", repoDir, "ls-remote", "--heads", "origin", branch)
-	out, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(string(out)) != ""
+	return remoteSHA == localSHA
 }
 
 func copyRepoWorkingTree(src, dst string) error {

--- a/cmd/amika/sandbox/sandbox_create_git.go
+++ b/cmd/amika/sandbox/sandbox_create_git.go
@@ -209,6 +209,30 @@ func detectHostCurrentBranch(startPath string) (string, error) {
 	return name, nil
 }
 
+// isBranchPushedToRemote checks whether the given branch has been pushed to
+// its upstream remote. Returns false if the branch has no upstream tracking
+// branch (never pushed) or if there are local commits not yet pushed.
+func isBranchPushedToRemote(repoDir, branch string) bool {
+	// Check if the branch has an upstream tracking ref set.
+	upstreamCmd := exec.Command("git", "-C", repoDir, "rev-parse", "--abbrev-ref", branch+"@{upstream}")
+	upstreamOut, err := upstreamCmd.Output()
+	if err != nil {
+		return false // No upstream configured — branch was never pushed
+	}
+	upstream := strings.TrimSpace(string(upstreamOut))
+	if upstream == "" {
+		return false
+	}
+
+	// Check if there are local commits ahead of the upstream.
+	countCmd := exec.Command("git", "-C", repoDir, "rev-list", "--count", upstream+".."+branch)
+	countOut, err := countCmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(countOut)) == "0"
+}
+
 func copyRepoWorkingTree(src, dst string) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return fmt.Errorf("failed to create no-clean parent for %q: %w", dst, err)

--- a/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -32,8 +32,6 @@ var sandboxStartCmd = &cobra.Command{
 	Long:  `Start (resume) one or more stopped sandboxes.`,
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-
 		target, err := getRemoteTarget(cmd)
 		if err != nil {
 			return err
@@ -96,8 +94,6 @@ var sandboxStopCmd = &cobra.Command{
 	Long:  `Stop one or more running sandboxes without removing them.`,
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-
 		target, err := getRemoteTarget(cmd)
 		if err != nil {
 			return err
@@ -231,8 +227,6 @@ var sandboxConnectCmd = &cobra.Command{
 	Long:  `Connect to a running sandbox container and open an interactive shell.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-
 		name := args[0]
 		shell, _ := cmd.Flags().GetString("shell")
 		if err := validateShell(shell); err != nil {

--- a/cmd/amika/sandbox/sandbox_ssh.go
+++ b/cmd/amika/sandbox/sandbox_ssh.go
@@ -57,9 +57,6 @@ Examples:
   amika sandbox ssh my-sandbox --revoke`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-
 		name := args[0]
 
 		mode := runmode.Resolve(cmd)
@@ -115,9 +112,6 @@ Examples:
   amika sandbox code my-sandbox --editor=cursor`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-
 		name := args[0]
 		editor, _ := cmd.Flags().GetString("editor")
 

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -46,8 +46,6 @@ Examples:
   amika secret extract --push
   amika secret extract --push --only=ANTHROPIC_API_KEY,OPENAI_API_KEY`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
 
 			homeDir, _ := cmd.Flags().GetString("homedir")
 			noOAuth, _ := cmd.Flags().GetBool("no-oauth")
@@ -169,8 +167,6 @@ Examples:
   amika secret push --from-file=.env
   amika secret push --from-file=.env CUSTOM_KEY=val --from-env=ANTHROPIC_API_KEY`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
 
 			fromEnvFlag, _ := cmd.Flags().GetString("from-env")
 			fromFileFlag, _ := cmd.Flags().GetString("from-file")
@@ -511,8 +507,6 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 		Short: fmt.Sprintf("Push %s credentials to the remote secrets store", p.DisplayName),
 		Long:  p.PushLongHelp,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
 
 			credValue, credType, err := parseProviderCreds(cmd, p)
 			if err != nil {
@@ -557,8 +551,6 @@ func newProviderListCmd(p providerConfig) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   fmt.Sprintf("List pushed %s credentials", p.DisplayName),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
 
 			client, err := getSecretsClient()
 			if err != nil {
@@ -592,8 +584,6 @@ func newProviderDeleteCmd(p providerConfig) *cobra.Command {
 		Short:   fmt.Sprintf("Delete a %s credential by ID", p.DisplayName),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
 
 			client, err := getSecretsClient()
 			if err != nil {

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -52,13 +52,14 @@ type CreateSandboxRequest struct {
 
 // RemoteSandbox represents a sandbox returned by the remote API.
 type RemoteSandbox struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Provider  string `json:"provider"`
-	GitHubURL string `json:"github_url"`
-	State     string `json:"state"`
-	CreatedAt string `json:"created_at"`
-	Branch    string `json:"branch"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Provider     string `json:"provider"`
+	GitHubURL    string `json:"github_url"`
+	State        string `json:"state"`
+	CreatedAt    string `json:"created_at"`
+	Branch       string `json:"branch"`
+	ErrorMessage string `json:"error_message"`
 }
 
 // ListSandboxes fetches sandboxes from the remote API.
@@ -99,6 +100,9 @@ func (c *Client) waitForSandboxState(name string, readyStates []string, failMsg 
 			return nil, err
 		}
 		if sb.State == "failed" {
+			if sb.ErrorMessage != "" {
+				return sb, fmt.Errorf("%s", sb.ErrorMessage)
+			}
 			return sb, fmt.Errorf("%s", failMsg)
 		}
 		for _, s := range readyStates {

--- a/internal/apiclient/errors.go
+++ b/internal/apiclient/errors.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+// APIErrorResponse mirrors the JSON error envelope returned by the Amika
+// API server (see api-error.ts). It carries a machine-readable error code
+// and a human-readable message.
+type APIErrorResponse struct {
+	Type      string `json:"type"`
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
 // HTTPError is returned by doJSON when the server responds with a non-2xx
 // status code. It carries the raw status and body so callers can inspect or
 // parse the response for structured error information.
@@ -15,8 +24,18 @@ type HTTPError struct {
 	Body       string
 }
 
+// UserMessage extracts the human-readable message from a structured API
+// error response. Falls back to the raw body if parsing fails.
+func (e *HTTPError) UserMessage() string {
+	var resp APIErrorResponse
+	if json.Unmarshal([]byte(e.Body), &resp) == nil && resp.Message != "" {
+		return resp.Message
+	}
+	return e.Body
+}
+
 func (e *HTTPError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.UserMessage())
 }
 
 // extractAgentAuthError inspects an error returned by the agent-send endpoint


### PR DESCRIPTION
## Summary

- Parse structured API error responses so users see the human-readable
  message instead of raw JSON
- Read `error_message` from sandbox responses when polling detects a
  failed sandbox, replacing the hardcoded "sandbox provisioning failed"
- Warn and exit early when the auto-detected branch has not been pushed
  to the remote, with a message explaining the issue
- Set `SilenceErrors` on the root cobra command so errors print once

Addresses KAPRO-245.