### PR TITLE
Add "l" and "xl" sandbox sizes

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -29,10 +29,10 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
 # Daytona snapshot size configurations (parallel arrays for Bash 3 compat)
-SIZES=("xs" "m")
-SIZE_CPUS=("1" "2")
-SIZE_MEMORY=("1" "8")
-SIZE_DISK=("3" "10")
+SIZES=("xs" "m" "l" "xl")
+SIZE_CPUS=("1" "2" "2" "4")
+SIZE_MEMORY=("1" "8" "12" "16")
+SIZE_DISK=("3" "10" "18" "24")
 
 VALID_IMAGES="amika/base, amika/coder, amika/claude, amika/daytona-coder, amika/daytona-claude, amika/dind, amika/coder-dind, amika/daytona-coder-dind, all"
 

--- a/cmd/amika/sandbox/command.go
+++ b/cmd/amika/sandbox/command.go
@@ -43,7 +43,7 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().String("git", "", "Mount a git repo into the sandbox. Accepts a local path or a git URL (HTTPS, SSH). If omitted and the cwd is in a git repo, that repo is used automatically.")
 	sandboxCreateCmd.Flags().Bool("no-git", false, "Skip git repo auto-detection; create a sandbox without mounting any repo.")
 	sandboxCreateCmd.Flags().Bool("no-clean", false, "With a local-path git source, include untracked files from the working tree instead of a clean clone. Local sandboxes only.")
-	sandboxCreateCmd.Flags().String("size", "", "Sandbox size: \"xs\" or \"m\" (default \"m\", remote only)")
+	sandboxCreateCmd.Flags().String("size", "", "Sandbox size: \"xs\", \"m\", \"l\", or \"xl\" (default \"m\", remote only)")
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().StringArray("secret", nil, "Inject a remote secret (env:FOO=SECRET_NAME or env:SECRET_NAME)")
 	sandboxCreateCmd.Flags().StringArray("agent-credential", nil, "Pin an agent credential by name (KIND=NAME, e.g. claude=personal-oauth). Repeatable per kind.")

--- a/internal/sandbox/image_resolution.go
+++ b/internal/sandbox/image_resolution.go
@@ -16,7 +16,7 @@ const DefaultCoderImage = "amika/coder:latest"
 var AllowedPresets = []string{"coder", "coder-dind"}
 
 // AllowedSizes lists the size names available for user selection via --size.
-var AllowedSizes = []string{"xs", "m"}
+var AllowedSizes = []string{"xs", "m", "l", "xl"}
 
 // ValidatePreset returns an error if preset is non-empty and not in AllowedPresets.
 func ValidatePreset(preset string) error {


### PR DESCRIPTION
## Summary
- Add `"l"` and `"xl"` to `AllowedSizes` and update the `--size` CLI flag help text
- Add `l`/`xl` rows to `bin/build-docker-images` so Daytona snapshots are built with the new sizes:
  - `l`: 2 vCPU, 12GB mem, 18GB disk
  - `xl`: 4 vCPU, 16GB mem, 24GB disk

Pairs with the matching change in amika-mono.

## Test plan
- [x] `bin/build-docker-images --push-daytona` builds and pushes `l` and `xl` snapshots with the expected CPU/mem/disk