### PR TITLE
Add amikalog beta:push / beta:fetch to sync captured events with org storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
 - `main.go` — Entry point, root Cobra command
 - `start.go` — `start` / `stop` commands that install/remove the agent hooks
 - `hook.go` — `hook --source claude|codex`, the hook entrypoint that records one event
+- `push.go` — `beta:push`, uploads not-yet-pushed events to the org storage bucket (auth via `AMIKA_API_KEY` only; requests a signed upload URL per file from `POST /api/v0beta1/storage/uploads/batch`, then PUTs the bytes)
+- `fetch.go` — `beta:fetch <destination>`, downloads the entire org storage bucket into a local directory, recreating the bucket key tree on disk (auth via `AMIKA_API_KEY` only; lists the bucket via `GET /api/v0beta1/storage/downloads`, paging through `next_cursor`, then GETs each object's signed download URL)
 
 ### Internal Packages (`go/internal/`)
 - `sandbox/` — Docker sandbox management, preset image resolution + auto-build, volume and file mount stores, random name generation
@@ -77,7 +79,7 @@ language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
 - `app/` — Application service layer implementation
 - `ports/` — Port interfaces for Docker and store operations
 - `materialize/` — Local sandbox script execution and rsync copying (v0 legacy)
-- `eventlog/` — amikalog's hook installer + capture: writes append-only events to `<state>/events/{claude,codex}/sessions/{ts}_{session_id}/event_{seq}_{ts}.json`, annotated with git context
+- `eventlog/` — amikalog's hook installer + capture: writes append-only events to `<state>/events/{claude,codex}/sessions/{ts}_{session_id}/event_{seq}_{ts}.json`, annotated with git context. `push.go` uploads not-yet-pushed events via an `Uploader`, tracking sent files in `<state>/events/.amikalog-push-state.json` (object key = `<repo>/<source>/sessions/...`, repo from each session's `git.repo_root`)
 
 ### Public Package (`go/pkg/amika/`)
 - `service.go` — Public service API used by both the CLI and HTTP server

--- a/go/cmd/amikalog/fetch.go
+++ b/go/cmd/amikalog/fetch.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var fetchCmd = &cobra.Command{
+	Use:   "beta:fetch <destination>",
+	Short: "Download your organization's captured events to a local directory",
+	Long: `Download your organization's captured events into <destination>, a local
+directory that is created if it does not exist.
+
+Set AMIKA_API_KEY to authenticate.`,
+	Args:          cobra.ExactArgs(1),
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := os.Getenv(config.EnvAPIKey)
+		if key == "" {
+			return fmt.Errorf("set %s to fetch; amikalog authenticates with an org API key only", config.EnvAPIKey)
+		}
+		client := apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewStaticTokenSource(key))
+		n, err := runFetch(apiBucketDownloader{client: client}, args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "fetched %d object(s) -> %s\n", n, args[0])
+		return nil
+	},
+}
+
+// bucketObject is one downloadable object: its bucket key and a signed URL to
+// fetch its bytes.
+type bucketObject struct {
+	key         string
+	downloadURL string
+}
+
+// bucketDownloader lists the org bucket one page at a time and fetches the
+// bytes for any one object.
+type bucketDownloader interface {
+	// ListPage returns one page of objects and the cursor for the next page, or
+	// "" when this is the last page. Pass "" to fetch the first page.
+	ListPage(cursor string) (objs []bucketObject, nextCursor string, err error)
+	// Get retrieves the bytes for one object.
+	Get(obj bucketObject) ([]byte, error)
+}
+
+// downloadPageLimit is the page size requested when listing the bucket.
+const downloadPageLimit = 1000
+
+// apiBucketDownloader adapts the Amika API client to bucketDownloader: it lists
+// the bucket one page at a time and GETs each object's signed download URL.
+type apiBucketDownloader struct {
+	client *apiclient.Client
+}
+
+func (a apiBucketDownloader) ListPage(cursor string) ([]bucketObject, string, error) {
+	resp, err := a.client.ListDownloads("", cursor, downloadPageLimit)
+	if err != nil {
+		return nil, "", err
+	}
+	objs := make([]bucketObject, 0, len(resp.Objects))
+	for _, o := range resp.Objects {
+		objs = append(objs, bucketObject{key: o.Key, downloadURL: o.DownloadURL})
+	}
+	next := ""
+	if resp.NextCursor != nil {
+		next = *resp.NextCursor
+	}
+	return objs, next, nil
+}
+
+func (a apiBucketDownloader) Get(obj bucketObject) ([]byte, error) {
+	return a.client.DownloadFromSignedURL(obj.downloadURL)
+}
+
+// runFetch downloads every object in the org bucket and writes each under
+// destDir at its bucket key, recreating the bucket's directory tree. It returns
+// the number of objects written.
+//
+// Objects are downloaded page by page: each page's bytes are fetched before the
+// next page is listed, so a signed download URL is used promptly after it is
+// issued rather than after the whole (possibly multi-page) listing completes —
+// keeping first-page URLs from expiring on large buckets.
+func runFetch(d bucketDownloader, destDir string) (int, error) {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return 0, fmt.Errorf("creating destination dir: %w", err)
+	}
+	// Resolve the destination to its real path once. bucketObjectPath's textual
+	// check (via filepath.Abs) does not follow symlinks, so a pre-existing
+	// symlinked component under destDir could otherwise redirect a write outside
+	// it; each object's parent is re-resolved against this root below.
+	realRoot, err := filepath.EvalSymlinks(destDir)
+	if err != nil {
+		return 0, fmt.Errorf("resolving destination dir: %w", err)
+	}
+
+	n := 0
+	cursor := ""
+	for {
+		objs, next, err := d.ListPage(cursor)
+		if err != nil {
+			return n, err
+		}
+		for _, obj := range objs {
+			target, err := bucketObjectPath(destDir, obj.key)
+			if err != nil {
+				return n, err
+			}
+			if err := ensureSafeParent(filepath.Dir(target), realRoot); err != nil {
+				return n, fmt.Errorf("object key %q: %w", obj.key, err)
+			}
+			if err := rejectSymlink(target); err != nil {
+				return n, fmt.Errorf("object key %q: %w", obj.key, err)
+			}
+			data, err := d.Get(obj)
+			if err != nil {
+				return n, fmt.Errorf("downloading %s: %w", obj.key, err)
+			}
+			if err := os.WriteFile(target, data, 0o644); err != nil {
+				return n, fmt.Errorf("writing %s: %w", target, err)
+			}
+			n++
+		}
+		if next == "" {
+			return n, nil
+		}
+		cursor = next
+	}
+}
+
+// ensureSafeParent creates dir and verifies its real (symlink-resolved) path
+// stays within realRoot, so a symlinked path component cannot redirect a write
+// outside the destination.
+func ensureSafeParent(dir, realRoot string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating destination dir: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return fmt.Errorf("resolving destination dir: %w", err)
+	}
+	if resolved != realRoot && !strings.HasPrefix(resolved, realRoot+string(os.PathSeparator)) {
+		return fmt.Errorf("path escapes the destination directory via a symlink")
+	}
+	return nil
+}
+
+// rejectSymlink refuses to write through an existing symlink at path, so a
+// planted symlink at the object's own location cannot redirect the write
+// outside the destination.
+func rejectSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("destination path is a symlink")
+	}
+	return nil
+}
+
+// bucketObjectPath resolves the local path for a bucket key under destDir,
+// preserving the key's directory structure. It rejects keys that would escape
+// destDir (e.g. via ".."), so a malformed listing cannot write outside the
+// target directory.
+func bucketObjectPath(destDir, key string) (string, error) {
+	target := filepath.Join(destDir, filepath.FromSlash(key))
+	// Compare absolute paths so a relative destination like "." (the current
+	// directory) works: a textual prefix check would reject every object because
+	// filepath.Join(".", key) drops the leading "./", yet the bytes still land
+	// safely inside the destination.
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", fmt.Errorf("resolving destination dir: %w", err)
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return "", fmt.Errorf("resolving target path: %w", err)
+	}
+	if absTarget != absDest && !strings.HasPrefix(absTarget, absDest+string(os.PathSeparator)) {
+		return "", fmt.Errorf("object key %q escapes destination directory", key)
+	}
+	return target, nil
+}
+
+func init() {
+	rootCmd.AddCommand(fetchCmd)
+}

