### PR TITLE
feat: allow modifying sandbox metadata after creation

### DIFF
--- a/cmd/amika/sandbox/command.go
+++ b/cmd/amika/sandbox/command.go
@@ -26,6 +26,7 @@ func New() *cobra.Command {
 	sandboxCmd.AddCommand(sandboxSSHCmd)
 	sandboxCmd.AddCommand(sandboxCodeCmd)
 	sandboxCmd.AddCommand(sandboxAgentSendCmd)
+	sandboxCmd.AddCommand(sandboxUpdateCmd)
 
 	sandboxCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
 	sandboxCmd.PersistentFlags().Bool("remote", false, "Only operate on remote sandboxes")
@@ -52,6 +53,12 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().Bool("no-setup", false, "Skip the setup script (uses a no-op script instead)")
 	sandboxCreateCmd.Flags().String("branch", "", "Check out this git branch, or create it if it doesn't exist.")
 	sandboxCreateCmd.Flags().String("new-branch", "", "Create a new git branch. With --branch, starts from that branch; otherwise starts from the current checkout.")
+	// Update flags
+	sandboxUpdateCmd.Flags().String("name", "", "New name for the sandbox")
+	sandboxUpdateCmd.Flags().String("ttl", "", "Time-to-live duration (e.g. \"2h\", \"30m\")")
+	sandboxUpdateCmd.Flags().String("inactivity-timeout", "", "Inactivity timeout duration")
+	sandboxUpdateCmd.Flags().String("auto-delete-timeout", "", "Auto-delete timeout for suspended sandboxes")
+
 	sandboxDeleteCmd.Flags().Bool("force", false, "Skip confirmation prompt")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")

--- a/cmd/amika/sandbox/sandbox_update.go
+++ b/cmd/amika/sandbox/sandbox_update.go
@@ -1,0 +1,71 @@
+package sandboxcmd
+
+// sandbox_update.go implements the sandbox update command.
+
+import (
+	"fmt"
+
+	"github.com/gofixpoint/amika/pkg/amika"
+	"github.com/spf13/cobra"
+)
+
+var sandboxUpdateCmd = &cobra.Command{
+	Use:   "update <name>",
+	Short: "Update sandbox metadata",
+	Long:  `Update metadata for an existing sandbox (rename, TTL, inactivity timeout, auto-delete timeout).`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		name := args[0]
+		svc := amika.NewService(amika.Options{})
+
+		req := amika.UpdateSandboxRequest{Name: name}
+		hasUpdate := false
+
+		if cmd.Flags().Changed("name") {
+			newName, _ := cmd.Flags().GetString("name")
+			req.NewName = &newName
+			hasUpdate = true
+		}
+		if cmd.Flags().Changed("ttl") {
+			ttl, _ := cmd.Flags().GetString("ttl")
+			req.TTL = &ttl
+			hasUpdate = true
+		}
+		if cmd.Flags().Changed("inactivity-timeout") {
+			timeout, _ := cmd.Flags().GetString("inactivity-timeout")
+			req.InactivityTimeout = &timeout
+			hasUpdate = true
+		}
+		if cmd.Flags().Changed("auto-delete-timeout") {
+			timeout, _ := cmd.Flags().GetString("auto-delete-timeout")
+			req.AutoDeleteTimeout = &timeout
+			hasUpdate = true
+		}
+
+		if !hasUpdate {
+			return fmt.Errorf("no update flags specified; use --name, --ttl, --inactivity-timeout, or --auto-delete-timeout")
+		}
+
+		result, err := svc.UpdateSandbox(cmd.Context(), req)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Sandbox %q updated successfully\n", result.Sandbox.Name)
+		if req.NewName != nil {
+			fmt.Printf("  Renamed to: %s\n", result.Sandbox.Name)
+		}
+		if req.TTL != nil {
+			fmt.Printf("  TTL: %s\n", result.Sandbox.TTL)
+		}
+		if req.InactivityTimeout != nil {
+			fmt.Printf("  Inactivity timeout: %s\n", result.Sandbox.InactivityTimeout)
+		}
+		if req.AutoDeleteTimeout != nil {
+			fmt.Printf("  Auto-delete timeout: %s\n", result.Sandbox.AutoDeleteTimeout)
+		}
+		return nil
+	},
+}

