### PR TITLE
Open Cursor via a stable per-sandbox SSH alias

### DIFF
--- a/go/cmd/amika/sandbox/sandbox_agent.go
+++ b/go/cmd/amika/sandbox/sandbox_agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/config"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
+	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/spf13/cobra"
 )
 
@@ -127,7 +128,7 @@ func buildRemoteAgentShellCmd(message string, noWait bool, workdir string, agent
 func runRemoteAgentSend(client *apiclient.Client, name, message string, noWait bool, workdir string, agent agentConfig, opts agentRunOpts, stdout io.Writer) error {
 	if noWait {
 		shellCmd := buildRemoteAgentShellCmd(message, noWait, workdir, agent, opts)
-		return execSSH(client, name, false, []string{shellCmd})
+		return ssh.ExecSSH(client, name, false, []string{shellCmd})
 	}
 
 	req := apiclient.AgentSendRequest{

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/constants"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
+	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/gofixpoint/amika/go/pkg/amika"
 	"github.com/spf13/cobra"
 )
@@ -397,7 +398,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 
 	connect, _ := cmd.Flags().GetBool("connect")
 	if connect {
-		return execSSH(client, sb.Name, false, nil)
+		return ssh.ExecSSH(client, sb.Name, false, nil)
 	}
 
 	return nil

--- a/go/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/go/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/config"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
+	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/gofixpoint/amika/go/pkg/amika"
 	"github.com/spf13/cobra"
 )
@@ -330,7 +331,7 @@ var sandboxConnectCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return execSSH(client, name, false, nil)
+		return ssh.ExecSSH(client, name, false, nil)
 	},
 }
 

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/ssh"
@@ -113,58 +114,67 @@ Examples:
 			return err
 		}
 
-		info, err := client.GetSSH(name)
+		cursorTarget, err := prepareCursorSSHTarget(client, basedir.New(""), name)
 		if err != nil {
 			return err
 		}
 
-		if info.SSHDestination == "" {
-			return fmt.Errorf("server returned empty SSH destination")
-		}
-
-		// Key the SSH host alias on the immutable sandbox id, not the rotating
-		// connection token, so Cursor re-links its Remote-SSH session (and agent
-		// chat) to the same host across reconnects. Older servers omit the id
-		// from the SSH response, so fall back to a sandbox lookup.
-		sandboxID := info.SandboxID
-		sandboxName := info.SandboxName
-		if sandboxID == "" {
-			sb, err := client.GetSandbox(name)
-			if err != nil {
-				return fmt.Errorf("look up sandbox id: %w", err)
-			}
-			sandboxID = sb.ID
-			sandboxName = sb.Name
-		}
-		if sandboxName == "" {
-			sandboxName = name
-		}
-
-		entry, err := ssh.NewHostEntry(sandboxID, sandboxName, info.SSHDestination, info.ExpiresAt)
-		if err != nil {
-			return err
-		}
-		alias, err := ssh.UpsertHost(basedir.New(""), entry)
-		if err != nil {
-			return fmt.Errorf("write managed SSH config: %w", err)
-		}
-
-		remotePath := "/home/amika/workspace"
-		if info.RepoName != "" {
-			remotePath = remotePath + "/" + info.RepoName
-		}
-
-		cursorCmd := exec.Command("cursor", "--remote", "ssh-remote+"+alias, remotePath)
+		cursorCmd := exec.Command("cursor", "--remote", "ssh-remote+"+cursorTarget.alias, cursorTarget.remotePath)
 		cursorCmd.Stdin = os.Stdin
 		cursorCmd.Stdout = os.Stdout
 		cursorCmd.Stderr = os.Stderr
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Opening sandbox %q in Cursor via SSH (%s)...\n", name, alias)
-		fmt.Fprintf(cmd.OutOrStdout(), "Running: cursor --remote ssh-remote+%s %s\n", alias, remotePath)
+		fmt.Fprintf(cmd.OutOrStdout(), "Opening sandbox %q in Cursor via SSH (%s)...\n", name, cursorTarget.alias)
+		fmt.Fprintf(cmd.OutOrStdout(), "Running: cursor --remote ssh-remote+%s %s\n", cursorTarget.alias, cursorTarget.remotePath)
 		fmt.Fprintf(cmd.OutOrStdout(), "Hint: if the file explorer is not visible, press Cmd+Shift+E in Cursor to open it.\n")
 		if err := cursorCmd.Run(); err != nil {
 			return fmt.Errorf("cursor failed: %w\n\nMake sure the \"Remote - SSH\" extension is installed in Cursor", err)
 		}
 		return nil
 	},
