### PR TITLE
Use npm OIDC trusted publishing for TypeScript SDK

### DIFF
--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -84,10 +84,16 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          # Trusted publishing (OIDC) requires Node >= 22.14.0.
+          node-version: "22.14.0"
           cache: "pnpm"
           cache-dependency-path: sdk/typescript/pnpm-lock.yaml
-          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for trusted publishing
+        # OIDC trusted publishing requires npm CLI >= 11.5.1, newer than the
+        # version bundled with Node 22. We publish with npm (not pnpm) because
+        # npm has documented, first-class OIDC support.
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -109,16 +115,10 @@ jobs:
 
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ steps.parse.outputs.npm_tag }}
         run: |
-          # Fail fast if the secret never reached this job; otherwise an empty
-          # token silently falls through to an interactive OTP prompt.
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "NPM_TOKEN is EMPTY — secret not reaching this job"; exit 1
-          fi
-          # setup-node writes an .npmrc to its user config that pnpm does not
-          # reliably read, so write a project-level .npmrc that pnpm honors.
-          # pnpm expands ${NODE_AUTH_TOKEN} from the environment at publish time.
-          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > .npmrc
-          pnpm publish --no-git-checks --provenance --access public --tag "$NPM_TAG"
+          # No NODE_AUTH_TOKEN: npm authenticates via the OIDC token minted from
+          # the `id-token: write` permission and the trusted publisher registered
+          # for @amika/sdk on npmjs.com. Provenance attestations are generated
+          # automatically under trusted publishing, so --provenance is omitted.
+          npm publish --access public --tag "$NPM_TAG"


### PR DESCRIPTION
Replace the long-lived NPM_TOKEN secret with OIDC trusted publishing. npm authenticates via the OIDC token minted from the id-token: write permission and a trusted publisher registered for @amika/sdk on npmjs.com.

- Pin Node to 22.14.0 (OIDC minimum) and upgrade npm to >= 11.5.1
- Publish with npm instead of pnpm for documented OIDC support; pnpm still handles install/typecheck/lint/build/test
- Drop NODE_AUTH_TOKEN, the empty-token guard, the manual .npmrc token write, registry-url, --no-git-checks, and --provenance (provenance is automatic under trusted publishing)