### PR TITLE
Capture per-turn git state and tool usage in session sidecars

### DIFF
--- a/go/cmd/amika/sessions.go
+++ b/go/cmd/amika/sessions.go
@@ -33,8 +33,12 @@ Writes to:
   ~/.codex/config.toml      (sets the notify program)
 
 Captured transcripts land under:
-  $AMIKA_STATE_DIRECTORY/sessions/{claude,codex}/
+  $AMIKA_STATE_DIRECTORY/raw-sessions/{claude,codex}/
 (default $AMIKA_STATE_DIRECTORY is ~/.local/state/amika).
+
+Each transcript gets a sibling <session>.meta.json sidecar recording, per
+turn, the git commit/branch the work happened on and the tool calls that
+turn made.
 
 The exact destination directories are printed when the command runs.
 

--- a/go/cmd/amika/sessions_test.go
+++ b/go/cmd/amika/sessions_test.go
@@ -35,7 +35,7 @@ func TestSessionsCapture_AcceptsCodexNotifyPayload(t *testing.T) {
 	}
 
 	stateDir := os.Getenv("AMIKA_STATE_DIRECTORY")
-	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "rollout-1.jsonl"))
+	mirrored, err := os.ReadFile(filepath.Join(stateDir, "raw-sessions", "codex", "2026-06-01", "rollout-1.jsonl"))
 	if err != nil {
 		t.Fatalf("mirror missing: %v", err)
 	}