+}
+
+type cursorSSHTarget struct {
+	alias      string
+	remotePath string
+}
+
+func prepareCursorSSHTarget(client *apiclient.Client, paths basedir.Paths, name string) (cursorSSHTarget, error) {
+	info, err := client.GetSSH(name)
+	if err != nil {
+		return cursorSSHTarget{}, err
+	}
+	if info.SSHDestination == "" {
+		return cursorSSHTarget{}, fmt.Errorf("server returned empty SSH destination")
+	}
+
+	sandboxID := info.SandboxID
+	sandboxName := info.SandboxName
+	if sandboxID == "" {
+		sb, err := client.GetSandbox(name)
+		if err != nil {
+			return cursorSSHTarget{}, fmt.Errorf("look up sandbox id: %w", err)
+		}
+		sandboxID = sb.ID
+		sandboxName = sb.Name
+	}
+	if sandboxName == "" {
+		sandboxName = name
+	}
+
+	entry, err := ssh.NewHostEntry(sandboxID, sandboxName, info.SSHDestination, info.ExpiresAt)
+	if err != nil {
+		return cursorSSHTarget{}, err
+	}
+	alias, err := ssh.UpsertHost(paths, entry)
+	if err != nil {
+		return cursorSSHTarget{}, fmt.Errorf("write managed SSH config: %w", err)
+	}
+
+	remotePath := "/home/amika/workspace"
+	if info.RepoName != "" {
+		remotePath = remotePath + "/" + info.RepoName
+	}
+
+	return cursorSSHTarget{alias: alias, remotePath: remotePath}, nil
 }

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
+	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/spf13/cobra"
@@ -122,21 +122,45 @@ Examples:
 			return fmt.Errorf("server returned empty SSH destination")
 		}
 
-		fields := strings.Fields(info.SSHDestination)
-		remoteHost := fields[len(fields)-1]
+		// Key the SSH host alias on the immutable sandbox id, not the rotating
+		// connection token, so Cursor re-links its Remote-SSH session (and agent
+		// chat) to the same host across reconnects. Older servers omit the id
+		// from the SSH response, so fall back to a sandbox lookup.
+		sandboxID := info.SandboxID
+		sandboxName := info.SandboxName
+		if sandboxID == "" {
+			sb, err := client.GetSandbox(name)
+			if err != nil {
+				return fmt.Errorf("look up sandbox id: %w", err)
+			}
+			sandboxID = sb.ID
+			sandboxName = sb.Name
+		}
+		if sandboxName == "" {
+			sandboxName = name
+		}
+
+		entry, err := ssh.NewHostEntry(sandboxID, sandboxName, info.SSHDestination, info.ExpiresAt)
+		if err != nil {
+			return err
+		}
+		alias, err := ssh.UpsertHost(basedir.New(""), entry)
+		if err != nil {
+			return fmt.Errorf("write managed SSH config: %w", err)
+		}
 
 		remotePath := "/home/amika/workspace"
 		if info.RepoName != "" {
 			remotePath = remotePath + "/" + info.RepoName
 		}
 
-		cursorCmd := exec.Command("cursor", "--remote", "ssh-remote+"+remoteHost, remotePath)
+		cursorCmd := exec.Command("cursor", "--remote", "ssh-remote+"+alias, remotePath)
 		cursorCmd.Stdin = os.Stdin
 		cursorCmd.Stdout = os.Stdout
 		cursorCmd.Stderr = os.Stderr
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Opening sandbox %q in Cursor via SSH (%s)...\n", name, remoteHost)
-		fmt.Fprintf(cmd.OutOrStdout(), "Running: cursor --remote ssh-remote+%s %s\n", remoteHost, remotePath)
+		fmt.Fprintf(cmd.OutOrStdout(), "Opening sandbox %q in Cursor via SSH (%s)...\n", name, alias)
+		fmt.Fprintf(cmd.OutOrStdout(), "Running: cursor --remote ssh-remote+%s %s\n", alias, remotePath)
 		fmt.Fprintf(cmd.OutOrStdout(), "Hint: if the file explorer is not visible, press Cmd+Shift+E in Cursor to open it.\n")
 		if err := cursorCmd.Run(); err != nil {
 			return fmt.Errorf("cursor failed: %w\n\nMake sure the \"Remote - SSH\" extension is installed in Cursor", err)

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -7,39 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 
-	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/runmode"
+	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/spf13/cobra"
 )
-
-func execSSH(client *apiclient.Client, name string, forcePTY bool, extraArgs []string) error {
-	info, err := client.GetSSH(name)
-	if err != nil {
-		return err
-	}
-	if info.SSHDestination == "" {
-		return fmt.Errorf("server returned empty SSH destination")
-	}
-
-	sshArgs := strings.Fields(info.SSHDestination)
-
-	if forcePTY {
-		dest := sshArgs[len(sshArgs)-1]
-		sshArgs = append(sshArgs[:len(sshArgs)-1], "-t", dest)
-	}
-
-	if len(extraArgs) > 0 {
-		sshArgs = append(sshArgs, extraArgs...)
-	}
-
-	sshBin, err := exec.LookPath("ssh")
-	if err != nil {
-		return fmt.Errorf("ssh not found: %w", err)
-	}
-	return syscall.Exec(sshBin, append([]string{"ssh"}, sshArgs...), os.Environ())
-}
 
 var sandboxSSHCmd = &cobra.Command{
 	Use:   "ssh <name> [-- <command>...]",
@@ -98,7 +70,7 @@ Examples:
 		if len(args) > 1 {
 			extraArgs = args[1:]
 		}
-		return execSSH(client, name, forcePTY, extraArgs)
+		return ssh.ExecSSH(client, name, forcePTY, extraArgs)
 	},
 }
 

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -162,7 +162,13 @@ type SSHInfo struct {
 	SSHDestination string `json:"ssh_destination"`
 	Token          string `json:"token"`
 	ExpiresAt      string `json:"expires_at"`
-	RepoName       string `json:"repo_name"`
+	// SandboxID is the sandbox's immutable identifier. It is used to key a
+	// stable SSH host alias so an editor's Remote-SSH session re-links across
+	// reconnects rather than treating each rotated token as a new host. It may
+	// be empty when talking to an older server that predates this field.
+	SandboxID   string `json:"sandbox_id"`
+	SandboxName string `json:"sandbox_name"`
+	RepoName    string `json:"repo_name"`
 }
 
 // GetSSH retrieves SSH connection details for a remote sandbox.

