### PR TITLE
Fix secret provider delete to hit the provider-scoped endpoint

### DIFF
--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -590,7 +590,7 @@ func newProviderDeleteCmd(p providerConfig) *cobra.Command {
 				return fmt.Errorf("authenticating with remote API: %w", err)
 			}
 
-			if err := client.DeleteProviderSecret(args[0]); err != nil {
+			if err := client.DeleteProviderSecret(p.APIPath, args[0]); err != nil {
 				return err
 			}
 

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -279,10 +279,11 @@ func (c *Client) ListProviderSecrets(provider string) ([]ProviderSecretListItem,
 	return result, nil
 }
 
-// DeleteProviderSecret deletes a provider-scoped credential by ID.
-func (c *Client) DeleteProviderSecret(id string) error {
-	if err := c.doJSON("DELETE", "/api/secrets/"+id, nil, nil); err != nil {
-		return fmt.Errorf("remote delete secret: %w", err)
+// DeleteProviderSecret deletes a provider-scoped credential by ID. provider is
+// the URL segment ("claude", "codex").
+func (c *Client) DeleteProviderSecret(provider, id string) error {
+	if err := c.doJSON("DELETE", "/api/secrets/"+provider+"/"+id, nil, nil); err != nil {
+		return fmt.Errorf("remote delete %s secret: %w", provider, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `amika secret claude rm <id>` (and codex) was returning 404 because `DeleteProviderSecret` hit `DELETE /api/secrets/<id>` — the generic-secrets endpoint, which cannot find provider-scoped rows.
- Route delete to `DELETE /api/secrets/<provider>/<id>` instead, matching `CreateProviderSecret` and `ListProviderSecrets`.

## Test plan
- [x] \`amika secret claude rm <id>\` succeeds against staging
- [x] \`amika secret codex rm <id>\` succeeds against staging
- [x] \`make ci\` passes