### PR TITLE
amikalog: store one JSONL file per session and parallelize sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
 - `app/` — Application service layer implementation
 - `ports/` — Port interfaces for Docker and store operations
 - `materialize/` — Local sandbox script execution and rsync copying (v0 legacy)
-- `eventlog/` — amikalog's hook installer + capture: writes append-only events to `<state>/events/{claude,codex}/sessions/{ts}_{session_id}/event_{seq}_{ts}.json`, annotated with git context. `push.go` uploads not-yet-pushed events via an `Uploader`, tracking sent files in `<state>/events/.amikalog-push-state.json` (object key = `<repo>/<source>/sessions/...`, repo from each session's `git.repo_root`)
+- `eventlog/` — amikalog's hook installer + capture: appends events (one JSON line each) to a per-session JSONL file `<state>/events/{claude,codex}/sessions/{ts}_{session_id}.jsonl`, annotated with git context. `push.go` uploads each changed session file in parallel via an `Uploader`, tracking each file's uploaded byte size in `<state>/events/.amikalog-push-state.json` so only sessions that grew are re-sent (object key = `<repo>/<source>/sessions/<ts>_<session_id>.jsonl`, repo from each session's `git.repo_root`; legacy per-event `event_*.json` files are still uploaded for backward compatibility)
 
 ### Public Package (`go/pkg/amika/`)
 - `service.go` — Public service API used by both the CLI and HTTP server

--- a/docs/amikalog.md
+++ b/docs/amikalog.md
@@ -96,12 +96,15 @@ Events are written under the amika state directory
 (`~/.local/state/amika` by default; override with `AMIKA_STATE_DIRECTORY`):
 
 ```
-<state>/events/{claude,codex}/sessions/<ts>_<session-id>/event_<seq>_<ts>.json
+<state>/events/{claude,codex}/sessions/<ts>_<session-id>.jsonl
 ```
 
-Each file is one JSON event and is never modified after being written.
-Sessions are ordinary directories you can `grep`, `jq`, sync, or load into a
-database. An event records:
+Each session is a single append-only [JSONL](https://jsonlines.org/) file, one
+JSON event per line; earlier lines are never modified. One file per session
+(rather than one file per event) keeps the tree small, so `beta:push` uploads a
+handful of session files instead of thousands of tiny ones. The files are
+ordinary text you can `grep`, `jq`, sync, or load into a database. Each line
+records:
 
 | Field        | Description                                                              |
 | ------------ | ------------------------------------------------------------------------ |
@@ -128,15 +131,16 @@ amikalog beta:push          # upload not-yet-pushed events
 amikalog beta:fetch <dir>   # download the org bucket into <dir>
 ```
 
-`beta:push` uploads each event file under the object key
-`<repo>/<source>/sessions/...`, where `<repo>` comes from the session's
-`git.repo_root`. Pushed files are tracked in
-`<state>/events/.amikalog-push-state.json`, so repeated runs upload only events
-captured since the last push, and re-pushing is idempotent.
+`beta:push` uploads each session file under the object key
+`<repo>/<source>/sessions/<ts>_<session-id>.jsonl`, where `<repo>` comes from the
+session's `git.repo_root`. Uploads run in parallel. Pushed files are tracked by
+size in `<state>/events/.amikalog-push-state.json`, so repeated runs re-upload
+only sessions that grew new events since the last push, and re-pushing is
+idempotent.
 
-`beta:fetch` downloads every object in the org bucket into a local directory,
-recreating the bucket's key tree on disk: your whole org's sessions, as
-ordinary files.
+`beta:fetch` downloads every object in the org bucket into a local directory (in
+parallel), recreating the bucket's key tree on disk: your whole org's sessions,
+as ordinary files.
 
 ## Command reference
 

--- a/go/cmd/amikalog/fetch.go
+++ b/go/cmd/amikalog/fetch.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/config"
@@ -56,6 +57,9 @@ type bucketDownloader interface {
 // downloadPageLimit is the page size requested when listing the bucket.
 const downloadPageLimit = 1000
 
+// fetchConcurrency bounds how many objects in a page are downloaded at once.
+const fetchConcurrency = 8
+
 // apiBucketDownloader adapts the Amika API client to bucketDownloader: it lists
 // the bucket one page at a time and GETs each object's signed download URL.
 type apiBucketDownloader struct {
@@ -86,10 +90,11 @@ func (a apiBucketDownloader) Get(obj bucketObject) ([]byte, error) {
 // destDir at its bucket key, recreating the bucket's directory tree. It returns
 // the number of objects written.
 //
-// Objects are downloaded page by page: each page's bytes are fetched before the
-// next page is listed, so a signed download URL is used promptly after it is
-// issued rather than after the whole (possibly multi-page) listing completes —
-// keeping first-page URLs from expiring on large buckets.
+// Objects are downloaded page by page: each page's objects are fetched (in
+// parallel, bounded by fetchConcurrency) before the next page is listed, so a
+// signed download URL is used promptly after it is issued rather than after the
+// whole (possibly multi-page) listing completes — keeping first-page URLs from
+// expiring on large buckets.
 func runFetch(d bucketDownloader, destDir string) (int, error) {
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return 0, fmt.Errorf("creating destination dir: %w", err)
@@ -103,38 +108,89 @@ func runFetch(d bucketDownloader, destDir string) (int, error) {
 		return 0, fmt.Errorf("resolving destination dir: %w", err)
 	}
 
-	n := 0
+	total := 0
 	cursor := ""
 	for {
 		objs, next, err := d.ListPage(cursor)
 		if err != nil {
-			return n, err
+			return total, err
 		}
-		for _, obj := range objs {
-			target, err := bucketObjectPath(destDir, obj.key)
-			if err != nil {
-				return n, err
-			}
-			if err := ensureSafeParent(filepath.Dir(target), realRoot); err != nil {
-				return n, fmt.Errorf("object key %q: %w", obj.key, err)
-			}
-			if err := rejectSymlink(target); err != nil {
-				return n, fmt.Errorf("object key %q: %w", obj.key, err)
-			}
-			data, err := d.Get(obj)
-			if err != nil {
-				return n, fmt.Errorf("downloading %s: %w", obj.key, err)
-			}
-			if err := os.WriteFile(target, data, 0o644); err != nil {
-				return n, fmt.Errorf("writing %s: %w", target, err)
-			}
-			n++
+		n, err := downloadPage(d, destDir, realRoot, objs)
+		total += n
+		if err != nil {
+			return total, err
 		}
 		if next == "" {
-			return n, nil
+			return total, nil
 		}
 		cursor = next
 	}
+}
+
+// downloadPage downloads objs concurrently into destDir, returning how many
+// were written. It stops scheduling new downloads once one fails and returns
+// the first error after in-flight downloads drain.
+func downloadPage(d bucketDownloader, destDir, realRoot string, objs []bucketObject) (int, error) {
+	var (
+		mu        sync.Mutex
+		firstErr  error
+		written   int
+		wg        sync.WaitGroup
+		semaphore = make(chan struct{}, fetchConcurrency)
+	)
+	for _, obj := range objs {
+		obj := obj
+		mu.Lock()
+		stop := firstErr != nil
+		mu.Unlock()
+		if stop {
+			break
+		}
+
+		semaphore <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+
+			if err := downloadObject(d, destDir, realRoot, obj); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			written++
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return written, firstErr
+}
+
+// downloadObject fetches one object and writes it under destDir at its key,
+// rejecting any key or pre-existing symlink that would escape destDir.
+func downloadObject(d bucketDownloader, destDir, realRoot string, obj bucketObject) error {
+	target, err := bucketObjectPath(destDir, obj.key)
+	if err != nil {
+		return err
+	}
+	if err := ensureSafeParent(filepath.Dir(target), realRoot); err != nil {
+		return fmt.Errorf("object key %q: %w", obj.key, err)
+	}
+	if err := rejectSymlink(target); err != nil {
+		return fmt.Errorf("object key %q: %w", obj.key, err)
+	}
+	data, err := d.Get(obj)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", obj.key, err)
+	}
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", target, err)
+	}
+	return nil
 }
 
 // ensureSafeParent creates dir and verifies its real (symlink-resolved) path

--- a/go/cmd/amikalog/fetch_test.go
+++ b/go/cmd/amikalog/fetch_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 )
 
@@ -89,16 +89,35 @@ func TestRunFetch_PropagatesDownloadError(t *testing.T) {
 	}
 }
 
+// opsLog records list/get calls; access is mutex-guarded because a page's
+// objects are fetched concurrently.
+type opsLog struct {
+	mu  sync.Mutex
+	ops []string
+}
+
+func (o *opsLog) add(s string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.ops = append(o.ops, s)
+}
+
+func (o *opsLog) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.ops...)
+}
+
 // pagedBucketDownloader serves objects across multiple pages and records the
 // order of list/get calls, so a test can assert each page is downloaded before
 // the next is listed (signed URLs are used promptly, not after the full walk).
 type pagedBucketDownloader struct {
 	pages [][]bucketObject
-	ops   *[]string
+	rec   *opsLog
 }
 
 func (p pagedBucketDownloader) ListPage(cursor string) ([]bucketObject, string, error) {
-	*p.ops = append(*p.ops, "list:"+cursor)
+	p.rec.add("list:" + cursor)
 	idx := 0
 	if cursor != "" {
 		idx, _ = strconv.Atoi(cursor)
@@ -114,7 +133,7 @@ func (p pagedBucketDownloader) ListPage(cursor string) ([]bucketObject, string, 
 }
 
 func (p pagedBucketDownloader) Get(obj bucketObject) ([]byte, error) {
-	*p.ops = append(*p.ops, "get:"+obj.key)
+	p.rec.add("get:" + obj.key)
 	return []byte(obj.key), nil
 }
 
@@ -153,13 +172,12 @@ func TestRunFetch_RejectsSymlinkedLeaf(t *testing.T) {
 }
 
 func TestRunFetch_DownloadsEachPageBeforeListingNext(t *testing.T) {
-	var ops []string
 	d := pagedBucketDownloader{
 		pages: [][]bucketObject{
 			{{key: "p0a.json"}, {key: "p0b.json"}},
 			{{key: "p1a.json"}},
 		},
-		ops: &ops,
+		rec: &opsLog{},
 	}
 
 	n, err := runFetch(d, t.TempDir())
@@ -169,9 +187,25 @@ func TestRunFetch_DownloadsEachPageBeforeListingNext(t *testing.T) {
 	if n != 3 {
 		t.Errorf("n = %d, want 3", n)
 	}
-	want := []string{"list:", "get:p0a.json", "get:p0b.json", "list:1", "get:p1a.json"}
-	if !reflect.DeepEqual(ops, want) {
-		t.Errorf("ops = %v, want %v", ops, want)
+
+	// A page's objects are fetched in parallel, so their relative order is not
+	// fixed; what must hold is that every get for a page happens between that
+	// page's list and the next page's list.
+	ops := d.rec.snapshot()
+	if len(ops) != 5 {
+		t.Fatalf("ops = %v, want 5 entries", ops)
+	}
+	if ops[0] != "list:" {
+		t.Errorf("ops[0] = %q, want list:", ops[0])
+	}
+	if page0 := map[string]bool{ops[1]: true, ops[2]: true}; !page0["get:p0a.json"] || !page0["get:p0b.json"] {
+		t.Errorf("ops[1:3] = %v, want page-0 gets before list:1", ops[1:3])
+	}
+	if ops[3] != "list:1" {
+		t.Errorf("ops[3] = %q, want list:1", ops[3])
+	}
+	if ops[4] != "get:p1a.json" {
+		t.Errorf("ops[4] = %q, want get:p1a.json", ops[4])
 	}
 }
 

--- a/go/cmd/amikalog/hook_test.go
+++ b/go/cmd/amikalog/hook_test.go
@@ -7,17 +7,20 @@ import (
 	"testing"
 )
 
-// countEventFiles walks dir and counts files named like event_*.json.
-func countEventFiles(t *testing.T, dir string) int {
+// countEvents walks dir and counts events recorded across all session JSONL
+// files (one event per line).
+func countEvents(t *testing.T, dir string) int {
 	t.Helper()
 	n := 0
-	_ = filepath.WalkDir(dir, func(_ string, d os.DirEntry, err error) error {
-		if err != nil {
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
 			return nil
 		}
-		if !d.IsDir() && strings.HasPrefix(d.Name(), "event_") {
-			n++
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
 		}
+		n += strings.Count(string(data), "\n")
 		return nil
 	})
 	return n
@@ -31,8 +34,8 @@ func TestHook_Claude_WritesEvent(t *testing.T) {
 	if _, err := runRootCommandStdin(strings.NewReader(payload), "hook", "--source", "claude"); err != nil {
 		t.Fatalf("hook --source claude: %v", err)
 	}
-	if got := countEventFiles(t, filepath.Join(stateDir, "events", "claude")); got != 1 {
-		t.Fatalf("got %d claude event files, want 1", got)
+	if got := countEvents(t, filepath.Join(stateDir, "events", "claude")); got != 1 {
+		t.Fatalf("got %d claude events, want 1", got)
 	}
 }
 
@@ -46,8 +49,8 @@ func TestHook_Codex_WritesEventFromStdin(t *testing.T) {
 	if _, err := runRootCommandStdin(strings.NewReader(payload), "hook", "--source", "codex"); err != nil {
 		t.Fatalf("hook --source codex (stdin): %v", err)
 	}
-	if got := countEventFiles(t, filepath.Join(stateDir, "events", "codex")); got != 1 {
-		t.Fatalf("got %d codex event files, want 1", got)
+	if got := countEvents(t, filepath.Join(stateDir, "events", "codex")); got != 1 {
+		t.Fatalf("got %d codex events, want 1", got)
 	}
 }
 
@@ -64,8 +67,8 @@ func TestHook_Codex_AcceptsNotifyPayload(t *testing.T) {
 	if _, err := runRootCommand("hook", "--source", "codex", payload); err != nil {
 		t.Fatalf("hook --source codex with payload: %v", err)
 	}
-	if got := countEventFiles(t, filepath.Join(stateDir, "events", "codex")); got != 1 {
-		t.Fatalf("got %d codex event files, want 1", got)
+	if got := countEvents(t, filepath.Join(stateDir, "events", "codex")); got != 1 {
+		t.Fatalf("got %d codex events, want 1", got)
 	}
 }
 

--- a/go/internal/eventlog/event.go
+++ b/go/internal/eventlog/event.go
@@ -1,9 +1,10 @@
 package eventlog
 
 import (
+	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,28 +67,24 @@ func rawPayload(data []byte) json.RawMessage {
 	return json.RawMessage(encoded)
 }
 
-// writeEvent appends ev as a new JSON file under
-// <stateDir>/events/<source>/sessions/<ts>_<session-id>/event_<seq>_<ts>.json.
+// writeEvent appends ev as one JSON line to the session's JSONL file at
+// <stateDir>/events/<source>/sessions/<ts>_<session-id>.jsonl.
 //
-// Writes are append-only: a new file is created for every call and existing
-// files are never modified.
+// One file per session (rather than one file per event) keeps the on-disk tree
+// small, so beta:push uploads a handful of session files instead of thousands
+// of tiny event files. Writes are append-only: the line is appended and earlier
+// lines are never modified.
 //
 // Concurrent hooks for the same session run as separate processes — Claude
 // fires PostToolUse hooks in parallel for parallel tool calls — so an
 // in-process mutex would not help. A cross-process advisory lock on the
-// source's sessions directory makes the whole "resolve session dir → count
-// existing events → create the next file" critical section atomic. Without it
-// two processes could read the same event count and, because each filename
-// carries its own timestamp, write distinct files with the same Seq. Locking at
-// the sessions-root level also serializes session-directory creation, so two
-// first-hooks of a brand-new session cannot create two directories for it.
+// source's sessions directory makes the whole "resolve session file → count
+// existing lines → append the next line" critical section atomic, so two
+// processes cannot assign the same Seq, interleave their bytes in the file, or
+// create two files for one brand-new session.
 //
-// Each event is written to a temporary file and then atomically renamed into
-// place. The lock only serializes writers; beta:push scans and uploads event
-// files without taking it, so a reader could otherwise observe an "event_" file
-// that exists but is not yet fully encoded and upload truncated bytes. The
-// temp file is named so it is ignored by countEvents and the pushed file set
-// (neither has the "event_" prefix) until the rename publishes it complete.
+// The lock only serializes writers; beta:push reads each session file while
+// holding the same lock so it can never observe a half-written final line.
 func writeEvent(stateDir string, ev Event) error {
 	now := time.Now().UTC()
 	ev.Timestamp = now.Format(time.RFC3339Nano)
@@ -103,90 +100,137 @@ func writeEvent(stateDir string, ev Event) error {
 	}
 	defer lock.release()
 
-	sessionDir, err := resolveSessionDir(root, ev.SessionID, now)
-	if err != nil {
-		return err
-	}
-
-	ts := fileTimestamp(now)
-	seq := countEvents(sessionDir)
-	// Pick the first unused sequence number. The lock means no other writer can
-	// claim it between this check and the rename below.
-	for {
-		path := filepath.Join(sessionDir, fmt.Sprintf("event_%d_%s.json", seq, ts))
-		_, statErr := os.Stat(path)
-		if statErr == nil {
-			seq++
-			continue
-		}
-		if !errors.Is(statErr, os.ErrNotExist) {
-			return fmt.Errorf("checking event file %s: %w", path, statErr)
-		}
-		ev.Seq = seq
-		return writeEventFile(sessionDir, path, ev)
-	}
+	sessionFile := resolveSessionFile(root, ev.SessionID, now)
+	ev.Seq = countLines(sessionFile)
+	return appendEvent(sessionFile, ev)
 }
 
-// writeEventFile encodes ev into a temp file in dir and atomically renames it to
-// finalPath, so a concurrent reader never sees a partially-written event.
-func writeEventFile(dir, finalPath string, ev Event) error {
-	f, err := os.CreateTemp(dir, ".event-*.json.tmp")
+// appendEvent appends ev to path as a single newline-terminated JSON line. The
+// event is marshaled fully before the lone Write call so a reader holding the
+// same lock sees either the whole line or none of it.
+//
+// Before writing, any partial trailing record is dropped: a completed record
+// always ends in '\n', so a non-newline tail is the remnant of an append that a
+// returned error, a process kill, or a power loss interrupted. Removing it keeps
+// records from concatenating, so the stream stays parseable and Seq cannot
+// repeat — the crash-safety the old temp-file-and-rename layout gave. A short or
+// failed write here is likewise rolled back to the pre-write length.
+func appendEvent(path string, ev Event) error {
+	line, err := json.Marshal(ev)
 	if err != nil {
-		return fmt.Errorf("creating temp event file in %s: %w", dir, err)
+		return fmt.Errorf("encoding event for %s: %w", path, err)
 	}
-	tmp := f.Name()
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "  ")
-	if encErr := enc.Encode(ev); encErr != nil {
+	line = append(line, '\n')
+
+	// O_RDWR (not O_WRONLY) so the heal step can read the tail; O_APPEND still
+	// forces the write itself to the current end.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening session file %s: %w", path, err)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
 		f.Close()
-		_ = os.Remove(tmp)
-		return fmt.Errorf("writing event %s: %w", finalPath, encErr)
+		return fmt.Errorf("sizing session file %s: %w", path, err)
 	}
-	if closeErr := f.Close(); closeErr != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("closing event %s: %w", finalPath, closeErr)
+	start, err := healPartialTail(f, info.Size())
+	if err != nil {
+		f.Close()
+		return fmt.Errorf("healing session file %s: %w", path, err)
 	}
-	if renErr := os.Rename(tmp, finalPath); renErr != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("publishing event %s: %w", finalPath, renErr)
+
+	n, writeErr := f.Write(line)
+	if writeErr != nil || n != len(line) {
+		// Drop any bytes this append managed to write. The advisory lock is held,
+		// so no concurrent writer can be sitting past start.
+		_ = f.Truncate(start)
+		f.Close()
+		if writeErr == nil {
+			writeErr = io.ErrShortWrite
+		}
+		return fmt.Errorf("appending event to %s: %w", path, writeErr)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing session file %s: %w", path, err)
 	}
 	return nil
 }
 
-// resolveSessionDir returns the directory holding sessionID's events, creating
-// it (named "<ts>_<session-id>") when it does not yet exist. An existing
-// directory is matched by its "_<session-id>" suffix so a session's events
-// accumulate together regardless of when the directory was first created.
-func resolveSessionDir(root, sessionID string, now time.Time) (string, error) {
+// healPartialTail removes an incomplete trailing record (any bytes after the
+// last newline) from f, returning the resulting size. The common case is cheap:
+// a completed record ends in '\n', so when the file is empty or already ends in
+// '\n' only the final byte is read. The file is read in full only in the rare
+// case of a crash-interrupted tail. The caller holds the advisory lock, so such
+// a tail can only be a dead writer's remnant, never a record in flight.
+func healPartialTail(f *os.File, size int64) (int64, error) {
+	if size == 0 {
+		return 0, nil
+	}
+	last := make([]byte, 1)
+	if _, err := f.ReadAt(last, size-1); err != nil {
+		return 0, err
+	}
+	if last[0] == '\n' {
+		return size, nil
+	}
+	buf := make([]byte, size)
+	if _, err := f.ReadAt(buf, 0); err != nil {
+		return 0, err
+	}
+	// LastIndexByte returns -1 when no newline exists (the whole file is one
+	// unterminated record), so healed becomes 0 and the file is cleared.
+	healed := int64(bytes.LastIndexByte(buf, '\n') + 1)
+	if err := f.Truncate(healed); err != nil {
+		return 0, err
+	}
+	return healed, nil
+}
+
+// resolveSessionFile returns the path to sessionID's JSONL file, named
+// "<ts>_<session-id>.jsonl". An existing file is matched by its
+// "_<session-id>.jsonl" suffix so a session's events keep accumulating in one
+// file regardless of when it was first created. The file itself is created on
+// first append by appendEvent.
+func resolveSessionFile(root, sessionID string, now time.Time) string {
 	safe := sanitizeSessionID(sessionID)
 	if entries, err := os.ReadDir(root); err == nil {
 		for _, e := range entries {
-			if !e.IsDir() {
+			if e.IsDir() {
 				continue
 			}
 			name := e.Name()
-			if idx := strings.IndexByte(name, '_'); idx >= 0 && name[idx+1:] == safe {
-				return filepath.Join(root, name), nil
+			base, ok := strings.CutSuffix(name, ".jsonl")
+			if !ok {
+				continue
+			}
+			if idx := strings.IndexByte(base, '_'); idx >= 0 && base[idx+1:] == safe {
+				return filepath.Join(root, name)
 			}
 		}
 	}
-	dir := filepath.Join(root, fileTimestamp(now)+"_"+safe)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("creating session dir %s: %w", dir, err)
-	}
-	return dir, nil
+	return filepath.Join(root, fileTimestamp(now)+"_"+safe+".jsonl")
 }
 
-// countEvents returns how many event files already live in sessionDir.
-func countEvents(sessionDir string) int {
-	entries, err := os.ReadDir(sessionDir)
+// countLines returns the number of newline-terminated lines (events) already in
+// path, or 0 when the file does not yet exist. It is the next event's Seq.
+func countLines(path string) int {
+	f, err := os.Open(path)
 	if err != nil {
 		return 0
 	}
+	defer f.Close()
 	n := 0
-	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), "event_") {
-			n++
+	buf := make([]byte, 64*1024)
+	for {
+		c, readErr := f.Read(buf)
+		for _, b := range buf[:c] {
+			if b == '\n' {
+				n++
+			}
+		}
+		if readErr != nil {
+			break
 		}
 	}
 	return n

--- a/go/internal/eventlog/eventlog.go
+++ b/go/internal/eventlog/eventlog.go
@@ -7,9 +7,9 @@
 // hook event) that invoke `amikalog hook --source ...` on every hook call.
 // Both agents deliver the hook payload on stdin with the same shape
 // (session_id, cwd, hook_event_name, ...). Each invocation appends one JSON
-// file:
+// line to the session's append-only JSONL file:
 //
-//	<state>/events/<source>/sessions/<ts>_<session-id>/event_<seq>_<ts>.json
+//	<state>/events/<source>/sessions/<ts>_<session-id>.jsonl
 //
 // No daemon and no background process are involved. The state directory is the
 // same one the rest of amika uses (see internal/config.StateDir), so
@@ -41,7 +41,7 @@ const (
 )
 
 // EventsDir returns the directory under stateDir that holds a source's session
-// directories: <stateDir>/events/<source>/sessions.
+// files: <stateDir>/events/<source>/sessions.
 func EventsDir(stateDir string, src Source) string {
 	return filepath.Join(stateDir, "events", string(src), "sessions")
 }

--- a/go/internal/eventlog/eventlog_test.go
+++ b/go/internal/eventlog/eventlog_test.go
@@ -61,8 +61,8 @@ func TestCaptureClaude_SecondEventSameSessionIncrementsSeq(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := countSessionDirs(t, stateDir, SourceClaude); got != 1 {
-		t.Fatalf("got %d session dirs, want 1 (events must share a session dir)", got)
+	if got := countSessions(t, stateDir, SourceClaude); got != 1 {
+		t.Fatalf("got %d session files, want 1 (events must share a session file)", got)
 	}
 	events := readEvents(t, stateDir, SourceClaude)
 	if len(events) != 2 {
@@ -100,9 +100,9 @@ func TestCaptureClaude_ConcurrentSameSessionUniqueSeqs(t *testing.T) {
 		t.Fatalf("concurrent CaptureClaude: %v", err)
 	}
 
-	// All events must land in one session directory...
-	if got := countSessionDirs(t, stateDir, SourceClaude); got != 1 {
-		t.Fatalf("got %d session dirs, want 1 (session-dir creation must be serialized)", got)
+	// All events must land in one session file...
+	if got := countSessions(t, stateDir, SourceClaude); got != 1 {
+		t.Fatalf("got %d session files, want 1 (session-file creation must be serialized)", got)
 	}
 
 	// ...with exactly the contiguous seqs 0..n-1, none duplicated.
@@ -121,6 +121,55 @@ func TestCaptureClaude_ConcurrentSameSessionUniqueSeqs(t *testing.T) {
 		if !seen[i] {
 			t.Errorf("missing seq %d", i)
 		}
+	}
+}
+
+func TestCaptureClaude_HealsPartialTrailingRecord(t *testing.T) {
+	stateDir := t.TempDir()
+	cwd := t.TempDir() // non-repo: deterministic null git
+	mk := func(event string) string {
+		return `{"session_id":"sess-1","cwd":"` + cwd + `","hook_event_name":"` + event + `"}`
+	}
+	if err := CaptureClaude(strings.NewReader(mk("UserPromptSubmit")), stateDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a crash mid-append: a partial record with no trailing newline.
+	sessionFile := onlySessionFile(t, stateDir, SourceClaude)
+	f, err := os.OpenFile(sessionFile, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"session_id":"sess-1","seq":99,"incomplete`); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	// The next capture must drop the partial tail before appending.
+	if err := CaptureClaude(strings.NewReader(mk("Stop")), stateDir); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(sessionFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "incomplete") {
+		t.Errorf("partial record was not healed; file:\n%s", raw)
+	}
+	events := readEvents(t, stateDir, SourceClaude)
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2 (partial dropped, both real events kept)", len(events))
+	}
+	seqs := map[int]bool{}
+	for _, ev := range events {
+		if seqs[ev.Seq] {
+			t.Fatalf("duplicate seq %d after healing", ev.Seq)
+		}
+		seqs[ev.Seq] = true
+	}
+	if !seqs[0] || !seqs[1] {
+		t.Errorf("expected contiguous seqs 0 and 1, got %v", seqs)
 	}
 }
 
