### PR TITLE
Trim sandbox list columns and rename creator header

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -55,6 +55,7 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().Bool("no-setup", false, "Skip the setup script (uses a no-op script instead)")
 	sandboxCreateCmd.Flags().String("branch", "", "Check out this git branch, or create it if it doesn't exist.")
 	sandboxCreateCmd.Flags().String("new-branch", "", "Create a new git branch. With --branch, starts from that branch; otherwise starts from the current checkout.")
+	sandboxListCmd.Flags().BoolP("long", "l", false, "Show additional columns (IMAGE, PORTS)")
 	sandboxDeleteCmd.Flags().Bool("force", false, "Skip confirmation prompt")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")

--- a/go/cmd/amika/sandbox/sandbox_create_mounts.go
+++ b/go/cmd/amika/sandbox/sandbox_create_mounts.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gofixpoint/amika/go/internal/sandbox"
+	"github.com/gofixpoint/amika/go/pkg/amika"
 )
 
 // parsePortFlags parses --port flag values in the format hostPort:containerPort[/protocol].
@@ -69,6 +70,25 @@ func parsePortFlags(flags []string, hostIP string) ([]sandbox.PortBinding, error
 		})
 	}
 	return ports, nil
+}
+
+func formatPortBindings(bindings []amika.PortBinding) string {
+	if len(bindings) == 0 {
+		return "-"
+	}
+	out := make([]string, 0, len(bindings))
+	for _, p := range bindings {
+		hostIP := p.HostIP
+		if strings.TrimSpace(hostIP) == "" {
+			hostIP = "127.0.0.1"
+		}
+		protocol := p.Protocol
+		if strings.TrimSpace(protocol) == "" {
+			protocol = "tcp"
+		}
+		out = append(out, fmt.Sprintf("%s:%d->%d/%s", hostIP, p.HostPort, p.ContainerPort, protocol))
+	}
+	return strings.Join(out, ",")
 }
 
 func formatPortBinding(binding sandbox.PortBinding) string {

--- a/go/cmd/amika/sandbox/sandbox_create_mounts.go
+++ b/go/cmd/amika/sandbox/sandbox_create_mounts.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/gofixpoint/amika/go/internal/sandbox"
-	"github.com/gofixpoint/amika/go/pkg/amika"
 )
 
 // parsePortFlags parses --port flag values in the format hostPort:containerPort[/protocol].
@@ -70,25 +69,6 @@ func parsePortFlags(flags []string, hostIP string) ([]sandbox.PortBinding, error
 		})
 	}
 	return ports, nil
-}
-
-func formatPortBindings(bindings []amika.PortBinding) string {
-	if len(bindings) == 0 {
-		return "-"
-	}
-	out := make([]string, 0, len(bindings))
-	for _, p := range bindings {
-		hostIP := p.HostIP
-		if strings.TrimSpace(hostIP) == "" {
-			hostIP = "127.0.0.1"
-		}
-		protocol := p.Protocol
-		if strings.TrimSpace(protocol) == "" {
-			protocol = "tcp"
-		}
-		out = append(out, fmt.Sprintf("%s:%d->%d/%s", hostIP, p.HostPort, p.ContainerPort, protocol))
-	}
-	return strings.Join(out, ",")
 }
 
 func formatPortBinding(binding sandbox.PortBinding) string {

--- a/go/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/go/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -215,9 +215,9 @@ var sandboxListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tPROVIDER\tIMAGE\tBRANCH\tREPO\tCREATED BY\tPORTS\tCREATED")
+		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tBRANCH\tREPO\tCREATOR\tCREATED")
 		for _, sb := range allItems {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Provider, sb.Image, sb.Branch, formatRepos(sb.Repos), formatCreatedBy(sb.CreatedBy), formatPortBindings(sb.Ports), sb.CreatedAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Branch, formatRepos(sb.Repos), formatCreatedBy(sb.CreatedBy), sb.CreatedAt)
 		}
 		w.Flush()
 		return nil

--- a/go/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/go/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -214,10 +214,22 @@ var sandboxListCmd = &cobra.Command{
 			return nil
 		}
 
+		long, err := cmd.Flags().GetBool("long")
+		if err != nil {
+			return err
+		}
+
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tBRANCH\tREPO\tCREATOR\tCREATED")
-		for _, sb := range allItems {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Branch, formatRepos(sb.Repos), formatCreatedBy(sb.CreatedBy), sb.CreatedAt)
+		if long {
+			fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tIMAGE\tBRANCH\tREPO\tCREATOR\tPORTS\tCREATED")
+			for _, sb := range allItems {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Image, sb.Branch, formatRepos(sb.Repos), formatCreatedBy(sb.CreatedBy), formatPortBindings(sb.Ports), sb.CreatedAt)
+			}
+		} else {
+			fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tBRANCH\tREPO\tCREATOR\tCREATED")
+			for _, sb := range allItems {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Branch, formatRepos(sb.Repos), formatCreatedBy(sb.CreatedBy), sb.CreatedAt)
+			}
 		}
 		w.Flush()
 		return nil

--- a/go/cmd/amika/sandbox_commands_test.go
+++ b/go/cmd/amika/sandbox_commands_test.go
@@ -71,13 +71,24 @@ func TestSandboxListCommand_PrintsRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sandbox list failed: %v", err)
 	}
-	if !strings.Contains(out, "NAME") || !strings.Contains(out, "PROVIDER") || !strings.Contains(out, "PORTS") {
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "CREATOR") {
 		t.Fatalf("missing header: %s", out)
+	}
+	if strings.Contains(out, "PROVIDER") || strings.Contains(out, "PORTS") || strings.Contains(out, "IMAGE") {
+		t.Fatalf("unexpected wide-only column in default output: %s", out)
 	}
 	if !strings.Contains(out, "sb-a") {
 		t.Fatalf("missing sandbox row: %s", out)
 	}
-	if !strings.Contains(out, "127.0.0.1:8080->80/tcp") {
-		t.Fatalf("missing ports in row: %s", out)
+
+	longOut, err := runRootCommand("sandbox", "list", "--local", "--long")
+	if err != nil {
+		t.Fatalf("sandbox list --long failed: %v", err)
+	}
+	if !strings.Contains(longOut, "IMAGE") || !strings.Contains(longOut, "PORTS") {
+		t.Fatalf("missing long header: %s", longOut)
+	}
+	if !strings.Contains(longOut, "127.0.0.1:8080->80/tcp") {
+		t.Fatalf("missing ports in long row: %s", longOut)
 	}
 }


### PR DESCRIPTION
Trim the default `amika sandbox list` output to the most relevant columns and rename the creator header.

Default columns are now: NAME, STATE, LOCATION, BRANCH, REPO, CREATOR, CREATED.

- Dropped PROVIDER (encapsulated by LOCATION) from the output entirely.
- Moved IMAGE and PORTS behind a new `-l` / `--long` flag for when the extra detail is needed.
- Renamed the `CREATED BY` header to `CREATOR`.