### PR TITLE
Hide sessions subtree from top-level help output

### DIFF
--- a/go/cmd/amika/sessions.go
+++ b/go/cmd/amika/sessions.go
@@ -10,8 +10,9 @@ import (
 )
 
 var sessionsCmd = &cobra.Command{
-	Use:   "sessions",
-	Short: "Manage local agent session capture",
+	Use:    "sessions",
+	Hidden: true,
+	Short:  "Manage local agent session capture",
 	Long: `Capture sessions from local AI coding agents (Claude Code, Codex) into
 the amika state directory by installing per-agent hooks.
 


### PR DESCRIPTION
## Summary

- Set `Hidden: true` on `sessionsCmd` so `amika --help` and bare `amika` no longer list the `sessions` subcommand.
- `amika sessions` and `amika sessions --help` still work normally.