### PR TITLE
Show repo in amika sandbox ls (KAPRO-304)

### DIFF
--- a/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -242,7 +242,7 @@ func repoNamesFromURL(repoURL string) []string {
 }
 
 func repoBasenameFromURL(repoURL string) string {
-	p := repoURL
+	p := strings.TrimRight(repoURL, "/")
 	if i := strings.LastIndex(p, "://"); i >= 0 {
 		p = p[i+3:]
 	}

--- a/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -202,6 +202,7 @@ var sandboxListCmd = &cobra.Command{
 					CreatedAt: rs.CreatedAt,
 					Location:  "remote",
 					Branch:    rs.Branch,
+					Repos:     repoNamesFromURL(rs.RepoURL),
 				})
 			}
 		}
@@ -212,13 +213,47 @@ var sandboxListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tPROVIDER\tIMAGE\tBRANCH\tPORTS\tCREATED")
+		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tPROVIDER\tIMAGE\tBRANCH\tREPO\tPORTS\tCREATED")
 		for _, sb := range allItems {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Provider, sb.Image, sb.Branch, formatPortBindings(sb.Ports), sb.CreatedAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Provider, sb.Image, sb.Branch, formatRepos(sb.Repos), formatPortBindings(sb.Ports), sb.CreatedAt)
 		}
 		w.Flush()
 		return nil
 	},