@@ -59,8 +59,8 @@ func TestSessionsCaptureInit_PrintsDestinations(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Captures will be written to:",
-		filepath.Join(stateDir, "sessions", "claude"),
-		filepath.Join(stateDir, "sessions", "codex"),
+		filepath.Join(stateDir, "raw-sessions", "claude"),
+		filepath.Join(stateDir, "raw-sessions", "codex"),
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q\n--- got ---\n%s", want, out)

--- a/go/internal/sessioncapture/meta.go
+++ b/go/internal/sessioncapture/meta.go
@@ -1,0 +1,271 @@
+package sessioncapture
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// The metadata sidecar records, per turn, the git state the work happened on
+// and the tool calls that turn made. It sits next to the mirrored transcript
+// as `<stem>.meta.json`. Capturing the commit at every turn is the only way
+// to see mid-session branch/commit switches: git only knows its current HEAD,
+// so a turn's commit can't be recovered after the fact — it has to be recorded
+// as each turn completes. Captures therefore accumulate across hook fires.
+
+// gitInfo is the git state observed in a session's working directory at the
+// moment a turn completed. Nil when the working directory isn't a git repo.
+type gitInfo struct {
+	Commit string `json:"commit"`
+	Branch string `json:"branch"`
+	Dirty  bool   `json:"dirty"`
+}
+
+// repoInfo identifies the repository a session's work happened in.
+type repoInfo struct {
+	RemoteURL string `json:"remote_url,omitempty"`
+	Root      string `json:"root,omitempty"`
+}
+
+// toolCall is a single tool invocation made during a turn, with its full
+// input arguments preserved verbatim.
+type toolCall struct {
+	Name  string          `json:"name"`
+	ID    string          `json:"id,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// captureRecord is one turn's worth of metadata: when the turn was captured,
+// the git state at that point, and the tool calls the turn made.
+type captureRecord struct {
+	Timestamp string     `json:"ts"`
+	Git       *gitInfo   `json:"git,omitempty"`
+	Tools     []toolCall `json:"tools"`
+}
+
+// sessionMeta is the full sidecar document for one session.
+type sessionMeta struct {
+	Source    Source          `json:"source"`
+	SessionID string          `json:"session_id,omitempty"`
+	Repo      *repoInfo       `json:"repo,omitempty"`
+	Captures  []captureRecord `json:"captures"`
+	// TranscriptLines is how many transcript lines have already been folded
+	// into Captures. It is the cursor that lets each turn's tool calls be
+	// sliced off the append-only transcript without re-recording earlier
+	// turns. Claude only.
+	TranscriptLines int `json:"transcript_lines,omitempty"`
+}
+
+// nowFunc and resolveGitState are indirected so tests can pin the timestamp
+// and stub git resolution without standing up a real repository.
+var (
+	nowFunc         = time.Now
+	resolveGitState = gitStateFromCmd
+)
+
+// metaPathFor returns the sidecar path for a mirrored transcript: the same
+// path with its `.jsonl` suffix replaced by `.meta.json`.
+func metaPathFor(transcriptDst string) string {
+	return strings.TrimSuffix(transcriptDst, ".jsonl") + ".meta.json"
+}
+
+// updateClaudeMeta folds the turn(s) appended to the transcript since the last
+// capture into the sidecar at metaPath: it parses the new transcript lines for
+// tool calls, resolves the current git state in the session's working
+// directory, and appends one capture record. Re-reading the whole transcript
+// each time would re-record earlier turns, so it resumes from the stored line
+// cursor.
+func updateClaudeMeta(metaPath string, in claudeStopHookInput) error {
+	meta, err := loadMeta(metaPath)
+	if err != nil {
+		return err
+	}
+	meta.Source = SourceClaude
+	if in.SessionID != "" {
+		meta.SessionID = in.SessionID
+	}
+
+	lines, err := readLines(in.TranscriptPath)
+	if err != nil {
+		return err
+	}
+	// If the transcript shrank (rotation, truncation) the cursor is stale;
+	// reparse from the top rather than slicing out of range.
+	start := meta.TranscriptLines
+	if start > len(lines) {
+		start = 0
+	}
+	tools, cwd := parseClaudeTurn(lines[start:])
+	if cwd == "" {
+		cwd = lastClaudeCwd(lines)
+	}
+	if cwd == "" {
+		cwd = in.Cwd
+	}
+
+	git, repo := resolveGitState(cwd)
+	if repo != nil {
+		meta.Repo = repo
+	}
+	meta.Captures = append(meta.Captures, captureRecord{
+		Timestamp: nowFunc().UTC().Format(time.RFC3339),
+		Git:       git,
+		Tools:     tools,
+	})
+	meta.TranscriptLines = len(lines)
+	return writeMeta(metaPath, meta)
+}
+
+// claudeEntry is the subset of a Claude transcript line we read: its type, the
+// working directory it ran in, and the message content (which may be a string
+// or a content-block array, hence RawMessage).
+type claudeEntry struct {
+	Type    string `json:"type"`
+	Cwd     string `json:"cwd"`
+	Message struct {
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+// claudeBlock is one content block within an assistant message.
+type claudeBlock struct {
+	Type  string          `json:"type"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+// parseClaudeTurn extracts the tool calls from a slice of transcript lines and
+// returns them along with the last working directory seen in those lines.
+// Malformed lines are skipped so a single bad record can't drop a turn.
+func parseClaudeTurn(lines []string) ([]toolCall, string) {
+	var tools []toolCall
+	var cwd string
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var e claudeEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			continue
+		}
+		if e.Cwd != "" {
+			cwd = e.Cwd
+		}
+		var blocks []claudeBlock
+		if err := json.Unmarshal(e.Message.Content, &blocks); err != nil {
+			continue // content was a plain string (e.g. a user line)
+		}
+		for _, b := range blocks {
+			if b.Type != "tool_use" {
+				continue
+			}
+			tools = append(tools, toolCall{Name: b.Name, ID: b.ID, Input: b.Input})
+		}
+	}
+	return tools, cwd
+}
+
+// lastClaudeCwd returns the working directory of the last transcript line that
+// records one, used when the current turn's new lines carry no cwd.
+func lastClaudeCwd(lines []string) string {
+	for i := len(lines) - 1; i >= 0; i-- {
+		var e claudeEntry
+		if err := json.Unmarshal([]byte(lines[i]), &e); err != nil {
+			continue
+		}
+		if e.Cwd != "" {
+			return e.Cwd
+		}
+	}
+	return ""
+}
+
+// gitStateFromCmd resolves the git state of cwd by shelling out to git.
+// Returns (nil, nil) when cwd is empty or not inside a git work tree; other
+// per-field failures degrade gracefully to empty values.
+func gitStateFromCmd(cwd string) (*gitInfo, *repoInfo) {
+	if cwd == "" {
+		return nil, nil
+	}
+	root, err := gitOutput(cwd, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, nil // not a git repo (or git unavailable)
+	}
+	commit, _ := gitOutput(cwd, "rev-parse", "HEAD")
+	branch, _ := gitOutput(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+	status, _ := gitOutput(cwd, "status", "--porcelain")
+	remote, _ := gitOutput(cwd, "remote", "get-url", "origin")
+	return &gitInfo{
+			Commit: commit,
+			Branch: branch,
+			Dirty:  strings.TrimSpace(status) != "",
+		}, &repoInfo{
+			RemoteURL: remote,
+			Root:      root,
+		}
+}
+
+func gitOutput(cwd string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// readLines reads a file and splits it into lines, dropping a trailing empty
+// element so a final newline doesn't yield a phantom line.
+func readLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines, nil
+}
+
+// loadMeta reads an existing sidecar, returning a zero-value sessionMeta when
+// none exists yet.
+func loadMeta(path string) (sessionMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return sessionMeta{}, nil
+		}
+		return sessionMeta{}, err
+	}
+	var meta sessionMeta
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return sessionMeta{}, nil
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return sessionMeta{}, err
+	}
+	return meta, nil
+}
+
+// writeMeta atomically writes the sidecar as indented JSON.
+func writeMeta(path string, meta sessionMeta) error {
+	encoded, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return writeFileAtomic(path, encoded)
+}