--- a/internal/app/service_impl.go
+++ b/internal/app/service_impl.go
@@ -88,17 +88,7 @@ func (s *Service) CreateSandbox(_ context.Context, req amika.CreateSandboxReques
 		return amika.Sandbox{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
 	}
 
-	return amika.Sandbox{
-		Name:        rec.Name,
-		Provider:    rec.Provider,
-		ContainerID: rec.ContainerID,
-		Image:       rec.Image,
-		CreatedAt:   rec.CreatedAt,
-		Preset:      rec.Preset,
-		Mounts:      toPublicMounts(rec.Mounts),
-		Env:         rec.Env,
-		Ports:       toPublicPorts(rec.Ports),
-	}, nil
+	return recordToSandbox(rec), nil
 }
 
 // DeleteSandbox removes one or more sandboxes and their backing runtime sandboxes.
@@ -131,17 +121,7 @@ func (s *Service) ListSandboxes(context.Context, amika.ListSandboxesRequest) (am
 	}
 	items := make([]amika.Sandbox, 0, len(recs))
 	for _, rec := range recs {
-		items = append(items, amika.Sandbox{
-			Name:        rec.Name,
-			Provider:    rec.Provider,
-			ContainerID: rec.ContainerID,
-			Image:       rec.Image,
-			CreatedAt:   rec.CreatedAt,
-			Preset:      rec.Preset,
-			Mounts:      toPublicMounts(rec.Mounts),
-			Env:         rec.Env,
-			Ports:       toPublicPorts(rec.Ports),
-		})
+		items = append(items, recordToSandbox(rec))
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt > items[j].CreatedAt })
 	return amika.ListSandboxesResult{Items: items}, nil
@@ -279,6 +259,61 @@ func (s *Service) ListServices(_ context.Context, req amika.ListServicesRequest)
 	return amika.ListServicesResult{Items: items}, nil
 }
 