--- a/go/cmd/amikalog/fetch_test.go
+++ b/go/cmd/amikalog/fetch_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+// fakeBucketDownloader serves a fixed set of objects keyed by bucket key in a
+// single page, and can be told to fail the listing or an individual object's
+// fetch.
+type fakeBucketDownloader struct {
+	data    map[string][]byte
+	listErr error
+	getErr  map[string]error
+}
+
+func (f fakeBucketDownloader) ListPage(string) ([]bucketObject, string, error) {
+	if f.listErr != nil {
+		return nil, "", f.listErr
+	}
+	keys := make([]string, 0, len(f.data))
+	for k := range f.data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	objs := make([]bucketObject, 0, len(keys))
+	for _, k := range keys {
+		objs = append(objs, bucketObject{key: k, downloadURL: "https://signed/" + k})
+	}
+	return objs, "", nil
+}
+
+func (f fakeBucketDownloader) Get(obj bucketObject) ([]byte, error) {
+	if err := f.getErr[obj.key]; err != nil {
+		return nil, err
+	}
+	data, ok := f.data[obj.key]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", obj.key)
+	}
+	return data, nil
+}
+
+func TestRunFetch_RecreatesBucketTree(t *testing.T) {
+	dir := t.TempDir()
+	d := fakeBucketDownloader{data: map[string][]byte{
+		"amika/claude/sessions/s/event_0.json":       []byte(`{"k":0}`),
+		"amika/claude/sessions/s/event_1.json":       []byte(`{"k":1}`),
+		"unknown-repo/codex/sessions/t/event_0.json": []byte("x"),
+	}}
+
+	n, err := runFetch(d, dir)
+	if err != nil {
+		t.Fatalf("runFetch: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("n = %d, want 3", n)
+	}
+	for key, want := range d.data {
+		got, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(key)))
+		if err != nil {
+			t.Fatalf("reading %s: %v", key, err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("%s = %q, want %q", key, string(got), string(want))
+		}
+	}
+}
+
+func TestRunFetch_PropagatesListError(t *testing.T) {
+	d := fakeBucketDownloader{listErr: fmt.Errorf("boom")}
+	if _, err := runFetch(d, t.TempDir()); err == nil {
+		t.Fatal("expected error from List, got nil")
+	}
+}
+
+func TestRunFetch_PropagatesDownloadError(t *testing.T) {
+	d := fakeBucketDownloader{
+		data:   map[string][]byte{"amika/x.json": []byte("x")},
+		getErr: map[string]error{"amika/x.json": fmt.Errorf("nope")},
+	}
+	if _, err := runFetch(d, t.TempDir()); err == nil {
+		t.Fatal("expected error from Get, got nil")
+	}
+}
+
+// pagedBucketDownloader serves objects across multiple pages and records the
+// order of list/get calls, so a test can assert each page is downloaded before
+// the next is listed (signed URLs are used promptly, not after the full walk).
+type pagedBucketDownloader struct {
+	pages [][]bucketObject
+	ops   *[]string
+}
+
+func (p pagedBucketDownloader) ListPage(cursor string) ([]bucketObject, string, error) {
+	*p.ops = append(*p.ops, "list:"+cursor)
+	idx := 0
+	if cursor != "" {
+		idx, _ = strconv.Atoi(cursor)
+	}
+	if idx >= len(p.pages) {
+		return nil, "", nil
+	}
+	next := ""
+	if idx+1 < len(p.pages) {
+		next = strconv.Itoa(idx + 1)
+	}
+	return p.pages[idx], next, nil
+}
+
+func (p pagedBucketDownloader) Get(obj bucketObject) ([]byte, error) {
+	*p.ops = append(*p.ops, "get:"+obj.key)
+	return []byte(obj.key), nil
+}
+
+func TestRunFetch_RejectsSymlinkedDirEscape(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	// A symlinked subdirectory in the destination pointing outside it.
+	if err := os.Symlink(outside, filepath.Join(dir, "amika")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	d := fakeBucketDownloader{data: map[string][]byte{"amika/evil.json": []byte("pwned")}}
+
+	if _, err := runFetch(d, dir); err == nil {
+		t.Fatal("expected error for symlinked directory escape, got nil")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "evil.json")); !os.IsNotExist(err) {
+		t.Errorf("write escaped the destination into %s", outside)
+	}
+}
+
+func TestRunFetch_RejectsSymlinkedLeaf(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	// A symlink at the object's own path pointing outside the destination.
+	if err := os.Symlink(filepath.Join(outside, "secret"), filepath.Join(dir, "evil.json")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	d := fakeBucketDownloader{data: map[string][]byte{"evil.json": []byte("pwned")}}
+
+	if _, err := runFetch(d, dir); err == nil {
+		t.Fatal("expected error for symlinked leaf, got nil")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "secret")); !os.IsNotExist(err) {
+		t.Errorf("write escaped the destination into %s", outside)
+	}
+}
+
+func TestRunFetch_DownloadsEachPageBeforeListingNext(t *testing.T) {
+	var ops []string
+	d := pagedBucketDownloader{
+		pages: [][]bucketObject{
+			{{key: "p0a.json"}, {key: "p0b.json"}},
+			{{key: "p1a.json"}},
+		},
+		ops: &ops,
+	}
+
+	n, err := runFetch(d, t.TempDir())
+	if err != nil {
+		t.Fatalf("runFetch: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("n = %d, want 3", n)
+	}
+	want := []string{"list:", "get:p0a.json", "get:p0b.json", "list:1", "get:p1a.json"}
+	if !reflect.DeepEqual(ops, want) {
+		t.Errorf("ops = %v, want %v", ops, want)
+	}
+}
+
+func TestBucketObjectPath(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name    string
+		destDir string // defaults to the temp dir when empty
+		key     string
+		wantErr bool
+		want    string
+	}{
+		{
+			name: "nested key preserved",
+			key:  "amika/claude/sessions/s/event_0.json",
+			want: filepath.Join(dir, "amika", "claude", "sessions", "s", "event_0.json"),
+		},
+		{
+			name: "top-level key",
+			key:  "x.json",
+			want: filepath.Join(dir, "x.json"),
+		},
+		{
+			name:    "escaping key rejected",
+			key:     "../evil.json",
+			wantErr: true,
+		},
+		{
+			name:    "current-dir destination",
+			destDir: ".",
+			key:     "amika/claude/x.json",
+			want:    filepath.Join(".", "amika", "claude", "x.json"),
+		},
+		{
+			name:    "escaping key rejected from current dir",
+			destDir: ".",
+			key:     "../evil.json",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destDir := dir
+			if tt.destDir != "" {
+				destDir = tt.destDir
+			}
+			got, err := bucketObjectPath(destDir, tt.key)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for key %q, got %q", tt.key, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("bucketObjectPath(%q): %v", tt.key, err)
+			}
+			if got != tt.want {
+				t.Errorf("bucketObjectPath(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/cmd/amikalog/push.go
+++ b/go/cmd/amikalog/push.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/config"
+	"github.com/gofixpoint/amika/go/internal/eventlog"
+	"github.com/spf13/cobra"
+)
+
+var pushCmd = &cobra.Command{
+	Use:   "beta:push",
+	Short: "Upload captured events to your organization",
+	Long: `Upload captured events that have not been pushed yet. Repeated runs upload
+only events captured since the last push.
+
+Set AMIKA_API_KEY to authenticate.`,
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		key := os.Getenv(config.EnvAPIKey)
+		if key == "" {
+			return fmt.Errorf("set %s to push; amikalog authenticates with an org API key only", config.EnvAPIKey)
+		}
+		stateDir, err := config.StateDir()
+		if err != nil {
+			return fmt.Errorf("resolving state directory: %w", err)
+		}
+
+		client := apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewStaticTokenSource(key))
+		report, err := eventlog.Push(stateDir, apiUploader{client: client})
+		if err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		fmt.Fprintf(out, "uploaded %d, skipped %d, failed %d\n", report.Uploaded, report.Skipped, report.Failed)
+		if report.Failed > 0 {
+			for _, e := range report.Errors {
+				fmt.Fprintf(cmd.ErrOrStderr(), "amikalog: %v\n", e)
+			}
+			return fmt.Errorf("%d file(s) failed to upload", report.Failed)
+		}
+		return nil
+	},
+}
+
+// apiUploader adapts the Amika API client to eventlog.Uploader: it requests a
+// signed URL for each object key and PUTs the bytes to it.
+type apiUploader struct {
+	client *apiclient.Client
+}
+
+func (a apiUploader) Upload(objectKey string, data []byte) error {
+	resp, err := a.client.CreateUploadBatch(apiclient.CreateUploadBatchRequest{
+		// Upsert so re-pushing is idempotent: event files are append-only and
+		// their object keys are deterministic, so if a PUT succeeded but the
+		// manifest write was lost (interrupted run, failed write), the next push
+		// re-uploads identical bytes and must overwrite rather than fail on the
+		// already-existing object.
+		Files: []apiclient.UploadFile{{Filename: objectKey, Upsert: true}},
+	})
+	if err != nil {
+		return err
+	}
+	if len(resp.Objects) == 0 {
+		return fmt.Errorf("no signed upload URL returned for %s", objectKey)
+	}
+	return a.client.UploadToSignedURL(resp.Objects[0].UploadURL, data, "application/json")
+}
+
+func init() {
+	rootCmd.AddCommand(pushCmd)
+}

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -440,6 +441,168 @@ func (c *Client) UpdateSession(sandboxName, sessionID string, req UpdateSessionR
 		return nil, fmt.Errorf("remote update session: %w", err)
 	}
 	return &result, nil
+}
+
+// UploadFile is one requested file in a CreateUploadBatchRequest.
+type UploadFile struct {
+	// Filename is the object key within the org bucket. Relative paths only;
+	// nested paths ("dir/report.json") are allowed.
+	Filename string `json:"filename"`
+	// Upsert overwrites an existing object at the same path when true. When
+	// false (the default) uploading to an existing path fails.
+	Upsert bool `json:"upsert,omitempty"`
+}
+
+// CreateUploadBatchRequest is the request body for POST
+// /api/v0beta1/storage/uploads/batch. It requests one signed upload URL per
+// file (1..100 files per call); the whole request fails if any file cannot be
+// signed.
+type CreateUploadBatchRequest struct {
+	Files []UploadFile `json:"files"`
+}
+
+// UploadObject is one signed upload URL in an UploadBatchResponse, bound to a
+// single object key.
+type UploadObject struct {
+	// Path is the sanitized object key the signed URL is bound to.
+	Path string `json:"path"`
+	// UploadURL is the absolute, single-use signed upload URL with the token
+	// embedded in its query string. PUT the file bytes here.
+	UploadURL string `json:"upload_url"`
+	// Token is the signed upload JWT (also embedded in UploadURL), provided
+	// separately for SDK clients that take a token argument.
+	Token string `json:"token"`
+}
+
+// UploadBatchResponse is the response from POST /api/v0beta1/storage/uploads/batch.
+// It carries one path-bound signed upload URL per requested file, in request
+// order. The bytes for each are uploaded by a separate PUT to its UploadURL
+// (see UploadToSignedURL); that PUT does not go through the Amika API.
+type UploadBatchResponse struct {
+	// Bucket is the org-scoped bucket name (derived server-side from the org id).
+	Bucket string `json:"bucket"`
+	// Objects holds one signed upload URL per requested file, in request order.
+	Objects []UploadObject `json:"objects"`
+	// ExpiresIn is the token lifetime in seconds.
+	ExpiresIn int `json:"expires_in"`
+}
+
+// CreateUploadBatch requests one-time signed upload URLs for one or more objects
+// in the caller's org-scoped storage bucket. Upload each file's bytes with
+// UploadToSignedURL using the matching object's UploadURL.
+func (c *Client) CreateUploadBatch(req CreateUploadBatchRequest) (*UploadBatchResponse, error) {
+	var result UploadBatchResponse
+	if err := c.doJSON("POST", apiBasePath+"/storage/uploads/batch", req, &result); err != nil {
+		return nil, fmt.Errorf("remote create upload batch: %w", err)
+	}
+	return &result, nil
+}
+
+// UploadToSignedURL PUTs body to a signed upload URL returned by CreateUpload.
+// The URL is absolute and carries its own token in the query string, so this
+// bypasses BaseURL and sends no Authorization header. A non-2xx response is
+// returned as a *HTTPError.
+func (c *Client) UploadToSignedURL(signedURL string, body []byte, contentType string) error {
+	req, err := http.NewRequest("PUT", signedURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("upload request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return &HTTPError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+	return nil
+}
+
+// DownloadObject is one object in a ListDownloadsResponse: its bucket key paired
+// with a short-lived signed URL to fetch its bytes.
+type DownloadObject struct {
+	// Key is the object key within the bucket, preserving directory structure so
+	// the tree can be recreated locally by writing each object to its key.
+	Key string `json:"key"`
+	// Size is the object size in bytes.
+	Size int64 `json:"size"`
+	// LastModified is the object's last-modified timestamp.
+	LastModified string `json:"last_modified"`
+	// DownloadURL is the absolute signed download URL; GET it to fetch the bytes.
+	DownloadURL string `json:"download_url"`
+}
+
+// ListDownloadsResponse is one page of GET /api/v0beta1/storage/downloads: a
+// flat, recursive, key-sorted listing of the org bucket, each object carrying
+// its own signed download URL. Follow NextCursor for the next page.
+type ListDownloadsResponse struct {
+	// Bucket is the org-scoped bucket name (derived server-side from the org id).
+	Bucket string `json:"bucket"`
+	// Prefix is the subtree this listing was restricted to (empty = whole bucket).
+	Prefix string `json:"prefix"`
+	// Objects holds this page of objects, key-sorted.
+	Objects []DownloadObject `json:"objects"`
+	// ExpiresIn is the signed-URL lifetime in seconds.
+	ExpiresIn int `json:"expires_in"`
+	// NextCursor is the keyset cursor for the next page, or nil on the last page.
+	NextCursor *string `json:"next_cursor"`
+}
+
+// ListDownloads fetches one page of the org bucket listing, each object paired
+// with a signed download URL. prefix restricts the listing to a subtree (empty
+// lists the whole bucket); cursor continues a prior page (empty starts at the
+// beginning); limit caps the page size (<=0 lets the server choose). Retrieve
+// each object's bytes with DownloadFromSignedURL.
+func (c *Client) ListDownloads(prefix, cursor string, limit int) (*ListDownloadsResponse, error) {
+	q := url.Values{}
+	if prefix != "" {
+		q.Set("prefix", prefix)
+	}
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := apiBasePath + "/storage/downloads"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var result ListDownloadsResponse
+	if err := c.doJSON("GET", path, nil, &result); err != nil {
+		return nil, fmt.Errorf("remote list downloads: %w", err)
+	}
+	return &result, nil
+}
+
+// DownloadFromSignedURL GETs the bytes from a signed download URL returned by
+// CreateDownload. The URL is absolute and carries its own token in the query
+// string, so this bypasses BaseURL and sends no Authorization header. A non-2xx
+// response is returned as a *HTTPError.
+func (c *Client) DownloadFromSignedURL(signedURL string) ([]byte, error) {
+	req, err := http.NewRequest("GET", signedURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading download response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+	return body, nil
 }
 
 func (c *Client) doJSON(method, path string, body interface{}, out interface{}) error {

--- a/go/internal/apiclient/client_test.go
+++ b/go/internal/apiclient/client_test.go
@@ -2,9 +2,12 @@ package apiclient
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -238,4 +241,228 @@ func mustJSON(t *testing.T, v interface{}) string {
 func mustJSONString(t *testing.T, v interface{}) string {
 	t.Helper()
 	return mustJSON(t, v)
+}
+
+func TestCreateUploadBatch_SendsFilesAndAuth(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotBody CreateUploadBatchRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"bucket": "org-123",
+			"objects": []map[string]any{{
+				"path":       "amika/claude/x.json",
+				"upload_url": "https://store.example/upload/sign/org-123/amika/claude/x.json?token=abc",
+				"token":      "abc",
+			}},
+			"expires_in": 7200,
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key-xyz")
+	resp, err := c.CreateUploadBatch(CreateUploadBatchRequest{Files: []UploadFile{{Filename: "amika/claude/x.json"}}})
+	if err != nil {
+		t.Fatalf("CreateUploadBatch: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v0beta1/storage/uploads/batch" {
+		t.Errorf("path = %q, want /api/v0beta1/storage/uploads/batch", gotPath)
+	}
+	if gotAuth != "Bearer key-xyz" {
+		t.Errorf("auth = %q, want Bearer key-xyz", gotAuth)
+	}
+	if len(gotBody.Files) != 1 || gotBody.Files[0].Filename != "amika/claude/x.json" {
+		t.Errorf("files = %+v", gotBody.Files)
+	}
+	if len(resp.Objects) != 1 || resp.Objects[0].UploadURL == "" || resp.Objects[0].Token != "abc" || resp.ExpiresIn != 7200 {
+		t.Errorf("response = %+v", resp)
+	}
+}
+
+func TestUploadToSignedURL_PutsBytesWithoutAuth(t *testing.T) {
+	var gotMethod, gotAuth, gotType string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		gotType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient("https://api.example", "key-xyz")
+	if err := c.UploadToSignedURL(srv.URL+"/upload?token=abc", []byte(`{"x":1}`), "application/json"); err != nil {
+		t.Fatalf("UploadToSignedURL: %v", err)
+	}
+	if gotMethod != "PUT" {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotAuth != "" {
+		t.Errorf("auth header = %q, want empty (token is in the URL)", gotAuth)
+	}
+	if gotType != "application/json" {
+		t.Errorf("content-type = %q", gotType)
+	}
+	if string(gotBody) != `{"x":1}` {
+		t.Errorf("body = %q", string(gotBody))
+	}
+}
+
+func TestUploadToSignedURL_Non2xxIsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("denied"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("https://api.example", "key-xyz")
+	err := c.UploadToSignedURL(srv.URL, []byte("x"), "application/json")
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error = %v, want *HTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", httpErr.StatusCode)
+	}
+}
+
+func TestListDownloads_SendsQueryAndParsesPage(t *testing.T) {
+	var gotMethod, gotPath, gotRawQuery, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"bucket": "org-123",
+			"prefix": "",
+			"objects": []map[string]any{{
+				"key":           "amika/claude/x.json",
+				"size":          12,
+				"last_modified": "2026-01-01T00:00:00Z",
+				"download_url":  "https://store.example/object/sign/org-123/amika/claude/x.json?token=abc",
+			}},
+			"expires_in":  3600,
+			"next_cursor": "CURSOR2",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key-xyz")
+	resp, err := c.ListDownloads("", "", 1000)
+	if err != nil {
+		t.Fatalf("ListDownloads: %v", err)
+	}
+	if gotMethod != "GET" {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotPath != "/api/v0beta1/storage/downloads" {
+		t.Errorf("path = %q, want /api/v0beta1/storage/downloads", gotPath)
+	}
+	if gotRawQuery != "limit=1000" {
+		t.Errorf("query = %q, want limit=1000", gotRawQuery)
+	}
+	if gotAuth != "Bearer key-xyz" {
+		t.Errorf("auth = %q, want Bearer key-xyz", gotAuth)
+	}
+	if len(resp.Objects) != 1 || resp.Objects[0].Key != "amika/claude/x.json" || resp.Objects[0].DownloadURL == "" {
+		t.Errorf("objects = %+v", resp.Objects)
+	}
+	if resp.Objects[0].Size != 12 {
+		t.Errorf("size = %d, want 12", resp.Objects[0].Size)
+	}
+	if resp.NextCursor == nil || *resp.NextCursor != "CURSOR2" {
+		t.Errorf("next_cursor = %v, want CURSOR2", resp.NextCursor)
+	}
+}
+
+func TestListDownloads_PassesPrefixAndCursorOmitsZeroLimit(t *testing.T) {
+	var gotRawQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"bucket":      "org-123",
+			"prefix":      "amika/",
+			"objects":     []any{},
+			"expires_in":  3600,
+			"next_cursor": nil,
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key-xyz")
+	resp, err := c.ListDownloads("amika/", "CUR", 0)
+	if err != nil {
+		t.Fatalf("ListDownloads: %v", err)
+	}
+	q, err := url.ParseQuery(gotRawQuery)
+	if err != nil {
+		t.Fatalf("parsing query %q: %v", gotRawQuery, err)
+	}
+	if q.Get("prefix") != "amika/" {
+		t.Errorf("prefix = %q, want amika/", q.Get("prefix"))
+	}
+	if q.Get("cursor") != "CUR" {
+		t.Errorf("cursor = %q, want CUR", q.Get("cursor"))
+	}
+	if _, ok := q["limit"]; ok {
+		t.Errorf("limit present in query %q, want omitted when <=0", gotRawQuery)
+	}
+	if resp.NextCursor != nil {
+		t.Errorf("next_cursor = %v, want nil", resp.NextCursor)
+	}
+}
+
+func TestDownloadFromSignedURL_GetsBytesWithoutAuth(t *testing.T) {
+	var gotMethod, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"event":1}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("https://api.example", "key-xyz")
+	body, err := c.DownloadFromSignedURL(srv.URL + "/object?token=abc")
+	if err != nil {
+		t.Fatalf("DownloadFromSignedURL: %v", err)
+	}
+	if gotMethod != "GET" {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotAuth != "" {
+		t.Errorf("auth header = %q, want empty (token is in the URL)", gotAuth)
+	}
+	if string(body) != `{"event":1}` {
+		t.Errorf("body = %q", string(body))
+	}
+}
+
+func TestDownloadFromSignedURL_Non2xxIsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("missing"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("https://api.example", "key-xyz")
+	_, err := c.DownloadFromSignedURL(srv.URL)
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error = %v, want *HTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", httpErr.StatusCode)
+	}
 }

--- a/go/internal/eventlog/event.go
+++ b/go/internal/eventlog/event.go
@@ -81,6 +81,13 @@ func rawPayload(data []byte) json.RawMessage {
 // carries its own timestamp, write distinct files with the same Seq. Locking at
 // the sessions-root level also serializes session-directory creation, so two
 // first-hooks of a brand-new session cannot create two directories for it.
+//
+// Each event is written to a temporary file and then atomically renamed into
+// place. The lock only serializes writers; beta:push scans and uploads event
+// files without taking it, so a reader could otherwise observe an "event_" file
+// that exists but is not yet fully encoded and upload truncated bytes. The
+// temp file is named so it is ignored by countEvents and the pushed file set
+// (neither has the "event_" prefix) until the rename publishes it complete.
 func writeEvent(stateDir string, ev Event) error {
 	now := time.Now().UTC()
 	ev.Timestamp = now.Format(time.RFC3339Nano)
@@ -103,29 +110,47 @@ func writeEvent(stateDir string, ev Event) error {
 
 	ts := fileTimestamp(now)
 	seq := countEvents(sessionDir)
+	// Pick the first unused sequence number. The lock means no other writer can
+	// claim it between this check and the rename below.
 	for {
 		path := filepath.Join(sessionDir, fmt.Sprintf("event_%d_%s.json", seq, ts))
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
-		if err != nil {
-			if errors.Is(err, os.ErrExist) {
-				seq++
-				continue
-			}
-			return fmt.Errorf("creating event file %s: %w", path, err)
+		_, statErr := os.Stat(path)
+		if statErr == nil {
+			seq++
+			continue
+		}
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return fmt.Errorf("checking event file %s: %w", path, statErr)
 		}
 		ev.Seq = seq
-		enc := json.NewEncoder(f)
-		enc.SetIndent("", "  ")
-		if encErr := enc.Encode(ev); encErr != nil {
-			f.Close()
-			_ = os.Remove(path)
-			return fmt.Errorf("writing event %s: %w", path, encErr)
-		}
-		if closeErr := f.Close(); closeErr != nil {
-			return fmt.Errorf("closing event %s: %w", path, closeErr)
-		}
-		return nil
+		return writeEventFile(sessionDir, path, ev)
 	}
+}
+
+// writeEventFile encodes ev into a temp file in dir and atomically renames it to
+// finalPath, so a concurrent reader never sees a partially-written event.
+func writeEventFile(dir, finalPath string, ev Event) error {
+	f, err := os.CreateTemp(dir, ".event-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp event file in %s: %w", dir, err)
+	}
+	tmp := f.Name()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if encErr := enc.Encode(ev); encErr != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("writing event %s: %w", finalPath, encErr)
+	}
+	if closeErr := f.Close(); closeErr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("closing event %s: %w", finalPath, closeErr)
+	}
+	if renErr := os.Rename(tmp, finalPath); renErr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("publishing event %s: %w", finalPath, renErr)
+	}
+	return nil
 }
 
 // resolveSessionDir returns the directory holding sessionID's events, creating

--- a/go/internal/eventlog/push.go
+++ b/go/internal/eventlog/push.go
@@ -1,0 +1,231 @@
+package eventlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Uploader uploads one object's bytes under the given object key. The key uses
+// forward slashes and is a relative path within the destination bucket.
+type Uploader interface {
+	Upload(objectKey string, data []byte) error
+}
+
+// PushReport summarizes a Push run.
+type PushReport struct {
+	// Uploaded is the number of event files uploaded this run.
+	Uploaded int
+	// Skipped is the number of event files already recorded in the manifest.
+	Skipped int
+	// Failed is the number of event files whose upload returned an error.
+	Failed int
+	// Errors holds one error per failed file (parallel to Failed).
+	Errors []error
+}
+
+// pushManifestName is the file under <state>/events that records which event
+// files have already been uploaded, so repeated pushes are incremental.
+const pushManifestName = ".amikalog-push-state.json"
+
+// unknownRepoSegment is the object-key prefix used for a session whose events
+// carry no git repository context.
+const unknownRepoSegment = "unknown-repo"
+
+// pushManifest tracks uploaded event files keyed by their path relative to
+// <state>/events (e.g. "claude/sessions/<dir>/event_0_<ts>.json"); the value
+// is the RFC3339 time the upload succeeded.
+type pushManifest struct {
+	Uploaded map[string]string `json:"uploaded"`
+}
+
+// Push uploads every not-yet-pushed event file under stateDir to up, recording
+// successes in a local manifest so subsequent runs only send new files.
+//
+// The object key for each file is its path relative to <state>/events prefixed
+// with the file's repository, i.e.
+// "<repo>/<source>/sessions/<session-dir>/<event-file>.json". Each session is
+// scoped to a single repository, so the repo segment is resolved once per
+// session directory from the captured git.repo_root (basename), falling back to
+// "unknown-repo" when no git context was recorded.
+//
+// Per-file upload failures are collected in the report and do not abort the
+// run; a non-nil error is returned only for failures that prevent the walk
+// itself (e.g. an unreadable manifest).
+func Push(stateDir string, up Uploader) (PushReport, error) {
+	eventsBase := filepath.Join(stateDir, "events")
+	manifestPath := filepath.Join(eventsBase, pushManifestName)
+
+	manifest, err := loadPushManifest(manifestPath)
+	if err != nil {
+		return PushReport{}, err
+	}
+
+	var report PushReport
+	for _, src := range []Source{SourceClaude, SourceCodex} {
+		sessionsRoot := EventsDir(stateDir, src)
+		sessions, err := os.ReadDir(sessionsRoot)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return report, fmt.Errorf("reading %s sessions: %w", src, err)
+		}
+		for _, session := range sessions {
+			if !session.IsDir() {
+				continue
+			}
+			sessionDir := filepath.Join(sessionsRoot, session.Name())
+			repoSeg := resolveRepoSegment(sessionDir)
+			if err := pushSession(up, manifest, manifestPath, eventsBase, sessionDir, repoSeg, &report); err != nil {
+				return report, err
+			}
+		}
+	}
+	return report, nil
+}
+
+// pushSession uploads the not-yet-pushed event files in one session directory.
+func pushSession(up Uploader, manifest *pushManifest, manifestPath, eventsBase, sessionDir, repoSeg string, report *PushReport) error {
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		return fmt.Errorf("reading session dir %s: %w", sessionDir, err)
+	}
+	// Sort so uploads (and the manifest) follow a stable, sequence-ordered path.
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "event_") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		filePath := filepath.Join(sessionDir, name)
+		relPath, err := filepath.Rel(eventsBase, filePath)
+		if err != nil {
+			return fmt.Errorf("relativizing %s: %w", filePath, err)
+		}
+		relKey := filepath.ToSlash(relPath)
+		if _, done := manifest.Uploaded[relKey]; done {
+			report.Skipped++
+			continue
+		}
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Errorf("reading %s: %w", relKey, err))
+			continue
+		}
+		// Lowercase the object key: storage listings fold case in directory
+		// segments, so an uppercase key can be listed but not signed back during
+		// beta:fetch. Normalizing here covers every event file regardless of its
+		// on-disk filename casing.
+		objectKey := strings.ToLower(path.Join(repoSeg, relKey))
+		if err := up.Upload(objectKey, data); err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Errorf("uploading %s: %w", objectKey, err))
+			continue
+		}
+		manifest.Uploaded[relKey] = time.Now().UTC().Format(time.RFC3339)
+		// Persist after each success so an interrupted run resumes cleanly.
+		if err := savePushManifest(manifestPath, manifest); err != nil {
+			return err
+		}
+		report.Uploaded++
+	}
+	return nil
+}
+
+// resolveRepoSegment returns the sanitized repository basename for a session,
+// read from the first event file that carries git context. It returns
+// "unknown-repo" when the session has no event with a git repo root.
+func resolveRepoSegment(sessionDir string) string {
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		return unknownRepoSegment
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "event_") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(sessionDir, name))
+		if err != nil {
+			continue
+		}
+		var ev Event
+		if json.Unmarshal(data, &ev) != nil {
+			continue
+		}
+		if ev.Git != nil && ev.Git.RepoRoot != "" {
+			return sanitizeRepoSegment(filepath.Base(ev.Git.RepoRoot))
+		}
+	}
+	return unknownRepoSegment
+}
+
+// sanitizeRepoSegment makes a repository name safe as a single object-key
+// segment, replacing path separators, whitespace, and the URL delimiters the
+// upload endpoint rejects. Empty input becomes "unknown-repo".
+func sanitizeRepoSegment(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." {
+		return unknownRepoSegment
+	}
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', ' ', '\t', '\n', '\r', '?', '#', '%':
+			return '-'
+		}
+		return r
+	}, name)
+}
+
+// loadPushManifest reads the manifest, returning an empty one when the file
+// does not yet exist.
+func loadPushManifest(path string) (*pushManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &pushManifest{Uploaded: map[string]string{}}, nil
+		}
+		return nil, fmt.Errorf("reading push manifest %s: %w", path, err)
+	}
+	var m pushManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing push manifest %s: %w", path, err)
+	}
+	if m.Uploaded == nil {
+		m.Uploaded = map[string]string{}
+	}
+	return &m, nil
+}
+
+// savePushManifest writes the manifest atomically (write-then-rename) so an
+// interrupted write cannot corrupt the existing manifest.
+func savePushManifest(path string, m *pushManifest) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating manifest dir: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("writing push manifest: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replacing push manifest: %w", err)
+	}
+	return nil
+}

