### PR TITLE
Replace unusable session on amika auth login (KAPRO-321)

### DIFF
--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -47,6 +47,19 @@ managers in CI (for example: "vault kv get -field=key … | amika auth login --a
 			return fmt.Errorf("reading stored API key: %w", keyErr)
 		}
 
+		// A stored session that can't be refreshed is unusable —
+		// commands gate on GetValidSession, so they'll already be
+		// telling the user to log in. Refusing with "already have a
+		// session" would trap the user behind a mandatory `auth
+		// logout`. Treat an unusable session as absent so the login
+		// flow can replace it in-place.
+		if existingSession != nil {
+			if _, refreshErr := auth.GetValidSession(config.WorkOSClientID()); refreshErr != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "Stored session for %s is unusable (%v); replacing.\n", existingSession.Email, refreshErr)
+				existingSession = nil
+			}
+		}
+
 		// A corrupt credential file counts as "something stored" —
 		// point the user at `auth logout`, which tolerates parse errors.
 		if existingSession != nil || existingKey != nil || sessionCorrupt || keyCorrupt {

--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -47,16 +47,36 @@ managers in CI (for example: "vault kv get -field=key … | amika auth login --a
 			return fmt.Errorf("reading stored API key: %w", keyErr)
 		}
 
-		// A stored session inside the GetValidSession refresh window
-		// (≤ 60s to expiry) is what commands actually trip on when
-		// telling the user to log in: if refresh then fails they see
-		// "not logged in", and refusing here with "already have a
-		// session" would trap them behind a mandatory `auth logout`.
-		// Check locally only — no network call — so `--api-key-file`
-		// login stays reliably non-interactive even when offline.
-		if existingSession != nil && time.Until(existingSession.ExpiresAt) < 60*time.Second {
-			fmt.Fprintf(cmd.OutOrStdout(), "Stored session for %s has expired; replacing.\n", existingSession.Email)
-			existingSession = nil
+		// --api-key-file is local-only by design (it pairs with secret
+		// managers in CI). Sessions don't conflict with stored API
+		// keys — defaultAuthChecker resolves API keys ahead of
+		// sessions — so neither valid nor stale sessions need to gate
+		// this path. Refusing only on existing API-key state keeps
+		// the path reliably non-interactive: no network, no session
+		// validation.
+		if apiKeyFile != "" {
+			if existingKey != nil || keyCorrupt {
+				who := "an API key"
+				if keyCorrupt {
+					who = "an unreadable API key file"
+				}
+				return fmt.Errorf("already have %s stored, run `amika auth logout` first", who)
+			}
+			return loginWithAPIKeyFile(cmd, apiKeyFile)
+		}
+
+		// Device-flow path. If GetValidSession (the same gate commands
+		// use) succeeds, the user is still effectively logged in and
+		// re-authenticating would be wasted work — refuse. If it
+		// fails, the user is stuck: commands say "not logged in" but
+		// the literal "already have a session" message would trap
+		// them behind a mandatory `auth logout`. Treat the session as
+		// absent so login can replace it in-place.
+		if existingSession != nil {
+			if _, refreshErr := auth.GetValidSession(config.WorkOSClientID()); refreshErr != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "Stored session for %s is unusable (%v); replacing.\n", existingSession.Email, refreshErr)
+				existingSession = nil
+			}
 		}
 
 		// A corrupt credential file counts as "something stored" —
@@ -74,10 +94,6 @@ managers in CI (for example: "vault kv get -field=key … | amika auth login --a
 				who = "an API key"
 			}
 			return fmt.Errorf("already have %s stored, run `amika auth logout` first", who)
-		}
-
-		if apiKeyFile != "" {
-			return loginWithAPIKeyFile(cmd, apiKeyFile)
 		}
 
 		session, err := auth.DeviceLogin(config.WorkOSClientID())

--- a/cmd/amika/auth.go
+++ b/cmd/amika/auth.go
@@ -47,17 +47,16 @@ managers in CI (for example: "vault kv get -field=key … | amika auth login --a
 			return fmt.Errorf("reading stored API key: %w", keyErr)
 		}
 