+// UpdateSandbox modifies metadata on an existing sandbox.
+func (s *Service) UpdateSandbox(_ context.Context, req amika.UpdateSandboxRequest) (amika.UpdateSandboxResult, error) {
+	if req.Name == "" {
+		return amika.UpdateSandboxResult{}, fmt.Errorf("%w: sandbox name is required", amika.ErrInvalidArgument)
+	}
+	rec, err := s.deps.Sandboxes.Get(req.Name)
+	if err != nil {
+		return amika.UpdateSandboxResult{}, fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, req.Name)
+	}
+
+	updated := rec
+
+	if err := validateOptionalDuration(req.TTL, "TTL"); err != nil {
+		return amika.UpdateSandboxResult{}, err
+	}
+	if req.TTL != nil {
+		updated.TTL = *req.TTL
+	}
+	if err := validateOptionalDuration(req.InactivityTimeout, "InactivityTimeout"); err != nil {
+		return amika.UpdateSandboxResult{}, err
+	}
+	if req.InactivityTimeout != nil {
+		updated.InactivityTimeout = *req.InactivityTimeout
+	}
+	if err := validateOptionalDuration(req.AutoDeleteTimeout, "AutoDeleteTimeout"); err != nil {
+		return amika.UpdateSandboxResult{}, err
+	}
+	if req.AutoDeleteTimeout != nil {
+		updated.AutoDeleteTimeout = *req.AutoDeleteTimeout
+	}
+
+	if req.NewName != nil && *req.NewName != "" && *req.NewName != req.Name {
+		if _, err := s.deps.Sandboxes.Get(*req.NewName); err == nil {
+			return amika.UpdateSandboxResult{}, fmt.Errorf("%w: sandbox %q already exists", amika.ErrInvalidArgument, *req.NewName)
+		}
+		if updated.Provider == "docker" {
+			if err := s.deps.Docker.RenameSandbox(req.Name, *req.NewName); err != nil {
+				return amika.UpdateSandboxResult{}, fmt.Errorf("%w: %v", amika.ErrDependency, err)
+			}
+		}
+		if err := s.deps.Sandboxes.Remove(req.Name); err != nil {
+			return amika.UpdateSandboxResult{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
+		}
+		updated.Name = *req.NewName
+	}
+
+	if err := s.deps.Sandboxes.Save(updated); err != nil {
+		return amika.UpdateSandboxResult{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
+	}
+
+	return amika.UpdateSandboxResult{
+		Sandbox: recordToSandbox(updated),
+	}, nil
+}
+
 // ExtractAuth extracts auth env assignment lines.
 func (s *Service) ExtractAuth(_ context.Context, req amika.AuthExtractRequest) (amika.AuthExtractResult, error) {
 	result, err := auth.Discover(auth.Options{HomeDir: req.HomeDir, IncludeOAuth: !req.NoOAuth})
@@ -286,6 +321,32 @@ func (s *Service) ExtractAuth(_ context.Context, req amika.AuthExtractRequest) (
 		return amika.AuthExtractResult{}, fmt.Errorf("%w: %v", amika.ErrDependency, err)
 	}
 	return amika.AuthExtractResult{Lines: auth.BuildEnvMap(result).Lines(req.WithExport)}, nil
+}
+
+func validateOptionalDuration(val *string, fieldName string) error {
+	if val != nil && *val != "" {
+		if _, err := time.ParseDuration(*val); err != nil {
+			return fmt.Errorf("%w: invalid %s %q: %v", amika.ErrInvalidArgument, fieldName, *val, err)
+		}
+	}
+	return nil
+}
+
+func recordToSandbox(rec ports.SandboxRecord) amika.Sandbox {
+	return amika.Sandbox{
+		Name:              rec.Name,
+		Provider:          rec.Provider,
+		ContainerID:       rec.ContainerID,
+		Image:             rec.Image,
+		CreatedAt:         rec.CreatedAt,
+		Preset:            rec.Preset,
+		Mounts:            toPublicMounts(rec.Mounts),
+		Env:               rec.Env,
+		Ports:             toPublicPorts(rec.Ports),
+		TTL:               rec.TTL,
+		InactivityTimeout: rec.InactivityTimeout,
+		AutoDeleteTimeout: rec.AutoDeleteTimeout,
+	}
 }
 
 func toPublicMounts(mounts []ports.Mount) []amika.Mount {

--- a/internal/app/service_impl_test.go
+++ b/internal/app/service_impl_test.go
@@ -19,6 +19,7 @@ func (stubDocker) RemoveSandbox(string) error               { return nil }
 func (stubDocker) CreateVolume(string) error                { return nil }
 func (stubDocker) RemoveVolume(string) error                { return nil }
 func (stubDocker) CopyHostDirToVolume(string, string) error { return nil }
+func (stubDocker) RenameSandbox(string, string) error       { return nil }
 
 type stubSandboxStore struct{}
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -23,6 +23,7 @@ func NewHandler(service amika.Service) http.Handler {
 	registerHealth(api)
 	registerListSandboxes(api, service)
 	registerCreateSandbox(api, service)
+	registerUpdateSandbox(api, service)
 	registerDeleteSandbox(api, service)
 	registerListVolumes(api, service)
 	registerDeleteVolume(api, service)
@@ -73,6 +74,24 @@ func registerCreateSandbox(api huma.API, service amika.Service) {
 			return nil, toHTTPError(err)
 		}
 		return &createSandboxOutput{Body: result}, nil
+	})
+}
+
+type updateSandboxInput struct {
+	Name string                     `path:"name"`
+	Body amika.UpdateSandboxRequest `json:"body"`
+}
+type updateSandboxOutput struct{ Body amika.UpdateSandboxResult }
+
+func registerUpdateSandbox(api huma.API, service amika.Service) {
+	huma.Patch(api, "/v1/sandboxes/{name}", func(ctx context.Context, input *updateSandboxInput) (*updateSandboxOutput, error) {
+		req := input.Body
+		req.Name = input.Name
+		result, err := service.UpdateSandbox(ctx, req)
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &updateSandboxOutput{Body: result}, nil
 	})
 }
 

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -16,6 +16,9 @@ type stubService struct{}
 func (stubService) CreateSandbox(context.Context, amika.CreateSandboxRequest) (amika.Sandbox, error) {
 	return amika.Sandbox{}, amika.ErrUnimplemented
 }
+func (stubService) UpdateSandbox(context.Context, amika.UpdateSandboxRequest) (amika.UpdateSandboxResult, error) {
+	return amika.UpdateSandboxResult{}, amika.ErrUnimplemented
+}
 func (stubService) DeleteSandbox(context.Context, amika.DeleteSandboxRequest) (amika.DeleteSandboxResult, error) {
 	return amika.DeleteSandboxResult{}, amika.ErrUnimplemented
 }

