### PR TITLE
Add `amika sessions capture-init` to mirror agent transcripts

### DIFF
--- a/go/cmd/amika/sessions.go
+++ b/go/cmd/amika/sessions.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gofixpoint/amika/go/internal/config"
+	"github.com/gofixpoint/amika/go/internal/sessioncapture"
+	"github.com/spf13/cobra"
+)
+
+var sessionsCmd = &cobra.Command{
+	Use:   "sessions",
+	Short: "Manage local agent session capture",
+	Long: `Capture sessions from local AI coding agents (Claude Code, Codex) into
+the amika state directory by installing per-agent hooks.
+
+Run "amika sessions capture-init" once to register the hooks. From then on,
+each agent will invoke "amika sessions capture" itself whenever it finishes
+a turn; no daemon is involved.`,
+}
+
+var sessionsCaptureInitCmd = &cobra.Command{
+	Use:   "capture-init",
+	Short: "Register session-capture hooks with Claude and Codex",
+	Long: `Install hooks into the local Claude Code and Codex configurations so that
+each agent mirrors its session transcripts into the amika state directory
+whenever it finishes a turn.
+
+Writes to:
+  ~/.claude/settings.json   (adds a Stop hook)
+  ~/.codex/config.toml      (sets the notify program)
+
+This command is idempotent.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolving home directory: %w", err)
+		}
+		hookCmd, err := sessioncapture.DefaultHookCommand()
+		if err != nil {
+			return err
+		}
+		rep, err := sessioncapture.Init(home, hookCmd)
+		if err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		if rep.ClaudeUpdated {
+			fmt.Fprintf(out, "Added Stop hook to %s\n", rep.ClaudeSettingsPath)
+		} else {
+			fmt.Fprintf(out, "Stop hook already present in %s\n", rep.ClaudeSettingsPath)
+		}
+		switch {
+		case rep.CodexConflict != "":
+			fmt.Fprintf(os.Stderr,
+				"Skipped %s: existing notify = %s does not look like amika; leaving it alone\n",
+				rep.CodexConfigPath, rep.CodexConflict)
+		case rep.CodexUpdated:
+			fmt.Fprintf(out, "Set notify program in %s\n", rep.CodexConfigPath)
+		default:
+			fmt.Fprintf(out, "Notify program already set in %s\n", rep.CodexConfigPath)
+		}
+		return nil
+	},
+}
+
+var sessionsCaptureCmd = &cobra.Command{
+	Use:   "capture",
+	Short: "Mirror the current agent session into the amika state directory",
+	Long: `Mirror the session transcript currently being written by Claude Code or
+Codex into the amika state directory.
+
+This is intended to be invoked by the agent's own hook system (see
+"amika sessions capture-init"), not by hand. The --source flag selects
+which agent's session to capture; the Claude variant reads the hook
+payload from stdin to learn the transcript path.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		source, _ := cmd.Flags().GetString("source")
+		stateDir, err := config.StateDir()
+		if err != nil {
+			return fmt.Errorf("resolving state directory: %w", err)
+		}
+		switch sessioncapture.Source(source) {
+		case sessioncapture.SourceClaude:
+			return sessioncapture.CaptureClaude(cmd.InOrStdin(), stateDir)
+		case sessioncapture.SourceCodex:
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("resolving home directory: %w", err)
+			}
+			return sessioncapture.CaptureCodex(home, stateDir)
+		default:
+			return fmt.Errorf("unknown --source %q (want claude or codex)", source)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(sessionsCmd)
+	sessionsCmd.AddCommand(sessionsCaptureInitCmd)
+	sessionsCmd.AddCommand(sessionsCaptureCmd)
+	sessionsCaptureCmd.Flags().String("source", "", "Source agent (claude|codex)")
+	_ = sessionsCaptureCmd.MarkFlagRequired("source")
+}

--- a/go/cmd/amika/sessions.go
+++ b/go/cmd/amika/sessions.go
@@ -31,6 +31,12 @@ Writes to:
   ~/.claude/settings.json   (adds a Stop hook)
   ~/.codex/config.toml      (sets the notify program)
 
+Captured transcripts land under:
+  $AMIKA_STATE_DIRECTORY/sessions/{claude,codex}/
+(default $AMIKA_STATE_DIRECTORY is ~/.local/state/amika).
+
+The exact destination directories are printed when the command runs.
+
 This command is idempotent.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -45,6 +51,10 @@ This command is idempotent.`,
 		rep, err := sessioncapture.Init(home, hookCmd)
 		if err != nil {
 			return err
+		}
+		stateDir, err := config.StateDir()
+		if err != nil {
+			return fmt.Errorf("resolving state directory: %w", err)
 		}
 		out := cmd.OutOrStdout()
 		if rep.ClaudeUpdated {
@@ -62,6 +72,9 @@ This command is idempotent.`,
 		default:
 			fmt.Fprintf(out, "Notify program already set in %s\n", rep.CodexConfigPath)
 		}
+		fmt.Fprintln(out, "Captures will be written to:")
+		fmt.Fprintf(out, "  claude: %s\n", sessioncapture.CaptureDir(stateDir, sessioncapture.SourceClaude))
+		fmt.Fprintf(out, "  codex:  %s\n", sessioncapture.CaptureDir(stateDir, sessioncapture.SourceCodex))
 		return nil
 	},
 }

--- a/go/cmd/amika/sessions.go
+++ b/go/cmd/amika/sessions.go
@@ -75,8 +75,15 @@ Codex into the amika state directory.
 This is intended to be invoked by the agent's own hook system (see
 "amika sessions capture-init"), not by hand. The --source flag selects
 which agent's session to capture; the Claude variant reads the hook
-payload from stdin to learn the transcript path.`,
-	Args: cobra.NoArgs,
+payload from stdin to learn the transcript path, while Codex's notify
+hook appends a JSON event payload as a positional argument that we
+accept and ignore.`,
+	// Codex's notify hook invokes the configured argv with one trailing
+	// JSON payload, e.g. '{"type":"agent-turn-complete",...}'. We accept
+	// 0 or 1 positional so that path doesn't fail at arg validation; the
+	// payload itself isn't needed for the mirror (we resolve the active
+	// session by mtime).
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		source, _ := cmd.Flags().GetString("source")
 		stateDir, err := config.StateDir()

--- a/go/cmd/amika/sessions_test.go
+++ b/go/cmd/amika/sessions_test.go
@@ -35,7 +35,7 @@ func TestSessionsCapture_AcceptsCodexNotifyPayload(t *testing.T) {
 	}
 
 	stateDir := os.Getenv("AMIKA_STATE_DIRECTORY")
-	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "rollout-1.jsonl"))
+	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "rollout-1.jsonl"))
 	if err != nil {
 		t.Fatalf("mirror missing: %v", err)
 	}

--- a/go/cmd/amika/sessions_test.go
+++ b/go/cmd/amika/sessions_test.go
@@ -44,6 +44,30 @@ func TestSessionsCapture_AcceptsCodexNotifyPayload(t *testing.T) {
 	}
 }
 
