### PR TITLE
Distill docs-style conventions from the amikalog docs session

### DIFF
--- a/.agents/skills/naive-reader-review/SKILL.md
+++ b/.agents/skills/naive-reader-review/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: naive-reader-review
+description: "Pressure-test a docs page for clarity by having a naive sub-agent read it cold. A Sonnet sub-agent with no prior context reports what the tool seems to do, gaps between what's promised and what the commands deliver, passages that needed a re-read, and terms it couldn't define. The supervisor then revises the doc from that feedback."
+---
+
+# Naive reader review
+
+Use when you want to know whether a docs page (a file under `docs/`, a README
+section, a tutorial) actually lands with a developer who has no prior context
+on this product.
+
+**Usage:** `/naive-reader-review <path to the doc>`
+
+---
+
+## Phase 1: Spawn the naive reader
+
+Spawn a sub-agent with the Agent tool:
+
+- `subagent_type: general-purpose`
+- `model: sonnet`
+- Point it at exactly one file. Tell it to read only that file: no exploring the repo, no outside knowledge about this product or company, no charitable assumptions. It should answer only from the literal words in the doc.
+
+Brief it as a blunt, impatient developer landing on the page cold (from a link
+or search). It has the audience's baseline knowledge — it vaguely knows what AI
+coding agents like Claude Code are — but knows nothing about amika or this
+repo, and will not fill in gaps. Have it answer:
+
+1. What does this tool do?
+2. What problem does it claim to solve, and did the problem feel real and concrete?
+3. What value would the reader get, specifically? Could they tell what they'd actually do with the tool after following the doc?
+4. Does the solution deliver on the problem, or is there a gap between what's promised and what the commands let you do?
+5. Was everything understandable on one read? List every spot that needed a re-read or felt like a logical leap.
+6. List every term or phrase it can't define from the text alone (jargon, product names used without introduction, references that assume context it doesn't have).
+
+Ask it to keep the answer short.
+
+## Phase 2: Revise
+
+Read the sub-agent's answers. Each point of confusion is a fix:
+
+- If it misread what the tool does or the value, the value prop isn't leading clearly enough.
+- If it found a gap between the promise and what the commands actually do, show the mechanism or state the boundary honestly; don't paper over it with bigger claims.
+- If it flagged an undefined term, define it in context or cut it.
+
+Apply the fixes in the main agent so the user sees the diff. Skip changes that
+would lose something the user explicitly asked for.
+
+## Notes
+
+- Run the reader on one representative page when several are near-identical; apply the resulting fixes to all of them.
+- The point is clarity to a cold reader, not polish. Don't let the revision get longer or more hedged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,15 @@ language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
 - No external dependencies need to be installed for linting; `make lint` uses `go run`
 - Ports 60899–60999 are reserved inside sandbox containers for Amika services. See `docs/sandbox-configuration.md` for the allocation table.
 
+## Documentation Style
+
+For user-facing docs (`docs/`, README):
+
+- Lead with the value prop: what the problem is and why it matters, then the solution, then how to use it. Reference tables (commands, env vars, schemas) come after the narrative, not instead of it.
+- Only document commands and behavior that exist in the current code — verify against the `go/cmd/` sources. Don't import claims from marketing material describing future features.
+- No mid-sentence em-dashes in running prose; the `**Term** — description` separator in bullet lists is fine.
+- Use the `naive-reader-review` skill to pressure-test a doc with a cold reader.
+
 ## Testing Notes
 
 - Docker must be running for integration tests and CLI end-to-end testing


### PR DESCRIPTION
Add a Documentation Style section to AGENTS.md (value-prop-first structure, claims verified against current code, no mid-sentence em-dashes in prose) and retarget the naive-reader-review skill at technical docs pages for developers instead of outreach messages.