### PR TITLE
Write project .npmrc so pnpm picks up NPM_TOKEN on publish

### DIFF
--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -111,4 +111,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ steps.parse.outputs.npm_tag }}
-        run: pnpm publish --no-git-checks --provenance --access public --tag "$NPM_TAG"
+        run: |
+          # setup-node writes an .npmrc to its user config that pnpm does not
+          # reliably read, so write a project-level .npmrc that pnpm honors.
+          # pnpm expands ${NODE_AUTH_TOKEN} from the environment at publish time.
+          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > .npmrc
+          pnpm publish --no-git-checks --provenance --access public --tag "$NPM_TAG"


### PR DESCRIPTION
pnpm did not read the user-level .npmrc that actions/setup-node writes, so publish fell through to an interactive OTP prompt and failed in CI. Write a project-level .npmrc whose registry _authToken references ${NODE_AUTH_TOKEN}, which pnpm reads and expands at publish time. The token value itself is never written to disk (only the placeholder), and npm excludes .npmrc from published tarballs.