### PR TITLE
Fail fast when NPM_TOKEN is empty on SDK publish

### DIFF
--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -112,6 +112,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ steps.parse.outputs.npm_tag }}
         run: |
+          # Fail fast if the secret never reached this job; otherwise an empty
+          # token silently falls through to an interactive OTP prompt.
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN is EMPTY — secret not reaching this job"; exit 1
+          fi
+          echo "NPM_TOKEN is present"
           # setup-node writes an .npmrc to its user config that pnpm does not
           # reliably read, so write a project-level .npmrc that pnpm honors.
           # pnpm expands ${NODE_AUTH_TOKEN} from the environment at publish time.


### PR DESCRIPTION
Distinguishes a missing/empty secret from a wrong-type token: an empty NODE_AUTH_TOKEN otherwise falls through silently to an interactive OTP prompt that fails in CI. Prints only presence, never the token value.