### PR TITLE
Mirror start.sh log alongside setup.sh in run-hook

### DIFF
--- a/internal/sandbox/pre_setup_test.go
+++ b/internal/sandbox/pre_setup_test.go
@@ -98,7 +98,7 @@ func TestPresetPreSetup_OpenCodeGatingContract(t *testing.T) {
 	}
 }
 
-func TestPresetRunHook_UsesAmikaOnlyForSetupAndMirrorsItToAmikad(t *testing.T) {
+func TestPresetRunHook_UsesAmikaForUserHooksAndMirrorsThemToAmikad(t *testing.T) {
 	data, err := presetFS.ReadFile("presets/run-hook.sh")
 	if err != nil {
 		t.Fatalf("ReadFile failed: %v", err)
@@ -108,8 +108,8 @@ func TestPresetRunHook_UsesAmikaOnlyForSetupAndMirrorsItToAmikad(t *testing.T) {
 	for _, want := range []string{
 		`daemon_log_dir="/var/log/amikad"`,
 		`daemon_log_file="$daemon_log_dir/${script_name%.sh}.log"`,
-		`if [[ "$script_name" == "setup.sh" ]]; then`,
-		`log_file="/var/log/amika/setup.log"`,
+		`if [[ "$script_name" == "setup.sh" || "$script_name" == "start.sh" ]]; then`,
+		`log_file="/var/log/amika/${script_name%.sh}.log"`,
 		`mirror_to_daemon=1`,
 		`exec >>"$log_file" 2>&1`,
 		`sudo cp "$log_file" "$daemon_log_file"`,

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -42,17 +42,20 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Default no-op setup script; users can shadow it via --setup-script.
-# This is the user-facing middle hook in the lifecycle:
+# Default no-op user-facing hooks; callers can shadow them via
+# --setup-script / --start-script or by uploading their own.
+# Lifecycle order:
 # 1. /usr/lib/amikad/pre-setup.sh
 # 2. /usr/local/etc/amikad/setup/setup.sh
-# 3. /usr/lib/amikad/post-setup.sh
-# We put setup.sh inside a setup/ directory so a whole setup volume can be
-# mounted there, and we use /usr/local/etc instead of /etc because some
-# sandbox providers ban mounting to /etc.
+# 3. /usr/local/etc/amikad/setup/start.sh
+# 4. /usr/lib/amikad/post-setup.sh
+# We put the user-facing hooks inside a setup/ directory so a whole setup
+# volume can be mounted there, and we use /usr/local/etc instead of /etc
+# because some sandbox providers ban mounting to /etc.
 RUN mkdir -p /usr/local/etc/amikad/setup \
     && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/setup.sh \
-    && chmod +x /usr/local/etc/amikad/setup/setup.sh
+    && printf '#!/bin/bash\nexit 0\n' > /usr/local/etc/amikad/setup/start.sh \
+    && chmod +x /usr/local/etc/amikad/setup/setup.sh /usr/local/etc/amikad/setup/start.sh
 
 # amikad is for the daemon; amika is for user-managed Amika files.
 RUN mkdir -p \

--- a/internal/sandbox/presets/claude/Dockerfile
+++ b/internal/sandbox/presets/claude/Dockerfile
@@ -5,8 +5,14 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# Install pnpm, TypeScript, and Claude Code CLI.
-RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code
+# Install pnpm, TypeScript, and Claude Code CLI. Some packages' postinstall
+# scripts write into /home/amika (e.g. creating /home/amika/.config) while
+# running as root, which leaves those paths root-owned and breaks
+# user-facing hooks that try to write under ~/.config. Reset ownership
+# before switching users so the image is consistent regardless of
+# postinstall behavior.
+RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code \
+    && chown -R amika:amika /home/amika
 
 USER amika
 

--- a/internal/sandbox/presets/coder-dind/Dockerfile
+++ b/internal/sandbox/presets/coder-dind/Dockerfile
@@ -5,8 +5,13 @@ FROM ${DIND_IMAGE}
 
 USER root
 
-# Install coding agent CLIs.
-RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai
+# Install coding agent CLIs. Some packages' postinstall scripts write into
+# /home/amika (e.g. creating /home/amika/.config) while running as root,
+# which leaves those paths root-owned and breaks user-facing hooks that try
+# to write under ~/.config. Reset ownership before switching users so the
+# image is consistent regardless of postinstall behavior.
+RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai \
+    && chown -R amika:amika /home/amika
 
 USER amika
 

--- a/internal/sandbox/presets/coder/Dockerfile
+++ b/internal/sandbox/presets/coder/Dockerfile
@@ -5,8 +5,13 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# Install coding agent CLIs.
-RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai
+# Install coding agent CLIs. Some packages' postinstall scripts write into
+# /home/amika (e.g. creating /home/amika/.config) while running as root,
+# which leaves those paths root-owned and breaks user-facing hooks that try
+# to write under ~/.config. Reset ownership before switching users so the
+# image is consistent regardless of postinstall behavior.
+RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai \
+    && chown -R amika:amika /home/amika
 
 USER amika
 

--- a/internal/sandbox/presets/run-hook.sh
+++ b/internal/sandbox/presets/run-hook.sh
@@ -42,8 +42,8 @@ if [[ -f /usr/local/etc/amikad/setup/env.sh ]]; then
   source /usr/local/etc/amikad/setup/env.sh
 fi
 
-# Change to the agent working directory for the user-facing setup hook only.
-if [[ "$script_name" == "setup.sh" ]]; then
+# Change to the agent working directory for user-facing hooks only.
+if [[ "$script_name" == "setup.sh" || "$script_name" == "start.sh" ]]; then
   _amika_cwd_file="/var/lib/amikad/agent-cwd"
   if [[ -f "$_amika_cwd_file" ]]; then
     cd "$(cat "$_amika_cwd_file")"

--- a/internal/sandbox/presets/run-hook.sh
+++ b/internal/sandbox/presets/run-hook.sh
@@ -2,10 +2,10 @@
 
 # run-hook.sh is the stable entrypoint for all setup lifecycle hooks.
 # It executes one hook script and injects a Bash ERR trap via BASH_ENV so
-# command failures are written to the same log. setup.sh logs to
-# /var/log/amika/setup.log so the amika user can write it, then mirrors the
-# finished file to /var/log/amikad/setup.log. Root-owned hooks log directly to
-# /var/log/amikad.
+# command failures are written to the same log. User-facing hooks (setup.sh,
+# start.sh) log to /var/log/amika/<hook>.log so the amika user can write them,
+# then mirror the finished file to /var/log/amikad/<hook>.log. Root-owned
+# hooks log directly to /var/log/amikad.
 
 set -Eeuo pipefail
 
@@ -21,8 +21,8 @@ daemon_log_file="$daemon_log_dir/${script_name%.sh}.log"
 log_file="$daemon_log_file"
 mirror_to_daemon=0
 
-if [[ "$script_name" == "setup.sh" ]]; then
-  log_file="/var/log/amika/setup.log"
+if [[ "$script_name" == "setup.sh" || "$script_name" == "start.sh" ]]; then
+  log_file="/var/log/amika/${script_name%.sh}.log"
   mirror_to_daemon=1
 fi
 


### PR DESCRIPTION
## Summary
- Extend `run-hook.sh` to treat `start.sh` like `setup.sh`: log to `/var/log/amika/start.log` (writable by the `amika` user) and mirror to `/var/log/amikad/start.log` when the hook finishes.
- Parameterize the log path off `${script_name%.sh}` so the user-facing branch handles both hooks without duplication.
- Update `TestPresetRunHook_*` to assert the broadened condition and parameterized path; rename to `…ForUserHooksAndMirrorsThemToAmikad`.

## Why
The control plane reads `/var/log/amikad/setup.log` to surface setup-script failures back to the user. A `start.sh` hook is materialized at `/usr/local/etc/amikad/setup/start.sh` (see `SANDBOX_START_SCRIPT` in `amika-mono`), and it needs the same log treatment so failures during the start phase can be surfaced the same way.

## Test plan
- [x] `make fmt`, `make vet`, `make test-unit` clean.
- [x] `go test ./internal/sandbox -run TestPresetRunHook -v` passes.
- [ ] Manual: invoke `run-hook.sh /usr/local/etc/amikad/setup/start.sh` inside a built image; confirm `/var/log/amika/start.log` is created and mirrored to `/var/log/amikad/start.log`.