### PR TITLE
Add --force flag to secret provider push

### DIFF
--- a/go/cmd/amika/secrets.go
+++ b/go/cmd/amika/secrets.go
@@ -518,9 +518,32 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 				return err
 			}
 
+			force, _ := cmd.Flags().GetBool("force")
+
 			client, err := getSecretsClient()
 			if err != nil {
 				return fmt.Errorf("authenticating with remote API: %w", err)
+			}
+
+			// Provider secrets have no update endpoint, so --force overwrites by
+			// deleting any same-named credential before creating the new one.
+			// This is not atomic: if the create below fails, the old credential
+			// is already gone.
+			replaced := false
+			if force {
+				existing, err := client.ListProviderSecrets(p.APIPath)
+				if err != nil {
+					return err
+				}
+				for _, item := range existing {
+					if item.Name == name {
+						if err := client.DeleteProviderSecret(p.APIPath, item.ID); err != nil {
+							return fmt.Errorf("overwriting existing %s credential %q: %w",
+								p.ShortName, name, err)
+						}
+						replaced = true
+					}
+				}
 			}
 
 			summary, err := client.CreateProviderSecret(p.APIPath, apiclient.CreateProviderSecretRequest{
@@ -532,7 +555,11 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Created %s credential %q\n", p.ShortName, summary.Name)
+			action := "Created"
+			if replaced {
+				action = "Updated"
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s credential %q\n", action, p.ShortName, summary.Name)
 			return nil
 		},
 	}
@@ -541,6 +568,7 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 	cmd.Flags().String("value", "", "Credential value (skips interactive discovery)")
 	cmd.Flags().String("from-file", "", "Path to a credentials file (skips interactive discovery)")
 	cmd.Flags().String("type", "oauth", "Credential type: \"oauth\" (default) or \"api_key\"")
+	cmd.Flags().Bool("force", false, fmt.Sprintf("Overwrite an existing %s credential with the same name", p.ShortName))
 
 	return cmd
 }

--- a/go/cmd/amika/secrets_test.go
+++ b/go/cmd/amika/secrets_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -545,6 +546,64 @@ func TestSecretClaudePush_FromFileMissing(t *testing.T) {
 	}
 }
 
+func TestSecretClaudePush_Force(t *testing.T) {
+	bin := buildAmika(t)
+
+	var mu sync.Mutex
+	var deletedIDs []string
+	mockEnv := setupMockClaudeAPIRecording(t, &mu, &deletedIDs, []map[string]string{
+		{"id": "cred-existing-1", "name": "Test OAuth", "type": "oauth"},
+		{"id": "cred-other-2", "name": "Other", "type": "oauth"},
+	})
+
+	cmd := exec.Command(bin, "secret", "claude", "push",
+		"--force",
+		"--value", `{"claudeAiOauth":{"accessToken":"test"}}`,
+		"--name", "Test OAuth")
+	cmd.Env = mockEnv
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected success, got error: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Updated") {
+		t.Fatalf("expected 'Updated' in output for forced overwrite, got:\n%s", out)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deletedIDs) != 1 || deletedIDs[0] != "cred-existing-1" {
+		t.Fatalf("expected exactly the same-named credential to be deleted, got: %v", deletedIDs)
+	}
+}
+
+func TestSecretClaudePush_NoForceDoesNotDelete(t *testing.T) {
+	bin := buildAmika(t)
+
+	var mu sync.Mutex
+	var deletedIDs []string
+	mockEnv := setupMockClaudeAPIRecording(t, &mu, &deletedIDs, []map[string]string{
+		{"id": "cred-existing-1", "name": "Test OAuth", "type": "oauth"},
+	})
+
+	cmd := exec.Command(bin, "secret", "claude", "push",
+		"--value", `{"claudeAiOauth":{"accessToken":"test"}}`,
+		"--name", "Test OAuth")
+	cmd.Env = mockEnv
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected success, got error: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Created") {
+		t.Fatalf("expected 'Created' in output without --force, got:\n%s", out)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deletedIDs) != 0 {
+		t.Fatalf("expected no deletes without --force, got: %v", deletedIDs)
+	}
+}
+
 func TestSecretClaudeList_WithMock(t *testing.T) {
 	bin := buildAmika(t)
 	mockEnv := setupMockClaudeAPI(t)
@@ -621,6 +680,40 @@ func setupMockClaudeAPI(t *testing.T) []string {
 		case r.Method == "GET" && r.URL.Path == "/api/v0beta1/secrets/claude":
 			json.NewEncoder(w).Encode([]interface{}{})
 		case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/api/v0beta1/secrets/"):
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return withEnv(os.Environ(),
+		"AMIKA_API_URL="+srv.URL,
+		"AMIKA_API_KEY=test-bearer-token",
+	)
+}
+
+// setupMockClaudeAPIRecording is like setupMockClaudeAPI but returns the given
+// existing credentials from the list endpoint and records the IDs passed to the
+// delete endpoint into deletedIDs (guarded by mu). Used to verify --force
+// overwrite behavior.
+func setupMockClaudeAPIRecording(t *testing.T, mu *sync.Mutex, deletedIDs *[]string, existing []map[string]string) []string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/api/v0beta1/secrets/claude":
+			json.NewEncoder(w).Encode(map[string]string{
+				"id":    "cred-test-123",
+				"name":  "Test OAuth",
+				"scope": "user",
+			})
+		case r.Method == "GET" && r.URL.Path == "/api/v0beta1/secrets/claude":
+			json.NewEncoder(w).Encode(existing)
+		case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/api/v0beta1/secrets/claude/"):
+			id := strings.TrimPrefix(r.URL.Path, "/api/v0beta1/secrets/claude/")
+			mu.Lock()
+			*deletedIDs = append(*deletedIDs, id)
+			mu.Unlock()
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
## Summary

Adds a `--force` flag to `amika secret <provider> push` (Claude and Codex) that overwrites an existing credential with the same `--name`. Previously, pushing a credential whose name already existed would be rejected by the remote API, forcing users to look up the credential ID and `secret <provider> delete` it before re-pushing.

Provider secrets only expose Create/List/Delete endpoints (no update), so `--force` lists existing credentials, deletes any matching the given name, then creates the new one. The output reports `Updated` when it replaced an existing credential and `Created` otherwise.

Note: the delete-then-create is not atomic — if the create fails after the delete, the old credential is gone. This is unavoidable without a server-side upsert.

## Changes

- `--force` flag on the shared provider push command, so both `secret claude push` and `secret codex push` support it.
- Tests covering forced overwrite (deletes only the same-named credential) and the default no-force behavior (no deletes).