### PR TITLE
Skip pushing "l" and "xl" snapshots to staging Daytona org

### DIFF
--- a/.github/workflows/build-daytona-snapshots.yml
+++ b/.github/workflows/build-daytona-snapshots.yml
@@ -1,8 +1,9 @@
 name: Build Daytona Snapshots
 
 # Manually builds the Daytona Coder snapshot images and pushes them to the
-# amika-prod and Fixpoint Daytona orgs. Runs `bin/build-docker-images`
-# against a chosen git ref (defaults to main HEAD).
+# amika-prod and Fixpoint Daytona orgs. The "l" and "xl" sizes only go to
+# amika-prod since the Fixpoint (staging) org has lower resource limits.
+# Runs `bin/build-docker-images` against a chosen git ref (defaults to main HEAD).
 #
 # Auth: each Daytona org has its own API key. DAYTONA_PROD_API_KEY is used
 # for amika-prod and DAYTONA_STAGING_API_KEY for Fixpoint. Both secrets

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -28,11 +28,15 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Determine git version tag
 VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
-# Daytona snapshot size configurations (parallel arrays for Bash 3 compat)
+# Daytona snapshot size configurations (parallel arrays for Bash 3 compat).
+# SIZE_ORGS limits which Daytona orgs each size is pushed to. The Fixpoint
+# (staging) org doesn't have high enough resource limits for the larger
+# sizes, so "l" and "xl" only go to amika-prod.
 SIZES=("xs" "m" "l" "xl")
 SIZE_CPUS=("1" "2" "2" "4")
 SIZE_MEMORY=("1" "8" "12" "16")
 SIZE_DISK=("3" "10" "18" "24")
+SIZE_ORGS=("amika-prod Fixpoint" "amika-prod Fixpoint" "amika-prod" "amika-prod")
 
 VALID_IMAGES="amika/base, amika/coder, amika/claude, amika/daytona-coder, amika/daytona-claude, amika/dind, amika/coder-dind, amika/daytona-coder-dind, all"
 
@@ -208,7 +212,7 @@ for preset in "${PRESETS[@]}"; do
       mem="${SIZE_MEMORY[$i]}"
       disk="${SIZE_DISK[$i]}"
       snapshot_name="amika/${preset}-${size}:${VERSION}"
-      for org in amika-prod Fixpoint; do
+      for org in ${SIZE_ORGS[$i]}; do
         if [ "$CI_AUTH" = true ]; then
           case "$org" in
             amika-prod) api_key="$DAYTONA_PROD_API_KEY" ;;


### PR DESCRIPTION
The Fixpoint (staging) Daytona org doesn't have high enough resource limits for the "l" and "xl" sizes, so only push those to amika-prod.