### PR TITLE
Gate SDK publish job behind protected npm-publish environment

### DIFF
--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publish
     defaults:
       run:
         working-directory: sdk/typescript


### PR DESCRIPTION
## Summary
- Attach the TypeScript SDK publish job to a GitHub Environment named `npm-publish`, requiring manual approval before a pushed `sdk-typescript@v*` tag can publish.

## Follow-up required
The `npm-publish` GitHub Environment must be created in repo settings with required reviewers and the `NPM_TOKEN` secret for this gate to take effect.

## Test plan
- [x] Create the `npm-publish` environment in repo settings (required reviewers + `NPM_TOKEN`)
- [x] Push a `sdk-typescript@v*` tag and confirm the publish job pauses for manual approval