--- a/go/internal/apiclient/client_test.go
+++ b/go/internal/apiclient/client_test.go
@@ -99,6 +99,36 @@ func TestPathEscapesSandboxName(t *testing.T) {
 	}
 }
 
+func TestGetSSHParsesResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"ssh_destination": "user-token@ssh.app.daytona.io",
+			"token":           "tok-123",
+			"expires_at":      "2026-06-04T18:30:00.000Z",
+			"sandbox_id":      "sb_01HXYZ",
+			"sandbox_name":    "my-sandbox",
+			"repo_name":       "my-repo",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	info, err := c.GetSSH("my-sandbox")
+	if err != nil {
+		t.Fatalf("GetSSH: %v", err)
+	}
+	if info.SandboxID != "sb_01HXYZ" {
+		t.Errorf("SandboxID = %q, want %q", info.SandboxID, "sb_01HXYZ")
+	}
+	if info.SandboxName != "my-sandbox" {
+		t.Errorf("SandboxName = %q, want %q", info.SandboxName, "my-sandbox")
+	}
+	if info.SSHDestination != "user-token@ssh.app.daytona.io" {
+		t.Errorf("SSHDestination = %q", info.SSHDestination)
+	}
+}
+
 func TestExtractAgentAuthError(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/go/internal/basedir/basedir.go
+++ b/go/internal/basedir/basedir.go
@@ -19,6 +19,10 @@ const (
 	fileMountsDir       = "rwcopy-mounts.d"
 	workosSessionFile   = "workos-session.json"
 	apiKeyFile          = "api-key.json"
+	sshHostsStateFile   = "ssh-hosts.json"
+	sshDirName          = ".ssh"
+	sshConfigFile       = "config"
+	sshAmikaConfigFile  = "amika.conf"
 	envXDGConfigHome    = "XDG_CONFIG_HOME"
 	envXDGDataHome      = "XDG_DATA_HOME"
 	envXDGCacheHome     = "XDG_CACHE_HOME"
@@ -48,6 +52,11 @@ type Paths interface {
 	FileMountsDir() (string, error)
 	WorkOSAuthSessionFile() (string, error)
 	APIKeyFile() (string, error)
+
+	SSHHostsStateFile() (string, error)
+	SSHDir() (string, error)
+	SSHConfigFile() (string, error)
+	SSHAmikaConfigFile() (string, error)
 }
 
 type xdgPaths struct {
@@ -227,6 +236,44 @@ func (p *xdgPaths) APIKeyFile() (string, error) {
 	return APIKeyFileIn(dir), nil
 }
 
+// SSHHostsStateFile returns the JSON file that records the managed SSH host
+// entries. It is the source of truth from which the SSH config is regenerated.
+func (p *xdgPaths) SSHHostsStateFile() (string, error) {
+	dir, err := p.AmikaStateDir()
+	if err != nil {
+		return "", err
+	}
+	return SSHHostsStateFileIn(dir), nil
+}
+
+// SSHDir returns the user's ~/.ssh directory.
+func (p *xdgPaths) SSHDir() (string, error) {
+	home, err := p.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, sshDirName), nil
+}
+
+// SSHConfigFile returns the user's primary ~/.ssh/config file.
+func (p *xdgPaths) SSHConfigFile() (string, error) {
+	dir, err := p.SSHDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, sshConfigFile), nil
+}
+
+// SSHAmikaConfigFile returns the Amika-managed ~/.ssh/amika.conf file, which is
+// pulled into the primary config via an Include directive.
+func (p *xdgPaths) SSHAmikaConfigFile() (string, error) {
+	dir, err := p.SSHDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, sshAmikaConfigFile), nil
+}
+
 // MountsStateFileIn returns the mounts state file path under the given state directory.
 func MountsStateFileIn(stateDir string) string {
 	return filepath.Join(stateDir, mountsStateFile)
@@ -260,4 +307,16 @@ func WorkOSAuthSessionFileIn(stateDir string) string {
 // APIKeyFileIn returns the stored API key file path under the given state directory.
 func APIKeyFileIn(stateDir string) string {
 	return filepath.Join(stateDir, apiKeyFile)
+}
+
+// SSHHostsStateFileIn returns the managed SSH hosts state file path under the given state directory.
+func SSHHostsStateFileIn(stateDir string) string {
+	return filepath.Join(stateDir, sshHostsStateFile)
+}
+
+// SSHAmikaConfigName returns the bare filename of the Amika-managed SSH config,
+// as it should appear in an `Include` directive within ~/.ssh/config (Include
+// paths are resolved relative to ~/.ssh).
+func SSHAmikaConfigName() string {
+	return sshAmikaConfigFile
 }

--- a/go/internal/basedir/basedir_test.go
+++ b/go/internal/basedir/basedir_test.go
@@ -77,9 +77,39 @@ func TestPaths_XDGOverrides(t *testing.T) {
 	}
 }
 
+func TestPaths_SSHPaths(t *testing.T) {
+	home := t.TempDir()
+	state := filepath.Join(t.TempDir(), "state")
+	setEnv(t, envXDGStateHome, state)
+
+	p := New(home)
+
+	if got, _ := p.SSHHostsStateFile(); got != filepath.Join(state, "amika", "ssh-hosts.json") {
+		t.Fatalf("SSHHostsStateFile = %q", got)
+	}
+	if got, _ := p.SSHDir(); got != filepath.Join(home, ".ssh") {
+		t.Fatalf("SSHDir = %q", got)
+	}
+	if got, _ := p.SSHConfigFile(); got != filepath.Join(home, ".ssh", "config") {
+		t.Fatalf("SSHConfigFile = %q", got)
+	}
+	if got, _ := p.SSHAmikaConfigFile(); got != filepath.Join(home, ".ssh", "amika.conf") {
+		t.Fatalf("SSHAmikaConfigFile = %q", got)
+	}
+}
+
+func TestSSHAmikaConfigName(t *testing.T) {
+	if got := SSHAmikaConfigName(); got != "amika.conf" {
+		t.Fatalf("SSHAmikaConfigName = %q", got)
+	}
+}
+
 func TestStateFileHelpers(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "state", "amika")
 
+	if got := SSHHostsStateFileIn(stateDir); got != filepath.Join(stateDir, "ssh-hosts.json") {
+		t.Fatalf("SSHHostsStateFileIn = %q", got)
+	}
 	if got := MountsStateFileIn(stateDir); got != filepath.Join(stateDir, "mounts.jsonl") {
 		t.Fatalf("MountsStateFileIn = %q", got)
 	}

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -1,0 +1,270 @@
+package ssh
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/gofixpoint/amika/go/internal/basedir"
+)
+
+// aliasPrefix is prepended to a sandbox id to form its stable SSH host alias.
+const aliasPrefix = "amika-"
+
+// managedHeader marks the generated config as owned by amika. The file is fully
+// regenerated from the JSON state on every change, so manual edits are lost.
+const managedHeader = `# This file is managed by amika. Do not edit by hand.
+# It is regenerated from the SSH hosts state on every ` + "`amika sandbox code`" + ` run.
+`
+
+// HostEntry is one managed SSH host: a stable alias for a sandbox plus the
+// last-known rotating connection details used to render its config block.
+type HostEntry struct {
+	SandboxID   string `json:"sandbox_id"`
+	SandboxName string `json:"sandbox_name"`
+	HostName    string `json:"host_name"`
+	User        string `json:"user"`
+	Port        int    `json:"port,omitempty"`
+	ExpiresAt   string `json:"expires_at,omitempty"`
+}
+
+// HostsState is the source of truth from which ~/.ssh/amika.conf is rendered.
+type HostsState struct {
+	Hosts []HostEntry `json:"hosts"`
+}
+
+// Alias returns the stable SSH host alias for a sandbox id. Cursor keys its
+// Remote-SSH workspace (and agent chat) off this string, so it must depend only
+// on the immutable id and never on the rotating connection token.
+func Alias(sandboxID string) string {
+	return aliasPrefix + sandboxID
+}
+
+// Destination is the user/host/port parsed out of an ssh destination string.
+type Destination struct {
+	User string
+	Host string
+	Port int
+}
+
+// ParseDestination extracts the user, host, and port from an ssh destination
+// such as "token@ssh.app.daytona.io" or "-p 2222 user@host". Unlike taking the
+// last whitespace token, this preserves an explicit port and tolerates flags.
+func ParseDestination(dest string) (Destination, error) {
+	var d Destination
+	var target string
+	fields := strings.Fields(dest)
+	for i := 0; i < len(fields); i++ {
+		f := fields[i]
+		switch {
+		case f == "-p" && i+1 < len(fields):
+			port, err := strconv.Atoi(fields[i+1])
+			if err != nil {
+				return d, fmt.Errorf("invalid ssh port %q: %w", fields[i+1], err)
+			}
+			d.Port = port
+			i++
+		case strings.HasPrefix(f, "-"):
+			// Ignore other flags; the destination is a bare token.
+			continue
+		default:
+			target = f
+		}
+	}
+	if target == "" {
+		return d, fmt.Errorf("no ssh destination found in %q", dest)
+	}
+	if at := strings.LastIndex(target, "@"); at >= 0 {
+		d.User = target[:at]
+		d.Host = target[at+1:]
+	} else {
+		d.Host = target
+	}
+	if d.Host == "" {
+		return d, fmt.Errorf("no ssh host found in %q", dest)
+	}
+	return d, nil
+}
+
+// Upsert adds or replaces the entry for a sandbox id, keeping entries sorted by
+// id so the rendered config is deterministic.
+func (s *HostsState) Upsert(entry HostEntry) {
+	for i, h := range s.Hosts {
+		if h.SandboxID == entry.SandboxID {
+			s.Hosts[i] = entry
+			return
+		}
+	}
+	s.Hosts = append(s.Hosts, entry)
+	sort.Slice(s.Hosts, func(i, j int) bool {
+		return s.Hosts[i].SandboxID < s.Hosts[j].SandboxID
+	})
+}
+
+// Render produces the contents of ~/.ssh/amika.conf from the state. Each block
+// is a stable `Host amika-<id>` alias preceded by the sandbox name as a comment
+// so the file stays human-readable even though it is keyed by id.
+func Render(state HostsState) string {
+	var b strings.Builder
+	b.WriteString(managedHeader)
+	for _, h := range state.Hosts {
+		b.WriteString("\n")
+		if h.SandboxName != "" {
+			fmt.Fprintf(&b, "# %s\n", h.SandboxName)
+		}
+		fmt.Fprintf(&b, "Host %s\n", Alias(h.SandboxID))
+		fmt.Fprintf(&b, "  HostName %s\n", h.HostName)
+		if h.User != "" {
+			fmt.Fprintf(&b, "  User %s\n", h.User)
+		}
+		if h.Port != 0 {
+			fmt.Fprintf(&b, "  Port %d\n", h.Port)
+		}
+		b.WriteString("  StrictHostKeyChecking accept-new\n")
+	}
+	return b.String()
+}
+
+// LoadState reads the SSH hosts state, returning an empty state if the file does
+// not exist yet.
+func LoadState(paths basedir.Paths) (HostsState, error) {
+	var state HostsState
+	path, err := paths.SSHHostsStateFile()
+	if err != nil {
+		return state, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state, nil
+		}
+		return state, fmt.Errorf("read ssh hosts state: %w", err)
+	}
+	if len(data) == 0 {
+		return state, nil
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return state, fmt.Errorf("parse ssh hosts state %q: %w", path, err)
+	}
+	return state, nil
+}
+
+// SaveState writes the SSH hosts state atomically with owner-only permissions.
+func SaveState(paths basedir.Paths, state HostsState) error {
+	path, err := paths.SSHHostsStateFile()
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode ssh hosts state: %w", err)
+	}
+	return writeFileAtomic(path, append(data, '\n'), 0o600)
+}
+
+// WriteAmikaConfig renders the state to ~/.ssh/amika.conf atomically.
+func WriteAmikaConfig(paths basedir.Paths, state HostsState) error {
+	path, err := paths.SSHAmikaConfigFile()
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(path, []byte(Render(state)), 0o600)
+}
+
+// EnsureInclude makes sure ~/.ssh/config pulls in the managed amika.conf via an
+// Include directive near the top (Include must precede Host blocks to take
+// effect, since ssh resolves options first-match-wins). It is idempotent and
+// creates ~/.ssh/config if absent.
+func EnsureInclude(paths basedir.Paths) error {
+	configPath, err := paths.SSHConfigFile()
+	if err != nil {
+		return err
+	}
+	includeLine := "Include " + basedir.SSHAmikaConfigName()
+
+	existing, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read ssh config: %w", err)
+	}
+	if hasIncludeLine(string(existing), includeLine) {
+		return nil
+	}
+
+	var content string
+	if len(existing) == 0 {
+		content = includeLine + "\n"
+	} else {
+		content = includeLine + "\n\n" + string(existing)
+	}
+	return writeFileAtomic(configPath, []byte(content), 0o600)
+}
+
+// hasIncludeLine reports whether the config already includes the managed file.
+func hasIncludeLine(content, includeLine string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		if strings.EqualFold(strings.TrimSpace(scanner.Text()), includeLine) {
+			return true
+		}
+	}
+	return false
+}
+
+// UpsertHost records (or refreshes) the managed SSH host for a sandbox: it
+// updates the JSON state, regenerates ~/.ssh/amika.conf, ensures ~/.ssh/config
+// includes it, and returns the stable alias to connect to. This is the single
+// entry point editors use so connection details stay behind one seam.
+func UpsertHost(paths basedir.Paths, entry HostEntry) (string, error) {
+	state, err := LoadState(paths)
+	if err != nil {
+		return "", err
+	}
+	state.Upsert(entry)
+	if err := SaveState(paths, state); err != nil {
+		return "", err
+	}
+	if err := WriteAmikaConfig(paths, state); err != nil {
+		return "", err
+	}
+	if err := EnsureInclude(paths); err != nil {
+		return "", err
+	}
+	return Alias(entry.SandboxID), nil
+}
+
+// writeFileAtomic writes data to path via a temp file + rename so a concurrent
+// run never observes a half-written file. The parent directory is created with
+// owner-only permissions.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create %q: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".amika-*")
+	if err != nil {
+		return fmt.Errorf("create temp file in %q: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write %q: %w", tmpName, err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod %q: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close %q: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename %q to %q: %w", tmpName, path, err)
+	}
+	return nil
+}

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -91,6 +91,24 @@ func ParseDestination(dest string) (Destination, error) {
 	return d, nil
 }
 
