### PR TITLE
Revert "Bump "medium" disk size: 10GB -> 16GB (#201)"

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -32,7 +32,7 @@ VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 SIZES=("xs" "m")
 SIZE_CPUS=("1" "2")
 SIZE_MEMORY=("1" "8")
-SIZE_DISK=("3" "16")
+SIZE_DISK=("3" "10")
 
 VALID_IMAGES="amika/base, amika/coder, amika/claude, amika/daytona-coder, amika/daytona-claude, amika/dind, amika/coder-dind, amika/daytona-coder-dind, all"
 


### PR DESCRIPTION
This reverts commit 4978172f9fd12f28737af90a251d343c0c6ef115.

Daytona has a default max storage of 10 GB.