### PR TITLE
Add amika version subcommand and simplify version output

### DIFF
--- a/cmd/amika-server/main_test.go
+++ b/cmd/amika-server/main_test.go
@@ -75,7 +75,7 @@ func TestRunVersion(t *testing.T) {
 	}
 
 	got := buf.String()
-	if !strings.Contains(got, "amika-server version v1.2.3-rc.1") {
+	if !strings.Contains(got, "version: v1.2.3-rc.1") {
 		t.Fatalf("run() output = %q, want version line", got)
 	}
 	if !strings.Contains(got, "commit: ") {

--- a/cmd/amika/main.go
+++ b/cmd/amika/main.go
@@ -21,6 +21,14 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.Version = versionString()
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			fmt.Fprintln(cmd.OutOrStdout(), versionString())
+		},
+	})
 }
 
 func versionString() string {

--- a/cmd/amika/main_test.go
+++ b/cmd/amika/main_test.go
@@ -21,10 +21,35 @@ func TestRootVersionFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runRootCommand() error = %v", err)
 	}
-	if !strings.Contains(output, "amika version v2.0.0-beta.1") {
+	if !strings.Contains(output, "version: v2.0.0-beta.1") {
 		t.Fatalf("runRootCommand() output = %q, want version line", output)
 	}
 	if !strings.Contains(output, "commit: ") {
 		t.Fatalf("runRootCommand() output = %q, want commit line", output)
+	}
+}
+
+func TestVersionSubcommand(t *testing.T) {
+	originalVersion := buildmeta.AmikaVersion
+	t.Cleanup(func() {
+		buildmeta.AmikaVersion = originalVersion
+		rootCmd.Version = versionString()
+	})
+
+	buildmeta.AmikaVersion = buildmeta.MustParseSemVer("v2.0.0-beta.1")
+	rootCmd.Version = versionString()
+
+	output, err := runRootCommand("version")
+	if err != nil {
+		t.Fatalf("runRootCommand() error = %v", err)
+	}
+	if !strings.Contains(output, "version: v2.0.0-beta.1") {
+		t.Fatalf("runRootCommand() output = %q, want version line", output)
+	}
+	if !strings.Contains(output, "commit: ") {
+		t.Fatalf("runRootCommand() output = %q, want commit line", output)
+	}
+	if !strings.Contains(output, "date: ") {
+		t.Fatalf("runRootCommand() output = %q, want date line", output)
 	}
 }

--- a/internal/buildmeta/buildmeta.go
+++ b/internal/buildmeta/buildmeta.go
@@ -124,5 +124,5 @@ func New(component string, version SemVer) Info {
 
 // String renders the build metadata for human-readable CLI output.
 func (i Info) String() string {
-	return fmt.Sprintf("%s version %s\ncommit: %s\ndate: %s", i.Component, i.Version, i.Commit, i.Date)
+	return fmt.Sprintf("version: %s\ncommit: %s\ndate: %s", i.Version, i.Commit, i.Date)
 }

--- a/internal/buildmeta/buildmeta_test.go
+++ b/internal/buildmeta/buildmeta_test.go
@@ -34,7 +34,7 @@ func TestInfoString(t *testing.T) {
 	}
 
 	got := info.String()
-	want := "amika-server version v1.2.3-rc.1\ncommit: abcdef123456\ndate: 2026-03-17T12:00:00Z"
+	want := "version: v1.2.3-rc.1\ncommit: abcdef123456\ndate: 2026-03-17T12:00:00Z"
 	if got != want {
 		t.Fatalf("info.String() = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- Add an `amika version` subcommand that prints the same build metadata as `amika --version`.
- Simplify the version output format to drop the component name. Output is now:

  ```
  version: ${version}
  commit: ${commit}
  date: ${date}
  ```

- `amika-server --version` uses the same format for consistency.