@@ -192,34 +241,31 @@ func TestCaptureCodex_LegacyNotifyDerivesSessionFromRollout(t *testing.T) {
 	}
 }
 
-// readEvents reads and decodes every event file for src under stateDir.
+// readEvents reads and decodes every event for src under stateDir, parsing each
+// session's JSONL file line by line.
 func readEvents(t *testing.T, stateDir string, src Source) []Event {
 	t.Helper()
 	root := EventsDir(stateDir, src)
 	var events []Event
-	sessionDirs, err := os.ReadDir(root)
+	entries, err := os.ReadDir(root)
 	if err != nil {
 		t.Fatalf("reading %s: %v", root, err)
 	}
-	for _, sd := range sessionDirs {
-		if !sd.IsDir() {
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
 			continue
 		}
-		files, err := os.ReadDir(filepath.Join(root, sd.Name()))
+		data, err := os.ReadFile(filepath.Join(root, e.Name()))
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, f := range files {
-			if !strings.HasPrefix(f.Name(), "event_") {
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
 				continue
 			}
-			data, err := os.ReadFile(filepath.Join(root, sd.Name(), f.Name()))
-			if err != nil {
-				t.Fatal(err)
-			}
 			var ev Event
-			if err := json.Unmarshal(data, &ev); err != nil {
-				t.Fatalf("decoding %s: %v", f.Name(), err)
+			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				t.Fatalf("decoding event in %s: %v", e.Name(), err)
 			}
 			events = append(events, ev)
 		}
@@ -227,9 +273,33 @@ func readEvents(t *testing.T, stateDir string, src Source) []Event {
 	return events
 }
 
-// countSessionDirs returns the number of session directories for src (ignoring
-// the .lock file and any other non-directory entries).
-func countSessionDirs(t *testing.T, stateDir string, src Source) int {
+// onlySessionFile returns the path of the single session JSONL file for src,
+// failing if there is not exactly one.
+func onlySessionFile(t *testing.T, stateDir string, src Source) string {
+	t.Helper()
+	root := EventsDir(stateDir, src)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("reading sessions dir: %v", err)
+	}
+	var found string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
+			if found != "" {
+				t.Fatalf("expected one session file, found multiple")
+			}
+			found = filepath.Join(root, e.Name())
+		}
+	}
+	if found == "" {
+		t.Fatalf("no session file found for %s", src)
+	}
+	return found
+}
+
+// countSessions returns the number of session JSONL files for src (ignoring the
+// .lock file and any other non-.jsonl entries).
+func countSessions(t *testing.T, stateDir string, src Source) int {
 	t.Helper()
 	entries, err := os.ReadDir(EventsDir(stateDir, src))
 	if err != nil {
@@ -237,7 +307,7 @@ func countSessionDirs(t *testing.T, stateDir string, src Source) int {
 	}
 	n := 0
 	for _, e := range entries {
-		if e.IsDir() {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
 			n++
 		}
 	}

--- a/go/internal/eventlog/lock.go
+++ b/go/internal/eventlog/lock.go
@@ -6,9 +6,8 @@ import (
 )
 
 // lockFileName is the advisory lock file amikalog places in each source's
-// sessions directory to serialize concurrent hook processes. It is ignored by
-// countEvents and resolveSessionDir because it neither starts with "event_"
-// nor is a directory.
+// sessions directory to serialize concurrent hook processes. It is ignored when
+// resolving and uploading session files because it lacks the ".jsonl" suffix.
 const lockFileName = ".lock"
 
 // fileLock is a cross-process advisory lock held on an open file.

--- a/go/internal/eventlog/push.go
+++ b/go/internal/eventlog/push.go
@@ -1,6 +1,8 @@
 package eventlog
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,22 +10,23 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
+	"sync"
 )
 
 // Uploader uploads one object's bytes under the given object key. The key uses
 // forward slashes and is a relative path within the destination bucket.
+// Implementations must be safe for concurrent use: Push uploads in parallel.
 type Uploader interface {
 	Upload(objectKey string, data []byte) error
 }
 
 // PushReport summarizes a Push run.
 type PushReport struct {
-	// Uploaded is the number of event files uploaded this run.
+	// Uploaded is the number of session files uploaded this run.
 	Uploaded int
-	// Skipped is the number of event files already recorded in the manifest.
+	// Skipped is the number of session files already up to date in the manifest.
 	Skipped int
-	// Failed is the number of event files whose upload returned an error.
+	// Failed is the number of session files whose upload returned an error.
 	Failed int
 	// Errors holds one error per failed file (parallel to Failed).
 	Errors []error
@@ -33,70 +36,343 @@ type PushReport struct {
 // files have already been uploaded, so repeated pushes are incremental.
 const pushManifestName = ".amikalog-push-state.json"
 
+// pushLockName is the advisory lock file under <state>/events that serializes
+// concurrent beta:push runs.
+const pushLockName = ".amikalog-push.lock"
+
 // unknownRepoSegment is the object-key prefix used for a session whose events
 // carry no git repository context.
 const unknownRepoSegment = "unknown-repo"
 
-// pushManifest tracks uploaded event files keyed by their path relative to
-// <state>/events (e.g. "claude/sessions/<dir>/event_0_<ts>.json"); the value
-// is the RFC3339 time the upload succeeded.
-type pushManifest struct {
-	Uploaded map[string]string `json:"uploaded"`
+// pushConcurrency bounds how many session files Push uploads at once.
+const pushConcurrency = 8
+
+// legacyUploaded marks a manifest entry written before uploads were tracked by
+// size (the value was an RFC3339 timestamp). Such a file was already uploaded,
+// so it is skipped regardless of its current size — safe because the only files
+// the old scheme tracked are the per-event JSON files, which are immutable.
+const legacyUploaded int64 = -1
+
+// manifestEntry records what was last uploaded for a file.
+type manifestEntry struct {
+	// Size is the byte length of the payload last uploaded. A session JSONL file
+	// grows as events are appended, so a size mismatch means new events to push;
+	// an unchanged size is skipped. legacyUploaded means "already uploaded under
+	// an older scheme, skip regardless of size".
+	Size int64 `json:"size"`
+	// ObjectKey is the destination key the file was first uploaded under, pinned
+	// so a session's key never changes — e.g. a session first pushed before any
+	// event carried git context (uploaded under "unknown-repo") keeps that key
+	// rather than creating a second object once git context appears.
+	ObjectKey string `json:"object_key,omitempty"`
 }
 
-// Push uploads every not-yet-pushed event file under stateDir to up, recording
-// successes in a local manifest so subsequent runs only send new files.
+// pushManifest tracks uploaded files keyed by their path relative to
+// <state>/events (e.g. "claude/sessions/<ts>_<sess>.jsonl").
+type pushManifest struct {
+	Uploaded map[string]manifestEntry `json:"uploaded"`
+}
+
+// UnmarshalJSON reads the manifest, tolerating two older value shapes: a bare
+// byte-size number (before the object key was pinned) and an upload-timestamp
+// string (before uploads were tracked by size, mapped to legacyUploaded). This
+// lets a format change reuse the existing manifest instead of re-pushing the
+// whole history.
+func (m *pushManifest) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Uploaded map[string]json.RawMessage `json:"uploaded"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	m.Uploaded = make(map[string]manifestEntry, len(raw.Uploaded))
+	for k, v := range raw.Uploaded {
+		var entry manifestEntry
+		if err := json.Unmarshal(v, &entry); err == nil {
+			m.Uploaded[k] = entry
+			continue
+		}
+		var size int64
+		if err := json.Unmarshal(v, &size); err == nil {
+			m.Uploaded[k] = manifestEntry{Size: size}
+			continue
+		}
+		m.Uploaded[k] = manifestEntry{Size: legacyUploaded}
+	}
+	return nil
+}
+
+// uploadUnit is one file Push may upload.
+type uploadUnit struct {
+	// relKey is the file's path relative to <state>/events, slash-separated; it
+	// keys the manifest.
+	relKey string
+	// repoSeg is the object-key repository prefix for legacy per-event files,
+	// resolved at collection time (they are immutable). It is empty for session
+	// JSONL files, whose prefix is derived from the locked snapshot instead — see
+	// objectKeyFor.
+	repoSeg string
+	// filePath is the absolute on-disk path of the file.
+	filePath string
+	// lockPath is the advisory lock to hold while snapshotting filePath, or ""
+	// for immutable legacy per-event files that need no lock.
+	lockPath string
+	// size is the file's size at collection time, compared against the manifest
+	// to skip unchanged files.
+	size int64
+}
+
+// objectKeyFor returns the destination object key for the snapshot bytes. For a
+// session JSONL file (repoSeg empty) the repository prefix is derived from the
+// snapshot, which was read under the lock, so a push racing the session's first
+// write cannot misfile a completed event under "unknown-repo".
+func (u uploadUnit) objectKeyFor(data []byte) string {
+	repoSeg := u.repoSeg
+	if repoSeg == "" {
+		repoSeg = repoSegmentFromJSONL(data)
+	}
+	return strings.ToLower(path.Join(repoSeg, u.relKey))
+}
+
+// Push uploads every changed session file under stateDir to up, recording each
+// success in a local manifest so subsequent runs only send files that grew.
 //
-// The object key for each file is its path relative to <state>/events prefixed
-// with the file's repository, i.e.
-// "<repo>/<source>/sessions/<session-dir>/<event-file>.json". Each session is
-// scoped to a single repository, so the repo segment is resolved once per
-// session directory from the captured git.repo_root (basename), falling back to
-// "unknown-repo" when no git context was recorded.
+// New sessions are stored as one append-only JSONL file per session; its object
+// key is its path relative to <state>/events prefixed with the session's
+// repository, i.e. "<repo>/<source>/sessions/<ts>_<sess>.jsonl". Legacy
+// per-event JSON files (from before the JSONL format) are still uploaded so
+// already-captured events are not lost. The repo segment is resolved from the
+// captured git.repo_root (basename), falling back to "unknown-repo".
 //
-// Per-file upload failures are collected in the report and do not abort the
-// run; a non-nil error is returned only for failures that prevent the walk
-// itself (e.g. an unreadable manifest).
+// Uploads run in parallel (bounded by pushConcurrency). Per-file failures are
+// collected in the report and do not abort the run; a non-nil error is returned
+// only for failures that prevent the walk itself (e.g. an unreadable manifest).
 func Push(stateDir string, up Uploader) (PushReport, error) {
 	eventsBase := filepath.Join(stateDir, "events")
-	manifestPath := filepath.Join(eventsBase, pushManifestName)
+	if err := os.MkdirAll(eventsBase, 0o755); err != nil {
+		return PushReport{}, fmt.Errorf("creating events dir %s: %w", eventsBase, err)
+	}
 
+	// Serialize concurrent pushes for the whole run. Two overlapping pushes could
+	// otherwise upload snapshots of the same growing session out of order;
+	// because uploads upsert, a late older snapshot would overwrite a newer one
+	// with fewer records, and the manifest would then mark the larger size as
+	// done — stranding the appended events in the bucket until the file grows
+	// again. (This lock is distinct from the per-source capture lock that
+	// snapshotOrSkip takes; a push acquires this one first, so there is no
+	// ordering cycle with hooks, which only take the capture lock.)
+	pushLock, err := acquireLock(filepath.Join(eventsBase, pushLockName))
+	if err != nil {
+		return PushReport{}, err
+	}
+	defer pushLock.release()
+
+	manifestPath := filepath.Join(eventsBase, pushManifestName)
 	manifest, err := loadPushManifest(manifestPath)
 	if err != nil {
 		return PushReport{}, err
 	}
 
+	units, err := collectUploadUnits(stateDir, eventsBase)
+	if err != nil {
+		return PushReport{}, err
+	}
+
 	var report PushReport
+	saveErr := processUnits(up, manifest, manifestPath, units, &report)
+	return report, saveErr
+}
+
+// processUnits handles each unit concurrently: it takes a locked snapshot,
+// skips the file when its current size already matches the manifest, otherwise
+// uploads it (reusing the file's pinned object key if it has one) and records
+// the new size and key. The manifest is persisted after every upload so an
+// interrupted run resumes cleanly. It returns the first manifest-save error
+// encountered, if any; per-file upload failures are recorded in report instead.
+func processUnits(up Uploader, manifest *pushManifest, manifestPath string, units []uploadUnit, report *PushReport) error {
+	var (
+		mu        sync.Mutex
+		saveErr   error
+		wg        sync.WaitGroup
+		semaphore = make(chan struct{}, pushConcurrency)
+	)
+	for _, u := range units {
+		u := u
+		semaphore <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+
+			mu.Lock()
+			entry, known := manifest.Uploaded[u.relKey]
+			mu.Unlock()
+
+			payload, fingerprint, skip, err := snapshotOrSkip(u, entry.Size, known)
+			if err != nil {
+				mu.Lock()
+				report.Failed++
+				report.Errors = append(report.Errors, err)
+				mu.Unlock()
+				return
+			}
+			// skip: already up to date. Empty payload: only a partial record so
+			// far (e.g. a crash before the first newline) — nothing complete to
+			// upload yet, so leave it unrecorded and retry on a later run.
+			if skip || len(payload) == 0 {
+				mu.Lock()
+				report.Skipped++
+				mu.Unlock()
+				return
+			}
+			// Reuse the key the session was first uploaded under, if any, so its
+			// prefix never changes (e.g. unknown-repo -> repo once git appears).
+			objectKey := entry.ObjectKey
+			if objectKey == "" {
+				objectKey = u.objectKeyFor(payload)
+			}
+			if err := up.Upload(objectKey, payload); err != nil {
+				mu.Lock()
+				report.Failed++
+				report.Errors = append(report.Errors, fmt.Errorf("uploading %s: %w", objectKey, err))
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			manifest.Uploaded[u.relKey] = manifestEntry{Size: fingerprint, ObjectKey: objectKey}
+			report.Uploaded++
+			if err := savePushManifest(manifestPath, manifest); err != nil && saveErr == nil {
+				saveErr = err
+			}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return saveErr
+}
+
+// snapshotOrSkip decides, for one unit, whether to skip it (its current size
+// matches the size recorded in the manifest) or to upload it. On upload it
+// returns the payload bytes and the fingerprint to record in the manifest.
+//
+// For a session JSONL file the size check and the read both happen while
+// holding the source's advisory lock, so a hook that appended after collection
+// is seen here rather than deferred to the next push, and the snapshot can never
+// contain a line another writer is mid-way through. The payload is trimmed to
+// its last newline (completeRecords) so a partial trailing record left by a
+// crash is never uploaded, and the fingerprint is the size of those uploaded
+// bytes — not the full on-disk size, which can include a partial tail. In the
+// normal case (file ends in a newline) the two are equal, so an unchanged file
+// still skips; when a partial tail is present the file simply re-processes each
+// run (idempotent) until the next capture heals it, and a heal that returns the
+// file to the same full size can never cause the new complete event to be
+// skipped. Legacy per-event files are a single immutable object, uploaded whole.
+func snapshotOrSkip(u uploadUnit, recorded int64, known bool) (payload []byte, fingerprint int64, skip bool, err error) {
+	unchanged := func(size int64) bool {
+		return known && (recorded == legacyUploaded || recorded == size)
+	}
+
+	if u.lockPath == "" {
+		if unchanged(u.size) {
+			return nil, 0, true, nil
+		}
+		b, readErr := os.ReadFile(u.filePath)
+		if readErr != nil {
+			return nil, 0, false, fmt.Errorf("reading %s: %w", u.relKey, readErr)
+		}
+		return b, int64(len(b)), false, nil
+	}
+
+	lock, err := acquireLock(u.lockPath)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	defer lock.release()
+
+	info, err := os.Stat(u.filePath)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("sizing %s: %w", u.relKey, err)
+	}
+	if unchanged(info.Size()) {
+		return nil, 0, true, nil
+	}
+	b, err := os.ReadFile(u.filePath)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("reading %s: %w", u.relKey, err)
+	}
+	records := completeRecords(b)
+	return records, int64(len(records)), false, nil
+}
+
+// completeRecords returns the prefix of data up to and including its last
+// newline — the whole, newline-terminated records — dropping any partial
+// trailing record. It returns nil when data has no newline (no complete record
+// yet).
+func completeRecords(data []byte) []byte {
+	if i := bytes.LastIndexByte(data, '\n'); i >= 0 {
+		return data[:i+1]
+	}
+	return nil
+}
+
+// collectUploadUnits lists every uploadable file under both sources: one unit
+// per session JSONL file, plus one per legacy per-event JSON file.
+func collectUploadUnits(stateDir, eventsBase string) ([]uploadUnit, error) {
+	var units []uploadUnit
 	for _, src := range []Source{SourceClaude, SourceCodex} {
 		sessionsRoot := EventsDir(stateDir, src)
-		sessions, err := os.ReadDir(sessionsRoot)
+		lockPath := filepath.Join(sessionsRoot, lockFileName)
+		entries, err := os.ReadDir(sessionsRoot)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return report, fmt.Errorf("reading %s sessions: %w", src, err)
+			return nil, fmt.Errorf("reading %s sessions: %w", src, err)
 		}
-		for _, session := range sessions {
-			if !session.IsDir() {
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() {
+				dir := filepath.Join(sessionsRoot, name)
+				legacy, err := collectLegacyUnits(eventsBase, dir, resolveRepoSegment(dir))
+				if err != nil {
+					return nil, err
+				}
+				units = append(units, legacy...)
 				continue
 			}
-			sessionDir := filepath.Join(sessionsRoot, session.Name())
-			repoSeg := resolveRepoSegment(sessionDir)
-			if err := pushSession(up, manifest, manifestPath, eventsBase, sessionDir, repoSeg, &report); err != nil {
-				return report, err
+			if !strings.HasSuffix(name, ".jsonl") {
+				continue
 			}
+			filePath := filepath.Join(sessionsRoot, name)
+			info, err := e.Info()
+			if err != nil {
+				return nil, fmt.Errorf("stat %s: %w", filePath, err)
+			}
+			relKey, err := relSlash(eventsBase, filePath)
+			if err != nil {
+				return nil, err
+			}
+			// repoSeg is left empty: it is derived from the locked snapshot at
+			// upload time so a push racing the first write cannot misfile it.
+			units = append(units, uploadUnit{
+				relKey:   relKey,
+				filePath: filePath,
+				lockPath: lockPath,
+				size:     info.Size(),
+			})
 		}
 	}
-	return report, nil
+	return units, nil
 }
 
-// pushSession uploads the not-yet-pushed event files in one session directory.
-func pushSession(up Uploader, manifest *pushManifest, manifestPath, eventsBase, sessionDir, repoSeg string, report *PushReport) error {
+// collectLegacyUnits lists the per-event JSON files in one legacy session
+// directory. These files are immutable, so they upload once (size never
+// changes) and need no lock when read.
+func collectLegacyUnits(eventsBase, sessionDir, repoSeg string) ([]uploadUnit, error) {
 	entries, err := os.ReadDir(sessionDir)
 	if err != nil {
-		return fmt.Errorf("reading session dir %s: %w", sessionDir, err)
+		return nil, fmt.Errorf("reading session dir %s: %w", sessionDir, err)
 	}
-	// Sort so uploads (and the manifest) follow a stable, sequence-ordered path.
 	names := make([]string, 0, len(entries))
 	for _, e := range entries {
 		if !e.IsDir() && strings.HasPrefix(e.Name(), "event_") {
@@ -105,46 +381,66 @@ func pushSession(up Uploader, manifest *pushManifest, manifestPath, eventsBase, 
 	}
 	sort.Strings(names)
 
+	units := make([]uploadUnit, 0, len(names))
 	for _, name := range names {
 		filePath := filepath.Join(sessionDir, name)
-		relPath, err := filepath.Rel(eventsBase, filePath)
+		info, err := os.Stat(filePath)
 		if err != nil {
-			return fmt.Errorf("relativizing %s: %w", filePath, err)
+			return nil, fmt.Errorf("stat %s: %w", filePath, err)
 		}
-		relKey := filepath.ToSlash(relPath)
-		if _, done := manifest.Uploaded[relKey]; done {
-			report.Skipped++
-			continue
-		}
-		data, err := os.ReadFile(filePath)
+		relKey, err := relSlash(eventsBase, filePath)
 		if err != nil {
-			report.Failed++
-			report.Errors = append(report.Errors, fmt.Errorf("reading %s: %w", relKey, err))
-			continue
+			return nil, err
 		}
-		// Lowercase the object key: storage listings fold case in directory
-		// segments, so an uppercase key can be listed but not signed back during
-		// beta:fetch. Normalizing here covers every event file regardless of its
-		// on-disk filename casing.
-		objectKey := strings.ToLower(path.Join(repoSeg, relKey))
-		if err := up.Upload(objectKey, data); err != nil {
-			report.Failed++
-			report.Errors = append(report.Errors, fmt.Errorf("uploading %s: %w", objectKey, err))
-			continue
-		}
-		manifest.Uploaded[relKey] = time.Now().UTC().Format(time.RFC3339)
-		// Persist after each success so an interrupted run resumes cleanly.
-		if err := savePushManifest(manifestPath, manifest); err != nil {
-			return err
-		}
-		report.Uploaded++
+		units = append(units, uploadUnit{
+			relKey:   relKey,
+			repoSeg:  repoSeg,
+			filePath: filePath,
+			size:     info.Size(),
+		})
 	}
-	return nil
+	return units, nil
 }
 
-// resolveRepoSegment returns the sanitized repository basename for a session,
-// read from the first event file that carries git context. It returns
-// "unknown-repo" when the session has no event with a git repo root.
+// relSlash returns target's path relative to base, slash-separated for use as
+// an object key and manifest key.
+func relSlash(base, target string) (string, error) {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return "", fmt.Errorf("relativizing %s: %w", target, err)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+// repoSegmentFromJSONL returns the sanitized repository basename for a session,
+// read from the first line of its JSONL snapshot that carries git context. The
+// snapshot is taken under the lock (see snapshotOrSkip), so this never sees a
+// partial first line. It returns "unknown-repo" when no line records a git repo
+// root.
+//
+// Lines are read with bufio.Reader.ReadBytes, which grows to fit each line, so
+// there is no cap on event size: a large hook payload (stored verbatim in the
+// event) still has its git context read rather than falling back to
+// "unknown-repo".
+func repoSegmentFromJSONL(data []byte) string {
+	r := bufio.NewReader(bytes.NewReader(data))
+	for {
+		line, readErr := r.ReadBytes('\n')
+		if len(line) > 0 {
+			var ev Event
+			if json.Unmarshal(line, &ev) == nil && ev.Git != nil && ev.Git.RepoRoot != "" {
+				return sanitizeRepoSegment(filepath.Base(ev.Git.RepoRoot))
+			}
+		}
+		if readErr != nil {
+			return unknownRepoSegment
+		}
+	}
+}
+
+// resolveRepoSegment returns the sanitized repository basename for a legacy
+// session directory, read from the first event file that carries git context.
+// It returns "unknown-repo" when the session has no event with a git repo root.
 func resolveRepoSegment(sessionDir string) string {
 	entries, err := os.ReadDir(sessionDir)
 	if err != nil {
@@ -196,7 +492,7 @@ func loadPushManifest(path string) (*pushManifest, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &pushManifest{Uploaded: map[string]string{}}, nil
+			return &pushManifest{Uploaded: map[string]manifestEntry{}}, nil
 		}
 		return nil, fmt.Errorf("reading push manifest %s: %w", path, err)
 	}
@@ -205,7 +501,7 @@ func loadPushManifest(path string) (*pushManifest, error) {
 		return nil, fmt.Errorf("parsing push manifest %s: %w", path, err)
 	}
 	if m.Uploaded == nil {
-		m.Uploaded = map[string]string{}
+		m.Uploaded = map[string]manifestEntry{}
 	}
 	return &m, nil
 }

--- a/go/internal/eventlog/push_test.go
+++ b/go/internal/eventlog/push_test.go
@@ -5,13 +5,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
+	"strings"
+	"sync"
 	"testing"
 )
 
 // fakeUploader records object keys (and bytes) it is asked to upload, and can
-// be told to fail for specific keys.
+// be told to fail for specific keys. Push uploads in parallel, so all access is
+// guarded by a mutex.
 type fakeUploader struct {
+	mu       sync.Mutex
 	uploaded map[string][]byte
 	failKeys map[string]bool
 }
@@ -21,20 +26,31 @@ func newFakeUploader() *fakeUploader {
 }
 
 func (f *fakeUploader) Upload(objectKey string, data []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.failKeys[objectKey] {
 		return fmt.Errorf("forced failure for %s", objectKey)
 	}
-	f.uploaded[objectKey] = data
+	// Copy: the caller may reuse the buffer after Upload returns.
+	f.uploaded[objectKey] = append([]byte(nil), data...)
 	return nil
 }
 
 func (f *fakeUploader) keys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	ks := make([]string, 0, len(f.uploaded))
 	for k := range f.uploaded {
 		ks = append(ks, k)
 	}
 	sort.Strings(ks)
 	return ks
+}
+
+func (f *fakeUploader) bytesFor(key string) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.uploaded[key]
 }
 
 // writeTestEvent writes one event JSON file into the on-disk layout under
@@ -159,5 +175,256 @@ func TestPush_NoEventsIsNoOp(t *testing.T) {
 	}
 	if report.Uploaded != 0 || report.Skipped != 0 || report.Failed != 0 {
 		t.Fatalf("report = %+v, want all zero", report)
+	}
+}
+
+// eventLine renders one event as a compact JSON line, as capture appends it.
+func eventLine(t *testing.T, git *GitInfo, seq int) string {
+	t.Helper()
+	b, err := json.Marshal(Event{
+		Source:    SourceClaude,
+		HookEvent: "PostToolUse",
+		SessionID: "sess",
+		Seq:       seq,
+		Git:       git,
+		Payload:   json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// writeSessionFile writes a session JSONL file (newline-terminated lines) under
+// the on-disk layout for src, returning its path.
+func writeSessionFile(t *testing.T, stateDir string, src Source, name string, lines ...string) string {
+	t.Helper()
+	dir := EventsDir(stateDir, src)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestPush_UploadsJSONLSessionFiles(t *testing.T) {
+	stateDir := t.TempDir()
+	writeSessionFile(t, stateDir, SourceClaude, "20240101T000000.000000000Z_sess-a.jsonl",
+		eventLine(t, &GitInfo{RepoRoot: "/home/u/work/amika"}, 0),
+		eventLine(t, &GitInfo{RepoRoot: "/home/u/work/amika"}, 1),
+	)
+	// A session whose events carry no git context falls back to unknown-repo.
+	writeSessionFile(t, stateDir, SourceCodex, "20240101T000000.000000000Z_sess-b.jsonl",
+		eventLine(t, nil, 0),
+	)
+
+	up := newFakeUploader()
+	report, err := Push(stateDir, up)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	// One upload per session file, not per event.
+	if report.Uploaded != 2 || report.Skipped != 0 || report.Failed != 0 {
+		t.Fatalf("report = %+v, want uploaded=2 skipped=0 failed=0", report)
+	}
+	want := []string{
+		"amika/claude/sessions/20240101t000000.000000000z_sess-a.jsonl",
+		"unknown-repo/codex/sessions/20240101t000000.000000000z_sess-b.jsonl",
+	}
+	if got := up.keys(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("uploaded keys = %v, want %v", got, want)
+	}
+}
+
+func TestPush_JSONLRepoPrefixFromLaterLine(t *testing.T) {
+	// The first event has no git context but a later one does. The repo prefix is
+	// derived from the whole locked snapshot, so the session must still be filed
+	// under its repo rather than unknown-repo.
+	stateDir := t.TempDir()
+	writeSessionFile(t, stateDir, SourceClaude, "20240101T000000.000000000Z_sess-a.jsonl",
+		eventLine(t, nil, 0),
+		eventLine(t, &GitInfo{RepoRoot: "/home/u/work/amika"}, 1),
+	)
+
+	up := newFakeUploader()
+	if _, err := Push(stateDir, up); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	want := []string{"amika/claude/sessions/20240101t000000.000000000z_sess-a.jsonl"}
+	if got := up.keys(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("uploaded keys = %v, want %v", got, want)
+	}
+}
+
+func TestPush_JSONLRepoPrefixNotCappedByLineSize(t *testing.T) {
+	// An event line larger than any fixed scanner cap must still have its git
+	// context read, so the session is filed under its repo, not unknown-repo.
+	stateDir := t.TempDir()
+	huge, err := json.Marshal(Event{
+		Source:    SourceClaude,
+		HookEvent: "PostToolUse",
+		SessionID: "sess",
+		Git:       &GitInfo{RepoRoot: "/home/u/work/amika"},
+		Payload:   json.RawMessage(`"` + strings.Repeat("x", 16*1024*1024+1024) + `"`),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	writeSessionFile(t, stateDir, SourceClaude, "20240101T000000.000000000Z_sess-a.jsonl", string(huge))
+
+	up := newFakeUploader()
+	if _, err := Push(stateDir, up); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	want := []string{"amika/claude/sessions/20240101t000000.000000000z_sess-a.jsonl"}
+	if got := up.keys(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("uploaded keys = %v, want %v", got, want)
+	}
+}
+
+func TestPush_UploadsOnlyCompleteRecords(t *testing.T) {
+	// A crash can leave a partial trailing record (no final newline). Push must
+	// upload only the whole records, never the partial tail.
+	stateDir := t.TempDir()
+	name := "20240101T000000.000000000Z_sess-a.jsonl"
+	key := "amika/claude/sessions/20240101t000000.000000000z_sess-a.jsonl"
+	dir := EventsDir(stateDir, SourceClaude)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := eventLine(t, &GitInfo{RepoRoot: "/x/amika"}, 0) + "\n" +
+		eventLine(t, &GitInfo{RepoRoot: "/x/amika"}, 1) + "\n" +
+		`{"seq":2,"incomplete` // partial tail, no trailing newline
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	up := newFakeUploader()
+	if _, err := Push(stateDir, up); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	got := string(up.bytesFor(key))
+	if strings.Contains(got, "incomplete") {
+		t.Errorf("uploaded the partial record:\n%s", got)
+	}
+	if n := strings.Count(got, "\n"); n != 2 {
+		t.Errorf("uploaded %d complete records, want 2", n)
+	}
+}
+
+func TestPush_PinsObjectKeyAcrossPushes(t *testing.T) {
+	// First push has no git context, so the key uses the unknown-repo prefix. A
+	// later event adds git context, but the key must stay pinned to the original
+	// so a second object (a duplicate prefix of the session) is never created.
+	stateDir := t.TempDir()
+	name := "20240101T000000.000000000Z_sess-a.jsonl"
+	path := filepath.Join(EventsDir(stateDir, SourceClaude), name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantKey := "unknown-repo/claude/sessions/20240101t000000.000000000z_sess-a.jsonl"
+
+	if err := os.WriteFile(path, []byte(eventLine(t, nil, 0)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	up1 := newFakeUploader()
+	if r, err := Push(stateDir, up1); err != nil || r.Uploaded != 1 {
+		t.Fatalf("push #1 = %+v (err %v), want uploaded=1", r, err)
+	}
+	if got := up1.keys(); !reflect.DeepEqual(got, []string{wantKey}) {
+		t.Fatalf("push #1 keys = %v, want %v", got, []string{wantKey})
+	}
+
+	// Append an event that does carry git context.
+	body := eventLine(t, nil, 0) + "\n" + eventLine(t, &GitInfo{RepoRoot: "/x/amika"}, 1) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	up2 := newFakeUploader()
+	if r, err := Push(stateDir, up2); err != nil || r.Uploaded != 1 {
+		t.Fatalf("push #2 = %+v (err %v), want uploaded=1", r, err)
+	}
+	if got := up2.keys(); !reflect.DeepEqual(got, []string{wantKey}) {
+		t.Fatalf("push #2 used key %v, want pinned %v (no duplicate under repo prefix)", got, []string{wantKey})
+	}
+}
+
+func TestPush_RecordsUploadedSizeNotFullFileSize(t *testing.T) {
+	// A crash-left partial tail is uploaded as complete records only, and the
+	// fingerprint must be the uploaded size, not the full file size. Otherwise a
+	// heal that replaces the partial tail with a real event of the same length
+	// returns the file to the old full size and the skip check would wrongly drop
+	// the new event.
+	stateDir := t.TempDir()
+	name := "20240101T000000.000000000Z_sess-a.jsonl"
+	key := "amika/claude/sessions/20240101t000000.000000000z_sess-a.jsonl"
+	path := filepath.Join(EventsDir(stateDir, SourceClaude), name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	git := &GitInfo{RepoRoot: "/x/amika"}
+	ev0 := eventLine(t, git, 0)
+	ev1 := eventLine(t, git, 1)
+
+	// v1: one complete record plus a partial tail exactly as long as the real
+	// ev1 line (incl newline) will be, so healing+appending ev1 returns the file
+	// to the same full byte size.
+	partial := strings.Repeat("x", len(ev1)+1)
+	if err := os.WriteFile(path, []byte(ev0+"\n"+partial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	up1 := newFakeUploader()
+	if r, err := Push(stateDir, up1); err != nil || r.Uploaded != 1 {
+		t.Fatalf("push #1 = %+v (err %v), want uploaded=1", r, err)
+	}
+	if got := up1.bytesFor(key); strings.Count(string(got), "\n") != 1 {
+		t.Fatalf("push #1 uploaded %q, want only the one complete record", got)
+	}
+
+	// Heal the partial and append a real ev1; the full size now equals v1's size.
+	if err := os.WriteFile(path, []byte(ev0+"\n"+ev1+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	up2 := newFakeUploader()
+	r, err := Push(stateDir, up2)
+	if err != nil {
+		t.Fatalf("push #2: %v", err)
+	}
+	if r.Uploaded != 1 || r.Skipped != 0 {
+		t.Fatalf("push #2 = %+v, want uploaded=1 skipped=0 (must not skip on equal full size)", r)
+	}
+	if n := strings.Count(string(up2.bytesFor(key)), "\n"); n != 2 {
+		t.Errorf("push #2 uploaded %d records, want 2", n)
+	}
+}
+
+func TestPush_ReuploadsGrownSessionAndSkipsUnchanged(t *testing.T) {
+	stateDir := t.TempDir()
+	name := "20240101T000000.000000000Z_sess-a.jsonl"
+	key := "amika/claude/sessions/20240101t000000.000000000z_sess-a.jsonl"
+	git := &GitInfo{RepoRoot: "/x/amika"}
+
+	writeSessionFile(t, stateDir, SourceClaude, name, eventLine(t, git, 0))
+	if r, err := Push(stateDir, newFakeUploader()); err != nil || r.Uploaded != 1 {
+		t.Fatalf("first push = %+v (err %v), want uploaded=1", r, err)
+	}
+
+	// Unchanged file: skipped, not re-uploaded.
+	if r, err := Push(stateDir, newFakeUploader()); err != nil || r.Uploaded != 0 || r.Skipped != 1 {
+		t.Fatalf("unchanged push = %+v (err %v), want uploaded=0 skipped=1", r, err)
+	}
+
+	// Append a second event: the file grew, so it re-uploads with both lines.
+	writeSessionFile(t, stateDir, SourceClaude, name, eventLine(t, git, 0), eventLine(t, git, 1))
+	up := newFakeUploader()
+	if r, err := Push(stateDir, up); err != nil || r.Uploaded != 1 || r.Skipped != 0 {
+		t.Fatalf("grown push = %+v (err %v), want uploaded=1 skipped=0", r, err)
+	}
+	if n := strings.Count(string(up.bytesFor(key)), "\n"); n != 2 {
+		t.Errorf("re-uploaded body has %d lines, want 2", n)
 	}
 }


### PR DESCRIPTION
Capture appended one JSON file per hook event, and beta:push/beta:fetch processed objects serially, so a single session produced hundreds of tiny files and hundreds of sequential signed-URL round-trips each way.

Capture now appends one compact JSON line per event to a per-session file (<state>/events/<source>/sessions/<ts>_<session-id>.jsonl) under the existing cross-process lock. Push uploads each changed session file in a bounded parallel pool, tracking each file's uploaded byte size so only sessions that grew new events are re-sent (idempotent upsert); session files are read under the lock so a half-written final line is never uploaded. Fetch downloads each page's objects in a bounded parallel pool, still page-by-page to keep signed URLs fresh.

Backward compatible: legacy per-event event_*.json files are still uploaded, and a tolerant manifest unmarshal maps old timestamp-string entries to "already uploaded" so the format change does not re-push existing history.