--- a/go/internal/sessioncapture/meta_codex.go
+++ b/go/internal/sessioncapture/meta_codex.go
@@ -1,0 +1,155 @@
+package sessioncapture
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Codex metadata is best-effort and weaker than Claude's. Codex's notify hook
+// hands us no session path or working directory, so capture walks the whole
+// tree (see CaptureCodex) rather than reacting to a single turn — there is no
+// reliable per-turn signal to hang a git observation on. So instead of the
+// per-turn timeline we build for Claude, the Codex sidecar is rebuilt in full
+// from the rollout on each refresh: the git state recorded in the rollout's
+// session-meta header (set when the session started) plus every tool call the
+// rollout contains, collapsed into a single capture record. Mid-session branch
+// switches are therefore not tracked for Codex.
+
+// codexLine is the envelope shape of a Codex rollout JSONL record. Older
+// rollouts inline the fields with no `payload` wrapper, so callers fall back to
+// treating the whole line as the payload when Payload is absent.
+type codexLine struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// codexSessionMeta is the subset of a `session_meta` payload we read.
+type codexSessionMeta struct {
+	Cwd string    `json:"cwd"`
+	Git *codexGit `json:"git"`
+}
+
+type codexGit struct {
+	CommitHash    string `json:"commit_hash"`
+	Branch        string `json:"branch"`
+	RepositoryURL string `json:"repository_url"`
+}
+
+// codexResponseItem is the subset of a response-item payload we read: function
+// calls carry the tool name, a call id, and JSON-encoded arguments.
+type codexResponseItem struct {
+	Type      string          `json:"type"`
+	Name      string          `json:"name"`
+	CallID    string          `json:"call_id"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// updateCodexMeta rebuilds the sidecar at metaPath from the Codex rollout at
+// rolloutPath. Best-effort: unrecognized or malformed lines are skipped.
+func updateCodexMeta(metaPath, rolloutPath string) error {
+	lines, err := readLines(rolloutPath)
+	if err != nil {
+		return err
+	}
+
+	meta := sessionMeta{
+		Source:    SourceCodex,
+		SessionID: sessionIDFromPath(rolloutPath),
+	}
+	var cwd string
+	var recordedGit *codexGit
+	var tools []toolCall
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var env codexLine
+		if err := json.Unmarshal([]byte(line), &env); err != nil {
+			continue
+		}
+		// Inline rollouts have no payload wrapper; fall back to the line.
+		payload := env.Payload
+		if len(payload) == 0 {
+			payload = json.RawMessage(line)
+		}
+
+		switch env.Type {
+		case "session_meta":
+			var sm codexSessionMeta
+			if err := json.Unmarshal(payload, &sm); err == nil {
+				if sm.Cwd != "" {
+					cwd = sm.Cwd
+				}
+				if sm.Git != nil {
+					recordedGit = sm.Git
+				}
+			}
+		default:
+			var item codexResponseItem
+			if err := json.Unmarshal(payload, &item); err != nil {
+				continue
+			}
+			if item.Type == "function_call" || item.Type == "local_shell_call" {
+				tools = append(tools, toolCall{
+					Name:  item.Name,
+					ID:    item.CallID,
+					Input: normalizeCodexArgs(item.Arguments),
+				})
+			}
+		}
+	}
+
+	git, repo := codexGitState(recordedGit, cwd)
+	if repo != nil {
+		meta.Repo = repo
+	}
+	meta.Captures = []captureRecord{{
+		Timestamp: nowFunc().UTC().Format("2006-01-02T15:04:05Z07:00"),
+		Git:       git,
+		Tools:     tools,
+	}}
+	return writeMeta(metaPath, meta)
+}
+
+// codexGitState prefers the git state recorded in the rollout header. When the
+// rollout carries none, it falls back to resolving git live in the recorded
+// cwd (consistent with the Claude path).
+func codexGitState(recorded *codexGit, cwd string) (*gitInfo, *repoInfo) {
+	if recorded != nil {
+		var repo *repoInfo
+		if recorded.RepositoryURL != "" {
+			repo = &repoInfo{RemoteURL: recorded.RepositoryURL}
+		}
+		return &gitInfo{Commit: recorded.CommitHash, Branch: recorded.Branch}, repo
+	}
+	return resolveGitState(cwd)
+}
+
+// normalizeCodexArgs unwraps Codex's JSON-string-encoded arguments into the
+// embedded JSON value when possible, so the sidecar stores `{"command":...}`
+// rather than an escaped string. Non-string or non-JSON values pass through
+// unchanged.
+func normalizeCodexArgs(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 || raw[0] != '"' {
+		return raw
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return raw
+	}
+	if json.Valid([]byte(s)) {
+		return json.RawMessage(s)
+	}
+	return raw
+}
+
+// sessionIDFromPath derives a session id from a rollout filename by stripping
+// its `.jsonl` extension.
+func sessionIDFromPath(path string) string {
+	base := path
+	if i := strings.LastIndexAny(base, "/\\"); i >= 0 {
+		base = base[i+1:]
+	}
+	return strings.TrimSuffix(base, ".jsonl")
+}

--- a/go/internal/sessioncapture/meta_test.go
+++ b/go/internal/sessioncapture/meta_test.go
@@ -1,0 +1,211 @@
+package sessioncapture
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubGit swaps resolveGitState for the duration of a test, returning a queued
+// gitInfo per call so a sequence of turns can simulate branch/commit switches.
+func stubGit(t *testing.T, states ...*gitInfo) {
+	t.Helper()
+	prev := resolveGitState
+	calls := 0
+	resolveGitState = func(cwd string) (*gitInfo, *repoInfo) {
+		g := states[calls%len(states)]
+		calls++
+		return g, &repoInfo{Root: cwd, RemoteURL: "git@example.com:org/repo.git"}
+	}
+	t.Cleanup(func() { resolveGitState = prev })
+}
+
+func pinNow(t *testing.T) {
+	t.Helper()
+	prev := nowFunc
+	nowFunc = func() time.Time { return time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { nowFunc = prev })
+}
+
+// captureClaudeWith mirrors a transcript whose mtime is pinned to a fixed day
+// so the sidecar path is deterministic, then returns the parsed sidecar.
+func captureClaudeWith(t *testing.T, transcript, stateDir, sessionID string) sessionMeta {
+	t.Helper()
+	day := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(transcript, day, day); err != nil {
+		t.Fatal(err)
+	}
+	stdin, err := json.Marshal(map[string]string{
+		"session_id":      sessionID,
+		"transcript_path": transcript,
+		"hook_event_name": "Stop",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := CaptureClaude(strings.NewReader(string(stdin)), stateDir); err != nil {
+		t.Fatalf("CaptureClaude: %v", err)
+	}
+	metaPath := filepath.Join(stateDir, "raw-sessions", "claude", "2026-05-14", sessionID+".meta.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("reading sidecar %s: %v", metaPath, err)
+	}
+	var meta sessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("decoding sidecar: %v", err)
+	}
+	return meta
+}
+
+func assistantToolLine(branch, toolName, toolID string) string {
+	return `{"type":"assistant","cwd":"/repo","gitBranch":"` + branch +
+		`","message":{"role":"assistant","content":[{"type":"tool_use","id":"` + toolID +
+		`","name":"` + toolName + `","input":{"k":"v"}}]}}`
+}
+
+func TestCaptureClaude_WritesMetaSidecar(t *testing.T) {
+	pinNow(t)
+	stubGit(t, &gitInfo{Commit: "a1b2c3d", Branch: "main", Dirty: true})
+
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "abc.jsonl")
+	body := `{"type":"user","cwd":"/repo","message":{"role":"user","content":"hi"}}` + "\n" +
+		assistantToolLine("main", "Bash", "t1") + "\n"
+	if err := os.WriteFile(transcript, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := captureClaudeWith(t, transcript, filepath.Join(tmp, "state"), "abc")
+
+	if meta.Source != SourceClaude || meta.SessionID != "abc" {
+		t.Errorf("unexpected meta header: %+v", meta)
+	}
+	if meta.Repo == nil || meta.Repo.RemoteURL == "" {
+		t.Errorf("expected repo info, got %+v", meta.Repo)
+	}
+	if len(meta.Captures) != 1 {
+		t.Fatalf("expected 1 capture, got %d", len(meta.Captures))
+	}
+	c := meta.Captures[0]
+	if c.Git == nil || c.Git.Commit != "a1b2c3d" || c.Git.Branch != "main" || !c.Git.Dirty {
+		t.Errorf("unexpected git state: %+v", c.Git)
+	}
+	if len(c.Tools) != 1 || c.Tools[0].Name != "Bash" || c.Tools[0].ID != "t1" {
+		t.Errorf("unexpected tools: %+v", c.Tools)
+	}
+	if !strings.Contains(string(c.Tools[0].Input), `"k"`) || !strings.Contains(string(c.Tools[0].Input), `"v"`) {
+		t.Errorf("tool input not preserved: %s", c.Tools[0].Input)
+	}
+}
+
+// TestCaptureClaude_PerTurnTimelineAcrossBranchSwitch is the core case: a
+// session that switches branches between turns must leave one capture per turn
+// with the commit/branch each turn ran on, and each turn's tools sliced off
+// the growing transcript via the stored cursor.
+func TestCaptureClaude_PerTurnTimelineAcrossBranchSwitch(t *testing.T) {
+	pinNow(t)
+	stubGit(t,
+		&gitInfo{Commit: "aaaaaaa", Branch: "main"},
+		&gitInfo{Commit: "bbbbbbb", Branch: "feature"},
+	)
+
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	transcript := filepath.Join(tmp, "sess.jsonl")
+
+	// Turn 1: one tool call on main.
+	turn1 := `{"type":"user","cwd":"/repo","message":{"role":"user","content":"hi"}}` + "\n" +
+		assistantToolLine("main", "Read", "t1") + "\n"
+	if err := os.WriteFile(transcript, []byte(turn1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := captureClaudeWith(t, transcript, stateDir, "sess")
+	if len(meta.Captures) != 1 {
+		t.Fatalf("after turn 1: expected 1 capture, got %d", len(meta.Captures))
+	}
+
+	// Turn 2: user switched branches, then a tool call on feature.
+	turn2 := assistantToolLine("feature", "Edit", "t2") + "\n"
+	f, err := os.OpenFile(transcript, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(turn2); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	meta = captureClaudeWith(t, transcript, stateDir, "sess")
+	if len(meta.Captures) != 2 {
+		t.Fatalf("after turn 2: expected 2 captures, got %d", len(meta.Captures))
+	}
+
+	c1, c2 := meta.Captures[0], meta.Captures[1]
+	if c1.Git.Commit != "aaaaaaa" || c1.Git.Branch != "main" {
+		t.Errorf("turn 1 git = %+v, want main/aaaaaaa", c1.Git)
+	}
+	if len(c1.Tools) != 1 || c1.Tools[0].Name != "Read" {
+		t.Errorf("turn 1 tools = %+v, want [Read]", c1.Tools)
+	}
+	if c2.Git.Commit != "bbbbbbb" || c2.Git.Branch != "feature" {
+		t.Errorf("turn 2 git = %+v, want feature/bbbbbbb", c2.Git)
+	}
+	// The cursor must slice only turn 2's new line — not re-record Read.
+	if len(c2.Tools) != 1 || c2.Tools[0].Name != "Edit" {
+		t.Errorf("turn 2 tools = %+v, want [Edit] only", c2.Tools)
+	}
+}
+
+func TestCaptureCodex_WritesMetaSidecar(t *testing.T) {
+	useCodexFallback(t)
+	pinNow(t)
+
+	home := t.TempDir()
+	stateDir := filepath.Join(home, "state")
+	rollout := filepath.Join(home, ".codex", "sessions", "2026", "06", "01", "r.jsonl")
+	if err := os.MkdirAll(filepath.Dir(rollout), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"session_meta","payload":{"cwd":"/repo","git":{"commit_hash":"deadbeef","branch":"main","repository_url":"git@example.com:org/repo.git"}}}` + "\n" +
+		`{"type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"c1","arguments":"{\"command\":[\"ls\"]}"}}` + "\n"
+	if err := os.WriteFile(rollout, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CaptureCodex(home, stateDir); err != nil {
+		t.Fatalf("CaptureCodex: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(stateDir, "raw-sessions", "codex", "2026-06-01", "r.meta.json"))
+	if err != nil {
+		t.Fatalf("reading codex sidecar: %v", err)
+	}
+	var meta sessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("decoding sidecar: %v", err)
+	}
+	if meta.Source != SourceCodex || meta.SessionID != "r" {
+		t.Errorf("unexpected header: %+v", meta)
+	}
+	if len(meta.Captures) != 1 {
+		t.Fatalf("expected 1 capture, got %d", len(meta.Captures))
+	}
+	c := meta.Captures[0]
+	if c.Git == nil || c.Git.Commit != "deadbeef" || c.Git.Branch != "main" {
+		t.Errorf("unexpected git: %+v", c.Git)
+	}
+	if meta.Repo == nil || meta.Repo.RemoteURL != "git@example.com:org/repo.git" {
+		t.Errorf("unexpected repo: %+v", meta.Repo)
+	}
+	if len(c.Tools) != 1 || c.Tools[0].Name != "shell" || c.Tools[0].ID != "c1" {
+		t.Fatalf("unexpected tools: %+v", c.Tools)
+	}
+	// Arguments should be unwrapped from the JSON-string into an object.
+	if !strings.Contains(string(c.Tools[0].Input), `"command"`) || strings.HasPrefix(string(c.Tools[0].Input), `"`) {
+		t.Errorf("codex args not normalized: %s", c.Tools[0].Input)
+	}
+}

--- a/go/internal/sessioncapture/sessioncapture.go
+++ b/go/internal/sessioncapture/sessioncapture.go
@@ -5,8 +5,13 @@
 // `~/.claude/settings.json` (Stop hook) and `<codex-home>/config.toml`
 // (notify program) that invoke `amika sessions capture --source ...`
 // whenever the agent finishes a turn. Each invocation copies the relevant
-// session JSONL into `<state>/sessions/<source>/<YYYY-MM-DD>/`, grouping a
+// session JSONL into `<state>/raw-sessions/<source>/<YYYY-MM-DD>/`, grouping a
 // day's sessions together. No daemon, no background process.
+//
+// Alongside each mirrored transcript, capture maintains a `<stem>.meta.json`
+// sidecar (see meta.go) recording, per turn, the git commit/branch the work
+// happened on plus the tool calls that turn made — so a session that switches
+// branches mid-stream leaves a turn-by-turn record of where each turn landed.
 //
 // `<codex-home>` is `$CODEX_HOME` when set, otherwise `~/.codex` (see
 // CodexHome). Honoring the env var matters because Codex itself reads
@@ -36,7 +41,7 @@ const (
 // CaptureDir returns the directory under stateDir where mirrored sessions
 // for the given source live.
 func CaptureDir(stateDir string, src Source) string {
-	return filepath.Join(stateDir, "sessions", string(src))
+	return filepath.Join(stateDir, "raw-sessions", string(src))
 }
 
 // claudeStopHookInput is the JSON shape Claude Code pipes on stdin when a
@@ -44,6 +49,10 @@ func CaptureDir(stateDir string, src Source) string {
 type claudeStopHookInput struct {
 	SessionID      string `json:"session_id"`
 	TranscriptPath string `json:"transcript_path"`
+	// Cwd is the working directory Claude reports for the session. We prefer
+	// the per-entry cwd recorded in the transcript, but fall back to this
+	// when the transcript carries none (e.g. an empty transcript).
+	Cwd string `json:"cwd"`
 }
 
 // CaptureClaude reads the Stop-hook JSON Claude pipes on stdin and copies
@@ -74,7 +83,10 @@ func CaptureClaude(stdin io.Reader, stateDir string) error {
 	}
 	day := info.ModTime().Format("2006-01-02")
 	dst := filepath.Join(CaptureDir(stateDir, SourceClaude), day, name)
-	return copyFile(in.TranscriptPath, dst)
+	if err := copyFile(in.TranscriptPath, dst); err != nil {
+		return err
+	}
+	return updateClaudeMeta(metaPathFor(dst), in)
 }
 
 // CaptureCodex mirrors every Codex session file whose source mtime is newer
@@ -127,7 +139,13 @@ func CaptureCodex(homeDir, stateDir string) error {
 		if fresh {
 			return nil
 		}
-		return copyFile(path, dst)
+		if err := copyFile(path, dst); err != nil {
+			return err
+		}
+		// Metadata is best-effort: the mirrored transcript is the artifact
+		// that must not be lost, so a meta failure never aborts the walk.
+		_ = updateCodexMeta(metaPathFor(dst), path)
+		return nil
 	})
 	if walkErr != nil && !errors.Is(walkErr, os.ErrNotExist) {
 		return walkErr

--- a/go/internal/sessioncapture/sessioncapture_test.go
+++ b/go/internal/sessioncapture/sessioncapture_test.go
@@ -47,7 +47,7 @@ func TestCaptureClaude_MirrorsTranscript(t *testing.T) {
 	if err := CaptureClaude(strings.NewReader(string(stdin)), stateDir); err != nil {
 		t.Fatalf("CaptureClaude: %v", err)
 	}
-	mirrored, err := os.ReadFile(filepath.Join(stateDir, "sessions", "claude", "2026-05-14", "abc.jsonl"))
+	mirrored, err := os.ReadFile(filepath.Join(stateDir, "raw-sessions", "claude", "2026-05-14", "abc.jsonl"))
 	if err != nil {
 		t.Fatalf("reading mirror: %v", err)
 	}
@@ -96,14 +96,14 @@ func TestCaptureCodex_MirrorsAllChangedSessions(t *testing.T) {
 	}
 
 	// Day stamp comes from the source path so basenames can't collide across days.
-	gotA, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "rollout-a.jsonl"))
+	gotA, err := os.ReadFile(filepath.Join(stateDir, "raw-sessions", "codex", "2026-06-01", "rollout-a.jsonl"))
 	if err != nil {
 		t.Fatalf("session a not mirrored: %v", err)
 	}
 	if !strings.Contains(string(gotA), "a-turn-1") {
 		t.Errorf("session a mirror has unexpected content: %s", gotA)
 	}
-	gotB, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-02", "rollout-b.jsonl"))
+	gotB, err := os.ReadFile(filepath.Join(stateDir, "raw-sessions", "codex", "2026-06-02", "rollout-b.jsonl"))
 	if err != nil {
 		t.Fatalf("session b not mirrored: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestCaptureCodex_SkipsUpToDateMirrors(t *testing.T) {
 		t.Fatalf("CaptureCodex first: %v", err)
 	}
 
-	mirrorB := filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "b.jsonl")
+	mirrorB := filepath.Join(stateDir, "raw-sessions", "codex", "2026-06-01", "b.jsonl")
 	infoBefore, err := os.Stat(mirrorB)
 	if err != nil {
 		t.Fatal(err)
@@ -155,7 +155,7 @@ func TestCaptureCodex_SkipsUpToDateMirrors(t *testing.T) {
 		t.Fatalf("CaptureCodex second: %v", err)
 	}
 
-	gotA, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "a.jsonl"))
+	gotA, err := os.ReadFile(filepath.Join(stateDir, "raw-sessions", "codex", "2026-06-01", "a.jsonl"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestCaptureCodex_NoSessionsIsNoOp(t *testing.T) {
 	if err := CaptureCodex(home, stateDir); err != nil {
 		t.Fatalf("CaptureCodex with no sessions: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(stateDir, "raw-sessions", "codex")); !os.IsNotExist(err) {
 		t.Errorf("expected no capture dir to be created, got %v", err)
 	}
 }
@@ -211,14 +211,14 @@ func TestCaptureCodex_HonorsCODEX_HOME(t *testing.T) {
 	if err := CaptureCodex(home, stateDir); err != nil {
 		t.Fatalf("CaptureCodex: %v", err)
 	}
-	got, err := os.ReadFile(filepath.Join(stateDir, "sessions", "codex", "2026-06-01", "right.jsonl"))
+	got, err := os.ReadFile(filepath.Join(stateDir, "raw-sessions", "codex", "2026-06-01", "right.jsonl"))
 	if err != nil {
 		t.Fatalf("expected right.jsonl to be mirrored: %v", err)
 	}
 	if !strings.Contains(string(got), `"right"`) {
 		t.Errorf("unexpected mirrored content: %s", got)
 	}
-	if _, err := os.Stat(filepath.Join(stateDir, "sessions", "codex", "2026-01-01", "wrong.jsonl")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(stateDir, "raw-sessions", "codex", "2026-01-01", "wrong.jsonl")); !os.IsNotExist(err) {
 		t.Errorf("file under ~/.codex was mirrored despite CODEX_HOME override")
 	}
 }


### PR DESCRIPTION
## Summary

Extends local session capture with per-turn metadata and renames the capture directory.

- **`sessions/` → `raw-sessions/`** — the mirrored-transcript directory is renamed; doc comments, CLI help, and tests updated.
- **`<session>.meta.json` sidecar** — written next to each mirrored transcript, recording one capture per turn: the git `commit`/`branch`/`dirty` state the work happened on, plus that turn's tool calls (full call + inputs).

## Why per-turn git

Capturing git at every turn is the only way to see **mid-session branch/commit switches**: git only knows its current HEAD, so a turn's commit can't be recovered after the fact and must be recorded as the turn completes. A `transcript_lines` cursor slices each turn's tool calls off the append-only transcript so earlier turns aren't re-recorded.

```jsonc
{
  "source": "claude",
  "session_id": "abc123",
  "repo": { "remote_url": "...", "root": "..." },
  "captures": [
    { "ts": "...", "git": { "commit": "aaaaaaa", "branch": "main",    "dirty": true },
      "tools": [ { "name": "Read", "id": "t1", "input": {} } ] },
    { "ts": "...", "git": { "commit": "bbbbbbb", "branch": "feature", "dirty": false },
      "tools": [ { "name": "Edit", "id": "t2", "input": {} } ] }
  ],
  "transcript_lines": 3
}
```

## Notes

- **Claude** resolves `cwd` from the transcript's per-entry `cwd` and shells out to `git` for each turn.
- **Codex** metadata is best-effort: its notify hook gives no path or per-turn signal, so the sidecar is rebuilt in full from the rollout (git from the `session_meta` header, all tool calls in one capture). A meta failure never aborts the transcript mirror. The Codex rollout parsing is written against the documented format but has not been validated against a real rollout yet.
- Pre-existing midnight-boundary quirk (day-dir derived from mtime) is left as-is.

## Testing

- New `meta_test.go`: sidecar generation, the per-turn timeline across a branch switch, and Codex extraction incl. arg normalization (`resolveGitState`/`nowFunc` indirected for stubbing).
- `make lint`, `make vet`, and the `sessioncapture` + `cmd/amika` test suites pass. (`internal/materialize` failures are environmental — `rsync` absent — and unrelated.)