### PR TITLE
Relax branch push check to allow local behind remote

### DIFF
--- a/cmd/amika/sandbox/sandbox_create.go
+++ b/cmd/amika/sandbox/sandbox_create.go
@@ -305,7 +305,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		if repoRoot, err := resolveGitRoot(gitValue); err == nil {
 			if !isLocalBranchReachableFromRemote(repoRoot, branch) {
 				return fmt.Errorf(
-					"current branch %q has not been pushed to the remote\n\n"+
+					"current branch %q has not been pushed or is not up-to-date with the remote\n\n"+
 						"The sandbox will either start from an older version of this branch or\n"+
 						"create it fresh from the default branch.\n\n"+
 						"Push your branch first, or use --branch to specify your branch explicitly.",

--- a/cmd/amika/sandbox/sandbox_create.go
+++ b/cmd/amika/sandbox/sandbox_create.go
@@ -299,10 +299,11 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		}
 	}
 
-	// Warn if the auto-detected branch hasn't been pushed to the remote.
+	// Warn if the auto-detected branch hasn't been pushed to the remote
+	// or has local commits that the remote doesn't have yet.
 	if branch != "" && newBranch == "" && gitValueIsLocalPath && !cmd.Flags().Changed("branch") {
 		if repoRoot, err := resolveGitRoot(gitValue); err == nil {
-			if !isBranchPushedToRemote(repoRoot, branch) {
+			if !isLocalBranchReachableFromRemote(repoRoot, branch) {
 				return fmt.Errorf(
 					"current branch %q has not been pushed to the remote\n\n"+
 						"The sandbox will either start from an older version of this branch or\n"+

--- a/cmd/amika/sandbox/sandbox_create_git.go
+++ b/cmd/amika/sandbox/sandbox_create_git.go
@@ -209,11 +209,20 @@ func detectHostCurrentBranch(startPath string) (string, error) {
 	return name, nil
 }
 
-// isBranchPushedToRemote checks whether the local branch tip matches the
-// tip on the "origin" remote. Always checks against origin directly (not
-// the upstream tracking branch) because sandbox creation resolves the
-// origin URL regardless of what remote the branch tracks.
-func isBranchPushedToRemote(repoDir, branch string) bool {
+// isLocalBranchReachableFromRemote returns true when the local branch tip
+// is an ancestor of (or equal to) the corresponding branch on the "origin"
+// remote. This means the remote already contains every commit on the local
+// branch, so it is safe to create a sandbox from the remote version.
+//
+// It always checks against origin directly (not the upstream tracking
+// branch) because sandbox creation resolves the origin URL regardless of
+// what remote the branch tracks.
+//
+// The ancestry check uses git merge-base --is-ancestor, which requires the
+// remote SHA to be present in the local object store (e.g. from a prior
+// fetch). If the remote SHA is not available locally the function
+// conservatively returns false.
+func isLocalBranchReachableFromRemote(repoDir, branch string) bool {
 	// Get the remote tip SHA from origin.
 	lsCmd := exec.Command("git", "-C", repoDir, "ls-remote", "--heads", "origin", branch)
 	lsOut, err := lsCmd.Output()
@@ -230,7 +239,15 @@ func isBranchPushedToRemote(repoDir, branch string) bool {
 	}
 	localSHA := strings.TrimSpace(string(localOut))
 
-	return remoteSHA == localSHA
+	if remoteSHA == localSHA {
+		return true
+	}
+
+	// Check if local is an ancestor of remote (i.e. the remote is ahead of
+	// or equal to local). This covers the case where someone else has pushed
+	// additional commits to the remote branch.
+	ancestorCmd := exec.Command("git", "-C", repoDir, "merge-base", "--is-ancestor", localSHA, remoteSHA)
+	return ancestorCmd.Run() == nil
 }
 
 func copyRepoWorkingTree(src, dst string) error {

--- a/cmd/amika/sandbox/sandbox_create_git.go
+++ b/cmd/amika/sandbox/sandbox_create_git.go
@@ -218,12 +218,16 @@ func detectHostCurrentBranch(startPath string) (string, error) {
 // branch) because sandbox creation resolves the origin URL regardless of
 // what remote the branch tracks.
 //
-// The ancestry check uses git merge-base --is-ancestor, which requires the
-// remote SHA to be present in the local object store (e.g. from a prior
-// fetch). If the remote SHA is not available locally the function
-// conservatively returns false.
+// The ancestry check uses "git merge-base --is-ancestor", which requires
+// both SHAs to be in the local object store. The remote SHA (obtained via
+// ls-remote) may not be local if the user hasn't fetched recently — the
+// common case when someone else pushes to the branch. To avoid a fetch
+// (which would mutate local state), we fall back to comparing against the
+// last-fetched tracking ref (refs/remotes/origin/<branch>). If local
+// hasn't moved past that ref, and the remote is even further ahead, then
+// local is certainly behind remote and it is safe to proceed.
 func isLocalBranchReachableFromRemote(repoDir, branch string) bool {
-	// Get the remote tip SHA from origin.
+	// Query origin for the branch tip SHA without downloading objects.
 	lsCmd := exec.Command("git", "-C", repoDir, "ls-remote", "--heads", "origin", branch)
 	lsOut, err := lsCmd.Output()
 	if err != nil || strings.TrimSpace(string(lsOut)) == "" {
@@ -239,15 +243,34 @@ func isLocalBranchReachableFromRemote(repoDir, branch string) bool {
 	}
 	localSHA := strings.TrimSpace(string(localOut))
 
+	// Fast path: tips match exactly.
 	if remoteSHA == localSHA {
 		return true
 	}
 
-	// Check if local is an ancestor of remote (i.e. the remote is ahead of
-	// or equal to local). This covers the case where someone else has pushed
-	// additional commits to the remote branch.
-	ancestorCmd := exec.Command("git", "-C", repoDir, "merge-base", "--is-ancestor", localSHA, remoteSHA)
-	return ancestorCmd.Run() == nil
+	// Check whether the remote SHA exists in the local object store. It
+	// will be present if the user has fetched recently, or if the commit
+	// was created locally and then pushed.
+	catCmd := exec.Command("git", "-C", repoDir, "cat-file", "-e", remoteSHA)
+	if catCmd.Run() == nil {
+		// Remote SHA is local — do a precise ancestry check.
+		// "merge-base --is-ancestor A B" exits 0 when A is an ancestor of B,
+		// meaning the remote (B) contains every commit in local (A).
+		ancestorCmd := exec.Command("git", "-C", repoDir, "merge-base", "--is-ancestor", localSHA, remoteSHA)
+		return ancestorCmd.Run() == nil
+	}
+
+	// Remote SHA is NOT in the local object store (e.g. someone else pushed
+	// new commits and we haven't fetched). Fall back to the last-fetched
+	// tracking ref: if local hasn't moved past origin/<branch>, then local
+	// has no unpushed commits and must be behind the (even newer) remote.
+	trackingRef := "refs/remotes/origin/" + branch
+	verifyCmd := exec.Command("git", "-C", repoDir, "rev-parse", "--verify", "--quiet", trackingRef)
+	if verifyCmd.Run() != nil {
+		return false // no tracking ref — can't determine relationship
+	}
+	trackingAncestorCmd := exec.Command("git", "-C", repoDir, "merge-base", "--is-ancestor", localSHA, trackingRef)
+	return trackingAncestorCmd.Run() == nil
 }
 
 func copyRepoWorkingTree(src, dst string) error {

--- a/cmd/amika/sandbox/sandbox_git_test.go
+++ b/cmd/amika/sandbox/sandbox_git_test.go
@@ -492,6 +492,72 @@ func TestIsLocalBranchReachableFromRemote(t *testing.T) {
 	})
 }
 
+// TestIsLocalBranchReachableFromRemote_TrackingRefFallback exercises the
+// fallback path where the remote SHA (from ls-remote) is NOT in the local
+// object store. This happens when someone else pushes to the remote and the
+// user hasn't fetched. The function should fall back to comparing against
+// the last-fetched tracking ref (refs/remotes/origin/<branch>).
+func TestIsLocalBranchReachableFromRemote_TrackingRefFallback(t *testing.T) {
+	bare := t.TempDir()
+	runGitCmd(t, bare, "init", "--bare")
+
+	// First clone: "work" — the repo under test.
+	work := filepath.Join(t.TempDir(), "work")
+	cloneCmd := exec.Command("git", "clone", bare, work)
+	if out, err := cloneCmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone failed: %s", out)
+	}
+	runGitCmd(t, work, "config", "user.name", "Test User")
+	runGitCmd(t, work, "config", "user.email", "test@example.com")
+
+	// Push an initial commit from work.
+	if err := os.WriteFile(filepath.Join(work, "a.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	runGitCmd(t, work, "add", "a.txt")
+	runGitCmd(t, work, "commit", "-m", "c1")
+	runGitCmd(t, work, "push", "origin", "HEAD")
+	branch := gitCurrentBranch(t, work)
+
+	// Second clone: "other" — simulates another contributor.
+	other := filepath.Join(t.TempDir(), "other")
+	cloneCmd2 := exec.Command("git", "clone", bare, other)
+	if out, err := cloneCmd2.CombinedOutput(); err != nil {
+		t.Fatalf("clone failed: %s", out)
+	}
+	runGitCmd(t, other, "config", "user.name", "Other User")
+	runGitCmd(t, other, "config", "user.email", "other@example.com")
+
+	// Push a new commit from "other" so the bare repo is ahead of "work".
+	// "work" has never seen this commit — its object store does not contain
+	// the new SHA.
+	if err := os.WriteFile(filepath.Join(other, "b.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	runGitCmd(t, other, "add", "b.txt")
+	runGitCmd(t, other, "commit", "-m", "c2-from-other")
+	runGitCmd(t, other, "push", "origin", "HEAD")
+
+	t.Run("local behind unfetched remote returns true via tracking ref", func(t *testing.T) {
+		if !isLocalBranchReachableFromRemote(work, branch) {
+			t.Fatal("expected true when local is behind remote and remote SHA is not in local store")
+		}
+	})
+
+	// Now make a local commit in "work" so it has diverged from the remote.
+	if err := os.WriteFile(filepath.Join(work, "c.txt"), []byte("c\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	runGitCmd(t, work, "add", "c.txt")
+	runGitCmd(t, work, "commit", "-m", "c3-local-only")
+
+	t.Run("local ahead of tracking ref with unfetched remote returns false", func(t *testing.T) {
+		if isLocalBranchReachableFromRemote(work, branch) {
+			t.Fatal("expected false when local has unpushed commits and remote SHA is not in local store")
+		}
+	})
+}
+
 func createGitRepo(t *testing.T, remotes map[string]string) string {
 	t.Helper()
 

--- a/cmd/amika/sandbox/sandbox_git_test.go
+++ b/cmd/amika/sandbox/sandbox_git_test.go
@@ -426,6 +426,72 @@ func TestIsNetworkRemoteURL(t *testing.T) {
 	}
 }
 
+func TestIsLocalBranchReachableFromRemote(t *testing.T) {
+	// Set up a bare repo to act as "origin" and a working clone.
+	bare := t.TempDir()
+	runGitCmd(t, bare, "init", "--bare")
+
+	work := filepath.Join(t.TempDir(), "work")
+	cmd := exec.Command("git", "clone", bare, work)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clone failed: %s", out)
+	}
+	runGitCmd(t, work, "config", "user.name", "Test User")
+	runGitCmd(t, work, "config", "user.email", "test@example.com")
+
+	// Initial commit and push.
+	if err := os.WriteFile(filepath.Join(work, "a.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	runGitCmd(t, work, "add", "a.txt")
+	runGitCmd(t, work, "commit", "-m", "c1")
+	runGitCmd(t, work, "push", "origin", "HEAD")
+
+	branch := gitCurrentBranch(t, work)
+
+	t.Run("exact match returns true", func(t *testing.T) {
+		if !isLocalBranchReachableFromRemote(work, branch) {
+			t.Fatal("expected true when local matches remote")
+		}
+	})
+
+	// Push another commit, then reset local back so remote is ahead.
+	if err := os.WriteFile(filepath.Join(work, "b.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	runGitCmd(t, work, "add", "b.txt")
+	runGitCmd(t, work, "commit", "-m", "c2")
+	runGitCmd(t, work, "push", "origin", "HEAD")
+	runGitCmd(t, work, "reset", "--hard", "HEAD~1")
+
+	t.Run("local behind remote returns true", func(t *testing.T) {
+		if !isLocalBranchReachableFromRemote(work, branch) {
+			t.Fatal("expected true when local is ancestor of remote")
+		}
+	})
+
+	// Create a divergent local commit (local is no longer an ancestor of remote).
+	if err := os.WriteFile(filepath.Join(work, "c.txt"), []byte("c\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	runGitCmd(t, work, "add", "c.txt")
+	runGitCmd(t, work, "commit", "-m", "c3-diverged")
+
+	t.Run("local diverged returns false", func(t *testing.T) {
+		if isLocalBranchReachableFromRemote(work, branch) {
+			t.Fatal("expected false when local has diverged from remote")
+		}
+	})
+
+	t.Run("branch not on remote returns false", func(t *testing.T) {
+		runGitCmd(t, work, "checkout", "-b", "no-remote")
+		if isLocalBranchReachableFromRemote(work, "no-remote") {
+			t.Fatal("expected false when branch does not exist on remote")
+		}
+	})
+}
+
 func createGitRepo(t *testing.T, remotes map[string]string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Replace `isBranchPushedToRemote` (exact SHA match) with `isLocalBranchReachableFromRemote` which uses `git merge-base --is-ancestor` to check if the local branch tip is an ancestor of the remote tip
- This allows `amika sandbox create --git` to proceed when the remote branch has additional commits beyond what is local (e.g. someone else pushed, or you haven't pulled yet)
- Update the error message to mention "not up-to-date" in addition to "not pushed"

## Test plan
- [x] Added tests covering: exact match, local behind remote, local diverged, branch not on remote
- [x] CI passes