+// NewHostEntry builds a managed host entry for a sandbox from its ssh
+// destination string and identity. The destination is parsed (rather than
+// split on whitespace) so an explicit port survives into the rendered config.
+func NewHostEntry(sandboxID, sandboxName, destination, expiresAt string) (HostEntry, error) {
+	d, err := ParseDestination(destination)
+	if err != nil {
+		return HostEntry{}, err
+	}
+	return HostEntry{
+		SandboxID:   sandboxID,
+		SandboxName: sandboxName,
+		HostName:    d.Host,
+		User:        d.User,
+		Port:        d.Port,
+		ExpiresAt:   expiresAt,
+	}, nil
+}
+
 // Upsert adds or replaces the entry for a sandbox id, keeping entries sorted by
 // id so the rendered config is deterministic.
 func (s *HostsState) Upsert(entry HostEntry) {

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -203,6 +203,10 @@ func EnsureInclude(paths basedir.Paths) error {
 	if err != nil {
 		return err
 	}
+	writePath, err := resolveWriteTarget(configPath)
+	if err != nil {
+		return err
+	}
 	includeLine := "Include " + basedir.SSHAmikaConfigName()
 
 	existing, err := os.ReadFile(configPath)
@@ -219,7 +223,7 @@ func EnsureInclude(paths basedir.Paths) error {
 	} else {
 		content = includeLine + "\n\n" + string(existing)
 	}
-	return writeFileAtomic(configPath, []byte(content), 0o600)
+	return writeFileAtomic(writePath, []byte(content), 0o600)
 }
 
 // hasIncludeLine reports whether the config already includes the managed file.
@@ -285,4 +289,33 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("rename %q to %q: %w", tmpName, path, err)
 	}
 	return nil
