### PR TITLE
Show sandbox creator in amika sandbox list (KAPRO-319)

### DIFF
--- a/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/gofixpoint/amika/internal/apiclient"
 	"github.com/gofixpoint/amika/internal/config"
 	"github.com/gofixpoint/amika/internal/runmode"
 	"github.com/gofixpoint/amika/internal/sandbox"
@@ -203,6 +204,7 @@ var sandboxListCmd = &cobra.Command{
 					Location:  "remote",
 					Branch:    rs.Branch,
 					Repos:     repoNamesFromURL(rs.RepoURL),
+					CreatedBy: creatorFromRemote(rs.CreatedBy),
 				})
 			}
 		}
@@ -213,13 +215,40 @@ var sandboxListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tPROVIDER\tIMAGE\tBRANCH\tREPO\tPORTS\tCREATED")
+		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tPROVIDER\tIMAGE\tBRANCH\tREPO\tCREATED BY\tPORTS\tCREATED")
 		for _, sb := range allItems {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Provider, sb.Image, sb.Branch, formatRepos(sb.Repos), formatPortBindings(sb.Ports), sb.CreatedAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Provider, sb.Image, sb.Branch, formatRepos(sb.Repos), formatCreatedBy(sb.CreatedBy), formatPortBindings(sb.Ports), sb.CreatedAt)
 		}
 		w.Flush()
 		return nil
 	},
+}
+
+func creatorFromRemote(c *apiclient.RemoteSandboxCreator) *amika.SandboxCreator {
+	if c == nil {
+		return nil
+	}
+	out := &amika.SandboxCreator{}
+	if c.Name != nil {
+		out.Name = *c.Name
+	}
+	if c.Email != nil {
+		out.Email = *c.Email
+	}
+	return out
+}
+
+func formatCreatedBy(c *amika.SandboxCreator) string {
+	if c == nil {
+		return "-"
+	}
+	if c.Name != "" {
+		return c.Name
+	}
+	if c.Email != "" {
+		return c.Email
+	}
+	return "-"
 }
 
 func formatRepos(repos []string) string {

--- a/cmd/amika/sandbox/sandbox_list_repos_test.go
+++ b/cmd/amika/sandbox/sandbox_list_repos_test.go
@@ -1,6 +1,11 @@
 package sandboxcmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gofixpoint/amika/internal/apiclient"
+	"github.com/gofixpoint/amika/pkg/amika"
+)
 
 func TestRepoBasenameFromURL(t *testing.T) {
 	cases := []struct {
@@ -50,5 +55,52 @@ func TestFormatRepos(t *testing.T) {
 	}
 	if got := formatRepos([]string{"alpha", "beta"}); got != "alpha,beta" {
 		t.Fatalf("multi: got %q, want alpha,beta", got)
+	}
+}
+
+func TestFormatCreatedBy(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *amika.SandboxCreator
+		want string
+	}{
+		{"nil", nil, "-"},
+		{"empty struct", &amika.SandboxCreator{}, "-"},
+		{"name only", &amika.SandboxCreator{Name: "Ada Lovelace"}, "Ada Lovelace"},
+		{"email only", &amika.SandboxCreator{Email: "ada@example.com"}, "ada@example.com"},
+		{"name preferred over email", &amika.SandboxCreator{Name: "Ada", Email: "ada@example.com"}, "Ada"},
+	}
+	for _, tc := range cases {
+		if got := formatCreatedBy(tc.in); got != tc.want {
+			t.Fatalf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCreatorFromRemote(t *testing.T) {
+	if got := creatorFromRemote(nil); got != nil {
+		t.Fatalf("nil remote: got %+v, want nil", got)
+	}
+
+	got := creatorFromRemote(&apiclient.RemoteSandboxCreator{})
+	if got == nil {
+		t.Fatalf("empty remote: got nil, want non-nil")
+	}
+	if got.Name != "" || got.Email != "" {
+		t.Fatalf("empty remote: got %+v, want zero", got)
+	}
+
+	name := "Ada"
+	email := "ada@example.com"
+	got = creatorFromRemote(&apiclient.RemoteSandboxCreator{Name: &name, Email: &email})
+	if got == nil || got.Name != "Ada" || got.Email != "ada@example.com" {
+		t.Fatalf("populated remote: got %+v, want Ada/ada@example.com", got)
+	}
+
+	// Null name with present email — server returned the email but couldn't
+	// produce a display name. The struct should pass the email through.
+	got = creatorFromRemote(&apiclient.RemoteSandboxCreator{Name: nil, Email: &email})
+	if got == nil || got.Name != "" || got.Email != "ada@example.com" {
+		t.Fatalf("null name: got %+v, want empty name / email passthrough", got)
 	}
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -118,9 +118,11 @@ List all tracked sandboxes.
 amika sandbox list
 ```
 
-Output columns: `NAME`, `STATE`, `LOCATION`, `PROVIDER`, `IMAGE`, `BRANCH`, `REPO`, `PORTS`, `CREATED`.
+Output columns: `NAME`, `STATE`, `LOCATION`, `PROVIDER`, `IMAGE`, `BRANCH`, `REPO`, `CREATED BY`, `PORTS`, `CREATED`.
 
 The `REPO` column lists the repositories mounted into the sandbox workspace (`/home/amika/workspace/<repo>`). For remote sandboxes it shows the repository name parsed from the sandbox's `repo_url`.
+
+The `CREATED BY` column shows the human who created a remote sandbox (name, falling back to email). It is always `-` for local sandboxes and for remote sandboxes whose creator the server could not resolve (deleted user, API-key principal, or `noop` auth mode).
 
 ### `amika sandbox connect`
 

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -88,6 +88,15 @@ type RemoteSandbox struct {
 	Branch                   string                    `json:"branch"`
 	ErrorMessage             string                    `json:"error_message"`
 	ResolvedAgentCredentials []ResolvedAgentCredential `json:"resolved_agent_credentials,omitempty"`
+	CreatedBy                *RemoteSandboxCreator     `json:"created_by,omitempty"`
+}
+
+// RemoteSandboxCreator describes the human who created a remote sandbox, as
+// returned by the API. Either field may be null if the server could not
+// resolve the user (deleted account, API-key principal, or noop auth mode).
+type RemoteSandboxCreator struct {
+	Name  *string `json:"name"`
+	Email *string `json:"email"`
 }
 
 // ListSandboxes fetches sandboxes from the remote API.

--- a/pkg/amika/responses.go
+++ b/pkg/amika/responses.go
@@ -16,6 +16,15 @@ type Sandbox struct {
 	Env         []string
 	Ports       []PortBinding
 	Services    []ServiceInfo
+	CreatedBy   *SandboxCreator
+}
+
+// SandboxCreator identifies the human who created a sandbox. Populated only
+// for remote sandboxes; both fields may be empty when the server could not
+// resolve the creator (deleted user, API-key principal, or noop auth mode).
+type SandboxCreator struct {
+	Name  string
+	Email string
 }
 
 // ServiceInfo describes a named service running in a sandbox.


### PR DESCRIPTION
Add a CREATED BY column to `amika sandbox list` that surfaces the human who created a remote sandbox, mirroring the server-side change that exposes `created_by: {name, email}` on the sandbox list response.

For local sandboxes and for remote sandboxes whose creator the server could not resolve (deleted user, API-key principal, or noop auth mode), the column shows `-`.