--- a/go/internal/eventlog/push_test.go
+++ b/go/internal/eventlog/push_test.go
@@ -1,0 +1,163 @@
+package eventlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// fakeUploader records object keys (and bytes) it is asked to upload, and can
+// be told to fail for specific keys.
+type fakeUploader struct {
+	uploaded map[string][]byte
+	failKeys map[string]bool
+}
+
+func newFakeUploader() *fakeUploader {
+	return &fakeUploader{uploaded: map[string][]byte{}, failKeys: map[string]bool{}}
+}
+
+func (f *fakeUploader) Upload(objectKey string, data []byte) error {
+	if f.failKeys[objectKey] {
+		return fmt.Errorf("forced failure for %s", objectKey)
+	}
+	f.uploaded[objectKey] = data
+	return nil
+}
+
+func (f *fakeUploader) keys() []string {
+	ks := make([]string, 0, len(f.uploaded))
+	for k := range f.uploaded {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+// writeTestEvent writes one event JSON file into the on-disk layout under
+// stateDir, returning the file path.
+func writeTestEvent(t *testing.T, stateDir string, src Source, sessionDir string, seq int, git *GitInfo) string {
+	t.Helper()
+	dir := filepath.Join(EventsDir(stateDir, src), sessionDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ev := Event{
+		Source:    src,
+		HookEvent: "PostToolUse",
+		SessionID: "sess",
+		Seq:       seq,
+		Git:       git,
+		Payload:   json.RawMessage(`{}`),
+	}
+	data, err := json.MarshalIndent(ev, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("event_%d_20240101T000000.000000000Z.json", seq))
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestPush_UploadsWithRepoPrefixedKeys(t *testing.T) {
+	stateDir := t.TempDir()
+	writeTestEvent(t, stateDir, SourceClaude, "20240101T000000.000000000Z_sess-a", 0, &GitInfo{RepoRoot: "/home/u/work/amika"})
+	writeTestEvent(t, stateDir, SourceClaude, "20240101T000000.000000000Z_sess-a", 1, &GitInfo{RepoRoot: "/home/u/work/amika"})
+	// A codex session with no git context falls back to the unknown-repo prefix.
+	writeTestEvent(t, stateDir, SourceCodex, "20240101T000000.000000000Z_sess-b", 0, nil)
+
+	up := newFakeUploader()
+	report, err := Push(stateDir, up)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if report.Uploaded != 3 || report.Skipped != 0 || report.Failed != 0 {
+		t.Fatalf("report = %+v, want uploaded=3 skipped=0 failed=0", report)
+	}
+
+	// On-disk names are uppercase, but object keys are lowercased at upload so
+	// they round-trip through case-folding storage listings.
+	want := []string{
+		"amika/claude/sessions/20240101t000000.000000000z_sess-a/event_0_20240101t000000.000000000z.json",
+		"amika/claude/sessions/20240101t000000.000000000z_sess-a/event_1_20240101t000000.000000000z.json",
+		"unknown-repo/codex/sessions/20240101t000000.000000000z_sess-b/event_0_20240101t000000.000000000z.json",
+	}
+	got := up.keys()
+	if len(got) != len(want) {
+		t.Fatalf("uploaded keys = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("key[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPush_SecondRunSkipsAlreadyUploaded(t *testing.T) {
+	stateDir := t.TempDir()
+	writeTestEvent(t, stateDir, SourceClaude, "20240101T000000.000000000Z_sess-a", 0, &GitInfo{RepoRoot: "/x/amika"})
+
+	first := newFakeUploader()
+	r1, err := Push(stateDir, first)
+	if err != nil {
+		t.Fatalf("Push #1: %v", err)
+	}
+	if r1.Uploaded != 1 {
+		t.Fatalf("first run uploaded = %d, want 1", r1.Uploaded)
+	}
+
+	// A new file appears; the second run uploads only that one.
+	writeTestEvent(t, stateDir, SourceClaude, "20240101T000000.000000000Z_sess-a", 1, &GitInfo{RepoRoot: "/x/amika"})
+	second := newFakeUploader()
+	r2, err := Push(stateDir, second)
+	if err != nil {
+		t.Fatalf("Push #2: %v", err)
+	}
+	if r2.Uploaded != 1 || r2.Skipped != 1 {
+		t.Fatalf("second run = %+v, want uploaded=1 skipped=1", r2)
+	}
+	if len(second.uploaded) != 1 {
+		t.Errorf("second run uploaded %d objects, want 1", len(second.uploaded))
+	}
+}
+
+func TestPush_FailedUploadIsNotMarkedDone(t *testing.T) {
+	stateDir := t.TempDir()
+	writeTestEvent(t, stateDir, SourceClaude, "20240101T000000.000000000Z_sess-a", 0, &GitInfo{RepoRoot: "/x/amika"})
+	key := "amika/claude/sessions/20240101t000000.000000000z_sess-a/event_0_20240101t000000.000000000z.json"
+
+	failing := newFakeUploader()
+	failing.failKeys[key] = true
+	r1, err := Push(stateDir, failing)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if r1.Failed != 1 || r1.Uploaded != 0 {
+		t.Fatalf("report = %+v, want failed=1 uploaded=0", r1)
+	}
+
+	// A subsequent successful run retries the previously-failed file.
+	ok := newFakeUploader()
+	r2, err := Push(stateDir, ok)
+	if err != nil {
+		t.Fatalf("Push retry: %v", err)
+	}
+	if r2.Uploaded != 1 || r2.Skipped != 0 {
+		t.Fatalf("retry report = %+v, want uploaded=1 skipped=0", r2)
+	}
+}
+
+func TestPush_NoEventsIsNoOp(t *testing.T) {
+	report, err := Push(t.TempDir(), newFakeUploader())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if report.Uploaded != 0 || report.Skipped != 0 || report.Failed != 0 {
+		t.Fatalf("report = %+v, want all zero", report)
+	}
+}


### PR DESCRIPTION
  Adds two `amikalog` commands to move captured Claude/Codex events to the
  org storage bucket and back:

  - **`beta:push`** — uploads not-yet-pushed event files (signed upload URLs from
    `POST /storage/uploads/batch`, then direct PUT). Tracks sent files in
    `<state>/events/.amikalog-push-state.json` so pushes are incremental.
  - **`beta:fetch <dest>`** — lists the bucket via `GET /storage/downloads`
    (paged), GETs each signed URL, and recreates the key tree under `<dest>`.

  Both auth with `AMIKA_API_KEY` only. Backed by new `apiclient` methods
  (`CreateUploadBatch`, `ListDownloads`, signed-URL upload/download).

  Session-capture paths are now written **lowercase**: the storage listing API
  folds case in directory segments, so a mixed-case key could be listed but not
  signed — `beta:fetch` would 502. Lowercase keys round-trip cleanly.

  Tests cover the apiclient flows and the push/fetch commands; `make
  build-amikalog` and eventlog tests pass.

  `beta:` = experimental, no compatibility guarantees yet.