### PR TITLE
Migrate CLI api client to /api/v0beta1 endpoints

### DIFF
--- a/cmd/amika/sandbox/sandbox_create.go
+++ b/cmd/amika/sandbox/sandbox_create.go
@@ -357,7 +357,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 	req := apiclient.CreateSandboxRequest{
 		Name:             name,
 		Provider:         "daytona",
-		GitHubURL:        gitURL,
+		RepoURL:          gitURL,
 		EnvVars:          envVars,
 		SecretEnvVars:    secretEnvVars,
 		Preset:           preset,

--- a/cmd/amika/sandbox/sandbox_create_credentials.go
+++ b/cmd/amika/sandbox/sandbox_create_credentials.go
@@ -2,7 +2,7 @@ package sandboxcmd
 
 // sandbox_create_credentials.go parses the --agent-credential,
 // --agent-credential-type, and --no-agent-credential flags into the
-// agent_credentials request body field accepted by POST /api/sandboxes.
+// agent_credentials request body field accepted by POST /api/v0beta1/sandboxes.
 
 import (
 	"fmt"

--- a/cmd/amika/secrets.go
+++ b/cmd/amika/secrets.go
@@ -420,7 +420,7 @@ type providerConfig struct {
 	// terse messages ("Claude", "Codex").
 	ShortName string
 	// APIPath is the provider segment of the API endpoint used to build
-	// /api/secrets/<APIPath>.
+	// /api/v0beta1/secrets/<APIPath>.
 	APIPath string
 	// PushLongHelp is the "Long" description for the push command.
 	PushLongHelp string

--- a/cmd/amika/secrets_test.go
+++ b/cmd/amika/secrets_test.go
@@ -612,15 +612,15 @@ func setupMockClaudeAPI(t *testing.T) []string {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "POST" && r.URL.Path == "/api/secrets/claude":
+		case r.Method == "POST" && r.URL.Path == "/api/v0beta1/secrets/claude":
 			json.NewEncoder(w).Encode(map[string]string{
 				"id":    "cred-test-123",
 				"name":  "Test",
 				"scope": "user",
 			})
-		case r.Method == "GET" && r.URL.Path == "/api/secrets/claude":
+		case r.Method == "GET" && r.URL.Path == "/api/v0beta1/secrets/claude":
 			json.NewEncoder(w).Encode([]interface{}{})
-		case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/api/secrets/"):
+		case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/api/v0beta1/secrets/"):
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			w.WriteHeader(http.StatusNotFound)

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+// apiBasePath is the URL prefix shared by all v0beta1 endpoints. The CLI
+// targets the versioned API surface; older unversioned paths are no longer
+// supported.
+const apiBasePath = "/api/v0beta1"
+
 // Client calls the remote Amika API with a bearer token.
 type Client struct {
 	BaseURL     string
@@ -33,11 +38,11 @@ func NewClientWithTokenSource(baseURL string, ts TokenSource) *Client {
 	}
 }
 
-// CreateSandboxRequest is the request body for POST /api/sandboxes.
+// CreateSandboxRequest is the request body for POST /api/v0beta1/sandboxes.
 type CreateSandboxRequest struct {
 	Name               string               `json:"name,omitempty"`
 	Provider           string               `json:"provider,omitempty"`
-	GitHubURL          string               `json:"github_url,omitempty"`
+	RepoURL            string               `json:"repo_url,omitempty"`
 	AutoStopInterval   *int                 `json:"auto_stop_interval,omitempty"`
 	AutoDeleteInterval *int                 `json:"auto_delete_interval,omitempty"`
 	EnvVars            map[string]string    `json:"env_vars,omitempty"`
@@ -77,7 +82,7 @@ type RemoteSandbox struct {
 	ID                       string                    `json:"id"`
 	Name                     string                    `json:"name"`
 	Provider                 string                    `json:"provider"`
-	GitHubURL                string                    `json:"github_url"`
+	RepoURL                  string                    `json:"repo_url"`
 	State                    string                    `json:"state"`
 	CreatedAt                string                    `json:"created_at"`
 	Branch                   string                    `json:"branch"`
@@ -88,7 +93,7 @@ type RemoteSandbox struct {
 // ListSandboxes fetches sandboxes from the remote API.
 func (c *Client) ListSandboxes() ([]RemoteSandbox, error) {
 	var result []RemoteSandbox
-	if err := c.doJSON("GET", "/api/sandboxes", nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/sandboxes", nil, &result); err != nil {
 		return nil, fmt.Errorf("remote list sandboxes: %w", err)
 	}
 	return result, nil
@@ -99,7 +104,7 @@ func (c *Client) ListSandboxes() ([]RemoteSandbox, error) {
 // Use GetSandbox or WaitForSandbox to poll until provisioning completes.
 func (c *Client) CreateSandbox(req CreateSandboxRequest) (*RemoteSandbox, error) {
 	var result RemoteSandbox
-	if err := c.doJSON("POST", "/api/sandboxes", req, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/sandboxes", req, &result); err != nil {
 		return nil, fmt.Errorf("remote create sandbox: %w", err)
 	}
 	return &result, nil
@@ -108,7 +113,7 @@ func (c *Client) CreateSandbox(req CreateSandboxRequest) (*RemoteSandbox, error)
 // GetSandbox fetches a single sandbox by name from the remote API.
 func (c *Client) GetSandbox(name string) (*RemoteSandbox, error) {
 	var result RemoteSandbox
-	if err := c.doJSON("GET", "/api/sandboxes/"+url.PathEscape(name), nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/sandboxes/"+url.PathEscape(name), nil, &result); err != nil {
 		return nil, fmt.Errorf("remote get sandbox: %w", err)
 	}
 	return &result, nil
@@ -154,13 +159,13 @@ type SSHInfo struct {
 // GetSSH retrieves SSH connection details for a remote sandbox.
 func (c *Client) GetSSH(name string) (*SSHInfo, error) {
 	var result SSHInfo
-	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(name)+"/ssh", nil, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/ssh", nil, &result); err != nil {
 		return nil, fmt.Errorf("remote ssh: %w", err)
 	}
 	return &result, nil
 }
 
-// RevokeSSHRequest is the request body for DELETE /api/sandboxes/{name}/ssh.
+// RevokeSSHRequest is the request body for DELETE /api/v0beta1/sandboxes/{id}/ssh.
 type RevokeSSHRequest struct {
 	Token string `json:"token"`
 }
@@ -168,7 +173,7 @@ type RevokeSSHRequest struct {
 // RevokeSSH revokes an SSH token for a remote sandbox.
 func (c *Client) RevokeSSH(name, token string) error {
 	req := RevokeSSHRequest{Token: token}
-	if err := c.doJSON("DELETE", "/api/sandboxes/"+url.PathEscape(name)+"/ssh", req, nil); err != nil {
+	if err := c.doJSON("DELETE", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/ssh", req, nil); err != nil {
 		return fmt.Errorf("remote revoke ssh: %w", err)
 	}
 	return nil
@@ -178,7 +183,7 @@ func (c *Client) RevokeSSH(name, token string) error {
 // The endpoint returns 202 Accepted with the sandbox in "initializing" state.
 // Use WaitForSandboxStart to poll until the sandbox is active.
 func (c *Client) StartSandbox(name string) error {
-	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(name)+"/start", nil, nil); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/start", nil, nil); err != nil {
 		return fmt.Errorf("remote start sandbox: %w", err)
 	}
 	return nil
@@ -194,7 +199,7 @@ func (c *Client) WaitForSandboxStart(name string) (*RemoteSandbox, error) {
 // The endpoint returns 202 Accepted with the sandbox in "stopping" state.
 // Use WaitForSandboxStop to poll until the sandbox is stopped.
 func (c *Client) StopSandbox(name string) error {
-	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(name)+"/stop", nil, nil); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/stop", nil, nil); err != nil {
 		return fmt.Errorf("remote stop sandbox: %w", err)
 	}
 	return nil
@@ -208,7 +213,7 @@ func (c *Client) WaitForSandboxStop(name string) (*RemoteSandbox, error) {
 
 // DeleteSandbox deletes a sandbox on the remote API.
 func (c *Client) DeleteSandbox(name string) error {
-	if err := c.doJSON("DELETE", "/api/sandboxes/"+url.PathEscape(name), nil, nil); err != nil {
+	if err := c.doJSON("DELETE", apiBasePath+"/sandboxes/"+url.PathEscape(name), nil, nil); err != nil {
 		return fmt.Errorf("remote delete sandbox: %w", err)
 	}
 	return nil
@@ -221,14 +226,14 @@ type Secret struct {
 	Scope string `json:"scope"`
 }
 
-// CreateSecretRequest is the request body for POST /api/secrets.
+// CreateSecretRequest is the request body for POST /api/v0beta1/secrets.
 type CreateSecretRequest struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 	Scope string `json:"scope"`
 }
 
-// UpdateSecretRequest is the request body for PUT /api/secrets/[id].
+// UpdateSecretRequest is the request body for PUT /api/v0beta1/secrets/[id].
 type UpdateSecretRequest struct {
 	Value string `json:"value"`
 }
@@ -236,7 +241,7 @@ type UpdateSecretRequest struct {
 // ListSecrets fetches user/org-scoped secrets from the remote API.
 func (c *Client) ListSecrets() ([]Secret, error) {
 	var result []Secret
-	if err := c.doJSON("GET", "/api/secrets", nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/secrets", nil, &result); err != nil {
 		return nil, fmt.Errorf("remote list secrets: %w", err)
 	}
 	return result, nil
@@ -244,7 +249,7 @@ func (c *Client) ListSecrets() ([]Secret, error) {
 
 // CreateSecret creates a new secret on the remote API.
 func (c *Client) CreateSecret(req CreateSecretRequest) error {
-	if err := c.doJSON("POST", "/api/secrets", req, nil); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/secrets", req, nil); err != nil {
 		return fmt.Errorf("remote create secret: %w", err)
 	}
 	return nil
@@ -252,14 +257,14 @@ func (c *Client) CreateSecret(req CreateSecretRequest) error {
 
 // UpdateSecret updates an existing secret on the remote API.
 func (c *Client) UpdateSecret(id string, req UpdateSecretRequest) error {
-	if err := c.doJSON("PUT", "/api/secrets/"+id, req, nil); err != nil {
+	if err := c.doJSON("PUT", apiBasePath+"/secrets/"+id, req, nil); err != nil {
 		return fmt.Errorf("remote update secret: %w", err)
 	}
 	return nil
 }
 
 // CreateProviderSecretRequest is the request body for
-// POST /api/secrets/<provider>. Shared by provider-scoped credential
+// POST /api/v0beta1/secrets/<provider>. Shared by provider-scoped credential
 // endpoints (e.g. Claude, Codex).
 type CreateProviderSecretRequest struct {
 	Name  string `json:"name"`
@@ -267,14 +272,14 @@ type CreateProviderSecretRequest struct {
 	Type  string `json:"type"` // "oauth" or "api_key" — required by the server
 }
 
-// ProviderSecretSummary is the response from POST /api/secrets/<provider>.
+// ProviderSecretSummary is the response from POST /api/v0beta1/secrets/<provider>.
 type ProviderSecretSummary struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Scope string `json:"scope"`
 }
 
-// ProviderSecretListItem is an item in the GET /api/secrets/<provider>
+// ProviderSecretListItem is an item in the GET /api/v0beta1/secrets/<provider>
 // response.
 type ProviderSecretListItem struct {
 	ID   string `json:"id"`
@@ -287,7 +292,7 @@ type ProviderSecretListItem struct {
 // ("claude", "codex").
 func (c *Client) CreateProviderSecret(provider string, req CreateProviderSecretRequest) (*ProviderSecretSummary, error) {
 	var result ProviderSecretSummary
-	if err := c.doJSON("POST", "/api/secrets/"+provider, req, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/secrets/"+provider, req, &result); err != nil {
 		return nil, fmt.Errorf("remote create %s secret: %w", provider, err)
 	}
 	return &result, nil
@@ -296,7 +301,7 @@ func (c *Client) CreateProviderSecret(provider string, req CreateProviderSecretR
 // ListProviderSecrets lists provider-scoped credentials for the current user.
 func (c *Client) ListProviderSecrets(provider string) ([]ProviderSecretListItem, error) {
 	var result []ProviderSecretListItem
-	if err := c.doJSON("GET", "/api/secrets/"+provider, nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/secrets/"+provider, nil, &result); err != nil {
 		return nil, fmt.Errorf("remote list %s secrets: %w", provider, err)
 	}
 	return result, nil
@@ -305,13 +310,13 @@ func (c *Client) ListProviderSecrets(provider string) ([]ProviderSecretListItem,
 // DeleteProviderSecret deletes a provider-scoped credential by ID. provider is
 // the URL segment ("claude", "codex").
 func (c *Client) DeleteProviderSecret(provider, id string) error {
-	if err := c.doJSON("DELETE", "/api/secrets/"+provider+"/"+id, nil, nil); err != nil {
+	if err := c.doJSON("DELETE", apiBasePath+"/secrets/"+provider+"/"+id, nil, nil); err != nil {
 		return fmt.Errorf("remote delete %s secret: %w", provider, err)
 	}
 	return nil
 }
 
-// AgentSendRequest is the request body for POST /api/sandboxes/{name}/agent-send.
+// AgentSendRequest is the request body for POST /api/v0beta1/sandboxes/{id}/agent-send.
 type AgentSendRequest struct {
 	Message    string `json:"message"`
 	NewSession bool   `json:"new_session,omitempty"`
@@ -319,7 +324,7 @@ type AgentSendRequest struct {
 	Agent      string `json:"agent,omitempty"`
 }
 
-// AgentSendResponse is the response from POST /api/sandboxes/{name}/agent-send.
+// AgentSendResponse is the response from POST /api/v0beta1/sandboxes/{id}/agent-send.
 type AgentSendResponse struct {
 	Result    string `json:"response"`
 	SessionID string `json:"session_id"`
@@ -335,7 +340,7 @@ func (c *Client) AgentSend(sandboxName string, req AgentSendRequest) (*AgentSend
 	defer func() { c.HTTP.Timeout = saved }()
 
 	var result AgentSendResponse
-	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/agent-send", req, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/agent-send", req, &result); err != nil {
 		if authErr := extractAgentAuthError(err); authErr != "" {
 			return nil, fmt.Errorf("remote agent-send: agent failed to authenticate with its AI provider: %s\n\nthe sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access", authErr)
 		}
@@ -358,23 +363,22 @@ type Session struct {
 	UpdatedAt string                 `json:"updated_at"`
 }
 
-// CreateSessionRequest is the request body for POST /api/sandboxes/{name}/sessions.
+// CreateSessionRequest is the request body for POST /api/v0beta1/sandboxes/{id}/sessions.
 type CreateSessionRequest struct {
 	AgentName string                 `json:"agent_name"`
 	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
 
-// UpdateSessionRequest is the request body for PATCH /api/sandboxes/{name}/sessions/{id}.
+// UpdateSessionRequest is the request body for PATCH /api/v0beta1/sandboxes/{id}/sessions/{sessionId}.
 type UpdateSessionRequest struct {
 	Status   string                 `json:"status,omitempty"`
-	EndedAt  string                 `json:"ended_at,omitempty"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // CreateSession creates a new agent session on a remote sandbox.
 func (c *Client) CreateSession(sandboxName string, req CreateSessionRequest) (*Session, error) {
 	var result Session
-	if err := c.doJSON("POST", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions", req, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions", req, &result); err != nil {
 		return nil, fmt.Errorf("remote create session: %w", err)
 	}
 	return &result, nil
@@ -382,18 +386,21 @@ func (c *Client) CreateSession(sandboxName string, req CreateSessionRequest) (*S
 
 // ListSessions lists agent sessions for a remote sandbox.
 func (c *Client) ListSessions(sandboxName string) ([]Session, error) {
-	var result []Session
-	if err := c.doJSON("GET", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions", nil, &result); err != nil {
+	var envelope struct {
+		Sessions []Session `json:"sessions"`
+		Total    int       `json:"total"`
+	}
+	if err := c.doJSON("GET", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions", nil, &envelope); err != nil {
 		return nil, fmt.Errorf("remote list sessions: %w", err)
 	}
-	return result, nil
+	return envelope.Sessions, nil
 }
 
 // GetLatestSession returns the most recent session for a remote sandbox.
 // Returns nil, nil if no session exists (HTTP 404).
 func (c *Client) GetLatestSession(sandboxName string) (*Session, error) {
 	var result Session
-	if err := c.doJSON("GET", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/latest", nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/latest", nil, &result); err != nil {
 		if strings.Contains(err.Error(), "HTTP 404") {
 			return nil, nil
 		}
@@ -405,7 +412,7 @@ func (c *Client) GetLatestSession(sandboxName string) (*Session, error) {
 // GetSession returns a specific session by ID.
 func (c *Client) GetSession(sandboxName, sessionID string) (*Session, error) {
 	var result Session
-	if err := c.doJSON("GET", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), nil, &result); err != nil {
 		return nil, fmt.Errorf("remote get session: %w", err)
 	}
 	return &result, nil
@@ -414,7 +421,7 @@ func (c *Client) GetSession(sandboxName, sessionID string) (*Session, error) {
 // UpdateSession updates a session on a remote sandbox.
 func (c *Client) UpdateSession(sandboxName, sessionID string, req UpdateSessionRequest) (*Session, error) {
 	var result Session
-	if err := c.doJSON("PATCH", "/api/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), req, &result); err != nil {
+	if err := c.doJSON("PATCH", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), req, &result); err != nil {
 		return nil, fmt.Errorf("remote update session: %w", err)
 	}
 	return &result, nil

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -20,43 +20,43 @@ func TestPathEscapesSandboxName(t *testing.T) {
 			name:       "GetSandbox with slash",
 			call:       func(c *Client) error { _, err := c.GetSandbox("org/proj"); return err },
 			wantMethod: "GET",
-			wantPath:   "/api/sandboxes/org%2Fproj",
+			wantPath:   "/api/v0beta1/sandboxes/org%2Fproj",
 		},
 		{
 			name:       "DeleteSandbox with slash",
 			call:       func(c *Client) error { return c.DeleteSandbox("org/proj") },
 			wantMethod: "DELETE",
-			wantPath:   "/api/sandboxes/org%2Fproj",
+			wantPath:   "/api/v0beta1/sandboxes/org%2Fproj",
 		},
 		{
 			name:       "StartSandbox with slash",
 			call:       func(c *Client) error { return c.StartSandbox("a/b") },
 			wantMethod: "POST",
-			wantPath:   "/api/sandboxes/a%2Fb/start",
+			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/start",
 		},
 		{
 			name:       "StopSandbox with slash",
 			call:       func(c *Client) error { return c.StopSandbox("a/b") },
 			wantMethod: "POST",
-			wantPath:   "/api/sandboxes/a%2Fb/stop",
+			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/stop",
 		},
 		{
 			name:       "GetSSH with slash",
 			call:       func(c *Client) error { _, err := c.GetSSH("a/b"); return err },
 			wantMethod: "POST",
-			wantPath:   "/api/sandboxes/a%2Fb/ssh",
+			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/ssh",
 		},
 		{
 			name:       "RevokeSSH with slash",
 			call:       func(c *Client) error { return c.RevokeSSH("a/b", "tok") },
 			wantMethod: "DELETE",
-			wantPath:   "/api/sandboxes/a%2Fb/ssh",
+			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/ssh",
 		},
 		{
 			name:       "ListSessions with slash",
 			call:       func(c *Client) error { _, err := c.ListSessions("a/b"); return err },
 			wantMethod: "GET",
-			wantPath:   "/api/sandboxes/a%2Fb/sessions",
+			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/sessions",
 		},
 		{
 			name: "AgentSend with slash",
@@ -65,13 +65,13 @@ func TestPathEscapesSandboxName(t *testing.T) {
 				return err
 			},
 			wantMethod: "POST",
-			wantPath:   "/api/sandboxes/a%2Fb/agent-send",
+			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/agent-send",
 		},
 		{
 			name:       "GetSandbox without slash",
 			call:       func(c *Client) error { _, err := c.GetSandbox("simple-name"); return err },
 			wantMethod: "GET",
-			wantPath:   "/api/sandboxes/simple-name",
+			wantPath:   "/api/v0beta1/sandboxes/simple-name",
 		},
 	}
 


### PR DESCRIPTION
Point all remote API calls at the versioned v0beta1 surface and update the request/response types to match the new schemas:

- Add apiBasePath constant; replace every "/api/..." path with "/api/v0beta1/...".
- Rename CreateSandboxRequest.GitHubURL and RemoteSandbox.GitHubURL to RepoURL (json: "repo_url") to match the new sandbox schema.
- Unwrap the new {sessions, total} envelope in ListSessions.
- Drop the unused EndedAt field from UpdateSessionRequest, which is no longer accepted by the server.
- Update mock servers and path-escaping tests to the new prefix.