-		// A stored session that can't be refreshed is unusable —
-		// commands gate on GetValidSession, so they'll already be
-		// telling the user to log in. Refusing with "already have a
-		// session" would trap the user behind a mandatory `auth
-		// logout`. Treat an unusable session as absent so the login
-		// flow can replace it in-place.
-		if existingSession != nil {
-			if _, refreshErr := auth.GetValidSession(config.WorkOSClientID()); refreshErr != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Stored session for %s is unusable (%v); replacing.\n", existingSession.Email, refreshErr)
-				existingSession = nil
-			}
+		// A stored session inside the GetValidSession refresh window
+		// (≤ 60s to expiry) is what commands actually trip on when
+		// telling the user to log in: if refresh then fails they see
+		// "not logged in", and refusing here with "already have a
+		// session" would trap them behind a mandatory `auth logout`.
+		// Check locally only — no network call — so `--api-key-file`
+		// login stays reliably non-interactive even when offline.
+		if existingSession != nil && time.Until(existingSession.ExpiresAt) < 60*time.Second {
+			fmt.Fprintf(cmd.OutOrStdout(), "Stored session for %s has expired; replacing.\n", existingSession.Email)
+			existingSession = nil
 		}
 
 		// A corrupt credential file counts as "something stored" —

--- a/cmd/amika/auth_test.go
+++ b/cmd/amika/auth_test.go
@@ -63,12 +63,15 @@ func TestAuthLogin_RefusesWhenAlreadyLoggedIn(t *testing.T) {
 	}
 }
 
