### PR TITLE
Drop user-facing WorkOS copy in favor of Amika branding

### DIFF
--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -23,11 +23,11 @@ var authLoginCmd = &cobra.Command{
 	Short: "Log in to Amika",
 	Long: `Authenticate with Amika.
 
-By default runs the WorkOS Device Authorization Flow and opens a browser.
+By default runs a device authorization flow and opens a browser.
 
-Pass --api-key-file to skip the browser flow and store a WorkOS organization
-API key instead. Use "-" to read the key from stdin, which pairs well with
-secret managers in CI (for example: "vault kv get -field=key … | amika auth login --api-key-file -").`,
+Pass --api-key-file to skip the browser flow and store an Amika API key
+instead. Use "-" to read the key from stdin, which pairs well with secret
+managers in CI (for example: "vault kv get -field=key … | amika auth login --api-key-file -").`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		apiKeyFile, _ := cmd.Flags().GetString("api-key-file")
 
@@ -227,5 +227,5 @@ func init() {
 	authCmd.AddCommand(authLogoutCmd)
 	authCmd.AddCommand(authStatusCmd)
 
-	authLoginCmd.Flags().String("api-key-file", "", `Read a WorkOS organization API key from this path instead of running the device flow ("-" for stdin)`)
+	authLoginCmd.Flags().String("api-key-file", "", `Read an Amika API key from this path instead of running the device flow ("-" for stdin)`)
 }

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -2,7 +2,7 @@
 
 ## Login
 
-`amika auth login` authenticates with Amika using the WorkOS Device Authorization Flow.
+`amika auth login` authenticates with Amika using a device authorization flow.
 
 ### Quick Start
 
@@ -19,9 +19,9 @@ amika auth logout
 
 ### How It Works
 
-1. The CLI requests a device code from WorkOS.
+1. The CLI requests a device code from Amika.
 2. A user code is displayed and the browser opens for you to authorize.
-3. The CLI polls WorkOS until you complete authorization.
+3. The CLI polls Amika until you complete authorization.
 4. The session (access token, refresh token, email, org) is saved to `${XDG_STATE_HOME}/amika/workos-session.json`.
 5. Access tokens are automatically refreshed when they are within 60 seconds of expiry.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -281,7 +281,7 @@ Authentication and credential commands.
 
 ### `amika auth login`
 
-Log in to Amika via the WorkOS Device Authorization Flow. Opens a browser for you to authorize the CLI.
+Log in to Amika via a device authorization flow. Opens a browser for you to authorize the CLI.
 
 ```bash
 amika auth login


### PR DESCRIPTION
## Summary

- Users see an "Amika API key" and authenticate "with Amika", not WorkOS. Scrub WorkOS mentions from the `amika auth login` docstring, the `--api-key-file` flag description, `docs/cli-reference.md`, and `docs/auth.md`.
- WorkOS remains an implementation detail; nothing about the auth flow changes.

## Out of scope (intentional)

- Env var names like `AMIKA_WORKOS_CLIENT_ID` — renaming is a breaking deploy change.
- On-disk filename `workos-session.json` — renaming would break existing installs.
- Go identifiers (`WorkOSSession`, `WorkOSClientID`, `workosSessionFile`).
- The env-var description text for `AMIKA_WORKOS_CLIENT_ID` — the var name already surfaces the word, so matching description stays.
- `AGENTS.md` — left alone per request.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./cmd/amika/...\`
- [x] \`amika auth login --help\` shows "Amika API key" in the flag description and no "WorkOS" in the docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)