--- a/internal/ports/docker.go
+++ b/internal/ports/docker.go
@@ -25,4 +25,5 @@ type DockerClient interface {
 	CreateVolume(name string) error
 	RemoveVolume(name string) error
 	CopyHostDirToVolume(volumeName, hostDir string) error
+	RenameSandbox(oldName, newName string) error
 }

--- a/internal/ports/store.go
+++ b/internal/ports/store.go
@@ -14,16 +14,19 @@ type ServicePortRecord struct {
 
 // SandboxRecord stores sandbox metadata.
 type SandboxRecord struct {
-	Name        string
-	Provider    string
-	ContainerID string
-	Image       string
-	CreatedAt   string
-	Preset      string
-	Mounts      []Mount
-	Env         []string
-	Ports       []PortBinding
-	Services    []ServiceRecord
+	Name              string
+	Provider          string
+	ContainerID       string
+	Image             string
+	CreatedAt         string
+	Preset            string
+	Mounts            []Mount
+	Env               []string
+	Ports             []PortBinding
+	Services          []ServiceRecord
+	TTL               string
+	InactivityTimeout string
+	AutoDeleteTimeout string
 }
 
 // VolumeRecord stores tracked volume metadata.

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -96,6 +96,16 @@ func RemoveDockerSandbox(name string) error {
 	return nil
 }
 
+// RenameDockerContainer renames a Docker container from oldName to newName.
+func RenameDockerContainer(oldName, newName string) error {
+	cmd := exec.Command("docker", "rename", oldName, newName)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to rename docker container: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 // CreateDockerVolume creates a named docker volume.
 func CreateDockerVolume(name string) error {
 	cmd := exec.Command("docker", "volume", "create", name)

--- a/internal/sandbox/store.go
+++ b/internal/sandbox/store.go
@@ -43,17 +43,20 @@ type ServicePortInfo struct {
 
 // Info represents a tracked sandbox.
 type Info struct {
-	Name        string         `json:"name"`
-	Provider    string         `json:"provider"`
-	ContainerID string         `json:"containerId"`
-	Image       string         `json:"image"`
-	CreatedAt   string         `json:"createdAt"`
-	Preset      string         `json:"preset,omitempty"`
-	Mounts      []MountBinding `json:"mounts,omitempty"`
-	Env         []string       `json:"env,omitempty"`
-	Ports       []PortBinding  `json:"ports,omitempty"`
-	Services    []ServiceInfo  `json:"services,omitempty"`
-	Branch      string         `json:"branch,omitempty"`
+	Name              string         `json:"name"`
+	Provider          string         `json:"provider"`
+	ContainerID       string         `json:"containerId"`
+	Image             string         `json:"image"`
+	CreatedAt         string         `json:"createdAt"`
+	Preset            string         `json:"preset,omitempty"`
+	Mounts            []MountBinding `json:"mounts,omitempty"`
+	Env               []string       `json:"env,omitempty"`
+	Ports             []PortBinding  `json:"ports,omitempty"`
+	Services          []ServiceInfo  `json:"services,omitempty"`
+	Branch            string         `json:"branch,omitempty"`
+	TTL               string         `json:"ttl,omitempty"`
+	InactivityTimeout string         `json:"inactivityTimeout,omitempty"`
+	AutoDeleteTimeout string         `json:"autoDeleteTimeout,omitempty"`
 }
 
 // Store manages sandbox state persistence.

--- a/pkg/amika/requests.go
+++ b/pkg/amika/requests.go
@@ -82,6 +82,16 @@ type AuthExtractRequest struct {
 	NoOAuth    bool
 }
 
+// UpdateSandboxRequest describes sandbox metadata update input.
+// Only non-zero fields are applied.
+type UpdateSandboxRequest struct {
+	Name              string  `json:"Name"`                        // sandbox to update (required)
+	NewName           *string `json:"NewName,omitempty"`           // rename the sandbox
+	TTL               *string `json:"TTL,omitempty"`               // time-to-live duration (e.g. "2h", "30m")
+	InactivityTimeout *string `json:"InactivityTimeout,omitempty"` // inactivity timeout duration
+	AutoDeleteTimeout *string `json:"AutoDeleteTimeout,omitempty"` // auto-delete timeout for suspended sandboxes
+}
+
 // ListServicesRequest describes service listing input.
 type ListServicesRequest struct {
 	SandboxName string // optional filter

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -2,19 +2,22 @@ package amika
 
 // Sandbox is a tracked sandbox description.
 type Sandbox struct {
-	Name        string
-	State       string
-	Provider    string
-	ContainerID string
-	Image       string
-	CreatedAt   string
-	Preset      string
-	Location    string // "local" or "remote"
-	Branch      string
-	Mounts      []Mount
-	Env         []string
-	Ports       []PortBinding
-	Services    []ServiceInfo
+	Name              string
+	State             string
+	Provider          string
+	ContainerID       string
+	Image             string
+	CreatedAt         string
+	Preset            string
+	Location          string // "local" or "remote"
+	Branch            string
+	Mounts            []Mount
+	Env               []string
+	Ports             []PortBinding
+	Services          []ServiceInfo
+	TTL               string
+	InactivityTimeout string
+	AutoDeleteTimeout string
 }
 
 // ServiceInfo describes a named service running in a sandbox.
@@ -76,6 +79,11 @@ type ListVolumesResult struct {
 // DeleteVolumeResult reports deleted volumes.
 type DeleteVolumeResult struct {
 	Deleted []string
+}
+
+// UpdateSandboxResult reports sandbox update details.
+type UpdateSandboxResult struct {
+	Sandbox Sandbox
 }
 
 // AuthExtractResult reports extracted env assignment lines.

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -23,6 +23,7 @@ import (
 // Service defines the public API surface for running Amika operations from Go.
 type Service interface {
 	CreateSandbox(ctx context.Context, req CreateSandboxRequest) (Sandbox, error)
+	UpdateSandbox(ctx context.Context, req UpdateSandboxRequest) (UpdateSandboxResult, error)
 	DeleteSandbox(ctx context.Context, req DeleteSandboxRequest) (DeleteSandboxResult, error)
 	ListSandboxes(ctx context.Context, req ListSandboxesRequest) (ListSandboxesResult, error)
 	ConnectSandbox(ctx context.Context, req ConnectSandboxRequest) error
@@ -176,20 +177,64 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	if err := s.sandboxes.Save(info); err != nil {
 		return Sandbox{}, fmt.Errorf("%w: %v", ErrInternal, err)
 	}
-	return Sandbox{
-		Name:        info.Name,
-		Provider:    info.Provider,
-		ContainerID: info.ContainerID,
-		Image:       info.Image,
-		CreatedAt:   info.CreatedAt,
-		Preset:      info.Preset,
-		Branch:      info.Branch,
-		Mounts:      toMounts(info.Mounts),
-		Env:         info.Env,
-		Ports:       toPortBindings(info.Ports),
-		Services:    toPublicServiceInfos(info.Services),
+	return sandboxFromInfo(info), nil
+}
+func (s *serviceImpl) UpdateSandbox(_ context.Context, req UpdateSandboxRequest) (UpdateSandboxResult, error) {
+	if req.Name == "" {
+		return UpdateSandboxResult{}, fmt.Errorf("%w: sandbox name is required", ErrInvalidArgument)
+	}
+	existing, err := s.sandboxes.Get(req.Name)
+	if err != nil {
+		return UpdateSandboxResult{}, fmt.Errorf("%w: sandbox %q", ErrNotFound, req.Name)
+	}
+
+	updated := existing
+
+	if err := validateOptionalDuration(req.TTL, "TTL"); err != nil {
+		return UpdateSandboxResult{}, err
+	}
+	if req.TTL != nil {
+		updated.TTL = *req.TTL
+	}
+	if err := validateOptionalDuration(req.InactivityTimeout, "InactivityTimeout"); err != nil {
+		return UpdateSandboxResult{}, err
+	}
+	if req.InactivityTimeout != nil {
+		updated.InactivityTimeout = *req.InactivityTimeout
+	}
+	if err := validateOptionalDuration(req.AutoDeleteTimeout, "AutoDeleteTimeout"); err != nil {
+		return UpdateSandboxResult{}, err
+	}
+	if req.AutoDeleteTimeout != nil {
+		updated.AutoDeleteTimeout = *req.AutoDeleteTimeout
+	}
+
+	// Handle rename: update Docker container name and store entry.
+	if req.NewName != nil && *req.NewName != "" && *req.NewName != existing.Name {
+		if _, err := s.sandboxes.Get(*req.NewName); err == nil {
+			return UpdateSandboxResult{}, fmt.Errorf("%w: sandbox %q already exists", ErrInvalidArgument, *req.NewName)
+		}
+		if existing.Provider == "docker" {
+			if err := sandbox.RenameDockerContainer(existing.Name, *req.NewName); err != nil {
+				return UpdateSandboxResult{}, fmt.Errorf("%w: %v", ErrDependency, err)
+			}
+		}
+		// Remove old entry and save with new name.
+		if err := s.sandboxes.Remove(existing.Name); err != nil {
+			return UpdateSandboxResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+		}
+		updated.Name = *req.NewName
+	}
+
+	if err := s.sandboxes.Save(updated); err != nil {
+		return UpdateSandboxResult{}, fmt.Errorf("%w: %v", ErrInternal, err)
+	}
+
+	return UpdateSandboxResult{
+		Sandbox: sandboxFromInfo(updated),
 	}, nil
 }
+
 func (s *serviceImpl) DeleteSandbox(_ context.Context, req DeleteSandboxRequest) (DeleteSandboxResult, error) {
 	deleted := make([]string, 0, len(req.Names))
 	for _, name := range req.Names {
@@ -241,19 +286,7 @@ func (s *serviceImpl) ListSandboxes(context.Context, ListSandboxesRequest) (List
 	}
 	out := make([]Sandbox, 0, len(items))
 	for _, it := range items {
-		out = append(out, Sandbox{
-			Name:        it.Name,
-			Provider:    it.Provider,
-			ContainerID: it.ContainerID,
-			Image:       it.Image,
-			CreatedAt:   it.CreatedAt,
-			Preset:      it.Preset,
-			Branch:      it.Branch,
-			Mounts:      toMounts(it.Mounts),
-			Env:         it.Env,
-			Ports:       toPortBindings(it.Ports),
-			Services:    toPublicServiceInfos(it.Services),
-		})
+		out = append(out, sandboxFromInfo(it))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt > out[j].CreatedAt })
 	return ListSandboxesResult{Items: out}, nil
@@ -645,6 +678,9 @@ type initErrorService struct{ err error }
 func (s *initErrorService) CreateSandbox(context.Context, CreateSandboxRequest) (Sandbox, error) {
 	return Sandbox{}, s.err
 }
+func (s *initErrorService) UpdateSandbox(context.Context, UpdateSandboxRequest) (UpdateSandboxResult, error) {
+	return UpdateSandboxResult{}, s.err
+}
 func (s *initErrorService) DeleteSandbox(context.Context, DeleteSandboxRequest) (DeleteSandboxResult, error) {
 	return DeleteSandboxResult{}, s.err
 }
@@ -666,6 +702,34 @@ func (s *initErrorService) ExtractAuth(context.Context, AuthExtractRequest) (Aut
 }
 func (s *initErrorService) ListServices(context.Context, ListServicesRequest) (ListServicesResult, error) {
 	return ListServicesResult{}, s.err
+}
+
+func sandboxFromInfo(info sandbox.Info) Sandbox {
+	return Sandbox{
+		Name:              info.Name,
+		Provider:          info.Provider,
+		ContainerID:       info.ContainerID,
+		Image:             info.Image,
+		CreatedAt:         info.CreatedAt,
+		Preset:            info.Preset,
+		Branch:            info.Branch,
+		Mounts:            toMounts(info.Mounts),
+		Env:               info.Env,
+		Ports:             toPortBindings(info.Ports),
+		Services:          toPublicServiceInfos(info.Services),
+		TTL:               info.TTL,
+		InactivityTimeout: info.InactivityTimeout,
+		AutoDeleteTimeout: info.AutoDeleteTimeout,
+	}
+}
+
+func validateOptionalDuration(val *string, fieldName string) error {
+	if val != nil && *val != "" {
+		if _, err := time.ParseDuration(*val); err != nil {
+			return fmt.Errorf("%w: invalid %s %q: %v", ErrInvalidArgument, fieldName, *val, err)
+		}
+	}
+	return nil
 }
 
 func toMounts(in []sandbox.MountBinding) []Mount {


### PR DESCRIPTION
Add CLI sandbox update command and HTTP PATCH endpoint to modify sandbox metadata including rename, TTL, and timeout settings. Extends Service interface with UpdateSandbox method using immutable update pattern with pointer-based optional fields for selective updates. Implements Docker container rename integration and duration validation. Updates SandboxRecord with TTL, InactivityTimeout, and AutoDeleteTimeout fields persisted as JSONL with omitempty tags for backward compatibility.

closses #157