+// TestSessionsCaptureInit_PrintsDestinations ensures `capture-init` tells the
+// user where mirrored sessions will land, so they don't have to grep the help
+// text or guess the XDG path.
+func TestSessionsCaptureInit_PrintsDestinations(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", "")
+
+	out, err := runRootCommand("sessions", "capture-init")
+	if err != nil {
+		t.Fatalf("capture-init: %v (out=%q)", err, out)
+	}
+	for _, want := range []string{
+		"Captures will be written to:",
+		filepath.Join(stateDir, "sessions", "claude"),
+		filepath.Join(stateDir, "sessions", "codex"),
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
 func TestSessionsCapture_RejectsExtraArgs(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	// Two positionals exceeds Codex's one-payload contract; cobra should

--- a/go/cmd/amika/sessions_test.go
+++ b/go/cmd/amika/sessions_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSessionsCapture_AcceptsCodexNotifyPayload guards against re-introducing
+// `cobra.NoArgs` on the capture command: Codex's notify hook appends one
+// trailing JSON payload to the configured argv, so the command must accept
+// it or session capture from Codex breaks entirely.
+func TestSessionsCapture_AcceptsCodexNotifyPayload(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("CODEX_HOME", "")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Seed a session so CaptureCodex has something to mirror.
+	dir := filepath.Join(home, ".codex", "sessions", "2026", "06", "01")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(dir, "rollout-1.jsonl")
+	if err := os.WriteFile(src, []byte(`{"k":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := `{"type":"agent-turn-complete","turn-id":"abc","last-assistant-message":"done"}`
+	out, err := runRootCommand("sessions", "capture", "--source", "codex", payload)
+	if err != nil {
+		t.Fatalf("capture with codex notify payload failed: %v (out=%q)", err, out)
+	}
+
+	stateDir := os.Getenv("AMIKA_STATE_DIRECTORY")
+	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "rollout-1.jsonl"))
+	if err != nil {
+		t.Fatalf("mirror missing: %v", err)
+	}
+	if !strings.Contains(string(mirrored), `"hi"`) {
+		t.Errorf("unexpected mirrored content: %s", mirrored)
+	}
+}
+
+func TestSessionsCapture_RejectsExtraArgs(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	// Two positionals exceeds Codex's one-payload contract; cobra should
+	// reject this so misconfigurations surface instead of being silently
+	// accepted.
+	_, err := runRootCommand("sessions", "capture", "--source", "codex", "a", "b")
+	if err == nil {
+		t.Fatal("expected error for >1 positional, got nil")
+	}
+}

--- a/go/cmd/amika/sessions_test.go
+++ b/go/cmd/amika/sessions_test.go
@@ -35,7 +35,7 @@ func TestSessionsCapture_AcceptsCodexNotifyPayload(t *testing.T) {
 	}
 
 	stateDir := os.Getenv("AMIKA_STATE_DIRECTORY")
-	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "rollout-1.jsonl"))
+	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "rollout-1.jsonl"))
 	if err != nil {
 		t.Fatalf("mirror missing: %v", err)
 	}

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,12 +3,12 @@ module github.com/gofixpoint/amika/go
 go 1.25.3
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/danielgtaylor/huma/v2 v2.37.2
 	github.com/spf13/cobra v1.10.2
 )
 
 require (
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 )

--- a/go/internal/sessioncapture/init.go
+++ b/go/internal/sessioncapture/init.go
@@ -296,16 +296,18 @@ func ensureCodexNotify(path string, argv []string) (updated bool, conflict strin
 	}
 
 	lines := splitLines(string(data))
-	idx, existing := findTopLevelNotify(lines)
+	start, end, existing := findTopLevelNotify(lines)
 
-	if idx >= 0 {
+	if start >= 0 {
 		if existing == want {
 			return false, "", nil
 		}
 		if !codexNotifyIsAmika(existing) {
 			return false, existing, nil
 		}
-		lines[idx] = "notify = " + want
+		replaced := append([]string{}, lines[:start]...)
+		replaced = append(replaced, "notify = "+want)
+		lines = append(replaced, lines[end+1:]...)
 	} else {
 		lines = insertCodexNotify(lines, "notify = "+want)
 	}
@@ -372,24 +374,59 @@ func splitLines(s string) []string {
 
 // findTopLevelNotify locates a top-level `notify = ...` assignment, ignoring
 // any assignments that appear after the first `[section]` header. Returns the
-// line index and the trimmed value (the right-hand side), or (-1, "").
-func findTopLevelNotify(lines []string) (int, string) {
+// line range (start, end inclusive) and the trimmed value (right-hand side),
+// or (-1, -1, "") when no top-level notify exists.
+//
+// When the value is an inline array spread across multiple lines, e.g.
+//
+//	notify = [
+//	  "amika",
+//	  "sessions",
+//	]
+//
+// the returned range covers every line of the assignment and the value is the
+// joined text, so [[codexNotifyIsAmika]] can parse it as TOML.
+func findTopLevelNotify(lines []string) (int, int, string) {
 	for i, raw := range lines {
 		trimmed := strings.TrimSpace(raw)
 		if strings.HasPrefix(trimmed, "[") {
-			return -1, ""
+			return -1, -1, ""
 		}
-		if strings.HasPrefix(trimmed, "notify") {
-			rest := strings.TrimPrefix(trimmed, "notify")
-			rest = strings.TrimLeft(rest, " \t")
-			if !strings.HasPrefix(rest, "=") {
-				continue
+		if !strings.HasPrefix(trimmed, "notify") {
+			continue
+		}
+		rest := strings.TrimPrefix(trimmed, "notify")
+		rest = strings.TrimLeft(rest, " \t")
+		if !strings.HasPrefix(rest, "=") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(rest, "="))
+		end := i
+		if strings.HasPrefix(value, "[") && !tomlValueParses(value) {
+			var buf strings.Builder
+			buf.WriteString(value)
+			for j := i + 1; j < len(lines); j++ {
+				buf.WriteByte('\n')
+				buf.WriteString(lines[j])
+				end = j
+				if tomlValueParses(buf.String()) {
+					break
+				}
 			}
-			rest = strings.TrimSpace(strings.TrimPrefix(rest, "="))
-			return i, rest
+			value = buf.String()
 		}
+		return i, end, value
 	}
-	return -1, ""
+	return -1, -1, ""
+}
+
+// tomlValueParses reports whether value is a complete, parseable TOML value
+// (any type). We use it to detect the end of a possibly-multiline inline array
+// without hand-rolling a TOML lexer.
+func tomlValueParses(value string) bool {
+	var holder map[string]interface{}
+	_, err := toml.Decode("x = "+value+"\n", &holder)
+	return err == nil
 }
 
 // codexNotifyIsAmika reports whether the value of `notify` invokes the amika

--- a/go/internal/sessioncapture/init.go
+++ b/go/internal/sessioncapture/init.go
@@ -76,8 +76,14 @@ func Init(homeDir string, cmd HookCommand) (InitReport, error) {
 }
 
 // ensureClaudeStopHook reads `~/.claude/settings.json`, ensures a `Stop` hook
-// matching command exists, and writes the file back. Returns whether the file
+// running command exists, and writes the file back. Returns whether the file
 // was modified.
+//
+// Any previously installed amika Stop hooks are stripped first (recognized by
+// argv shape, not exact-string equality) so that re-running capture-init from
+// a different `amika` executable path replaces the stale entry instead of
+// appending a second one. The Codex notify path has equivalent handling; this
+// keeps the two in sync.
 //
 // The Claude hooks schema is documented at
 // https://docs.claude.com/en/docs/claude-code/hooks. We model it as nested
@@ -94,11 +100,16 @@ func ensureClaudeStopHook(path, command string) (bool, error) {
 	}
 
 	stopGroups, _ := hooks["Stop"].([]interface{})
-	if claudeHookAlreadyPresent(stopGroups, command) {
+	filtered, removed := stripClaudeAmikaStopHooks(stopGroups)
+
+	// If the only amika hook we removed already matched the current
+	// command, nothing actually changes — short-circuit so callers can
+	// report "already present".
+	if len(removed) == 1 && removed[0] == command {
 		return false, nil
 	}
 
-	stopGroups = append(stopGroups, map[string]interface{}{
+	filtered = append(filtered, map[string]interface{}{
 		"hooks": []interface{}{
 			map[string]interface{}{
 				"type":    "command",
@@ -106,30 +117,114 @@ func ensureClaudeStopHook(path, command string) (bool, error) {
 			},
 		},
 	})
-	hooks["Stop"] = stopGroups
+	hooks["Stop"] = filtered
 	settings["hooks"] = hooks
 
 	return true, writeJSONObject(path, settings)
 }
 
-func claudeHookAlreadyPresent(groups []interface{}, command string) bool {
+// stripClaudeAmikaStopHooks returns the input Stop-hook groups with every
+// amika-installed entry removed (groups that become empty are dropped), plus
+// the raw command strings of the entries that were removed.
+func stripClaudeAmikaStopHooks(groups []interface{}) ([]interface{}, []string) {
+	filtered := make([]interface{}, 0, len(groups))
+	var removed []string
 	for _, raw := range groups {
 		group, ok := raw.(map[string]interface{})
 		if !ok {
+			filtered = append(filtered, raw)
 			continue
 		}
 		entries, _ := group["hooks"].([]interface{})
+		kept := make([]interface{}, 0, len(entries))
 		for _, e := range entries {
 			entry, ok := e.(map[string]interface{})
 			if !ok {
+				kept = append(kept, e)
 				continue
 			}
-			if s, _ := entry["command"].(string); s == command {
-				return true
+			cmd, _ := entry["command"].(string)
+			if looksLikeClaudeAmikaHook(cmd) {
+				removed = append(removed, cmd)
+				continue
 			}
+			kept = append(kept, e)
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		group["hooks"] = kept
+		filtered = append(filtered, group)
+	}
+	return filtered, removed
+}
+
+// looksLikeClaudeAmikaHook reports whether cmd is a Stop-hook command line
+// that invokes an amika executable with the Claude capture argv. The
+// executable path may have been quoted (paths with spaces) and may differ
+// from the current amika binary's path — we identify by argv shape rather
+// than exact-string equality so renames don't strand a stale hook entry.
+func looksLikeClaudeAmikaHook(cmd string) bool {
+	argv := splitShellArgv(cmd)
+	wantTail := []string{"sessions", "capture", "--source", "claude"}
+	if len(argv) != len(wantTail)+1 {
+		return false
+	}
+	for i, w := range wantTail {
+		if argv[i+1] != w {
+			return false
 		}
 	}
-	return false
+	return filepath.Base(argv[0]) == "amika"
+}
+
+// splitShellArgv tokenizes a string the way /bin/sh would for the subset of
+// quoting shellQuote produces: single-quoted regions plus the `'\”` escape
+// sequence for literal apostrophes. This is not a full shell parser; it is
+// sufficient to recognize commands we ourselves wrote and a wide range of
+// hand-edited variants.
+func splitShellArgv(s string) []string {
+	var out []string
+	var cur []byte
+	inSingle := false
+	started := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inSingle {
+			if c == '\'' {
+				inSingle = false
+				continue
+			}
+			cur = append(cur, c)
+			started = true
+			continue
+		}
+		if c == '\\' && i+1 < len(s) {
+			cur = append(cur, s[i+1])
+			started = true
+			i++
+			continue
+		}
+		if c == '\'' {
+			inSingle = true
+			started = true
+			continue
+		}
+		if c == ' ' || c == '\t' {
+			if started {
+				out = append(out, string(cur))
+				cur = cur[:0]
+				started = false
+			}
+			continue
+		}
+		cur = append(cur, c)
+		started = true
+	}
+	if started {
+		out = append(out, string(cur))
+	}
+	return out
 }
 
 func readJSONObject(path string) (map[string]interface{}, error) {

--- a/go/internal/sessioncapture/init.go
+++ b/go/internal/sessioncapture/init.go
@@ -1,0 +1,370 @@
+package sessioncapture
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// HookCommand is the command Claude/Codex hooks invoke to mirror sessions.
+// Exposed so callers (and tests) can swap the executable name.
+type HookCommand struct {
+	// Exe is the absolute path or bare name of the amika executable.
+	Exe string
+}
+
+// DefaultHookCommand returns a HookCommand using the running amika binary.
+func DefaultHookCommand() (HookCommand, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return HookCommand{}, fmt.Errorf("resolving amika executable: %w", err)
+	}
+	abs, err := filepath.Abs(exe)
+	if err != nil {
+		return HookCommand{}, fmt.Errorf("resolving absolute path of amika executable: %w", err)
+	}
+	return HookCommand{Exe: abs}, nil
+}
+
+// ClaudeCommand returns the shell command Claude's Stop hook should run.
+func (h HookCommand) ClaudeCommand() string {
+	return fmt.Sprintf("%s sessions capture --source claude", shellQuote(h.Exe))
+}
+
+// CodexNotify returns the program-and-args list Codex's `notify` should run.
+func (h HookCommand) CodexNotify() []string {
+	return []string{h.Exe, "sessions", "capture", "--source", "codex"}
+}
+
+// InitReport summarizes what `Init` did so the CLI can print useful feedback.
+type InitReport struct {
+	ClaudeSettingsPath string
+	ClaudeUpdated      bool // false when hook already present
+	CodexConfigPath    string
+	CodexUpdated       bool   // false when notify already pointed at amika
+	CodexConflict      string // non-empty when notify pointed elsewhere; we left it alone
+}
+
+// Init wires the Stop hook into Claude Code's settings and a notify program
+// into Codex's config under homeDir. It is idempotent: running it twice is a
+// no-op.
+func Init(homeDir string, cmd HookCommand) (InitReport, error) {
+	rep := InitReport{
+		ClaudeSettingsPath: filepath.Join(homeDir, ".claude", "settings.json"),
+		CodexConfigPath:    filepath.Join(homeDir, ".codex", "config.toml"),
+	}
+	claudeUpdated, err := ensureClaudeStopHook(rep.ClaudeSettingsPath, cmd.ClaudeCommand())
+	if err != nil {
+		return rep, err
+	}
+	rep.ClaudeUpdated = claudeUpdated
+
+	codexUpdated, conflict, err := ensureCodexNotify(rep.CodexConfigPath, cmd.CodexNotify())
+	if err != nil {
+		return rep, err
+	}
+	rep.CodexUpdated = codexUpdated
+	rep.CodexConflict = conflict
+
+	return rep, nil
+}
+
+// ensureClaudeStopHook reads `~/.claude/settings.json`, ensures a `Stop` hook
+// matching command exists, and writes the file back. Returns whether the file
+// was modified.
+//
+// The Claude hooks schema is documented at
+// https://docs.claude.com/en/docs/claude-code/hooks. We model it as nested
+// `map[string]interface{}` so unrelated keys round-trip unchanged.
+func ensureClaudeStopHook(path, command string) (bool, error) {
+	settings, err := readJSONObject(path)
+	if err != nil {
+		return false, err
+	}
+
+	hooks, _ := settings["hooks"].(map[string]interface{})
+	if hooks == nil {
+		hooks = map[string]interface{}{}
+	}
+
+	stopGroups, _ := hooks["Stop"].([]interface{})
+	if claudeHookAlreadyPresent(stopGroups, command) {
+		return false, nil
+	}
+
+	stopGroups = append(stopGroups, map[string]interface{}{
+		"hooks": []interface{}{
+			map[string]interface{}{
+				"type":    "command",
+				"command": command,
+			},
+		},
+	})
+	hooks["Stop"] = stopGroups
+	settings["hooks"] = hooks
+
+	return true, writeJSONObject(path, settings)
+}
+
+func claudeHookAlreadyPresent(groups []interface{}, command string) bool {
+	for _, raw := range groups {
+		group, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		entries, _ := group["hooks"].([]interface{})
+		for _, e := range entries {
+			entry, ok := e.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if s, _ := entry["command"].(string); s == command {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func readJSONObject(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]interface{}{}, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return map[string]interface{}{}, nil
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if out == nil {
+		out = map[string]interface{}{}
+	}
+	return out, nil
+}
+
+func writeJSONObject(path string, obj map[string]interface{}) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating dir for %s: %w", path, err)
+	}
+	encoded, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding %s: %w", path, err)
+	}
+	encoded = append(encoded, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".settings-*")
+	if err != nil {
+		return fmt.Errorf("creating tempfile for %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(encoded); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing tempfile for %s: %w", path, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming tempfile to %s: %w", path, err)
+	}
+	tmpPath = ""
+	return nil
+}
+
+// ensureCodexNotify ensures Codex's top-level `notify` array invokes the given
+// argv. It edits the TOML file line-wise so user comments and formatting are
+// preserved. Returns:
+//   - updated: true when we modified the file
+//   - conflict: a description of an existing notify value that points at
+//     something other than amika; in that case we make no changes
+func ensureCodexNotify(path string, argv []string) (updated bool, conflict string, err error) {
+	want := formatCodexNotify(argv)
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return false, "", fmt.Errorf("reading %s: %w", path, readErr)
+	}
+
+	lines := splitLines(string(data))
+	idx, existing := findTopLevelNotify(lines)
+
+	if idx >= 0 {
+		if existing == want {
+			return false, "", nil
+		}
+		if !codexNotifyIsAmika(existing) {
+			return false, existing, nil
+		}
+		lines[idx] = "notify = " + want
+	} else {
+		lines = insertCodexNotify(lines, "notify = "+want)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, "", fmt.Errorf("creating dir for %s: %w", path, err)
+	}
+	out := strings.Join(lines, "\n")
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	if err := writeFileAtomic(path, []byte(out)); err != nil {
+		return false, "", err
+	}
+	return true, "", nil
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".config-*")
+	if err != nil {
+		return fmt.Errorf("creating tempfile for %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing tempfile for %s: %w", path, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming tempfile to %s: %w", path, err)
+	}
+	tmpPath = ""
+	return nil
+}
+
+func formatCodexNotify(argv []string) string {
+	parts := make([]string, len(argv))
+	for i, a := range argv {
+		b, _ := json.Marshal(a) // JSON strings happen to be valid TOML basic strings
+		parts[i] = string(b)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// splitLines splits on '\n' while preserving an empty trailing element so a
+// final newline survives round-tripping.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	out := strings.Split(s, "\n")
+	if len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// findTopLevelNotify locates a top-level `notify = ...` assignment, ignoring
+// any assignments that appear after the first `[section]` header. Returns the
+// line index and the trimmed value (the right-hand side), or (-1, "").
+func findTopLevelNotify(lines []string) (int, string) {
+	for i, raw := range lines {
+		trimmed := strings.TrimSpace(raw)
+		if strings.HasPrefix(trimmed, "[") {
+			return -1, ""
+		}
+		if strings.HasPrefix(trimmed, "notify") {
+			rest := strings.TrimPrefix(trimmed, "notify")
+			rest = strings.TrimLeft(rest, " \t")
+			if !strings.HasPrefix(rest, "=") {
+				continue
+			}
+			rest = strings.TrimSpace(strings.TrimPrefix(rest, "="))
+			return i, rest
+		}
+	}
+	return -1, ""
+}
+
+// codexNotifyIsAmika reports whether the value of `notify` invokes the amika
+// binary. We only treat array-form values with an "amika" argv[0] as ours, so
+// users running other notify programs aren't silently overwritten.
+func codexNotifyIsAmika(value string) bool {
+	v := strings.TrimSpace(value)
+	if !strings.HasPrefix(v, "[") {
+		return false
+	}
+	var argv []string
+	if err := tomlArrayDecode(v, &argv); err != nil {
+		return false
+	}
+	if len(argv) == 0 {
+		return false
+	}
+	return strings.HasSuffix(argv[0], "amika") || strings.HasSuffix(argv[0], "/amika")
+}
+
+// tomlArrayDecode decodes a TOML inline array of strings (e.g.
+// `["a", "b"]`) into argv. We wrap it as `x = <value>` and let the toml
+// library do the parsing rather than write our own.
+func tomlArrayDecode(value string, dst *[]string) error {
+	doc := "x = " + value + "\n"
+	var holder struct {
+		X []string `toml:"x"`
+	}
+	if _, err := toml.Decode(doc, &holder); err != nil {
+		return err
+	}
+	*dst = holder.X
+	return nil
+}
+
+func insertCodexNotify(lines []string, assignment string) []string {
+	// Insert before the first [section] header so the assignment is top-level.
+	for i, raw := range lines {
+		if strings.HasPrefix(strings.TrimSpace(raw), "[") {
+			head := append([]string{}, lines[:i]...)
+			if len(head) > 0 && head[len(head)-1] != "" {
+				head = append(head, "")
+			}
+			head = append(head, assignment, "")
+			return append(head, lines[i:]...)
+		}
+	}
+	// No section headers — append. Add a blank line before only if the file
+	// already has content that doesn't end on a blank line.
+	if len(lines) > 0 && lines[len(lines)-1] != "" {
+		lines = append(lines, "")
+	}
+	return append(lines, assignment)
+}
+
+// shellQuote wraps s in single quotes if it contains characters that would
+// otherwise be interpreted by /bin/sh. Hook commands are passed through a
+// shell, so paths with spaces need quoting.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '_', '-', '/', '.', ':', ',', '=', '+':
+			continue
+		}
+		return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+	}
+	return s
+}

--- a/go/internal/sessioncapture/init.go
+++ b/go/internal/sessioncapture/init.go
@@ -51,12 +51,13 @@ type InitReport struct {
 }
 
 // Init wires the Stop hook into Claude Code's settings and a notify program
-// into Codex's config under homeDir. It is idempotent: running it twice is a
-// no-op.
+// into Codex's config under homeDir. The Codex side honors `CODEX_HOME` (see
+// CodexHome) so the hook is written where Codex will actually read it.
+// Init is idempotent: running it twice is a no-op.
 func Init(homeDir string, cmd HookCommand) (InitReport, error) {
 	rep := InitReport{
 		ClaudeSettingsPath: filepath.Join(homeDir, ".claude", "settings.json"),
-		CodexConfigPath:    filepath.Join(homeDir, ".codex", "config.toml"),
+		CodexConfigPath:    filepath.Join(CodexHome(homeDir), "config.toml"),
 	}
 	claudeUpdated, err := ensureClaudeStopHook(rep.ClaudeSettingsPath, cmd.ClaudeCommand())
 	if err != nil {

--- a/go/internal/sessioncapture/init.go
+++ b/go/internal/sessioncapture/init.go
@@ -393,8 +393,10 @@ func findTopLevelNotify(lines []string) (int, string) {
 }
 
 // codexNotifyIsAmika reports whether the value of `notify` invokes the amika
-// binary. We only treat array-form values with an "amika" argv[0] as ours, so
-// users running other notify programs aren't silently overwritten.
+// binary. We only treat array-form values whose argv[0] has basename "amika"
+// as ours, so users running other notify programs aren't silently overwritten.
+// The basename check (vs. a HasSuffix check) is important: "/usr/bin/notamika"
+// and "my-amika" must be treated as third-party tools, not stale Amika hooks.
 func codexNotifyIsAmika(value string) bool {
 	v := strings.TrimSpace(value)
 	if !strings.HasPrefix(v, "[") {
@@ -407,7 +409,7 @@ func codexNotifyIsAmika(value string) bool {
 	if len(argv) == 0 {
 		return false
 	}
-	return strings.HasSuffix(argv[0], "amika") || strings.HasSuffix(argv[0], "/amika")
+	return filepath.Base(argv[0]) == "amika"
 }
 
 // tomlArrayDecode decodes a TOML inline array of strings (e.g.

--- a/go/internal/sessioncapture/init_test.go
+++ b/go/internal/sessioncapture/init_test.go
@@ -145,6 +145,26 @@ notify = ["/old/path/amika", "sessions", "capture", "--source", "codex"]
 	}
 }
 
+func TestInit_HonorsCODEX_HOME(t *testing.T) {
+	home := t.TempDir()
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+
+	rep, err := Init(home, HookCommand{Exe: "/usr/local/bin/amika"})
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if rep.CodexConfigPath != filepath.Join(codexHome, "config.toml") {
+		t.Errorf("CodexConfigPath = %q, want under CODEX_HOME (%q)", rep.CodexConfigPath, codexHome)
+	}
+	if _, err := os.Stat(filepath.Join(codexHome, "config.toml")); err != nil {
+		t.Errorf("expected config.toml under CODEX_HOME: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "config.toml")); !os.IsNotExist(err) {
+		t.Errorf("config.toml should not be written to ~/.codex when CODEX_HOME is set: %v", err)
+	}
+}
+
 func TestInit_InsertsBeforeFirstSection(t *testing.T) {
 	home := t.TempDir()
 	cfg := filepath.Join(home, ".codex", "config.toml")

--- a/go/internal/sessioncapture/init_test.go
+++ b/go/internal/sessioncapture/init_test.go
@@ -152,6 +152,38 @@ notify = ["/old/path/amika", "sessions", "capture", "--source", "codex"]
 	}
 }
 
+func TestInit_TreatsLookalikeNotifyAsConflict(t *testing.T) {
+	useCodexFallback(t)
+	for _, name := range []string{"notamika", "my-amika", "amikatool"} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			cfg := filepath.Join(home, ".codex", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			contents := `notify = ["/usr/local/bin/` + name + `", "--watch"]` + "\n"
+			if err := os.WriteFile(cfg, []byte(contents), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			rep, err := Init(home, HookCommand{Exe: "/usr/local/bin/amika"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if rep.CodexUpdated {
+				t.Errorf("expected lookalike %q to be treated as conflict, not replaced", name)
+			}
+			if rep.CodexConflict == "" {
+				t.Errorf("expected CodexConflict to be reported for lookalike %q", name)
+			}
+			got, _ := os.ReadFile(cfg)
+			if string(got) != contents {
+				t.Errorf("notify for lookalike %q was modified:\n%s", name, got)
+			}
+		})
+	}
+}
+
 func TestInit_HonorsCODEX_HOME(t *testing.T) {
 	home := t.TempDir()
 	codexHome := t.TempDir()

--- a/go/internal/sessioncapture/init_test.go
+++ b/go/internal/sessioncapture/init_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -200,6 +202,142 @@ trust_level = "trusted"
 	}
 }
 
+func TestInit_UpdatesStaleClaudeHookPath(t *testing.T) {
+	useCodexFallback(t)
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"Stop": []interface{}{
+				map[string]interface{}{
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "/old/path/amika sessions capture --source claude"},
+					},
+				},
+			},
+		},
+	}
+	raw, _ := json.Marshal(stale)
+	if err := os.WriteFile(settingsPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := Init(home, HookCommand{Exe: "/new/path/amika"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.ClaudeUpdated {
+		t.Errorf("expected ClaudeUpdated=true when binary path changed, got %+v", rep)
+	}
+
+	settings := readClaudeSettings(t, settingsPath)
+	stopCommands := claudeStopCommands(settings)
+	if len(stopCommands) != 1 {
+		t.Fatalf("expected exactly one Stop command after update, got %v", stopCommands)
+	}
+	if stopCommands[0] != "/new/path/amika sessions capture --source claude" {
+		t.Errorf("Stop command not updated: %v", stopCommands)
+	}
+	for _, c := range stopCommands {
+		if strings.Contains(c, "/old/path/amika") {
+			t.Errorf("stale path still present: %v", stopCommands)
+		}
+	}
+}
+
+func TestInit_PreservesNonAmikaStopHooks(t *testing.T) {
+	useCodexFallback(t)
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"Stop": []interface{}{
+				map[string]interface{}{
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "other-tool --watch"},
+						map[string]interface{}{"type": "command", "command": "/old/amika sessions capture --source claude"},
+					},
+				},
+			},
+		},
+	}
+	raw, _ := json.Marshal(existing)
+	if err := os.WriteFile(settingsPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Init(home, HookCommand{Exe: "/new/amika"}); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := readClaudeSettings(t, settingsPath)
+	stopCommands := claudeStopCommands(settings)
+	sort.Strings(stopCommands)
+	want := []string{"/new/amika sessions capture --source claude", "other-tool --watch"}
+	if !reflect.DeepEqual(stopCommands, want) {
+		t.Errorf("Stop commands = %v, want %v", stopCommands, want)
+	}
+}
+
+func TestInit_CollapsesDuplicateAmikaHooks(t *testing.T) {
+	useCodexFallback(t)
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"Stop": []interface{}{
+				map[string]interface{}{"hooks": []interface{}{
+					map[string]interface{}{"type": "command", "command": "/a/amika sessions capture --source claude"},
+				}},
+				map[string]interface{}{"hooks": []interface{}{
+					map[string]interface{}{"type": "command", "command": "/b/amika sessions capture --source claude"},
+				}},
+			},
+		},
+	}
+	raw, _ := json.Marshal(existing)
+	if err := os.WriteFile(settingsPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Init(home, HookCommand{Exe: "/c/amika"}); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := readClaudeSettings(t, settingsPath)
+	if got := claudeStopCommands(settings); len(got) != 1 || got[0] != "/c/amika sessions capture --source claude" {
+		t.Errorf("expected one collapsed hook pointing at /c/amika, got %v", got)
+	}
+}
+
+func TestLooksLikeClaudeAmikaHook(t *testing.T) {
+	cases := map[string]bool{
+		"/usr/local/bin/amika sessions capture --source claude":     true,
+		"amika sessions capture --source claude":                    true,
+		"./dist/amika sessions capture --source claude":             true,
+		"'/path with space/amika' sessions capture --source claude": true,
+		"/usr/local/bin/not-amika sessions capture --source claude": false,
+		"other-tool --watch":                               false,
+		"amika sessions capture --source codex":            false,
+		"amika sessions capture --source claude --verbose": false,
+		"": false,
+	}
+	for in, want := range cases {
+		if got := looksLikeClaudeAmikaHook(in); got != want {
+			t.Errorf("looksLikeClaudeAmikaHook(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
 func TestShellQuote(t *testing.T) {
 	cases := map[string]string{
 		"/usr/local/bin/amika":   "/usr/local/bin/amika",
@@ -229,7 +367,27 @@ func readClaudeSettings(t *testing.T, path string) map[string]interface{} {
 }
 
 func claudeHasHook(settings map[string]interface{}, command string) bool {
+	for _, c := range claudeStopCommands(settings) {
+		if c == command {
+			return true
+		}
+	}
+	return false
+}
+
+func claudeStopCommands(settings map[string]interface{}) []string {
 	hooks, _ := settings["hooks"].(map[string]interface{})
 	stop, _ := hooks["Stop"].([]interface{})
-	return claudeHookAlreadyPresent(stop, command)
+	var out []string
+	for _, raw := range stop {
+		group, _ := raw.(map[string]interface{})
+		entries, _ := group["hooks"].([]interface{})
+		for _, e := range entries {
+			entry, _ := e.(map[string]interface{})
+			if cmd, ok := entry["command"].(string); ok {
+				out = append(out, cmd)
+			}
+		}
+	}
+	return out
 }

--- a/go/internal/sessioncapture/init_test.go
+++ b/go/internal/sessioncapture/init_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestInit_FreshClaudeAndCodex(t *testing.T) {
+	useCodexFallback(t)
 	home := t.TempDir()
 	rep, err := Init(home, HookCommand{Exe: "/usr/local/bin/amika"})
 	if err != nil {
@@ -35,6 +36,7 @@ func TestInit_FreshClaudeAndCodex(t *testing.T) {
 }
 
 func TestInit_Idempotent(t *testing.T) {
+	useCodexFallback(t)
 	home := t.TempDir()
 	cmd := HookCommand{Exe: "/usr/local/bin/amika"}
 	if _, err := Init(home, cmd); err != nil {
@@ -50,6 +52,7 @@ func TestInit_Idempotent(t *testing.T) {
 }
 
 func TestInit_PreservesExistingClaudeKeys(t *testing.T) {
+	useCodexFallback(t)
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
@@ -85,6 +88,7 @@ func TestInit_PreservesExistingClaudeKeys(t *testing.T) {
 }
 
 func TestInit_PreservesCodexConflict(t *testing.T) {
+	useCodexFallback(t)
 	home := t.TempDir()
 	cfg := filepath.Join(home, ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
@@ -117,6 +121,7 @@ trust_level = "trusted"
 }
 
 func TestInit_UpdatesExistingAmikaNotify(t *testing.T) {
+	useCodexFallback(t)
 	home := t.TempDir()
 	cfg := filepath.Join(home, ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
@@ -166,6 +171,7 @@ func TestInit_HonorsCODEX_HOME(t *testing.T) {
 }
 
 func TestInit_InsertsBeforeFirstSection(t *testing.T) {
+	useCodexFallback(t)
 	home := t.TempDir()
 	cfg := filepath.Join(home, ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {

--- a/go/internal/sessioncapture/init_test.go
+++ b/go/internal/sessioncapture/init_test.go
@@ -1,0 +1,209 @@
+package sessioncapture
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInit_FreshClaudeAndCodex(t *testing.T) {
+	home := t.TempDir()
+	rep, err := Init(home, HookCommand{Exe: "/usr/local/bin/amika"})
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if !rep.ClaudeUpdated || !rep.CodexUpdated {
+		t.Fatalf("expected both to be updated, got %+v", rep)
+	}
+
+	settings := readClaudeSettings(t, rep.ClaudeSettingsPath)
+	wantCmd := "/usr/local/bin/amika sessions capture --source claude"
+	if !claudeHasHook(settings, wantCmd) {
+		t.Errorf("Claude settings missing Stop hook with command %q: %#v", wantCmd, settings)
+	}
+
+	codex, err := os.ReadFile(rep.CodexConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `notify = ["/usr/local/bin/amika", "sessions", "capture", "--source", "codex"]`
+	if !strings.Contains(string(codex), want) {
+		t.Errorf("codex config missing %q, got:\n%s", want, codex)
+	}
+}
+
+func TestInit_Idempotent(t *testing.T) {
+	home := t.TempDir()
+	cmd := HookCommand{Exe: "/usr/local/bin/amika"}
+	if _, err := Init(home, cmd); err != nil {
+		t.Fatal(err)
+	}
+	rep, err := Init(home, cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.ClaudeUpdated || rep.CodexUpdated {
+		t.Errorf("expected no changes on second run, got %+v", rep)
+	}
+}
+
+func TestInit_PreservesExistingClaudeKeys(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := map[string]interface{}{
+		"theme": "dark",
+		"hooks": map[string]interface{}{
+			"PreToolUse": []interface{}{
+				map[string]interface{}{"hooks": []interface{}{map[string]interface{}{"type": "command", "command": "other-tool"}}},
+			},
+		},
+	}
+	raw, _ := json.Marshal(existing)
+	if err := os.WriteFile(settingsPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Init(home, HookCommand{Exe: "amika"}); err != nil {
+		t.Fatal(err)
+	}
+	got := readClaudeSettings(t, settingsPath)
+	if v, _ := got["theme"].(string); v != "dark" {
+		t.Errorf("theme key lost: %#v", got)
+	}
+	hooks, _ := got["hooks"].(map[string]interface{})
+	if _, ok := hooks["PreToolUse"]; !ok {
+		t.Errorf("PreToolUse hooks lost: %#v", hooks)
+	}
+	if !claudeHasHook(got, "amika sessions capture --source claude") {
+		t.Errorf("Stop hook not added: %#v", hooks)
+	}
+}
+
+func TestInit_PreservesCodexConflict(t *testing.T) {
+	home := t.TempDir()
+	cfg := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	contents := `model = "gpt-5"
+notify = ["my-tool", "--watch"]
+
+[projects."/x"]
+trust_level = "trusted"
+`
+	if err := os.WriteFile(cfg, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := Init(home, HookCommand{Exe: "/usr/local/bin/amika"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.CodexUpdated {
+		t.Errorf("expected to leave conflicting notify alone, got updated=true")
+	}
+	if rep.CodexConflict == "" {
+		t.Errorf("expected CodexConflict to be reported")
+	}
+	got, _ := os.ReadFile(cfg)
+	if string(got) != contents {
+		t.Errorf("config was modified despite conflict:\n%s", got)
+	}
+}
+
+func TestInit_UpdatesExistingAmikaNotify(t *testing.T) {
+	home := t.TempDir()
+	cfg := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	contents := `model = "gpt-5"
+notify = ["/old/path/amika", "sessions", "capture", "--source", "codex"]
+`
+	if err := os.WriteFile(cfg, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := Init(home, HookCommand{Exe: "/new/path/amika"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.CodexUpdated {
+		t.Errorf("expected update when path changed, got %+v", rep)
+	}
+	got, _ := os.ReadFile(cfg)
+	if !strings.Contains(string(got), `"/new/path/amika"`) {
+		t.Errorf("notify not updated: %s", got)
+	}
+	if strings.Contains(string(got), `"/old/path/amika"`) {
+		t.Errorf("old notify path still present: %s", got)
+	}
+}
+
+func TestInit_InsertsBeforeFirstSection(t *testing.T) {
+	home := t.TempDir()
+	cfg := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	contents := `model = "gpt-5"
+
+[projects."/x"]
+trust_level = "trusted"
+`
+	if err := os.WriteFile(cfg, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Init(home, HookCommand{Exe: "amika"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(cfg)
+	notifyIdx := strings.Index(string(got), "notify =")
+	sectionIdx := strings.Index(string(got), "[projects")
+	if notifyIdx < 0 || sectionIdx < 0 {
+		t.Fatalf("missing expected content: %s", got)
+	}
+	if notifyIdx >= sectionIdx {
+		t.Errorf("notify not inserted before [projects] section:\n%s", got)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := map[string]string{
+		"/usr/local/bin/amika":   "/usr/local/bin/amika",
+		"/path with space/amika": "'/path with space/amika'",
+		"weird'name":             `'weird'\''name'`,
+		"":                       "''",
+		"plain-thing_1.2":        "plain-thing_1.2",
+	}
+	for in, want := range cases {
+		if got := shellQuote(in); got != want {
+			t.Errorf("shellQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func readClaudeSettings(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading claude settings: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decoding claude settings: %v", err)
+	}
+	return out
+}
+
+func claudeHasHook(settings map[string]interface{}, command string) bool {
+	hooks, _ := settings["hooks"].(map[string]interface{})
+	stop, _ := hooks["Stop"].([]interface{})
+	return claudeHookAlreadyPresent(stop, command)
+}

--- a/go/internal/sessioncapture/init_test.go
+++ b/go/internal/sessioncapture/init_test.go
@@ -152,6 +152,48 @@ notify = ["/old/path/amika", "sessions", "capture", "--source", "codex"]
 	}
 }
 
+func TestInit_UpdatesMultilineAmikaNotify(t *testing.T) {
+	useCodexFallback(t)
+	home := t.TempDir()
+	cfg := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	contents := `model = "gpt-5"
+notify = [
+  "/old/path/amika",
+  "sessions",
+  "capture",
+  "--source",
+  "codex",
+]
+`
+	if err := os.WriteFile(cfg, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := Init(home, HookCommand{Exe: "/new/path/amika"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.CodexUpdated {
+		t.Errorf("expected multiline amika notify to be replaced, got %+v", rep)
+	}
+	if rep.CodexConflict != "" {
+		t.Errorf("expected no conflict for amika-pointed multiline notify, got %q", rep.CodexConflict)
+	}
+	got, _ := os.ReadFile(cfg)
+	if !strings.Contains(string(got), `notify = ["/new/path/amika", "sessions", "capture", "--source", "codex"]`) {
+		t.Errorf("notify not rewritten to single-line form:\n%s", got)
+	}
+	if strings.Contains(string(got), "/old/path/amika") {
+		t.Errorf("old multiline entries still present:\n%s", got)
+	}
+	if !strings.Contains(string(got), `model = "gpt-5"`) {
+		t.Errorf("unrelated keys lost:\n%s", got)
+	}
+}
+
 func TestInit_TreatsLookalikeNotifyAsConflict(t *testing.T) {
 	useCodexFallback(t)
 	for _, name := range []string{"notamika", "my-amika", "amikatool"} {

--- a/go/internal/sessioncapture/sessioncapture.go
+++ b/go/internal/sessioncapture/sessioncapture.go
@@ -1,0 +1,146 @@
+// Package sessioncapture mirrors Claude Code and OpenAI Codex session
+// transcripts into the amika state directory.
+//
+// Capture is driven by the agents themselves: `Init` writes hook entries into
+// `~/.claude/settings.json` (Stop hook) and `~/.codex/config.toml` (notify
+// program) that invoke `amika sessions capture --source ...` whenever the
+// agent finishes a turn. Each invocation copies the relevant session JSONL
+// into `<state>/sessions/<source>/`. No daemon, no background process.
+package sessioncapture
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Source identifies the agent that produced the session being captured.
+type Source string
+
+const (
+	// SourceClaude is the source identifier for Claude Code sessions.
+	SourceClaude Source = "claude"
+	// SourceCodex is the source identifier for OpenAI Codex sessions.
+	SourceCodex Source = "codex"
+)
+
+// CaptureDir returns the directory under stateDir where mirrored sessions
+// for the given source live.
+func CaptureDir(stateDir string, src Source) string {
+	return filepath.Join(stateDir, "sessions", string(src))
+}
+
+// claudeStopHookInput is the JSON shape Claude Code pipes on stdin when a
+// `Stop` hook fires. Only the fields amika consumes are listed.
+type claudeStopHookInput struct {
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+}
+
+// CaptureClaude reads the Stop-hook JSON Claude pipes on stdin and copies
+// the referenced transcript into the amika state directory.
+func CaptureClaude(stdin io.Reader, stateDir string) error {
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return fmt.Errorf("reading claude hook stdin: %w", err)
+	}
+	var in claudeStopHookInput
+	if err := json.Unmarshal(data, &in); err != nil {
+		return fmt.Errorf("decoding claude hook stdin: %w", err)
+	}
+	if in.TranscriptPath == "" {
+		return errors.New("claude hook input missing transcript_path")
+	}
+	name := filepath.Base(in.TranscriptPath)
+	if in.SessionID != "" && !strings.HasSuffix(name, ".jsonl") {
+		name = in.SessionID + ".jsonl"
+	}
+	dst := filepath.Join(CaptureDir(stateDir, SourceClaude), name)
+	return copyFile(in.TranscriptPath, dst)
+}
+
+// CaptureCodex copies the most recently modified Codex session file under
+// ~/.codex/sessions into the amika state directory. Codex's notify hook
+// does not pass a session path, so we resolve the active session by mtime.
+//
+// homeDir is the directory containing the `.codex` config (i.e. the user's
+// home). Returns nil with no error when no Codex session file exists yet.
+func CaptureCodex(homeDir, stateDir string) error {
+	sessionsDir := filepath.Join(homeDir, ".codex", "sessions")
+	latest, err := newestSessionFile(sessionsDir)
+	if err != nil {
+		return err
+	}
+	if latest == "" {
+		return nil
+	}
+	dst := filepath.Join(CaptureDir(stateDir, SourceCodex), filepath.Base(latest))
+	return copyFile(latest, dst)
+}
+
+func newestSessionFile(dir string) (string, error) {
+	var newest string
+	var newestMod time.Time
+	walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return filepath.SkipAll
+			}
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if info.ModTime().After(newestMod) {
+			newestMod = info.ModTime()
+			newest = path
+		}
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, os.ErrNotExist) {
+		return "", walkErr
+	}
+	return newest, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening session source %s: %w", src, err)
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("creating capture dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".capture-*")
+	if err != nil {
+		return fmt.Errorf("creating capture tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		return fmt.Errorf("copying session contents: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing capture tempfile: %w", err)
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		return fmt.Errorf("renaming capture file to %s: %w", dst, err)
+	}
+	tmpPath = ""
+	return nil
+}

--- a/go/internal/sessioncapture/sessioncapture.go
+++ b/go/internal/sessioncapture/sessioncapture.go
@@ -5,8 +5,8 @@
 // `~/.claude/settings.json` (Stop hook) and `<codex-home>/config.toml`
 // (notify program) that invoke `amika sessions capture --source ...`
 // whenever the agent finishes a turn. Each invocation copies the relevant
-// session JSONL into `<state>/sessions/<source>/`. No daemon, no background
-// process.
+// session JSONL into `<state>/sessions/<source>/<YYYY-MM-DD>/`, grouping a
+// day's sessions together. No daemon, no background process.
 //
 // `<codex-home>` is `$CODEX_HOME` when set, otherwise `~/.codex` (see
 // CodexHome). Honoring the env var matters because Codex itself reads
@@ -48,6 +48,10 @@ type claudeStopHookInput struct {
 
 // CaptureClaude reads the Stop-hook JSON Claude pipes on stdin and copies
 // the referenced transcript into the amika state directory.
+//
+// Mirrors land under a `YYYY-MM-DD/` subdirectory derived from the
+// transcript file's mtime, so a day's sessions sit together without nesting
+// year/month/day directories.
 func CaptureClaude(stdin io.Reader, stateDir string) error {
 	data, err := io.ReadAll(stdin)
 	if err != nil {
@@ -60,11 +64,16 @@ func CaptureClaude(stdin io.Reader, stateDir string) error {
 	if in.TranscriptPath == "" {
 		return errors.New("claude hook input missing transcript_path")
 	}
+	info, err := os.Stat(in.TranscriptPath)
+	if err != nil {
+		return fmt.Errorf("statting claude transcript %s: %w", in.TranscriptPath, err)
+	}
 	name := filepath.Base(in.TranscriptPath)
 	if in.SessionID != "" && !strings.HasSuffix(name, ".jsonl") {
 		name = in.SessionID + ".jsonl"
 	}
-	dst := filepath.Join(CaptureDir(stateDir, SourceClaude), name)
+	day := info.ModTime().Format("2006-01-02")
+	dst := filepath.Join(CaptureDir(stateDir, SourceClaude), day, name)
 	return copyFile(in.TranscriptPath, dst)
 }
 
@@ -75,9 +84,10 @@ func CaptureClaude(stdin io.Reader, stateDir string) error {
 // Codex's notify payload does not include a session path. Picking only the
 // globally newest file across the tree would skip a turn whenever a second
 // concurrent Codex session wrote something more recently — so we walk the
-// whole tree and copy any file that's changed. Mirrors preserve Codex's
-// `YYYY/MM/DD/<rollout>.jsonl` layout under `<state>/sessions/codex/` so
-// nothing collides across days.
+// whole tree and copy any file that's changed. Mirrors flatten Codex's
+// nested `YYYY/MM/DD/<rollout>.jsonl` source layout into a single
+// `YYYY-MM-DD/<rollout>.jsonl` directory under `<state>/sessions/codex/` —
+// session basenames are unique so nothing collides within a day.
 //
 // The Codex state root is `$CODEX_HOME` when set, falling back to
 // `<homeDir>/.codex`. Returns nil with no error when no Codex session
@@ -100,7 +110,15 @@ func CaptureCodex(homeDir, stateDir string) error {
 		if relErr != nil {
 			return relErr
 		}
-		dst := filepath.Join(dstRoot, rel)
+		day, ok := codexDayFromRel(rel)
+		if !ok {
+			info, statErr := os.Stat(path)
+			if statErr != nil {
+				return statErr
+			}
+			day = info.ModTime().Format("2006-01-02")
+		}
+		dst := filepath.Join(dstRoot, day, filepath.Base(rel))
 
 		fresh, freshErr := mirrorIsFresh(path, dst)
 		if freshErr != nil {
@@ -115,6 +133,28 @@ func CaptureCodex(homeDir, stateDir string) error {
 		return walkErr
 	}
 	return nil
+}
+
+// codexDayFromRel extracts a `YYYY-MM-DD` day stamp from a Codex session
+// relative path of the form `YYYY/MM/DD/<rollout>.jsonl`. Returns ok=false
+// if the path doesn't have that shape so callers can fall back to mtime.
+func codexDayFromRel(rel string) (string, bool) {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) < 4 {
+		return "", false
+	}
+	y, m, d := parts[0], parts[1], parts[2]
+	if len(y) != 4 || len(m) != 2 || len(d) != 2 {
+		return "", false
+	}
+	for _, s := range []string{y, m, d} {
+		for _, r := range s {
+			if r < '0' || r > '9' {
+				return "", false
+			}
+		}
+	}
+	return y + "-" + m + "-" + d, true
 }
 
 // CodexHome returns the directory Codex uses for config, sessions, auth and

--- a/go/internal/sessioncapture/sessioncapture.go
+++ b/go/internal/sessioncapture/sessioncapture.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
 // Source identifies the agent that produced the session being captured.
@@ -69,24 +68,53 @@ func CaptureClaude(stdin io.Reader, stateDir string) error {
 	return copyFile(in.TranscriptPath, dst)
 }
 
-// CaptureCodex copies the most recently modified Codex session file under
-// the Codex state root into the amika state directory. Codex's notify hook
-// does not pass a session path, so we resolve the active session by mtime.
+// CaptureCodex mirrors every Codex session file whose source mtime is newer
+// than its mirror (or that has no mirror yet) under the Codex state root
+// into the amika state directory.
+//
+// Codex's notify payload does not include a session path. Picking only the
+// globally newest file across the tree would skip a turn whenever a second
+// concurrent Codex session wrote something more recently — so we walk the
+// whole tree and copy any file that's changed. Mirrors preserve Codex's
+// `YYYY/MM/DD/<rollout>.jsonl` layout under `<state>/sessions/codex/` so
+// nothing collides across days.
 //
 // The Codex state root is `$CODEX_HOME` when set, falling back to
-// `<homeDir>/.codex`. Returns nil with no error when no Codex session file
-// exists yet.
+// `<homeDir>/.codex`. Returns nil with no error when no Codex session
+// directory exists yet.
 func CaptureCodex(homeDir, stateDir string) error {
 	sessionsDir := filepath.Join(CodexHome(homeDir), "sessions")
-	latest, err := newestSessionFile(sessionsDir)
-	if err != nil {
-		return err
+	dstRoot := CaptureDir(stateDir, SourceCodex)
+
+	walkErr := filepath.WalkDir(sessionsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return filepath.SkipAll
+			}
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(sessionsDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		dst := filepath.Join(dstRoot, rel)
+
+		fresh, freshErr := mirrorIsFresh(path, dst)
+		if freshErr != nil {
+			return freshErr
+		}
+		if fresh {
+			return nil
+		}
+		return copyFile(path, dst)
+	})
+	if walkErr != nil && !errors.Is(walkErr, os.ErrNotExist) {
+		return walkErr
 	}
-	if latest == "" {
-		return nil
-	}
-	dst := filepath.Join(CaptureDir(stateDir, SourceCodex), filepath.Base(latest))
-	return copyFile(latest, dst)
+	return nil
 }
 
 // CodexHome returns the directory Codex uses for config, sessions, auth and
@@ -99,33 +127,21 @@ func CodexHome(homeDir string) string {
 	return filepath.Join(homeDir, ".codex")
 }
 
-func newestSessionFile(dir string) (string, error) {
-	var newest string
-	var newestMod time.Time
-	walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return filepath.SkipAll
-			}
-			return err
-		}
-		if d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
-			return nil
-		}
-		info, infoErr := d.Info()
-		if infoErr != nil {
-			return infoErr
-		}
-		if info.ModTime().After(newestMod) {
-			newestMod = info.ModTime()
-			newest = path
-		}
-		return nil
-	})
-	if walkErr != nil && !errors.Is(walkErr, os.ErrNotExist) {
-		return "", walkErr
+// mirrorIsFresh reports whether dst exists and its mtime is at least as new
+// as src's. Used to skip rewrites of session files we've already mirrored.
+func mirrorIsFresh(src, dst string) (bool, error) {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return false, err
 	}
-	return newest, nil
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return !srcInfo.ModTime().After(dstInfo.ModTime()), nil
 }
 
 func copyFile(src, dst string) error {

--- a/go/internal/sessioncapture/sessioncapture.go
+++ b/go/internal/sessioncapture/sessioncapture.go
@@ -2,10 +2,15 @@
 // transcripts into the amika state directory.
 //
 // Capture is driven by the agents themselves: `Init` writes hook entries into
-// `~/.claude/settings.json` (Stop hook) and `~/.codex/config.toml` (notify
-// program) that invoke `amika sessions capture --source ...` whenever the
-// agent finishes a turn. Each invocation copies the relevant session JSONL
-// into `<state>/sessions/<source>/`. No daemon, no background process.
+// `~/.claude/settings.json` (Stop hook) and `<codex-home>/config.toml`
+// (notify program) that invoke `amika sessions capture --source ...`
+// whenever the agent finishes a turn. Each invocation copies the relevant
+// session JSONL into `<state>/sessions/<source>/`. No daemon, no background
+// process.
+//
+// `<codex-home>` is `$CODEX_HOME` when set, otherwise `~/.codex` (see
+// CodexHome). Honoring the env var matters because Codex itself reads
+// config and writes sessions there, not under `~/.codex`.
 package sessioncapture
 
 import (
@@ -65,13 +70,14 @@ func CaptureClaude(stdin io.Reader, stateDir string) error {
 }
 
 // CaptureCodex copies the most recently modified Codex session file under
-// ~/.codex/sessions into the amika state directory. Codex's notify hook
+// the Codex state root into the amika state directory. Codex's notify hook
 // does not pass a session path, so we resolve the active session by mtime.
 //
-// homeDir is the directory containing the `.codex` config (i.e. the user's
-// home). Returns nil with no error when no Codex session file exists yet.
+// The Codex state root is `$CODEX_HOME` when set, falling back to
+// `<homeDir>/.codex`. Returns nil with no error when no Codex session file
+// exists yet.
 func CaptureCodex(homeDir, stateDir string) error {
-	sessionsDir := filepath.Join(homeDir, ".codex", "sessions")
+	sessionsDir := filepath.Join(CodexHome(homeDir), "sessions")
 	latest, err := newestSessionFile(sessionsDir)
 	if err != nil {
 		return err
@@ -81,6 +87,16 @@ func CaptureCodex(homeDir, stateDir string) error {
 	}
 	dst := filepath.Join(CaptureDir(stateDir, SourceCodex), filepath.Base(latest))
 	return copyFile(latest, dst)
+}
+
+// CodexHome returns the directory Codex uses for config, sessions, auth and
+// related state. Honors the `CODEX_HOME` environment variable when set,
+// falling back to `<homeDir>/.codex`.
+func CodexHome(homeDir string) string {
+	if v := os.Getenv("CODEX_HOME"); v != "" {
+		return v
+	}
+	return filepath.Join(homeDir, ".codex")
 }
 
 func newestSessionFile(dir string) (string, error) {

--- a/go/internal/sessioncapture/sessioncapture_test.go
+++ b/go/internal/sessioncapture/sessioncapture_test.go
@@ -27,6 +27,11 @@ func TestCaptureClaude_MirrorsTranscript(t *testing.T) {
 	if err := os.WriteFile(transcript, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// Pin mtime so the derived day stamp is deterministic.
+	day := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(transcript, day, day); err != nil {
+		t.Fatal(err)
+	}
 
 	stateDir := filepath.Join(tmp, "state")
 	payload := map[string]string{
@@ -42,7 +47,7 @@ func TestCaptureClaude_MirrorsTranscript(t *testing.T) {
 	if err := CaptureClaude(strings.NewReader(string(stdin)), stateDir); err != nil {
 		t.Fatalf("CaptureClaude: %v", err)
 	}
-	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "claude", "abc.jsonl"))
+	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "claude", "2026-05-14", "abc.jsonl"))
 	if err != nil {
 		t.Fatalf("reading mirror: %v", err)
 	}
@@ -90,15 +95,15 @@ func TestCaptureCodex_MirrorsAllChangedSessions(t *testing.T) {
 		t.Fatalf("CaptureCodex: %v", err)
 	}
 
-	// Layout is preserved so basenames can't collide across days.
-	gotA, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "rollout-a.jsonl"))
+	// Day stamp comes from the source path so basenames can't collide across days.
+	gotA, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "rollout-a.jsonl"))
 	if err != nil {
 		t.Fatalf("session a not mirrored: %v", err)
 	}
 	if !strings.Contains(string(gotA), "a-turn-1") {
 		t.Errorf("session a mirror has unexpected content: %s", gotA)
 	}
-	gotB, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "02", "rollout-b.jsonl"))
+	gotB, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-02", "rollout-b.jsonl"))
 	if err != nil {
 		t.Fatalf("session b not mirrored: %v", err)
 	}
@@ -130,7 +135,7 @@ func TestCaptureCodex_SkipsUpToDateMirrors(t *testing.T) {
 		t.Fatalf("CaptureCodex first: %v", err)
 	}
 
-	mirrorB := filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "b.jsonl")
+	mirrorB := filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "b.jsonl")
 	infoBefore, err := os.Stat(mirrorB)
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +155,7 @@ func TestCaptureCodex_SkipsUpToDateMirrors(t *testing.T) {
 		t.Fatalf("CaptureCodex second: %v", err)
 	}
 
-	gotA, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "a.jsonl"))
+	gotA, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "a.jsonl"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,14 +211,14 @@ func TestCaptureCodex_HonorsCODEX_HOME(t *testing.T) {
 	if err := CaptureCodex(home, stateDir); err != nil {
 		t.Fatalf("CaptureCodex: %v", err)
 	}
-	got, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "right.jsonl"))
+	got, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "right.jsonl"))
 	if err != nil {
 		t.Fatalf("expected right.jsonl to be mirrored: %v", err)
 	}
 	if !strings.Contains(string(got), `"right"`) {
 		t.Errorf("unexpected mirrored content: %s", got)
 	}
-	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex", "2026", "01", "01", "wrong.jsonl")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex", "2026-01-01", "wrong.jsonl")); !os.IsNotExist(err) {
 		t.Errorf("file under ~/.codex was mirrored despite CODEX_HOME override")
 	}
 }

--- a/go/internal/sessioncapture/sessioncapture_test.go
+++ b/go/internal/sessioncapture/sessioncapture_test.go
@@ -1,0 +1,100 @@
+package sessioncapture
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCaptureClaude_MirrorsTranscript(t *testing.T) {
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "src", "abc.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const body = `{"role":"user","content":"hi"}` + "\n" + `{"role":"assistant","content":"hello"}` + "\n"
+	if err := os.WriteFile(transcript, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := filepath.Join(tmp, "state")
+	payload := map[string]string{
+		"session_id":      "abc",
+		"transcript_path": transcript,
+		"hook_event_name": "Stop",
+	}
+	stdin, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CaptureClaude(strings.NewReader(string(stdin)), stateDir); err != nil {
+		t.Fatalf("CaptureClaude: %v", err)
+	}
+	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "claude", "abc.jsonl"))
+	if err != nil {
+		t.Fatalf("reading mirror: %v", err)
+	}
+	if string(mirrored) != body {
+		t.Errorf("mirrored body = %q, want %q", mirrored, body)
+	}
+}
+
+func TestCaptureClaude_MissingTranscriptPath(t *testing.T) {
+	stdin := strings.NewReader(`{"session_id":"abc"}`)
+	err := CaptureClaude(stdin, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "transcript_path") {
+		t.Fatalf("expected transcript_path error, got %v", err)
+	}
+}
+
+func TestCaptureCodex_MirrorsNewestSession(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".codex", "sessions", "2026", "06", "01")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	older := filepath.Join(dir, "older.jsonl")
+	newer := filepath.Join(dir, "newer.jsonl")
+	if err := os.WriteFile(older, []byte(`{"k":"older"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newer, []byte(`{"k":"newer"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Force older to be older than newer regardless of FS resolution.
+	past := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(older, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := filepath.Join(home, "state")
+	if err := CaptureCodex(home, stateDir); err != nil {
+		t.Fatalf("CaptureCodex: %v", err)
+	}
+	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "newer.jsonl"))
+	if err != nil {
+		t.Fatalf("reading mirror: %v", err)
+	}
+	if !strings.Contains(string(mirrored), `"newer"`) {
+		t.Errorf("mirrored unexpected content: %s", mirrored)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex", "older.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("did not expect older session to be mirrored: %v", err)
+	}
+}
+
+func TestCaptureCodex_NoSessionsIsNoOp(t *testing.T) {
+	home := t.TempDir()
+	stateDir := filepath.Join(home, "state")
+	if err := CaptureCodex(home, stateDir); err != nil {
+		t.Fatalf("CaptureCodex with no sessions: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex")); !os.IsNotExist(err) {
+		t.Errorf("expected no capture dir to be created, got %v", err)
+	}
+}

--- a/go/internal/sessioncapture/sessioncapture_test.go
+++ b/go/internal/sessioncapture/sessioncapture_test.go
@@ -98,3 +98,42 @@ func TestCaptureCodex_NoSessionsIsNoOp(t *testing.T) {
 		t.Errorf("expected no capture dir to be created, got %v", err)
 	}
 }
+
+func TestCaptureCodex_HonorsCODEX_HOME(t *testing.T) {
+	home := t.TempDir()
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+
+	// A file under ~/.codex/sessions must NOT be picked up when CODEX_HOME
+	// points elsewhere — otherwise we'd mirror a stale path.
+	bogus := filepath.Join(home, ".codex", "sessions", "2026", "01", "01", "wrong.jsonl")
+	if err := os.MkdirAll(filepath.Dir(bogus), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bogus, []byte(`{"k":"wrong"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(codexHome, "sessions", "2026", "06", "01", "right.jsonl")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, []byte(`{"k":"right"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := filepath.Join(home, "state")
+	if err := CaptureCodex(home, stateDir); err != nil {
+		t.Fatalf("CaptureCodex: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "right.jsonl"))
+	if err != nil {
+		t.Fatalf("expected right.jsonl to be mirrored: %v", err)
+	}
+	if !strings.Contains(string(got), `"right"`) {
+		t.Errorf("unexpected mirrored content: %s", got)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex", "wrong.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("file under ~/.codex was mirrored despite CODEX_HOME override")
+	}
+}

--- a/go/internal/sessioncapture/sessioncapture_test.go
+++ b/go/internal/sessioncapture/sessioncapture_test.go
@@ -9,6 +9,14 @@ import (
 	"time"
 )
 
+// useCodexFallback ensures CodexHome falls back to <home>/.codex by masking
+// any ambient CODEX_HOME for the duration of the test. Tests that exercise
+// the override use t.Setenv directly instead.
+func useCodexFallback(t *testing.T) {
+	t.Helper()
+	t.Setenv("CODEX_HOME", "")
+}
+
 func TestCaptureClaude_MirrorsTranscript(t *testing.T) {
 	tmp := t.TempDir()
 	transcript := filepath.Join(tmp, "src", "abc.jsonl")
@@ -52,6 +60,7 @@ func TestCaptureClaude_MissingTranscriptPath(t *testing.T) {
 }
 
 func TestCaptureCodex_MirrorsNewestSession(t *testing.T) {
+	useCodexFallback(t)
 	home := t.TempDir()
 	dir := filepath.Join(home, ".codex", "sessions", "2026", "06", "01")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -89,6 +98,7 @@ func TestCaptureCodex_MirrorsNewestSession(t *testing.T) {
 }
 
 func TestCaptureCodex_NoSessionsIsNoOp(t *testing.T) {
+	useCodexFallback(t)
 	home := t.TempDir()
 	stateDir := filepath.Join(home, "state")
 	if err := CaptureCodex(home, stateDir); err != nil {

--- a/go/internal/sessioncapture/sessioncapture_test.go
+++ b/go/internal/sessioncapture/sessioncapture_test.go
@@ -59,41 +59,111 @@ func TestCaptureClaude_MissingTranscriptPath(t *testing.T) {
 	}
 }
 
-func TestCaptureCodex_MirrorsNewestSession(t *testing.T) {
+func TestCaptureCodex_MirrorsAllChangedSessions(t *testing.T) {
 	useCodexFallback(t)
 	home := t.TempDir()
-	dir := filepath.Join(home, ".codex", "sessions", "2026", "06", "01")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	older := filepath.Join(dir, "older.jsonl")
-	newer := filepath.Join(dir, "newer.jsonl")
-	if err := os.WriteFile(older, []byte(`{"k":"older"}`+"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(newer, []byte(`{"k":"newer"}`+"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// Force older to be older than newer regardless of FS resolution.
-	past := time.Now().Add(-1 * time.Hour)
-	if err := os.Chtimes(older, past, past); err != nil {
-		t.Fatal(err)
-	}
-
 	stateDir := filepath.Join(home, "state")
+
+	// Two concurrent sessions on different days. Mirroring only the global
+	// newest would skip whichever session wrote less recently — exactly
+	// the regression this case guards against.
+	a := filepath.Join(home, ".codex", "sessions", "2026", "06", "01", "rollout-a.jsonl")
+	b := filepath.Join(home, ".codex", "sessions", "2026", "06", "02", "rollout-b.jsonl")
+	for _, p := range []string{a, b} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(a, []byte(`{"k":"a-turn-1"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte(`{"k":"b-turn-1"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Make a older than b so a clearly isn't the global newest.
+	past := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(a, past, past); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := CaptureCodex(home, stateDir); err != nil {
 		t.Fatalf("CaptureCodex: %v", err)
 	}
-	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "newer.jsonl"))
+
+	// Layout is preserved so basenames can't collide across days.
+	gotA, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "rollout-a.jsonl"))
 	if err != nil {
-		t.Fatalf("reading mirror: %v", err)
+		t.Fatalf("session a not mirrored: %v", err)
 	}
-	if !strings.Contains(string(mirrored), `"newer"`) {
-		t.Errorf("mirrored unexpected content: %s", mirrored)
+	if !strings.Contains(string(gotA), "a-turn-1") {
+		t.Errorf("session a mirror has unexpected content: %s", gotA)
 	}
-	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex", "older.jsonl")); !os.IsNotExist(err) {
-		t.Errorf("did not expect older session to be mirrored: %v", err)
+	gotB, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "02", "rollout-b.jsonl"))
+	if err != nil {
+		t.Fatalf("session b not mirrored: %v", err)
+	}
+	if !strings.Contains(string(gotB), "b-turn-1") {
+		t.Errorf("session b mirror has unexpected content: %s", gotB)
+	}
+}
+
+func TestCaptureCodex_SkipsUpToDateMirrors(t *testing.T) {
+	useCodexFallback(t)
+	home := t.TempDir()
+	stateDir := filepath.Join(home, "state")
+
+	a := filepath.Join(home, ".codex", "sessions", "2026", "06", "01", "a.jsonl")
+	b := filepath.Join(home, ".codex", "sessions", "2026", "06", "01", "b.jsonl")
+	for _, p := range []string{a, b} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(a, []byte("a-v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("b-v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CaptureCodex(home, stateDir); err != nil {
+		t.Fatalf("CaptureCodex first: %v", err)
+	}
+
+	mirrorB := filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "b.jsonl")
+	infoBefore, err := os.Stat(mirrorB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only `a` advances on disk; `b` is unchanged. The second capture
+	// should rewrite a's mirror but leave b's alone (verified via mtime).
+	future := time.Now().Add(2 * time.Second)
+	if err := os.WriteFile(a, []byte("a-v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(a, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CaptureCodex(home, stateDir); err != nil {
+		t.Fatalf("CaptureCodex second: %v", err)
+	}
+
+	gotA, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "a.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(gotA), "a-v2") {
+		t.Errorf("a's mirror not refreshed: %s", gotA)
+	}
+
+	infoAfter, err := os.Stat(mirrorB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !infoAfter.ModTime().Equal(infoBefore.ModTime()) {
+		t.Errorf("b's mirror mtime changed (%v → %v), expected no rewrite", infoBefore.ModTime(), infoAfter.ModTime())
 	}
 }
 
@@ -136,14 +206,14 @@ func TestCaptureCodex_HonorsCODEX_HOME(t *testing.T) {
 	if err := CaptureCodex(home, stateDir); err != nil {
 		t.Fatalf("CaptureCodex: %v", err)
 	}
-	got, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "right.jsonl"))
+	got, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026", "06", "01", "right.jsonl"))
 	if err != nil {
 		t.Fatalf("expected right.jsonl to be mirrored: %v", err)
 	}
 	if !strings.Contains(string(got), `"right"`) {
 		t.Errorf("unexpected mirrored content: %s", got)
 	}
-	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex", "wrong.jsonl")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex", "2026", "01", "01", "wrong.jsonl")); !os.IsNotExist(err) {
 		t.Errorf("file under ~/.codex was mirrored despite CODEX_HOME override")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `amika sessions capture-init`, which installs hooks into Claude Code and Codex so each agent mirrors its session transcripts into the amika state directory on every turn — no daemon.
- Add the hook-invoked `amika sessions capture --source {claude|codex}` that does the actual copy into `<state>/sessions/{claude,codex}/<YYYY-MM-DD>/`, grouping a day's sessions together.
- Idempotent: existing Claude hook events and Codex TOML keys / comments are preserved; an existing non-amika `notify` is left alone with a warning.

## How it works

`amika sessions capture-init`:
- Appends a `Stop` hook to `~/.claude/settings.json` running `amika sessions capture --source claude`. Other keys (theme, other hook events) round-trip unchanged.
- Sets a top-level `notify = [...]` array in `~/.codex/config.toml` running `amika sessions capture --source codex`. The TOML is edited line-wise so existing formatting / comments survive, and the assignment is inserted before the first `[section]` header.

`amika sessions capture --source ...` (invoked by the agent hooks):
- Claude: reads the `transcript_path` from the JSON payload Claude pipes on stdin and atomically copies it to `<state>/sessions/claude/<YYYY-MM-DD>/<session_id>.jsonl`, where the day stamp comes from the transcript's mtime.
- Codex: Codex's notify payload doesn't include a session path, so we walk `<codex-home>/sessions/**` and mirror every `.jsonl` whose source mtime is newer than its mirror (or that has no mirror yet) into `<state>/sessions/codex/<YYYY-MM-DD>/`. The day stamp is derived from Codex's nested `YYYY/MM/DD/` source layout, falling back to mtime if the shape doesn't match.

`github.com/BurntSushi/toml` is promoted from indirect to direct so we can decode existing Codex `notify` values before deciding whether to overwrite them.

## Test plan

- [x] `make fmt vet lint build` clean
- [x] `go test ./internal/sessioncapture/ -v` — unit tests cover: Claude transcript mirror with per-day grouping, Codex mirror of every changed session (not just the global newest), `CODEX_HOME` override, idempotent re-runs that skip up-to-date mirrors, init idempotency, preservation of unrelated Claude keys + hooks, refusal to clobber an existing non-amika Codex notify, in-place update of an amika notify whose path changed, insertion before `[section]` headers, and shell-quoting edge cases.
- [x] End-to-end smoke test from a temp `HOME`: `capture-init` produces the expected `~/.claude/settings.json` Stop hook and `~/.codex/config.toml` notify array; piping a synthetic Claude Stop payload mirrors the JSONL; running the Codex variant mirrors the newest rollout file; re-running `capture-init` is a no-op.
- [ ] Run against a real Claude Code session and verify the Stop hook fires and the mirror lands under `~/.local/state/amika/sessions/claude/<YYYY-MM-DD>/`.
- [ ] Run against a real Codex session and verify the notify program fires and the mirror lands under `~/.local/state/amika/sessions/codex/<YYYY-MM-DD>/`.

## Notes

- Pre-existing `make test` failures in `internal/materialize` come from `rsync` not being installed in this sandbox; verified unrelated by re-running with these changes stashed out.
