### PR TITLE
Install ncurses-term in base image for Alacritty terminfo (KAPRO-336)

### DIFF
--- a/internal/sandbox/presets/.bashrc
+++ b/internal/sandbox/presets/.bashrc
@@ -1,4 +1,4 @@
-# Only set TERM if not already set by tmux or a capable terminal like Ghostty.
+# Only set TERM if not already set by tmux or a capable terminal like Ghostty or Alacritty.
 if [ -z "$TMUX" ] && [ "$TERM" = "linux" -o "$TERM" = "dumb" ]; then
   export TERM=xterm-256color
 fi

--- a/internal/sandbox/presets/.zshrc
+++ b/internal/sandbox/presets/.zshrc
@@ -1,4 +1,4 @@
-# Only set TERM if not already set by tmux or a capable terminal like Ghostty.
+# Only set TERM if not already set by tmux or a capable terminal like Ghostty or Alacritty.
 if [ -z "$TMUX" ] && [ "$TERM" = "linux" -o "$TERM" = "dumb" ]; then
   export TERM=xterm-256color
 fi

--- a/internal/sandbox/presets/base/Dockerfile
+++ b/internal/sandbox/presets/base/Dockerfile
@@ -18,9 +18,12 @@ RUN apt-get update && apt-get install -y \
     vim \
     nano \
     tmux \
+    ncurses-term \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Ghostty terminfo so SSH sessions from Ghostty render correctly.
+# (Alacritty, kitty, foot, etc. come from the ncurses-term package above;
+# Ghostty isn't in ncurses-term on Ubuntu 24.04, so we vendor it.)
 # Source vendored from ghostty-org/ghostty src/terminfo/ghostty.zig.
 COPY ghostty.terminfo /tmp/ghostty.terminfo
 RUN tic -x -o /usr/share/terminfo /tmp/ghostty.terminfo \


### PR DESCRIPTION
Ubuntu 24.04's `ncurses-term` ships `alacritty`/`alacritty-direct` (and kitty, foot, etc.) but not ghostty, so we still vendor `ghostty.terminfo`.

Fixes [KAPRO-336](https://linear.app/fixpoint/issue/KAPRO-336/support-alacritty-terminal-similar-to-ghostty).

## How I tested

Docker wasn't available in my workspace, so I verified against the actual `.deb` that `apt-get install ncurses-term` resolves to on noble (`ncurses-term_6.4+20240113-1ubuntu2_all.deb` from `archive.ubuntu.com`):

1. Extracted the `.deb` and confirmed it ships `/usr/share/terminfo/a/alacritty`, `alacritty+common`, `alacritty-direct` — and no ghostty entries (so the vendored `ghostty.terminfo` step stays).
2. Started a detached tmux session with `TERMINFO_DIRS` pointed at the extracted dir and `TERM=alacritty`, then ran:
   - `infocmp alacritty` → real "alacritty terminal emulator" entry
   - `tput colors` → `256`
   - `tput setaf 1/2/4` → emitted correct color escapes
   - `tput clear` → 11-byte escape sequence (capability present)
3. Negative control with `TERMINFO_DIRS=` reproduced the KAPRO-336 symptom exactly: `tput: unknown terminal "alacritty"`, `zsh: can't find terminal definition for alacritty`, `infocmp: couldn't open terminfo file`.

Worth a quick post-merge sanity check on a freshly-rebuilt preset image:

```
docker run --rm amika/base infocmp alacritty | head -3
```