### PR TITLE
feat: add sandbox filesystem operations (cp, ls, cat, rm, stat)

### DIFF
--- a/cmd/amika/sandbox_filesystem.go
+++ b/cmd/amika/sandbox_filesystem.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/gofixpoint/amika/pkg/amika"
+	"github.com/spf13/cobra"
+)
+
+// parseSandboxPath splits "sandbox:/path" into (sandboxName, containerPath).
+// The container path must be absolute (start with /).
+func parseSandboxPath(arg string) (string, string, error) {
+	idx := strings.Index(arg, ":")
+	if idx < 0 {
+		return "", "", fmt.Errorf("invalid format %q: expected <sandbox>:<path>", arg)
+	}
+	name := arg[:idx]
+	path := arg[idx+1:]
+	if name == "" {
+		return "", "", fmt.Errorf("sandbox name is required in %q", arg)
+	}
+	if path == "" {
+		return "", "", fmt.Errorf("path is required in %q", arg)
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "", "", fmt.Errorf("container path must be absolute (start with /): %q", path)
+	}
+	return name, path, nil
+}
+
+var sandboxCpCmd = &cobra.Command{
+	Use:   "cp <sandbox>:<container-path> <host-path>",
+	Short: "Copy files from a sandbox to the host",
+	Long:  `Copy a file or directory from a sandbox container to the local filesystem.`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		name, containerPath, err := parseSandboxPath(args[0])
+		if err != nil {
+			return err
+		}
+		hostPath := args[1]
+		svc := amika.NewService(amika.Options{})
+		_, err = svc.CopyFromSandbox(cmd.Context(), amika.CopyFromSandboxRequest{
+			Name:          name,
+			ContainerPath: containerPath,
+			HostPath:      hostPath,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Copied %s:%s → %s\n", name, containerPath, hostPath)
+		return nil
+	},
+}
+
+var sandboxLsCmd = &cobra.Command{
+	Use:   "ls <sandbox>:<path>",
+	Short: "List directory contents in a sandbox",
+	Long:  `List files and directories at the given path inside a running sandbox.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		name, path, err := parseSandboxPath(args[0])
+		if err != nil {
+			return err
+		}
+		svc := amika.NewService(amika.Options{})
+		result, err := svc.SandboxLs(cmd.Context(), amika.SandboxLsRequest{
+			Name: name,
+			Path: path,
+		})
+		if err != nil {
+			return err
+		}
+		if len(result.Entries) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "(empty)")
+			return nil
+		}
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tSIZE\tMODE\tMODIFIED\tTYPE")
+		for _, e := range result.Entries {
+			typ := "file"
+			if e.IsDir {
+				typ = "dir"
+			}
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\n", e.Name, e.Size, e.Mode, e.ModTime, typ)
+		}
+		w.Flush()
+		return nil
+	},
+}
+
+var sandboxCatCmd = &cobra.Command{
+	Use:   "cat <sandbox>:<path>",
+	Short: "Print file contents from a sandbox",
+	Long:  `Read and print the contents of a file inside a running sandbox (10MB limit).`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		name, path, err := parseSandboxPath(args[0])
+		if err != nil {
+			return err
+		}
+		maxBytes, _ := cmd.Flags().GetInt64("max-bytes")
+		svc := amika.NewService(amika.Options{})
+		result, err := svc.SandboxCat(cmd.Context(), amika.SandboxCatRequest{
+			Name:     name,
+			Path:     path,
+			MaxBytes: maxBytes,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(cmd.OutOrStdout(), result.Content)
+		return nil
+	},
+}
+
+var sandboxRmCmd = &cobra.Command{
+	Use:   "rm <sandbox>:<path>",
+	Short: "Remove files from a sandbox",
+	Long:  `Delete a file or directory inside a running sandbox.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		name, path, err := parseSandboxPath(args[0])
+		if err != nil {
+			return err
+		}
+		recursive, _ := cmd.Flags().GetBool("recursive")
+		force, _ := cmd.Flags().GetBool("force")
+		svc := amika.NewService(amika.Options{})
+		_, err = svc.SandboxRm(cmd.Context(), amika.SandboxRmRequest{
+			Name:      name,
+			Path:      path,
+			Recursive: recursive,
+			Force:     force,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Removed %s:%s\n", name, path)
+		return nil
+	},
+}
+
+var sandboxStatCmd = &cobra.Command{
+	Use:   "stat <sandbox>:<path>",
+	Short: "Show file metadata from a sandbox",
+	Long:  `Display file or directory metadata (size, permissions, modification time) from a running sandbox.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		name, path, err := parseSandboxPath(args[0])
+		if err != nil {
+			return err
+		}
+		svc := amika.NewService(amika.Options{})
+		result, err := svc.SandboxStat(cmd.Context(), amika.SandboxStatRequest{
+			Name: name,
+			Path: path,
+		})
+		if err != nil {
+			return err
+		}
+		info := result.Info
+		typ := "file"
+		if info.IsDir {
+			typ = "directory"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  Name: %s\n", info.Name)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Size: %d\n", info.Size)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Mode: %s\n", info.Mode)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Type: %s\n", typ)
+		fmt.Fprintf(cmd.OutOrStdout(), "Modified: %s\n", info.ModTime)
+		return nil
+	},
+}
+
+func init() {
+	sandboxCmd.AddCommand(sandboxCpCmd)
+	sandboxCmd.AddCommand(sandboxLsCmd)
+	sandboxCmd.AddCommand(sandboxCatCmd)
+	sandboxCmd.AddCommand(sandboxRmCmd)
+	sandboxCmd.AddCommand(sandboxStatCmd)
+
+	sandboxCatCmd.Flags().Int64("max-bytes", 0, "Maximum bytes to read (default 10MB)")
+	sandboxRmCmd.Flags().BoolP("recursive", "r", false, "Remove directories and their contents recursively")
+	sandboxRmCmd.Flags().BoolP("force", "f", false, "Ignore nonexistent files, never prompt")
+}

--- a/cmd/amika/sandbox_filesystem_test.go
+++ b/cmd/amika/sandbox_filesystem_test.go
@@ -1,0 +1,85 @@
+package main
+
+import "testing"
+
+func TestParseSandboxPath(t *testing.T) {
+	cases := []struct {
+		input       string
+		wantName    string
+		wantPath    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			input:    "mysandbox:/tmp/file.txt",
+			wantName: "mysandbox",
+			wantPath: "/tmp/file.txt",
+		},
+		{
+			input:    "sb:/home/amika/workspace/repo",
+			wantName: "sb",
+			wantPath: "/home/amika/workspace/repo",
+		},
+		{
+			input:    "sb:/path/with:colon",
+			wantName: "sb",
+			wantPath: "/path/with:colon",
+		},
+		{
+			input:       "no-colon",
+			wantErr:     true,
+			errContains: "expected <sandbox>:<path>",
+		},
+		{
+			input:       ":/tmp/file",
+			wantErr:     true,
+			errContains: "sandbox name is required",
+		},
+		{
+			input:       "sb:",
+			wantErr:     true,
+			errContains: "path is required",
+		},
+		{
+			input:       "sb:relative/path",
+			wantErr:     true,
+			errContains: "must be absolute",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			name, path, err := parseSandboxPath(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errContains)
+				}
+				if tc.errContains != "" && !contains(err.Error(), tc.errContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if name != tc.wantName {
+				t.Errorf("name = %q, want %q", name, tc.wantName)
+			}
+			if path != tc.wantPath {
+				t.Errorf("path = %q, want %q", path, tc.wantPath)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/service_impl.go
+++ b/internal/app/service_impl.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -277,6 +278,154 @@ func (s *Service) ListServices(_ context.Context, req amika.ListServicesRequest)
 		}
 	}
 	return amika.ListServicesResult{Items: items}, nil
+}
+
+// CopyFromSandbox copies files from a sandbox container to the host.
+func (s *Service) CopyFromSandbox(_ context.Context, req amika.CopyFromSandboxRequest) (amika.CopyFromSandboxResult, error) {
+	if req.Name == "" {
+		return amika.CopyFromSandboxResult{}, fmt.Errorf("%w: sandbox name is required", amika.ErrInvalidArgument)
+	}
+	if req.ContainerPath == "" {
+		return amika.CopyFromSandboxResult{}, fmt.Errorf("%w: container path is required", amika.ErrInvalidArgument)
+	}
+	if req.HostPath == "" {
+		return amika.CopyFromSandboxResult{}, fmt.Errorf("%w: host path is required", amika.ErrInvalidArgument)
+	}
+	if _, err := s.deps.Sandboxes.Get(req.Name); err != nil {
+		return amika.CopyFromSandboxResult{}, fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, req.Name)
+	}
+	if err := s.deps.Docker.CopyFromContainer(req.Name, req.ContainerPath, req.HostPath); err != nil {
+		return amika.CopyFromSandboxResult{}, mapDockerErr(err, req.Name, req.ContainerPath)
+	}
+	return amika.CopyFromSandboxResult{}, nil
+}
+
+// SandboxLs lists directory contents inside a sandbox.
+func (s *Service) SandboxLs(_ context.Context, req amika.SandboxLsRequest) (amika.SandboxLsResult, error) {
+	if req.Name == "" {
+		return amika.SandboxLsResult{}, fmt.Errorf("%w: sandbox name is required", amika.ErrInvalidArgument)
+	}
+	if req.Path == "" {
+		return amika.SandboxLsResult{}, fmt.Errorf("%w: path is required", amika.ErrInvalidArgument)
+	}
+	if _, err := s.deps.Sandboxes.Get(req.Name); err != nil {
+		return amika.SandboxLsResult{}, fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, req.Name)
+	}
+	out, err := s.deps.Docker.ExecInContainer(req.Name, []string{
+		"sh", "-c", fmt.Sprintf("stat -c '%%n|%%s|%%a|%%Y|%%F' %s/* %s/.* 2>/dev/null || true", req.Path, req.Path),
+	})
+	if err != nil {
+		return amika.SandboxLsResult{}, mapDockerErr(err, req.Name, req.Path)
+	}
+	entries := amika.ParseStatOutput(out)
+	filtered := make([]amika.SandboxFileInfo, 0, len(entries))
+	for _, e := range entries {
+		base := e.Name
+		if idx := strings.LastIndex(base, "/"); idx >= 0 {
+			base = base[idx+1:]
+		}
+		if base == "." || base == ".." {
+			continue
+		}
+		e.Name = base
+		filtered = append(filtered, e)
+	}
+	return amika.SandboxLsResult{Entries: filtered}, nil
+}
+
+// SandboxCat reads file contents from a sandbox.
+func (s *Service) SandboxCat(_ context.Context, req amika.SandboxCatRequest) (amika.SandboxCatResult, error) {
+	if req.Name == "" {
+		return amika.SandboxCatResult{}, fmt.Errorf("%w: sandbox name is required", amika.ErrInvalidArgument)
+	}
+	if req.Path == "" {
+		return amika.SandboxCatResult{}, fmt.Errorf("%w: path is required", amika.ErrInvalidArgument)
+	}
+	if _, err := s.deps.Sandboxes.Get(req.Name); err != nil {
+		return amika.SandboxCatResult{}, fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, req.Name)
+	}
+	maxBytes := req.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = 10 * 1024 * 1024
+	}
+	limit := maxBytes + 1
+	out, err := s.deps.Docker.ExecInContainer(req.Name, []string{
+		"head", "-c", strconv.FormatInt(limit, 10), req.Path,
+	})
+	if err != nil {
+		return amika.SandboxCatResult{}, mapDockerErr(err, req.Name, req.Path)
+	}
+	if int64(len(out)) > maxBytes {
+		return amika.SandboxCatResult{}, fmt.Errorf("%w: file exceeds %dMB limit; use 'sandbox cp' instead", amika.ErrInvalidArgument, maxBytes/(1024*1024))
+	}
+	return amika.SandboxCatResult{Content: out, Truncated: false}, nil
+}
+
+// SandboxRm removes files inside a sandbox.
+func (s *Service) SandboxRm(_ context.Context, req amika.SandboxRmRequest) (amika.SandboxRmResult, error) {
+	if req.Name == "" {
+		return amika.SandboxRmResult{}, fmt.Errorf("%w: sandbox name is required", amika.ErrInvalidArgument)
+	}
+	if req.Path == "" {
+		return amika.SandboxRmResult{}, fmt.Errorf("%w: path is required", amika.ErrInvalidArgument)
+	}
+	if _, err := s.deps.Sandboxes.Get(req.Name); err != nil {
+		return amika.SandboxRmResult{}, fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, req.Name)
+	}
+	rmArgs := []string{"rm"}
+	if req.Recursive {
+		rmArgs = append(rmArgs, "-r")
+	}
+	if req.Force {
+		rmArgs = append(rmArgs, "-f")
+	}
+	rmArgs = append(rmArgs, req.Path)
+	if _, err := s.deps.Docker.ExecInContainer(req.Name, rmArgs); err != nil {
+		return amika.SandboxRmResult{}, mapDockerErr(err, req.Name, req.Path)
+	}
+	return amika.SandboxRmResult{}, nil
+}
+
+// SandboxStat returns file metadata from a sandbox.
+func (s *Service) SandboxStat(_ context.Context, req amika.SandboxStatRequest) (amika.SandboxStatResult, error) {
+	if req.Name == "" {
+		return amika.SandboxStatResult{}, fmt.Errorf("%w: sandbox name is required", amika.ErrInvalidArgument)
+	}
+	if req.Path == "" {
+		return amika.SandboxStatResult{}, fmt.Errorf("%w: path is required", amika.ErrInvalidArgument)
+	}
+	if _, err := s.deps.Sandboxes.Get(req.Name); err != nil {
+		return amika.SandboxStatResult{}, fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, req.Name)
+	}
+	out, err := s.deps.Docker.ExecInContainer(req.Name, []string{
+		"stat", "-c", "%n|%s|%a|%Y|%F", req.Path,
+	})
+	if err != nil {
+		return amika.SandboxStatResult{}, mapDockerErr(err, req.Name, req.Path)
+	}
+	entries := amika.ParseStatOutput(out)
+	if len(entries) == 0 {
+		return amika.SandboxStatResult{}, fmt.Errorf("%w: path %q not found in sandbox %q", amika.ErrNotFound, req.Path, req.Name)
+	}
+	return amika.SandboxStatResult{Info: entries[0]}, nil
+}
+
+// mapDockerErr maps Docker error messages to typed sentinel errors.
+func mapDockerErr(err error, sandboxName, path string) error {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "not found"):
+		if strings.Contains(msg, "container") {
+			return fmt.Errorf("%w: sandbox %q", amika.ErrNotFound, sandboxName)
+		}
+		return fmt.Errorf("%w: path %q not found in sandbox %q", amika.ErrNotFound, path, sandboxName)
+	case strings.Contains(msg, "not running"):
+		return fmt.Errorf("%w: sandbox %q is not running", amika.ErrInvalidArgument, sandboxName)
+	case strings.Contains(msg, "permission denied"):
+		return fmt.Errorf("%w: permission denied: %q in sandbox %q", amika.ErrInternal, path, sandboxName)
+	default:
+		return fmt.Errorf("%w: %v", amika.ErrDependency, err)
+	}
 }
 
 // ExtractAuth extracts auth env assignment lines.

--- a/internal/app/service_impl_test.go
+++ b/internal/app/service_impl_test.go
@@ -15,10 +15,12 @@ type stubDocker struct{}
 func (stubDocker) CreateSandbox(string, string, []ports.Mount, []string, []ports.PortBinding) (string, error) {
 	return "container-123", nil
 }
-func (stubDocker) RemoveSandbox(string) error               { return nil }
-func (stubDocker) CreateVolume(string) error                { return nil }
-func (stubDocker) RemoveVolume(string) error                { return nil }
-func (stubDocker) CopyHostDirToVolume(string, string) error { return nil }
+func (stubDocker) RemoveSandbox(string) error                       { return nil }
+func (stubDocker) CreateVolume(string) error                        { return nil }
+func (stubDocker) RemoveVolume(string) error                        { return nil }
+func (stubDocker) CopyHostDirToVolume(string, string) error         { return nil }
+func (stubDocker) CopyFromContainer(string, string, string) error   { return nil }
+func (stubDocker) ExecInContainer(string, []string) (string, error) { return "", nil }
 
 type stubSandboxStore struct{}
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -29,6 +29,11 @@ func NewHandler(service amika.Service) http.Handler {
 	registerAuthExtract(api, service)
 	registerMaterialize(api, service)
 	registerListServices(api, service)
+	registerSandboxCp(api, service)
+	registerSandboxLs(api, service)
+	registerSandboxCat(api, service)
+	registerSandboxRm(api, service)
+	registerSandboxStat(api, service)
 	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.OpenAPI())
@@ -158,6 +163,119 @@ func registerListServices(api huma.API, service amika.Service) {
 			return nil, toHTTPError(err)
 		}
 		return &listServicesOutput{Body: result}, nil
+	})
+}
+
+type sandboxCpInput struct {
+	Name string `path:"name"`
+	Body struct {
+		ContainerPath string `json:"containerPath"`
+		HostPath      string `json:"hostPath"`
+	}
+}
+type sandboxCpOutput struct{ Body amika.CopyFromSandboxResult }
+
+func registerSandboxCp(api huma.API, service amika.Service) {
+	huma.Post(api, "/v1/sandboxes/{name}/cp", func(ctx context.Context, input *sandboxCpInput) (*sandboxCpOutput, error) {
+		result, err := service.CopyFromSandbox(ctx, amika.CopyFromSandboxRequest{
+			Name:          input.Name,
+			ContainerPath: input.Body.ContainerPath,
+			HostPath:      input.Body.HostPath,
+		})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &sandboxCpOutput{Body: result}, nil
+	})
+}
+
+type sandboxLsInput struct {
+	Name string `path:"name"`
+	Body struct {
+		Path string `json:"path"`
+	}
+}
+type sandboxLsOutput struct{ Body amika.SandboxLsResult }
+
+func registerSandboxLs(api huma.API, service amika.Service) {
+	huma.Post(api, "/v1/sandboxes/{name}/ls", func(ctx context.Context, input *sandboxLsInput) (*sandboxLsOutput, error) {
+		result, err := service.SandboxLs(ctx, amika.SandboxLsRequest{
+			Name: input.Name,
+			Path: input.Body.Path,
+		})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &sandboxLsOutput{Body: result}, nil
+	})
+}
+
+type sandboxCatInput struct {
+	Name string `path:"name"`
+	Body struct {
+		Path     string `json:"path"`
+		MaxBytes int64  `json:"maxBytes,omitempty"`
+	}
+}
+type sandboxCatOutput struct{ Body amika.SandboxCatResult }
+
+func registerSandboxCat(api huma.API, service amika.Service) {
+	huma.Post(api, "/v1/sandboxes/{name}/cat", func(ctx context.Context, input *sandboxCatInput) (*sandboxCatOutput, error) {
+		result, err := service.SandboxCat(ctx, amika.SandboxCatRequest{
+			Name:     input.Name,
+			Path:     input.Body.Path,
+			MaxBytes: input.Body.MaxBytes,
+		})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &sandboxCatOutput{Body: result}, nil
+	})
+}
+
+type sandboxRmInput struct {
+	Name string `path:"name"`
+	Body struct {
+		Path      string `json:"path"`
+		Recursive bool   `json:"recursive,omitempty"`
+		Force     bool   `json:"force,omitempty"`
+	}
+}
+type sandboxRmOutput struct{ Body amika.SandboxRmResult }
+
+func registerSandboxRm(api huma.API, service amika.Service) {
+	huma.Post(api, "/v1/sandboxes/{name}/rm", func(ctx context.Context, input *sandboxRmInput) (*sandboxRmOutput, error) {
+		result, err := service.SandboxRm(ctx, amika.SandboxRmRequest{
+			Name:      input.Name,
+			Path:      input.Body.Path,
+			Recursive: input.Body.Recursive,
+			Force:     input.Body.Force,
+		})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &sandboxRmOutput{Body: result}, nil
+	})
+}
+
+type sandboxStatInput struct {
+	Name string `path:"name"`
+	Body struct {
+		Path string `json:"path"`
+	}
+}
+type sandboxStatOutput struct{ Body amika.SandboxStatResult }
+
+func registerSandboxStat(api huma.API, service amika.Service) {
+	huma.Post(api, "/v1/sandboxes/{name}/stat", func(ctx context.Context, input *sandboxStatInput) (*sandboxStatOutput, error) {
+		result, err := service.SandboxStat(ctx, amika.SandboxStatRequest{
+			Name: input.Name,
+			Path: input.Body.Path,
+		})
+		if err != nil {
+			return nil, toHTTPError(err)
+		}
+		return &sandboxStatOutput{Body: result}, nil
 	})
 }
 

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -40,6 +40,21 @@ func (stubService) ExtractAuth(context.Context, amika.AuthExtractRequest) (amika
 func (stubService) ListServices(context.Context, amika.ListServicesRequest) (amika.ListServicesResult, error) {
 	return amika.ListServicesResult{}, nil
 }
+func (stubService) CopyFromSandbox(context.Context, amika.CopyFromSandboxRequest) (amika.CopyFromSandboxResult, error) {
+	return amika.CopyFromSandboxResult{}, amika.ErrUnimplemented
+}
+func (stubService) SandboxLs(context.Context, amika.SandboxLsRequest) (amika.SandboxLsResult, error) {
+	return amika.SandboxLsResult{}, amika.ErrUnimplemented
+}
+func (stubService) SandboxCat(context.Context, amika.SandboxCatRequest) (amika.SandboxCatResult, error) {
+	return amika.SandboxCatResult{}, amika.ErrUnimplemented
+}
+func (stubService) SandboxRm(context.Context, amika.SandboxRmRequest) (amika.SandboxRmResult, error) {
+	return amika.SandboxRmResult{}, amika.ErrUnimplemented
+}
+func (stubService) SandboxStat(context.Context, amika.SandboxStatRequest) (amika.SandboxStatResult, error) {
+	return amika.SandboxStatResult{}, amika.ErrUnimplemented
+}
 
 type captureCreateSandboxService struct {
 	stubService
@@ -98,7 +113,7 @@ func TestOpenAPIIncludesV1Paths(t *testing.T) {
 		t.Fatal(err)
 	}
 	paths := doc["paths"].(map[string]any)
-	for _, p := range []string{"/v1/sandboxes", "/v1/volumes", "/v1/auth/extract", "/v1/materialize"} {
+	for _, p := range []string{"/v1/sandboxes", "/v1/volumes", "/v1/auth/extract", "/v1/materialize", "/v1/sandboxes/{name}/cp", "/v1/sandboxes/{name}/ls", "/v1/sandboxes/{name}/cat", "/v1/sandboxes/{name}/rm", "/v1/sandboxes/{name}/stat"} {
 		if _, ok := paths[p]; !ok {
 			t.Fatalf("missing path %s", p)
 		}
@@ -184,5 +199,32 @@ func TestOpenAPICreateSandboxUsesPascalCaseSetupScriptFields(t *testing.T) {
 		if field == "SetupScript" || field == "SetupScriptText" {
 			t.Fatalf("field %v should not be required", field)
 		}
+	}
+}
+
+func TestFilesystemEndpoints(t *testing.T) {
+	h := NewHandler(stubService{})
+	cases := []struct {
+		name string
+		m, u string
+		body string
+		code int
+	}{
+		{"cp returns 501", http.MethodPost, "/v1/sandboxes/sb/cp", `{"containerPath":"/tmp","hostPath":"/local"}`, 501},
+		{"ls returns 501", http.MethodPost, "/v1/sandboxes/sb/ls", `{"path":"/tmp"}`, 501},
+		{"cat returns 501", http.MethodPost, "/v1/sandboxes/sb/cat", `{"path":"/tmp/f"}`, 501},
+		{"rm returns 501", http.MethodPost, "/v1/sandboxes/sb/rm", `{"path":"/tmp/f"}`, 501},
+		{"stat returns 501", http.MethodPost, "/v1/sandboxes/sb/stat", `{"path":"/tmp/f"}`, 501},
+		{"cp missing fields returns 422", http.MethodPost, "/v1/sandboxes/sb/cp", `{}`, 422},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.m, tc.u, bytes.NewReader([]byte(tc.body)))
+			res := httptest.NewRecorder()
+			h.ServeHTTP(res, req)
+			if res.Code != tc.code {
+				t.Fatalf("%s %s status=%d want=%d body=%s", tc.m, tc.u, res.Code, tc.code, res.Body.String())
+			}
+		})
 	}
 }

--- a/internal/ports/docker.go
+++ b/internal/ports/docker.go
@@ -25,4 +25,6 @@ type DockerClient interface {
 	CreateVolume(name string) error
 	RemoveVolume(name string) error
 	CopyHostDirToVolume(volumeName, hostDir string) error
+	CopyFromContainer(containerName, containerPath, hostPath string) error
+	ExecInContainer(containerName string, cmd []string) (string, error)
 }

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -190,6 +190,48 @@ func portPublishSpec(p PortBinding) string {
 	return fmt.Sprintf("%s:%d:%d/%s", hostIP, p.HostPort, p.ContainerPort, protocol)
 }
 
+// CopyFromContainer copies a file or directory from a Docker container to the
+// host filesystem using `docker cp`. Works on both running and stopped containers.
+func CopyFromContainer(containerName, containerPath, hostPath string) error {
+	cmd := exec.Command("docker", "cp", containerName+":"+containerPath, hostPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		stderr := strings.TrimSpace(string(out))
+		switch {
+		case strings.Contains(stderr, "No such container"):
+			return fmt.Errorf("container %q not found", containerName)
+		case strings.Contains(stderr, "Could not find the file"),
+			strings.Contains(stderr, "no such file or directory"):
+			return fmt.Errorf("path %q not found in container %q", containerPath, containerName)
+		default:
+			return fmt.Errorf("docker cp failed: %s", stderr)
+		}
+	}
+	return nil
+}
+
+// ExecInContainer runs a command inside a running Docker container and returns
+// the combined stdout/stderr output. Returns typed errors based on Docker stderr.
+func ExecInContainer(containerName string, cmdArgs []string) (string, error) {
+	args := append([]string{"exec", containerName}, cmdArgs...)
+	cmd := exec.Command("docker", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		stderr := strings.TrimSpace(string(out))
+		switch {
+		case strings.Contains(stderr, "No such container"),
+			strings.Contains(stderr, "is not running"):
+			return "", fmt.Errorf("container %q is not running", containerName)
+		case strings.Contains(stderr, "No such file or directory"),
+			strings.Contains(stderr, "cannot access"):
+			return "", fmt.Errorf("path not found in container %q: %s", containerName, stderr)
+		default:
+			return "", fmt.Errorf("docker exec failed: %s", stderr)
+		}
+	}
+	return string(out), nil
+}
+
 func mountVolumeSpec(m MountBinding) string {
 	var src string
 	if m.Type == "volume" {

--- a/pkg/amika/requests.go
+++ b/pkg/amika/requests.go
@@ -86,3 +86,37 @@ type AuthExtractRequest struct {
 type ListServicesRequest struct {
 	SandboxName string // optional filter
 }
+
+// CopyFromSandboxRequest describes copying files from a sandbox container to the host.
+type CopyFromSandboxRequest struct {
+	Name          string
+	ContainerPath string
+	HostPath      string
+}
+
+// SandboxLsRequest describes listing directory contents inside a sandbox.
+type SandboxLsRequest struct {
+	Name string
+	Path string
+}
+
+// SandboxCatRequest describes reading file contents from a sandbox.
+type SandboxCatRequest struct {
+	Name     string
+	Path     string
+	MaxBytes int64 // 0 = default 10MB
+}
+
+// SandboxRmRequest describes removing files inside a sandbox.
+type SandboxRmRequest struct {
+	Name      string
+	Path      string
+	Recursive bool
+	Force     bool
+}
+
+// SandboxStatRequest describes getting file metadata from a sandbox.
+type SandboxStatRequest struct {
+	Name string
+	Path string
+}

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -82,3 +82,34 @@ type DeleteVolumeResult struct {
 type AuthExtractResult struct {
 	Lines []string
 }
+
+// CopyFromSandboxResult reports sandbox file copy outcome.
+type CopyFromSandboxResult struct{}
+
+// SandboxLsResult reports directory listing from a sandbox.
+type SandboxLsResult struct {
+	Entries []SandboxFileInfo
+}
+
+// SandboxCatResult reports file contents from a sandbox.
+type SandboxCatResult struct {
+	Content   string
+	Truncated bool
+}
+
+// SandboxRmResult reports file removal from a sandbox.
+type SandboxRmResult struct{}
+
+// SandboxStatResult reports file metadata from a sandbox.
+type SandboxStatResult struct {
+	Info SandboxFileInfo
+}
+
+// SandboxFileInfo describes a file or directory inside a sandbox.
+type SandboxFileInfo struct {
+	Name    string `json:"Name"`
+	Size    int64  `json:"Size"`
+	Mode    string `json:"Mode"`
+	ModTime string `json:"ModTime"`
+	IsDir   bool   `json:"IsDir"`
+}

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -31,6 +31,11 @@ type Service interface {
 	DeleteVolume(ctx context.Context, req DeleteVolumeRequest) (DeleteVolumeResult, error)
 	ExtractAuth(ctx context.Context, req AuthExtractRequest) (AuthExtractResult, error)
 	ListServices(ctx context.Context, req ListServicesRequest) (ListServicesResult, error)
+	CopyFromSandbox(ctx context.Context, req CopyFromSandboxRequest) (CopyFromSandboxResult, error)
+	SandboxLs(ctx context.Context, req SandboxLsRequest) (SandboxLsResult, error)
+	SandboxCat(ctx context.Context, req SandboxCatRequest) (SandboxCatResult, error)
+	SandboxRm(ctx context.Context, req SandboxRmRequest) (SandboxRmResult, error)
+	SandboxStat(ctx context.Context, req SandboxStatRequest) (SandboxStatResult, error)
 }
 
 // Options controls construction of a public Amika service.
@@ -666,6 +671,21 @@ func (s *initErrorService) ExtractAuth(context.Context, AuthExtractRequest) (Aut
 }
 func (s *initErrorService) ListServices(context.Context, ListServicesRequest) (ListServicesResult, error) {
 	return ListServicesResult{}, s.err
+}
+func (s *initErrorService) CopyFromSandbox(context.Context, CopyFromSandboxRequest) (CopyFromSandboxResult, error) {
+	return CopyFromSandboxResult{}, s.err
+}
+func (s *initErrorService) SandboxLs(context.Context, SandboxLsRequest) (SandboxLsResult, error) {
+	return SandboxLsResult{}, s.err
+}
+func (s *initErrorService) SandboxCat(context.Context, SandboxCatRequest) (SandboxCatResult, error) {
+	return SandboxCatResult{}, s.err
+}
+func (s *initErrorService) SandboxRm(context.Context, SandboxRmRequest) (SandboxRmResult, error) {
+	return SandboxRmResult{}, s.err
+}
+func (s *initErrorService) SandboxStat(context.Context, SandboxStatRequest) (SandboxStatResult, error) {
+	return SandboxStatResult{}, s.err
 }
 
 func toMounts(in []sandbox.MountBinding) []Mount {

--- a/pkg/amika/service_filesystem.go
+++ b/pkg/amika/service_filesystem.go
@@ -1,0 +1,205 @@
+package amika
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofixpoint/amika/internal/sandbox"
+)
+
+const defaultMaxCatBytes int64 = 10 * 1024 * 1024 // 10MB
+
+// requireRunningSandbox looks up a sandbox by name and verifies its container
+// is in the "running" state. Returns the sandbox record or a typed error.
+func (s *serviceImpl) requireRunningSandbox(name string) (sandbox.Info, error) {
+	info, err := s.sandboxes.Get(name)
+	if err != nil {
+		return sandbox.Info{}, fmt.Errorf("%w: sandbox %q", ErrNotFound, name)
+	}
+	state, err := sandbox.GetDockerContainerState(name)
+	if err != nil {
+		return sandbox.Info{}, fmt.Errorf("%w: %v", ErrDependency, err)
+	}
+	if state != "running" {
+		return sandbox.Info{}, fmt.Errorf("%w: sandbox %q is not running; start it first or use 'sandbox cp'", ErrInvalidArgument, name)
+	}
+	return info, nil
+}
+
+func (s *serviceImpl) CopyFromSandbox(_ context.Context, req CopyFromSandboxRequest) (CopyFromSandboxResult, error) {
+	if req.Name == "" {
+		return CopyFromSandboxResult{}, fmt.Errorf("%w: sandbox name is required", ErrInvalidArgument)
+	}
+	if req.ContainerPath == "" {
+		return CopyFromSandboxResult{}, fmt.Errorf("%w: container path is required", ErrInvalidArgument)
+	}
+	if req.HostPath == "" {
+		return CopyFromSandboxResult{}, fmt.Errorf("%w: host path is required", ErrInvalidArgument)
+	}
+	if _, err := s.sandboxes.Get(req.Name); err != nil {
+		return CopyFromSandboxResult{}, fmt.Errorf("%w: sandbox %q", ErrNotFound, req.Name)
+	}
+	if err := sandbox.CopyFromContainer(req.Name, req.ContainerPath, req.HostPath); err != nil {
+		return CopyFromSandboxResult{}, mapDockerError(err, req.Name, req.ContainerPath)
+	}
+	return CopyFromSandboxResult{}, nil
+}
+
+func (s *serviceImpl) SandboxLs(_ context.Context, req SandboxLsRequest) (SandboxLsResult, error) {
+	if req.Name == "" {
+		return SandboxLsResult{}, fmt.Errorf("%w: sandbox name is required", ErrInvalidArgument)
+	}
+	if req.Path == "" {
+		return SandboxLsResult{}, fmt.Errorf("%w: path is required", ErrInvalidArgument)
+	}
+	if _, err := s.requireRunningSandbox(req.Name); err != nil {
+		return SandboxLsResult{}, err
+	}
+	// Use stat -c to get structured output for each entry
+	out, err := sandbox.ExecInContainer(req.Name, []string{
+		"sh", "-c", fmt.Sprintf("stat -c '%%n|%%s|%%a|%%Y|%%F' %s/* %s/.* 2>/dev/null || true", req.Path, req.Path),
+	})
+	if err != nil {
+		return SandboxLsResult{}, mapDockerError(err, req.Name, req.Path)
+	}
+	entries := ParseStatOutput(out)
+	// Filter out . and .. entries
+	filtered := make([]SandboxFileInfo, 0, len(entries))
+	for _, e := range entries {
+		base := e.Name
+		if idx := strings.LastIndex(base, "/"); idx >= 0 {
+			base = base[idx+1:]
+		}
+		if base == "." || base == ".." {
+			continue
+		}
+		e.Name = base
+		filtered = append(filtered, e)
+	}
+	return SandboxLsResult{Entries: filtered}, nil
+}
+
+func (s *serviceImpl) SandboxCat(_ context.Context, req SandboxCatRequest) (SandboxCatResult, error) {
+	if req.Name == "" {
+		return SandboxCatResult{}, fmt.Errorf("%w: sandbox name is required", ErrInvalidArgument)
+	}
+	if req.Path == "" {
+		return SandboxCatResult{}, fmt.Errorf("%w: path is required", ErrInvalidArgument)
+	}
+	if _, err := s.requireRunningSandbox(req.Name); err != nil {
+		return SandboxCatResult{}, err
+	}
+	maxBytes := req.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxCatBytes
+	}
+	// Use head -c to cap at maxBytes+1 to detect truncation
+	limit := maxBytes + 1
+	out, err := sandbox.ExecInContainer(req.Name, []string{
+		"head", "-c", strconv.FormatInt(limit, 10), req.Path,
+	})
+	if err != nil {
+		return SandboxCatResult{}, mapDockerError(err, req.Name, req.Path)
+	}
+	if int64(len(out)) > maxBytes {
+		return SandboxCatResult{}, fmt.Errorf("%w: file exceeds %dMB limit; use 'sandbox cp' instead", ErrInvalidArgument, maxBytes/(1024*1024))
+	}
+	return SandboxCatResult{Content: out, Truncated: false}, nil
+}
+
+func (s *serviceImpl) SandboxRm(_ context.Context, req SandboxRmRequest) (SandboxRmResult, error) {
+	if req.Name == "" {
+		return SandboxRmResult{}, fmt.Errorf("%w: sandbox name is required", ErrInvalidArgument)
+	}
+	if req.Path == "" {
+		return SandboxRmResult{}, fmt.Errorf("%w: path is required", ErrInvalidArgument)
+	}
+	if _, err := s.requireRunningSandbox(req.Name); err != nil {
+		return SandboxRmResult{}, err
+	}
+	rmArgs := []string{"rm"}
+	if req.Recursive {
+		rmArgs = append(rmArgs, "-r")
+	}
+	if req.Force {
+		rmArgs = append(rmArgs, "-f")
+	}
+	rmArgs = append(rmArgs, req.Path)
+	if _, err := sandbox.ExecInContainer(req.Name, rmArgs); err != nil {
+		return SandboxRmResult{}, mapDockerError(err, req.Name, req.Path)
+	}
+	return SandboxRmResult{}, nil
+}
+
+func (s *serviceImpl) SandboxStat(_ context.Context, req SandboxStatRequest) (SandboxStatResult, error) {
+	if req.Name == "" {
+		return SandboxStatResult{}, fmt.Errorf("%w: sandbox name is required", ErrInvalidArgument)
+	}
+	if req.Path == "" {
+		return SandboxStatResult{}, fmt.Errorf("%w: path is required", ErrInvalidArgument)
+	}
+	if _, err := s.requireRunningSandbox(req.Name); err != nil {
+		return SandboxStatResult{}, err
+	}
+	out, err := sandbox.ExecInContainer(req.Name, []string{
+		"stat", "-c", "%n|%s|%a|%Y|%F", req.Path,
+	})
+	if err != nil {
+		return SandboxStatResult{}, mapDockerError(err, req.Name, req.Path)
+	}
+	entries := ParseStatOutput(out)
+	if len(entries) == 0 {
+		return SandboxStatResult{}, fmt.Errorf("%w: path %q not found in sandbox %q", ErrNotFound, req.Path, req.Name)
+	}
+	return SandboxStatResult{Info: entries[0]}, nil
+}
+
+// ParseStatOutput parses lines of `stat -c '%n|%s|%a|%Y|%F'` output into SandboxFileInfo entries.
+func ParseStatOutput(output string) []SandboxFileInfo {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	entries := make([]SandboxFileInfo, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 5)
+		if len(parts) < 5 {
+			continue
+		}
+		size, _ := strconv.ParseInt(parts[1], 10, 64)
+		mtime, _ := strconv.ParseInt(parts[3], 10, 64)
+		modTime := time.Unix(mtime, 0).UTC().Format(time.RFC3339)
+		fileType := strings.TrimSpace(parts[4])
+		isDir := fileType == "directory"
+		entries = append(entries, SandboxFileInfo{
+			Name:    parts[0],
+			Size:    size,
+			Mode:    parts[2],
+			ModTime: modTime,
+			IsDir:   isDir,
+		})
+	}
+	return entries
+}
+
+// mapDockerError maps Docker error messages to typed sentinel errors.
+func mapDockerError(err error, sandboxName, path string) error {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "not found"):
+		if strings.Contains(msg, "container") {
+			return fmt.Errorf("%w: sandbox %q", ErrNotFound, sandboxName)
+		}
+		return fmt.Errorf("%w: path %q not found in sandbox %q", ErrNotFound, path, sandboxName)
+	case strings.Contains(msg, "not running"):
+		return fmt.Errorf("%w: sandbox %q is not running", ErrInvalidArgument, sandboxName)
+	case strings.Contains(msg, "permission denied"):
+		return fmt.Errorf("%w: permission denied: %q in sandbox %q", ErrInternal, path, sandboxName)
+	default:
+		return fmt.Errorf("%w: %v", ErrDependency, err)
+	}
+}

--- a/pkg/amika/service_filesystem_test.go
+++ b/pkg/amika/service_filesystem_test.go
@@ -1,0 +1,78 @@
+package amika
+
+import "testing"
+
+func TestParseStatOutput(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantLen int
+		check   func([]SandboxFileInfo) string // returns "" on success, error message on failure
+	}{
+		{
+			name:    "empty input",
+			input:   "",
+			wantLen: 0,
+		},
+		{
+			name:    "single file",
+			input:   "/tmp/test.txt|1024|644|1700000000|regular file\n",
+			wantLen: 1,
+			check: func(entries []SandboxFileInfo) string {
+				e := entries[0]
+				if e.Name != "/tmp/test.txt" {
+					return "Name = " + e.Name
+				}
+				if e.Size != 1024 {
+					return "Size mismatch"
+				}
+				if e.Mode != "644" {
+					return "Mode = " + e.Mode
+				}
+				if e.IsDir {
+					return "IsDir should be false"
+				}
+				return ""
+			},
+		},
+		{
+			name:    "directory entry",
+			input:   "/tmp/dir|4096|755|1700000000|directory\n",
+			wantLen: 1,
+			check: func(entries []SandboxFileInfo) string {
+				if !entries[0].IsDir {
+					return "IsDir should be true"
+				}
+				return ""
+			},
+		},
+		{
+			name:    "multiple entries",
+			input:   "/tmp/a|100|644|1700000000|regular file\n/tmp/b|200|755|1700000000|directory\n",
+			wantLen: 2,
+		},
+		{
+			name:    "skips malformed lines",
+			input:   "bad line\n/tmp/ok|100|644|1700000000|regular file\n",
+			wantLen: 1,
+		},
+		{
+			name:    "trims whitespace",
+			input:   "  /tmp/test|100|644|1700000000|regular file  \n",
+			wantLen: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := ParseStatOutput(tc.input)
+			if len(entries) != tc.wantLen {
+				t.Fatalf("len(entries) = %d, want %d", len(entries), tc.wantLen)
+			}
+			if tc.check != nil {
+				if msg := tc.check(entries); msg != "" {
+					t.Fatalf("check failed: %s", msg)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add 5 new CLI commands under 'sandbox' subcommand
- Add public API types (requests, responses, SandboxFileInfo)
- Add service implementations for both pkg/amika and internal/app
- Add HTTP API endpoints with Huma v2 handlers
- Add Docker CopyFromContainer and ExecInContainer operations
- Add ParseStatOutput shared utility for stat output parsing
- Add error mapping (mapDockerErr) for proper HTTP status codes
- Add unit tests for parseSandboxPath and ParseStatOutput

closes #155