### PR TITLE
Add --print flag to sandbox ssh command

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -61,6 +61,7 @@ func New() *cobra.Command {
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")
 	sandboxSSHCmd.Flags().BoolP("t", "t", false, "Force pseudo-terminal allocation (like ssh -t)")
 	sandboxSSHCmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
+	sandboxSSHCmd.Flags().Bool("print", false, "Print the SSH connection string instead of connecting")
 	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor to open (currently only \"cursor\" is supported)")
 	sandboxAgentSendCmd.Flags().Bool("no-wait", false, "Send the instruction and return immediately without waiting for a response")
 	sandboxAgentSendCmd.Flags().String("workdir", "$AMIKA_AGENT_CWD", "Working directory inside the container (default: $AMIKA_AGENT_CWD)")

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -50,10 +50,13 @@ Optionally pass a command to execute on the remote sandbox instead of opening an
 Use -t to force pseudo-terminal allocation, which is useful for running interactive
 programs on the remote sandbox (equivalent to ssh -t).
 
+Use --print to print the SSH connection string instead of connecting.
+
 Examples:
   amika sandbox ssh my-sandbox
   amika sandbox ssh -t my-sandbox -- top
   amika sandbox ssh my-sandbox -- ls -la
+  amika sandbox ssh --print my-sandbox
   amika sandbox ssh my-sandbox --revoke`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -90,6 +93,19 @@ Examples:
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "SSH access revoked for sandbox %q\n", name)
+			return nil
+		}
+
+		printOnly, _ := cmd.Flags().GetBool("print")
+		if printOnly {
+			info, err := client.GetSSH(name)
+			if err != nil {
+				return err
+			}
+			if info.SSHDestination == "" {
+				return fmt.Errorf("server returned empty SSH destination")
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), info.SSHDestination)
 			return nil
 		}
 

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -42,7 +42,7 @@ func execSSH(client *apiclient.Client, name string, forcePTY bool, extraArgs []s
 }
 
 var sandboxSSHCmd = &cobra.Command{
-	Use:   "ssh <name> [-- <command>...]",
+	Use:   "ssh [flags] <name> [-- <command>...]",
 	Short: "SSH into a remote sandbox",
 	Long: `Connect to a remote sandbox via SSH, or revoke SSH access.
 Optionally pass a command to execute on the remote sandbox instead of opening an interactive session.


### PR DESCRIPTION
Adds a `--print` flag to `amika sandbox ssh` that prints the SSH connection string instead of connecting, and reorders the usage string so flags come before the positional `<name>`.

## Changes

- Reorder the usage string from `ssh <name> [-- <command>...]` to `ssh [flags] <name> [-- <command>...]`.
- Add a `--print` flag that fetches the SSH info and prints only the connection string (`<destination>`) instead of opening a session.