### PR TITLE
Validate --size client-side on remote sandbox create

### DIFF
--- a/cmd/amika/sandbox/sandbox_create.go
+++ b/cmd/amika/sandbox/sandbox_create.go
@@ -272,6 +272,9 @@ func createRemoteSandbox(cmd *cobra.Command, target string) error {
 		return err
 	}
 	size, _ := cmd.Flags().GetString("size")
+	if err := sandbox.ValidateSize(size); err != nil {
+		return err
+	}
 	setupScript, _ := cmd.Flags().GetString("setup-script")
 	branch, _ := cmd.Flags().GetString("branch")
 	newBranch, _ := cmd.Flags().GetString("new-branch")

--- a/internal/sandbox/image_resolution.go
+++ b/internal/sandbox/image_resolution.go
@@ -15,6 +15,9 @@ const DefaultCoderImage = "amika/coder:latest"
 // AllowedPresets lists the preset names available for user selection via --preset.
 var AllowedPresets = []string{"coder", "coder-dind"}
 
+// AllowedSizes lists the size names available for user selection via --size.
+var AllowedSizes = []string{"xs", "m"}
+
 // ValidatePreset returns an error if preset is non-empty and not in AllowedPresets.
 func ValidatePreset(preset string) error {
 	if preset == "" {
@@ -26,6 +29,19 @@ func ValidatePreset(preset string) error {
 		}
 	}
 	return fmt.Errorf("unknown preset %q; allowed presets: %s", preset, strings.Join(AllowedPresets, ", "))
+}
+
+// ValidateSize returns an error if size is non-empty and not in AllowedSizes.
+func ValidateSize(size string) error {
+	if size == "" {
+		return nil
+	}
+	for _, s := range AllowedSizes {
+		if size == s {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown size %q; allowed sizes: %s", size, strings.Join(AllowedSizes, ", "))
 }
 
 // PresetImageOptions controls how image/preset resolution and auto-build work.


### PR DESCRIPTION
Reject unknown values for --size before hitting the API, mirroring how --preset is validated. Adds sandbox.ValidateSize / AllowedSizes alongside ValidatePreset / AllowedPresets.