### PR TITLE
Add npm publish workflow for TypeScript SDK

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -17,6 +17,8 @@ name: Create Release Tag
 #   amika@v1.2.3-rc.1
 #   amika-server@v1.2.3
 #   amika-server@v1.2.3-beta.1
+#   sdk-typescript@v1.2.3
+#   sdk-typescript@v1.2.3-rc.1
 
 on:
   workflow_dispatch:
@@ -28,6 +30,7 @@ on:
         options:
           - amika
           - amika-server
+          - sdk-typescript
       major:
         description: Major version number
         required: true
@@ -204,11 +207,25 @@ jobs:
         run: |
           git checkout "$TARGET_SHA"
 
-      - name: Verify repository is healthy enough to tag
+      - name: Verify Go repository is healthy enough to tag
+        if: inputs.component != 'sdk-typescript'
         run: |
           make fmtcheck
           make vet
           make test-unit
+
+      - name: Verify sdk/typescript/package.json version matches tag
+        if: inputs.component == 'sdk-typescript'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          expected="${VERSION#v}"
+          actual=$(node -p "require('./sdk/typescript/package.json').version")
+          if [ "$actual" != "$expected" ]; then
+            echo "sdk/typescript/package.json version ($actual) does not match tag version ($expected)." >&2
+            echo "Bump the package.json version on main before cutting this tag." >&2
+            exit 1
+          fi
 
       - name: Create and push annotated tag
         env:

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -1,0 +1,113 @@
+name: SDK TypeScript Publish
+
+# Publishes @amika/sdk to npm when a sdk-typescript@v* tag is pushed.
+#
+# Guardrails:
+#   1. Only runs for tags shaped `sdk-typescript@vX.Y.Z[-suffix]`.
+#   2. Refuses to publish unless the tagged commit is an ancestor of origin/main
+#      (i.e. the tag points at a commit that has been merged to main).
+#   3. Refuses to publish unless the tag version matches sdk/typescript/package.json.
+#   4. Re-runs typecheck, lint, formatcheck, build, and tests before publishing.
+#
+# Tags are expected to be cut via release-tag.yml. Pushing a tag by hand from a
+# branch that isn't merged to main will fail the ancestry check.
+
+on:
+  push:
+    tags:
+      - "sdk-typescript@v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse and validate tag
+        id: parse
+        working-directory: .
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if ! printf '%s' "$TAG" | grep -Eq '^sdk-typescript@v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'; then
+            echo "Unsupported tag format: $TAG" >&2
+            exit 1
+          fi
+
+          version="${TAG#sdk-typescript@v}"
+          npm_tag="latest"
+          if printf '%s' "$version" | grep -q -- '-'; then
+            npm_tag="next"
+          fi
+
+          {
+            echo "version=$version"
+            echo "npm_tag=$npm_tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag commit is on main
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git fetch origin main --depth=0 >/dev/null 2>&1 || git fetch origin main
+          tag_sha=$(git rev-list -n 1 "$TAG")
+          if ! git merge-base --is-ancestor "$tag_sha" origin/main; then
+            echo "Tag $TAG points at $tag_sha, which is not an ancestor of origin/main." >&2
+            echo "Publishing is only allowed from commits merged to main." >&2
+            exit 1
+          fi
+          echo "Tag commit $tag_sha is on main."
+
+      - name: Verify package.json version matches tag
+        env:
+          EXPECTED: ${{ steps.parse.outputs.version }}
+        run: |
+          actual=$(node -p "require('./package.json').version")
+          if [ "$actual" != "$EXPECTED" ]; then
+            echo "package.json version ($actual) does not match tag version ($EXPECTED)." >&2
+            exit 1
+          fi
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: sdk/typescript/pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Format check
+        run: pnpm formatcheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TAG: ${{ steps.parse.outputs.npm_tag }}
+        run: pnpm publish --no-git-checks --provenance --access public --tag "$NPM_TAG"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -26,8 +26,8 @@
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",
-    "format": "pnpm dlx prettier --write .",
-    "formatcheck": "pnpm dlx prettier --check .",
+    "format": "pnpm exec prettier --write .",
+    "formatcheck": "pnpm exec prettier --check .",
     "test": "vitest run",
     "test:functional": "vitest run --config vitest.functional.config.ts",
     "ci": "pnpm run typecheck && pnpm run lint && pnpm run formatcheck && pnpm run build && pnpm test"
@@ -37,6 +37,7 @@
     "@types/node": "^20.12.0",
     "eslint": "^9.0.0",
     "globals": "^15.0.0",
+    "prettier": "^3.8.3",
     "tsc-alias": "^1.8.10",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.0",

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       globals:
         specifier: ^15.0.0
         version: 15.15.0
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.17
@@ -933,6 +936,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1976,6 +1984,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.3: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
Publishes @amika/sdk on sdk-typescript@v* tags. Verifies the tag commit is on main and that the tag version matches package.json before running the CI gates and pnpm publish with provenance.