-func TestAuthLogin_RefusesWhenSessionStillValid(t *testing.T) {
+func TestAuthLogin_APIKeyFileIgnoresStoredSession(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	t.Setenv("AMIKA_API_KEY", "")
 
-	// Session expiring well past the 60s refresh window — GetValidSession
-	// returns it without a network call, so login must refuse.
+	// A stored session — valid or not — must not block API-key login.
+	// defaultAuthChecker resolves API keys ahead of sessions, so they
+	// never conflict; and this path is documented to stay reliably
+	// non-interactive (no network, no session validation), which is
+	// load-bearing for CI/offline recovery.
 	if err := auth.SaveSession(auth.WorkOSSession{
 		AccessToken: "tok",
 		Email:       "user@example.com",
@@ -83,46 +86,8 @@ func TestAuthLogin_RefusesWhenSessionStillValid(t *testing.T) {
 	}
 
 	out, err := runRootCommand("auth", "login", "--api-key-file", keyPath)
-	if err == nil {
-		t.Fatalf("expected refusal, got output %q", out)
-	}
-	if !strings.Contains(err.Error(), "already have") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(err.Error(), "user@example.com") {
-		t.Fatalf("error should name the stored session: %v", err)
-	}
-}
-
-func TestAuthLogin_ReplacesStaleSession(t *testing.T) {
-	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
-	t.Setenv("AMIKA_API_KEY", "")
-
-	// Session with an already-elapsed expiry — commands would say
-	// "not logged in" after a failed refresh, so login must proceed
-	// instead of trapping the user behind a mandatory `auth logout`.
-	// The staleness check is local-only: no network call, no override
-	// of the WorkOS URL needed.
-	if err := auth.SaveSession(auth.WorkOSSession{
-		AccessToken:  "stale",
-		RefreshToken: "stale-refresh",
-		Email:        "stale@example.com",
-		ExpiresAt:    time.Now().Add(-time.Hour),
-	}); err != nil {
-		t.Fatalf("SaveSession: %v", err)
-	}
-
-	keyPath := filepath.Join(t.TempDir(), "key")
-	if err := os.WriteFile(keyPath, []byte("sk_recovered\n"), 0600); err != nil {
-		t.Fatalf("write key: %v", err)
-	}
-
-	out, err := runRootCommand("auth", "login", "--api-key-file", keyPath)
 	if err != nil {
-		t.Fatalf("login should proceed past stale session: %v (out=%q)", err, out)
-	}
-	if !strings.Contains(out, "Stored session for stale@example.com has expired") {
-		t.Fatalf("missing replacement notice: %q", out)
+		t.Fatalf("api-key login should ignore stored session: %v (out=%q)", err, out)
 	}
 	if !strings.Contains(out, "Stored API key") {
 		t.Fatalf("login did not store the new API key: %q", out)
@@ -132,7 +97,7 @@ func TestAuthLogin_ReplacesStaleSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadAPIKey: %v", err)
 	}
-	if loaded == nil || loaded.Key != "sk_recovered" {
+	if loaded == nil || loaded.Key != "sk_new" {
 		t.Fatalf("api key not stored: %+v", loaded)
 	}
 }

--- a/cmd/amika/auth_test.go
+++ b/cmd/amika/auth_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,6 +62,86 @@ func TestAuthLogin_RefusesWhenAlreadyLoggedIn(t *testing.T) {
 	loaded, _ := auth.LoadAPIKey()
 	if loaded == nil || loaded.Key != "existing" {
 		t.Fatalf("stored key should be unchanged: %+v", loaded)
+	}
+}
+
+func TestAuthLogin_RefusesWhenSessionStillValid(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	// Session expiring well past the 60s refresh window — GetValidSession
+	// returns it without a network call, so login must refuse.
+	if err := auth.SaveSession(auth.WorkOSSession{
+		AccessToken: "tok",
+		Email:       "user@example.com",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_new\n"), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "login", "--api-key-file", keyPath)
+	if err == nil {
+		t.Fatalf("expected refusal, got output %q", out)
+	}
+	if !strings.Contains(err.Error(), "already have") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "user@example.com") {
+		t.Fatalf("error should name the stored session: %v", err)
+	}
+}
+
+func TestAuthLogin_ReplacesStaleSession(t *testing.T) {
+	// Refresh server that always rejects — simulates an expired or
+	// revoked refresh token. Login must then proceed instead of trapping
+	// the user behind a mandatory `auth logout`.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	restore := auth.SetWorkOSAuthenticateURLForTesting(srv.URL)
+	defer restore()
+
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	// Session with an already-elapsed expiry forces a refresh attempt.
+	if err := auth.SaveSession(auth.WorkOSSession{
+		AccessToken:  "stale",
+		RefreshToken: "stale-refresh",
+		Email:        "stale@example.com",
+		ExpiresAt:    time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_recovered\n"), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	out, err := runRootCommand("auth", "login", "--api-key-file", keyPath)
+	if err != nil {
+		t.Fatalf("login should proceed past stale session: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "Stored session for stale@example.com is unusable") {
+		t.Fatalf("missing replacement notice: %q", out)
+	}
+	if !strings.Contains(out, "Stored API key") {
+		t.Fatalf("login did not store the new API key: %q", out)
+	}
+
+	loaded, err := auth.LoadAPIKey()
+	if err != nil {
+		t.Fatalf("LoadAPIKey: %v", err)
+	}
+	if loaded == nil || loaded.Key != "sk_recovered" {
+		t.Fatalf("api key not stored: %+v", loaded)
 	}
 }
 

--- a/cmd/amika/auth_test.go
+++ b/cmd/amika/auth_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,20 +95,14 @@ func TestAuthLogin_RefusesWhenSessionStillValid(t *testing.T) {
 }
 
 func TestAuthLogin_ReplacesStaleSession(t *testing.T) {
-	// Refresh server that always rejects — simulates an expired or
-	// revoked refresh token. Login must then proceed instead of trapping
-	// the user behind a mandatory `auth logout`.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, `{"error":"invalid_grant"}`, http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-	restore := auth.SetWorkOSAuthenticateURLForTesting(srv.URL)
-	defer restore()
-
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	t.Setenv("AMIKA_API_KEY", "")
 
-	// Session with an already-elapsed expiry forces a refresh attempt.
+	// Session with an already-elapsed expiry — commands would say
+	// "not logged in" after a failed refresh, so login must proceed
+	// instead of trapping the user behind a mandatory `auth logout`.
+	// The staleness check is local-only: no network call, no override
+	// of the WorkOS URL needed.
 	if err := auth.SaveSession(auth.WorkOSSession{
 		AccessToken:  "stale",
 		RefreshToken: "stale-refresh",
@@ -129,7 +121,7 @@ func TestAuthLogin_ReplacesStaleSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("login should proceed past stale session: %v (out=%q)", err, out)
 	}
-	if !strings.Contains(out, "Stored session for stale@example.com is unusable") {
+	if !strings.Contains(out, "Stored session for stale@example.com has expired") {
 		t.Fatalf("missing replacement notice: %q", out)
 	}
 	if !strings.Contains(out, "Stored API key") {

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -9,7 +9,19 @@ import (
 	"strings"
 )
 
-const workosAuthenticateURL = "https://api.workos.com/user_management/authenticate"
+// workosAuthenticateURL is the WorkOS endpoint used for both refresh-token
+// exchange and device-authorization polling. It is a var (not a const) so
+// tests can point it at a local httptest server.
+var workosAuthenticateURL = "https://api.workos.com/user_management/authenticate"
+
+// SetWorkOSAuthenticateURLForTesting overrides the WorkOS authenticate URL
+// and returns a function that restores the previous value. Intended only
+// for use in cross-package tests.
+func SetWorkOSAuthenticateURLForTesting(url string) func() {
+	prev := workosAuthenticateURL
+	workosAuthenticateURL = url
+	return func() { workosAuthenticateURL = prev }
+}
 
 // RefreshAccessToken exchanges a refresh token for a new access token via WorkOS.
 func RefreshAccessToken(clientID, refreshToken string) (*WorkOSSession, error) {

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -9,19 +9,7 @@ import (
 	"strings"
 )
 
-// workosAuthenticateURL is the WorkOS endpoint used for both refresh-token
-// exchange and device-authorization polling. It is a var (not a const) so
-// tests can point it at a local httptest server.
-var workosAuthenticateURL = "https://api.workos.com/user_management/authenticate"
-
-// SetWorkOSAuthenticateURLForTesting overrides the WorkOS authenticate URL
-// and returns a function that restores the previous value. Intended only
-// for use in cross-package tests.
-func SetWorkOSAuthenticateURLForTesting(url string) func() {
-	prev := workosAuthenticateURL
-	workosAuthenticateURL = url
-	return func() { workosAuthenticateURL = prev }
-}
+const workosAuthenticateURL = "https://api.workos.com/user_management/authenticate"
 
 // RefreshAccessToken exchanges a refresh token for a new access token via WorkOS.
 func RefreshAccessToken(clientID, refreshToken string) (*WorkOSSession, error) {


### PR DESCRIPTION
## Summary
- `amika auth login` now matches the auth check commands use (`GetValidSession`) instead of `LoadSession`. If the stored session can't be refreshed, login replaces it in place instead of refusing with "already have a session, run auth logout first".
- Valid (or refreshable) sessions still block login as before — only stale/unusable sessions are auto-replaced.

## Why
Commands gate on `GetValidSession` (refresh-aware); `auth login` gated on `LoadSession` (file-existence only). That mismatch trapped users with a revoked or expired refresh token: commands said "not logged in", but login said "already logged in". The only way out was a manual `auth logout`.

Linear: [KAPRO-321](https://linear.app/fixpoint/issue/KAPRO-321/fix-loginlogout-bug-on-amika)

## Test plan
- [x] `go test ./cmd/amika/ -run TestAuthLogin` — all six cases pass, including new `TestAuthLogin_RefusesWhenSessionStillValid` and `TestAuthLogin_ReplacesStaleSession`.
- [x] `make fmt`, `make vet`, `make lint`, `make build` clean.
- [ ] Manual: with a stale session file (refresh token revoked server-side), `amika auth login` now proceeds and replaces the session instead of redirecting to `auth logout`.