+}
+
+func formatRepos(repos []string) string {
+	if len(repos) == 0 {
+		return ""
+	}
+	return strings.Join(repos, ",")
+}
+
+func repoNamesFromURL(repoURL string) []string {
+	repoURL = strings.TrimSpace(repoURL)
+	if repoURL == "" {
+		return nil
+	}
+	name := repoBasenameFromURL(repoURL)
+	if name == "" {
+		return nil
+	}
+	return []string{name}
+}
+
+func repoBasenameFromURL(repoURL string) string {
+	p := repoURL
+	if i := strings.LastIndex(p, "://"); i >= 0 {
+		p = p[i+3:]
+	}
+	if i := strings.LastIndex(p, ":"); i >= 0 {
+		// SCP-style or URL with port; take what's after the last colon as path.
+		p = p[i+1:]
+	}
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		p = p[i+1:]
+	}
+	return strings.TrimSuffix(p, ".git")
 }
 
 var sandboxConnectCmd = &cobra.Command{

--- a/cmd/amika/sandbox/sandbox_list_repos_test.go
+++ b/cmd/amika/sandbox/sandbox_list_repos_test.go
@@ -1,0 +1,51 @@
+package sandboxcmd
+
+import "testing"
+
+func TestRepoBasenameFromURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"https://github.com/gofixpoint/amika.git", "amika"},
+		{"https://github.com/gofixpoint/amika", "amika"},
+		{"git@github.com:gofixpoint/amika.git", "amika"},
+		{"ssh://git@github.com/gofixpoint/amika.git", "amika"},
+		{"file:///srv/repos/amika.git", "amika"},
+	}
+	for _, tc := range cases {
+		got := repoBasenameFromURL(tc.in)
+		if got != tc.want {
+			t.Fatalf("repoBasenameFromURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRepoNamesFromURL(t *testing.T) {
+	if got := repoNamesFromURL(""); got != nil {
+		t.Fatalf("empty URL: got %v, want nil", got)
+	}
+	if got := repoNamesFromURL("   "); got != nil {
+		t.Fatalf("whitespace URL: got %v, want nil", got)
+	}
+	got := repoNamesFromURL("https://github.com/gofixpoint/amika.git")
+	if len(got) != 1 || got[0] != "amika" {
+		t.Fatalf("got %v, want [amika]", got)
+	}
+}
+
+func TestFormatRepos(t *testing.T) {
+	if got := formatRepos(nil); got != "" {
+		t.Fatalf("nil: got %q, want empty", got)
+	}
+	if got := formatRepos([]string{}); got != "" {
+		t.Fatalf("empty: got %q, want empty", got)
+	}
+	if got := formatRepos([]string{"amika"}); got != "amika" {
+		t.Fatalf("single: got %q, want amika", got)
+	}
+	if got := formatRepos([]string{"alpha", "beta"}); got != "alpha,beta" {
+		t.Fatalf("multi: got %q, want alpha,beta", got)
+	}
+}

--- a/cmd/amika/sandbox/sandbox_list_repos_test.go
+++ b/cmd/amika/sandbox/sandbox_list_repos_test.go
@@ -13,6 +13,9 @@ func TestRepoBasenameFromURL(t *testing.T) {
 		{"git@github.com:gofixpoint/amika.git", "amika"},
 		{"ssh://git@github.com/gofixpoint/amika.git", "amika"},
 		{"file:///srv/repos/amika.git", "amika"},
+		{"https://github.com/gofixpoint/amika.git/", "amika"},
+		{"https://github.com/gofixpoint/amika/", "amika"},
+		{"https://github.com/gofixpoint/amika.git///", "amika"},
 	}
 	for _, tc := range cases {
 		got := repoBasenameFromURL(tc.in)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -118,7 +118,9 @@ List all tracked sandboxes.
 amika sandbox list
 ```
 
-Output columns: `NAME`, `STATE`, `LOCATION`, `PROVIDER`, `IMAGE`, `BRANCH`, `PORTS`, `CREATED`.
+Output columns: `NAME`, `STATE`, `LOCATION`, `PROVIDER`, `IMAGE`, `BRANCH`, `REPO`, `PORTS`, `CREATED`.
+
+The `REPO` column lists the repositories mounted into the sandbox workspace (`/home/amika/workspace/<repo>`). For remote sandboxes it shows the repository name parsed from the sandbox's `repo_url`.
 
 ### `amika sandbox connect`
 

--- a/internal/app/service_impl.go
+++ b/internal/app/service_impl.go
@@ -88,6 +88,7 @@ func (s *Service) CreateSandbox(_ context.Context, req amika.CreateSandboxReques
 		return amika.Sandbox{}, fmt.Errorf("%w: %v", amika.ErrInternal, err)
 	}
 
+	publicMounts := toPublicMounts(rec.Mounts)
 	return amika.Sandbox{
 		Name:        rec.Name,
 		Provider:    rec.Provider,
@@ -95,7 +96,8 @@ func (s *Service) CreateSandbox(_ context.Context, req amika.CreateSandboxReques
 		Image:       rec.Image,
 		CreatedAt:   rec.CreatedAt,
 		Preset:      rec.Preset,
-		Mounts:      toPublicMounts(rec.Mounts),
+		Repos:       amika.ExtractRepoNamesFromMounts(publicMounts),
+		Mounts:      publicMounts,
 		Env:         rec.Env,
 		Ports:       toPublicPorts(rec.Ports),
 	}, nil
@@ -131,6 +133,7 @@ func (s *Service) ListSandboxes(context.Context, amika.ListSandboxesRequest) (am
 	}
 	items := make([]amika.Sandbox, 0, len(recs))
 	for _, rec := range recs {
+		publicMounts := toPublicMounts(rec.Mounts)
 		items = append(items, amika.Sandbox{
 			Name:        rec.Name,
 			Provider:    rec.Provider,
@@ -138,7 +141,8 @@ func (s *Service) ListSandboxes(context.Context, amika.ListSandboxesRequest) (am
 			Image:       rec.Image,
 			CreatedAt:   rec.CreatedAt,
 			Preset:      rec.Preset,
-			Mounts:      toPublicMounts(rec.Mounts),
+			Repos:       amika.ExtractRepoNamesFromMounts(publicMounts),
+			Mounts:      publicMounts,
 			Env:         rec.Env,
 			Ports:       toPublicPorts(rec.Ports),
 		})

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -11,6 +11,7 @@ type Sandbox struct {
 	Preset      string
 	Location    string // "local" or "remote"
 	Branch      string
+	Repos       []string
 	Mounts      []Mount
 	Env         []string
 	Ports       []PortBinding

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -688,10 +688,11 @@ func ExtractRepoNamesFromMounts(mounts []Mount) []string {
 	seen := make(map[string]bool, len(mounts))
 	var out []string
 	for _, m := range mounts {
-		if !strings.HasPrefix(m.Target, prefix) {
+		target := strings.TrimRight(m.Target, "/")
+		if !strings.HasPrefix(target, prefix) {
 			continue
 		}
-		rest := strings.TrimPrefix(m.Target, prefix)
+		rest := strings.TrimPrefix(target, prefix)
 		if rest == "" || strings.Contains(rest, "/") {
 			continue
 		}

--- a/pkg/amika/service.go
+++ b/pkg/amika/service.go
@@ -176,6 +176,7 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 	if err := s.sandboxes.Save(info); err != nil {
 		return Sandbox{}, fmt.Errorf("%w: %v", ErrInternal, err)
 	}
+	publicMounts := toMounts(info.Mounts)
 	return Sandbox{
 		Name:        info.Name,
 		Provider:    info.Provider,
@@ -184,7 +185,8 @@ func (s *serviceImpl) CreateSandbox(_ context.Context, req CreateSandboxRequest)
 		CreatedAt:   info.CreatedAt,
 		Preset:      info.Preset,
 		Branch:      info.Branch,
-		Mounts:      toMounts(info.Mounts),
+		Repos:       ExtractRepoNamesFromMounts(publicMounts),
+		Mounts:      publicMounts,
 		Env:         info.Env,
 		Ports:       toPortBindings(info.Ports),
 		Services:    toPublicServiceInfos(info.Services),
@@ -241,6 +243,7 @@ func (s *serviceImpl) ListSandboxes(context.Context, ListSandboxesRequest) (List
 	}
 	out := make([]Sandbox, 0, len(items))
 	for _, it := range items {
+		publicMounts := toMounts(it.Mounts)
 		out = append(out, Sandbox{
 			Name:        it.Name,
 			Provider:    it.Provider,
@@ -249,7 +252,8 @@ func (s *serviceImpl) ListSandboxes(context.Context, ListSandboxesRequest) (List
 			CreatedAt:   it.CreatedAt,
 			Preset:      it.Preset,
 			Branch:      it.Branch,
-			Mounts:      toMounts(it.Mounts),
+			Repos:       ExtractRepoNamesFromMounts(publicMounts),
+			Mounts:      publicMounts,
 			Env:         it.Env,
 			Ports:       toPortBindings(it.Ports),
 			Services:    toPublicServiceInfos(it.Services),
@@ -672,6 +676,30 @@ func toMounts(in []sandbox.MountBinding) []Mount {
 	out := make([]Mount, 0, len(in))
 	for _, m := range in {
 		out = append(out, Mount{Type: m.Type, Source: m.Source, Volume: m.Volume, Target: m.Target, Mode: m.Mode, SnapshotFrom: m.SnapshotFrom})
+	}
+	return out
+}
+
+// ExtractRepoNamesFromMounts returns the repository names mounted into the
+// sandbox workspace, derived from mount targets that are direct children of
+// the sandbox workspace root.
+func ExtractRepoNamesFromMounts(mounts []Mount) []string {
+	prefix := sandbox.SandboxWorkdir + "/"
+	seen := make(map[string]bool, len(mounts))
+	var out []string
+	for _, m := range mounts {
+		if !strings.HasPrefix(m.Target, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(m.Target, prefix)
+		if rest == "" || strings.Contains(rest, "/") {
+			continue
+		}
+		if seen[rest] {
+			continue
+		}
+		seen[rest] = true
+		out = append(out, rest)
 	}
 	return out
 }

--- a/pkg/amika/service_test.go
+++ b/pkg/amika/service_test.go
@@ -10,6 +10,73 @@ import (
 	"github.com/gofixpoint/amika/internal/sandbox"
 )
 
+func TestExtractRepoNamesFromMounts(t *testing.T) {
+	workdir := sandbox.SandboxWorkdir
+	cases := []struct {
+		name   string
+		mounts []Mount
+		want   []string
+	}{
+		{
+			name:   "no mounts",
+			mounts: nil,
+			want:   nil,
+		},
+		{
+			name: "git mount under workspace",
+			mounts: []Mount{
+				{Target: workdir + "/amika"},
+			},
+			want: []string{"amika"},
+		},
+		{
+			name: "ignores mounts outside workspace",
+			mounts: []Mount{
+				{Target: "/etc/foo"},
+				{Target: "/usr/local/bin"},
+			},
+			want: nil,
+		},
+		{
+			name: "ignores nested paths inside workspace",
+			mounts: []Mount{
+				{Target: workdir + "/amika/internal"},
+			},
+			want: nil,
+		},
+		{
+			name: "ignores duplicate repo names",
+			mounts: []Mount{
+				{Target: workdir + "/amika"},
+				{Target: workdir + "/amika"},
+			},
+			want: []string{"amika"},
+		},
+		{
+			name: "preserves order across multiple repos",
+			mounts: []Mount{
+				{Target: workdir + "/alpha"},
+				{Target: workdir + "/beta"},
+			},
+			want: []string{"alpha", "beta"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractRepoNamesFromMounts(tc.mounts)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
 func TestNewService_ReturnsService(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	svc := NewService(Options{})

--- a/pkg/amika/service_test.go
+++ b/pkg/amika/service_test.go
@@ -60,6 +60,13 @@ func TestExtractRepoNamesFromMounts(t *testing.T) {
 			},
 			want: []string{"alpha", "beta"},
 		},
+		{
+			name: "handles trailing slash on direct child mount",
+			mounts: []Mount{
+				{Target: workdir + "/amika/"},
+			},
+			want: []string{"amika"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- Adds a `REPO` column to `amika sandbox list` output so users can see which repository each sandbox is using.
- For local sandboxes the repo names are derived from mount targets under `/home/amika/workspace/`; for remote sandboxes the name is parsed from the API's `repo_url`.
- Exposes a new `Repos []string` field on `pkg/amika.Sandbox` and an `ExtractRepoNamesFromMounts` helper.

## Test plan
- [x] `make fmt vet lint build` (clean)
- [x] New unit tests: `TestExtractRepoNamesFromMounts`, `TestRepoBasenameFromURL`, `TestRepoNamesFromURL`, `TestFormatRepos`
- [ ] Manual: `amika sandbox create --git` then `amika sandbox list` shows REPO column populated
- [ ] Manual: `amika sandbox list` against a remote sandbox shows REPO column from `repo_url`

Linear: KAPRO-304