### PR TITLE
Escape sandbox name in AgentSend URL path

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -311,7 +311,7 @@ func (c *Client) AgentSend(sandboxName string, req AgentSendRequest) (*AgentSend
 	defer func() { c.HTTP.Timeout = saved }()
 
 	var result AgentSendResponse
-	if err := c.doJSON("POST", "/api/sandboxes/"+sandboxName+"/agent-send", req, &result); err != nil {
+	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/agent-send", req, &result); err != nil {
 		if authErr := extractAgentAuthError(err); authErr != "" {
 			return nil, fmt.Errorf("remote agent-send: agent failed to authenticate with its AI provider: %s\n\nthe sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access", authErr)
 		}

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -59,6 +59,15 @@ func TestPathEscapesSandboxName(t *testing.T) {
 			wantPath:   "/api/sandboxes/a%2Fb/sessions",
 		},
 		{
+			name: "AgentSend with slash",
+			call: func(c *Client) error {
+				_, err := c.AgentSend("a/b", AgentSendRequest{Message: "hi"})
+				return err
+			},
+			wantMethod: "POST",
+			wantPath:   "/api/sandboxes/a%2Fb/agent-send",
+		},
+		{
 			name:       "GetSandbox without slash",
 			call:       func(c *Client) error { _, err := c.GetSandbox("simple-name"); return err },
 			wantMethod: "GET",


### PR DESCRIPTION
## Summary

- `AgentSend` built its request URL by concatenating the sandbox name directly into the path without `url.PathEscape`, unlike every other `/api/sandboxes/{name}/...` call in `internal/apiclient/client.go`.
- When a sandbox name contained `/` (e.g. `dylan/delete-me`), the literal slash split the path into extra segments. The server's single-segment `[id]` route at `js/coding-agents/src/app/api/sandboxes/[id]/agent-send/route.ts` never matched, and the CLI surfaced a confusing `HTTP 404: API route not found`.
- Route the name through `url.PathEscape` so `/` encodes as `%2F` and the full name arrives as a single segment.
- Extend the existing `TestPathEscapesSandboxName` table with an `AgentSend` case so this regression can't recur silently — it was the only `/api/sandboxes/{name}/...` endpoint not covered by that test.

## Reproduction

```
$ amika sandbox agent-send dylan/delete-me 'Change the heading to say "hello, dylan"'
agent-send failed for sandbox "dylan/delete-me": remote agent-send: HTTP 404: API route not found
```

## Test plan

- [ ] `make test-unit` passes locally (includes the new `AgentSend with slash` case in `TestPathEscapesSandboxName`)
- [ ] `amika sandbox agent-send <owner>/<name> '...'` reaches the server and returns the agent response instead of 404