+}
+
+func resolveWriteTarget(path string) (string, error) {
+	resolved := path
+	for i := 0; i < 32; i++ {
+		info, err := os.Lstat(resolved)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return resolved, nil
+			}
+			return "", fmt.Errorf("stat %q: %w", resolved, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return resolved, nil
+		}
+
+		target, err := os.Readlink(resolved)
+		if err != nil {
+			return "", fmt.Errorf("read symlink %q: %w", resolved, err)
+		}
+		if target == "" {
+			return "", fmt.Errorf("symlink %q has empty target", resolved)
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(resolved), target)
+		}
+		resolved = filepath.Clean(target)
+	}
+	return "", fmt.Errorf("too many symlinks resolving %q", path)
 }

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -50,6 +50,30 @@ func TestParseDestination(t *testing.T) {
 	}
 }
 
+func TestNewHostEntry(t *testing.T) {
+	entry, err := NewHostEntry("sb_1", "my-sandbox", "-p 2222 token@ssh.app.daytona.io", "2026-06-04T18:30:00.000Z")
+	if err != nil {
+		t.Fatalf("NewHostEntry: %v", err)
+	}
+	want := HostEntry{
+		SandboxID:   "sb_1",
+		SandboxName: "my-sandbox",
+		HostName:    "ssh.app.daytona.io",
+		User:        "token",
+		Port:        2222,
+		ExpiresAt:   "2026-06-04T18:30:00.000Z",
+	}
+	if entry != want {
+		t.Fatalf("entry = %+v, want %+v", entry, want)
+	}
+}
+
+func TestNewHostEntryRejectsEmptyDestination(t *testing.T) {
+	if _, err := NewHostEntry("sb_1", "n", "", ""); err == nil {
+		t.Fatal("expected error for empty destination")
+	}
+}
+
 func TestRender(t *testing.T) {
 	state := HostsState{Hosts: []HostEntry{
 		{SandboxID: "sb_1", SandboxName: "my-sandbox", HostName: "ssh.app.daytona.io", User: "token"},

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -191,6 +191,57 @@ func TestEnsureIncludePreservesExistingConfig(t *testing.T) {
 	}
 }
 
+func TestEnsureIncludePreservesSymlinkedConfig(t *testing.T) {
+	paths := testPaths(t)
+	configPath, _ := paths.SSHConfigFile()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	targetDir := filepath.Join(t.TempDir(), "dotfiles")
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	targetPath := filepath.Join(targetDir, "ssh_config")
+	existing := "Host example\n  HostName example.com\n"
+	if err := os.WriteFile(targetPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	relativeTarget, err := filepath.Rel(filepath.Dir(configPath), targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(relativeTarget, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude: %v", err)
+	}
+
+	info, err := os.Lstat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%q is no longer a symlink", configPath)
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "Include "+basedir.SSHAmikaConfigName()) {
+		t.Errorf("target config missing include:\n%s", content)
+	}
+	if !strings.Contains(content, existing) {
+		t.Errorf("target config did not preserve existing content:\n%s", content)
+	}
+	assertPerm(t, targetPath, 0o600)
+}
+
 func TestUpsertHostWritesAllArtifacts(t *testing.T) {
 	paths := testPaths(t)
 
@@ -249,6 +300,8 @@ func TestUpsertHostWritesAllArtifacts(t *testing.T) {
 func testPaths(t *testing.T) basedir.Paths {
 	t.Helper()
 	home := t.TempDir()
+	// basedir.New(home) only controls the fallback home-derived paths. Pin
+	// XDG_STATE_HOME too so package tests never touch the developer's real state.
 	t.Setenv("XDG_STATE_HOME", filepath.Join(t.TempDir(), "state"))
 	return basedir.New(home)
 }

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -1,0 +1,241 @@
+package ssh
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/amika/go/internal/basedir"
+)
+
+func TestAlias(t *testing.T) {
+	if got := Alias("sb_1"); got != "amika-sb_1" {
+		t.Fatalf("Alias = %q", got)
+	}
+}
+
+func TestParseDestination(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantUser string
+		wantHost string
+		wantPort int
+		wantErr  bool
+	}{
+		{name: "user@host", in: "token@ssh.app.daytona.io", wantUser: "token", wantHost: "ssh.app.daytona.io"},
+		{name: "with port", in: "-p 2222 user@host", wantUser: "user", wantHost: "host", wantPort: 2222},
+		{name: "host only", in: "host", wantHost: "host"},
+		{name: "ignores unknown flags", in: "-4 token@host", wantUser: "token", wantHost: "host"},
+		{name: "empty", in: "", wantErr: true},
+		{name: "bad port", in: "-p notanumber user@host", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDestination(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDestination(%q): %v", tt.in, err)
+			}
+			if got.User != tt.wantUser || got.Host != tt.wantHost || got.Port != tt.wantPort {
+				t.Fatalf("got %+v, want user=%q host=%q port=%d", got, tt.wantUser, tt.wantHost, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestRender(t *testing.T) {
+	state := HostsState{Hosts: []HostEntry{
+		{SandboxID: "sb_1", SandboxName: "my-sandbox", HostName: "ssh.app.daytona.io", User: "token"},
+	}}
+	want := managedHeader + "\n# my-sandbox\nHost amika-sb_1\n  HostName ssh.app.daytona.io\n  User token\n  StrictHostKeyChecking accept-new\n"
+	if got := Render(state); got != want {
+		t.Fatalf("Render mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestRenderIncludesPortAndNameComment(t *testing.T) {
+	state := HostsState{Hosts: []HostEntry{
+		{SandboxID: "sb_2", SandboxName: "named", HostName: "h", User: "u", Port: 2222},
+	}}
+	got := Render(state)
+	if !strings.Contains(got, "  Port 2222\n") {
+		t.Errorf("expected Port line, got:\n%s", got)
+	}
+	nameIdx := strings.Index(got, "# named")
+	hostIdx := strings.Index(got, "Host amika-sb_2")
+	if nameIdx < 0 || hostIdx < 0 || nameIdx > hostIdx {
+		t.Errorf("name comment should precede the Host line, got:\n%s", got)
+	}
+}
+
+func TestStateRoundTrip(t *testing.T) {
+	paths := testPaths(t)
+	if got, err := LoadState(paths); err != nil || len(got.Hosts) != 0 {
+		t.Fatalf("LoadState empty: got %+v err %v", got, err)
+	}
+
+	state := HostsState{Hosts: []HostEntry{{SandboxID: "sb_1", SandboxName: "n", HostName: "h", User: "u"}}}
+	if err := SaveState(paths, state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	loaded, err := LoadState(paths)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(loaded.Hosts) != 1 || loaded.Hosts[0].SandboxID != "sb_1" {
+		t.Fatalf("round trip mismatch: %+v", loaded)
+	}
+
+	statePath, _ := paths.SSHHostsStateFile()
+	assertPerm(t, statePath, 0o600)
+}
+
+func TestUpsertReplacesAndSorts(t *testing.T) {
+	state := HostsState{}
+	state.Upsert(HostEntry{SandboxID: "sb_b", HostName: "old"})
+	state.Upsert(HostEntry{SandboxID: "sb_a", HostName: "a"})
+	state.Upsert(HostEntry{SandboxID: "sb_b", HostName: "new"})
+
+	if len(state.Hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(state.Hosts))
+	}
+	if state.Hosts[0].SandboxID != "sb_a" || state.Hosts[1].SandboxID != "sb_b" {
+		t.Fatalf("hosts not sorted by id: %+v", state.Hosts)
+	}
+	if state.Hosts[1].HostName != "new" {
+		t.Fatalf("expected replaced host, got %q", state.Hosts[1].HostName)
+	}
+}
+
+func TestEnsureIncludeCreatesAndIsIdempotent(t *testing.T) {
+	paths := testPaths(t)
+	configPath, _ := paths.SSHConfigFile()
+	includeLine := "Include " + basedir.SSHAmikaConfigName()
+
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude (create): %v", err)
+	}
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude (idempotent): %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if n := strings.Count(string(data), includeLine); n != 1 {
+		t.Fatalf("expected exactly 1 include line, got %d:\n%s", n, data)
+	}
+	assertPerm(t, configPath, 0o600)
+}
+
+func TestEnsureIncludePreservesExistingConfig(t *testing.T) {
+	paths := testPaths(t)
+	configPath, _ := paths.SSHConfigFile()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := "Host example\n  HostName example.com\n"
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, existing) {
+		t.Errorf("existing config not preserved:\n%s", content)
+	}
+	includeIdx := strings.Index(content, "Include "+basedir.SSHAmikaConfigName())
+	hostIdx := strings.Index(content, "Host example")
+	if includeIdx < 0 || includeIdx > hostIdx {
+		t.Errorf("include should precede existing Host blocks:\n%s", content)
+	}
+}
+
+func TestUpsertHostWritesAllArtifacts(t *testing.T) {
+	paths := testPaths(t)
+
+	alias, err := UpsertHost(paths, HostEntry{
+		SandboxID:   "sb_1",
+		SandboxName: "my-sandbox",
+		HostName:    "ssh.app.daytona.io",
+		User:        "token",
+	})
+	if err != nil {
+		t.Fatalf("UpsertHost: %v", err)
+	}
+	if alias != "amika-sb_1" {
+		t.Fatalf("alias = %q", alias)
+	}
+
+	confPath, _ := paths.SSHAmikaConfigFile()
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	if !strings.Contains(string(conf), "Host amika-sb_1") || !strings.Contains(string(conf), "# my-sandbox") {
+		t.Errorf("amika.conf missing alias or name comment:\n%s", conf)
+	}
+	assertPerm(t, confPath, 0o600)
+
+	configPath, _ := paths.SSHConfigFile()
+	cfg, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read ssh config: %v", err)
+	}
+	if !strings.Contains(string(cfg), "Include "+basedir.SSHAmikaConfigName()) {
+		t.Errorf("ssh config missing include:\n%s", cfg)
+	}
+
+	// Refreshing the same sandbox replaces its entry rather than duplicating it.
+	if _, err := UpsertHost(paths, HostEntry{
+		SandboxID:   "sb_1",
+		SandboxName: "my-sandbox",
+		HostName:    "ssh.app.daytona.io",
+		User:        "token-2",
+	}); err != nil {
+		t.Fatalf("UpsertHost refresh: %v", err)
+	}
+	state, err := LoadState(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Hosts) != 1 || state.Hosts[0].User != "token-2" {
+		t.Fatalf("expected single refreshed host, got %+v", state.Hosts)
+	}
+}
+
+// testPaths returns a basedir.Paths rooted in temp dirs so tests touch neither
+// the real ~/.ssh nor the real XDG state directory.
+func testPaths(t *testing.T) basedir.Paths {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(t.TempDir(), "state"))
+	return basedir.New(home)
+}
+
+func assertPerm(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %q: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("perm of %q = %o, want %o", path, got, want)
+	}
+}

--- a/go/internal/ssh/ssh.go
+++ b/go/internal/ssh/ssh.go
@@ -1,0 +1,44 @@
+// Package ssh abstracts how the CLI connects editors and shells to remote
+// sandboxes over SSH: minting connection details from the API, generating a
+// stable per-sandbox host alias in ~/.ssh/amika.conf, and execing ssh.
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+)
+
+// ExecSSH replaces the current process with an interactive ssh session to the
+// named sandbox. It fetches fresh connection details from the API and execs the
+// system ssh binary directly, forwarding any extra args (e.g. a remote command).
+func ExecSSH(client *apiclient.Client, name string, forcePTY bool, extraArgs []string) error {
+	info, err := client.GetSSH(name)
+	if err != nil {
+		return err
+	}
+	if info.SSHDestination == "" {
+		return fmt.Errorf("server returned empty SSH destination")
+	}
+
+	sshArgs := strings.Fields(info.SSHDestination)
+
+	if forcePTY {
+		dest := sshArgs[len(sshArgs)-1]
+		sshArgs = append(sshArgs[:len(sshArgs)-1], "-t", dest)
+	}
+
+	if len(extraArgs) > 0 {
+		sshArgs = append(sshArgs, extraArgs...)
+	}
+
+	sshBin, err := exec.LookPath("ssh")
+	if err != nil {
+		return fmt.Errorf("ssh not found: %w", err)
+	}
+	return syscall.Exec(sshBin, append([]string{"ssh"}, sshArgs...), os.Environ())
+}


### PR DESCRIPTION
## Summary

Fixes [KAPRO-365](https://linear.app/fixpoint/issue/KAPRO-365/cursor-agent-chat-lost-when-remote-ssh-connection-drops): when a Cursor Remote-SSH connection to an Amika sandbox drops, the agent chat is lost.

**Root cause:** `amika sandbox code` handed Cursor the raw Daytona SSH destination (`ssh-remote+<token>@ssh.app.daytona.io`). Daytona mints a fresh token on every connection, so the destination, and therefore Cursor's remote identity, changed every reconnect. Cursor stores chat client-side keyed to that identity, so it could never re-link an existing session.

**Fix:** give Cursor a stable per-sandbox identity. `amika sandbox code` now writes a managed `Host amika-<sandbox-id>` block to `~/.ssh/amika.conf` and launches Cursor against `ssh-remote+amika-<sandbox-id>`. The alias is keyed on the sandbox's immutable id, so it never changes across reconnects; the rotating Daytona credentials live behind it and are refreshed on each run.

> **Note on the alias key:** I used the sandbox **id**, not the name, because a name can be reused by a future sandbox (which would wrongly inherit a dead sandbox's chat) while the id is immutable and unique.

> **Why not a `ProxyCommand` for auto-refresh:** Daytona puts the rotating token in the SSH *username* (`ssh <token>@ssh.app.daytona.io`), which SSH fixes from config before `ProxyCommand` runs, so a proxy can't refresh it. A stable alias keeps the identity (and chat) stable; an expired token is refreshed by re-running `amika sandbox code`, which rewrites the same block. The companion server PR raises the token lifetime to 8h to make this rare.

## Changes

- **`internal/ssh` package** centralizing how the CLI connects to sandboxes over SSH. `execSSH` moved here as `ExecSSH`; `config.go` adds a JSON-backed host state (`~/.local/state/amika/ssh-hosts.json`, the source of truth), an ssh-destination parser that preserves port/flags, rendering of `~/.ssh/amika.conf` (keyed by id, sandbox name as a comment), and idempotent management of the `Include` line in `~/.ssh/config`. State/config writes are atomic and `0600`.
- **`basedir`** path helpers for the new state file and the `~/.ssh` paths.
- **`apiclient.SSHInfo`** gains `SandboxID`/`SandboxName` (from the server PR). When talking to an older server that omits them, `sandbox code` falls back to a `GetSandbox` lookup so the alias is still id-keyed.
- **`amika sandbox code`** rewired to the stable alias. `amika sandbox ssh` is unchanged (it has no chat-persistence problem).

## Testing

Unit tests alongside each change: destination parsing, config rendering, `Include` injection/idempotency, state round-trip + file permissions, and the full `UpsertHost` flow against temp dirs (no real `~/.ssh`). `go test ./...` passes.

## Manual verification still needed

Needs a live sandbox + Cursor: run `amika sandbox code <name>`, confirm `~/.ssh/amika.conf` + the `Include`, open Cursor, then drop/reconnect Remote-SSH and confirm the agent chat persists.

## Depends on

gofixpoint/amika-mono#454 (server returns `sandbox_id`/`sandbox_name`). Works against an older server via the `GetSandbox` fallback.
