### PR TITLE
Add --content flag to akfs fm and rename output key to frontmatter

### DIFF
--- a/docs/labs/README.md
+++ b/docs/labs/README.md
@@ -21,4 +21,4 @@ Trying a Labs tool? Start with its doc, then build it from the repo root.
 
 | **Tool** | **Description** | **Documentation** |
 |:---------|:----------------|:------------------|
-| `akfs` | Extract YAML frontmatter from Markdown files as JSON Lines; broader filesystem-data tooling is planned. | [akfs.md](akfs.md) |
+| `akfs` | Extract YAML frontmatter (and optionally the document body) from Markdown files as JSON Lines; broader filesystem-data tooling is planned. | [akfs.md](akfs.md) |

--- a/docs/labs/akfs.md
+++ b/docs/labs/akfs.md
@@ -3,10 +3,11 @@
 `akfs` (Amika filesystem) is experimental tooling for treating files as
 structured data that humans and AI agents can both work with.
 
-Today it does one thing: extract YAML frontmatter, the `---`-delimited metadata
-block at the top of a Markdown file, and emit it as JSON Lines. That makes a
-directory of posts, docs, notes, or plans queryable with standard tools like
-`jq`, scripts, databases, or a content management system (CMS) import.
+Today it focuses on one thing: extract YAML frontmatter, the `---`-delimited
+metadata block at the top of a Markdown file, and emit it as JSON Lines —
+optionally alongside (or instead of) the document body. That makes a directory
+of posts, docs, notes, or plans queryable with standard tools like `jq`,
+scripts, databases, or a content management system (CMS) import.
 
 For example, a docs directory might store `title`, `status`, `author`, and
 `tags` in each Markdown file. `akfs fm` can stream that metadata so you can list
@@ -87,13 +88,38 @@ One line of compact JSON per document (JSON Lines), each an object with:
 
 - `filename` — the source file path. Present for file arguments and paths read
   from stdin file-list mode; omitted only when the document was read via `-`.
-- `data` — the parsed frontmatter.
+- `frontmatter` — the parsed frontmatter.
 
-Within `data`, keys are emitted in sorted lexicographic order.
+Within `frontmatter`, keys are emitted in sorted lexicographic order.
 
 ```bash
 $ akfs fm notes/plan.md
-{"filename":"notes/plan.md","data":{"author":"Ada","status":"draft","tags":["planning","agents"],"title":"Quarterly planning notes"}}
+{"filename":"notes/plan.md","frontmatter":{"author":"Ada","status":"draft","tags":["planning","agents"],"title":"Quarterly planning notes"}}
+```
+
+#### Including the document body (`--content`)
+
+By default `akfs fm` emits only the frontmatter. The `--content` flag controls
+whether the document body — everything after the closing delimiter — is
+included under a top-level `content` key:
+
+| `--content` | Output                                                          |
+|-------------|-----------------------------------------------------------------|
+| `none`      | Only `frontmatter` (the default).                               |
+| `also`      | Both `frontmatter` and `content`.                               |
+| `only`      | Only `content`; the `frontmatter` field is dropped.             |
+
+The `content` value is the document body as if the frontmatter block were not
+there: the single newline separating the closing delimiter from the body is
+stripped, while any trailing newline at the end of the file is preserved. When
+present, fields are ordered `filename`, `frontmatter`, `content`.
+
+```bash
+$ akfs fm --content also notes/plan.md
+{"filename":"notes/plan.md","frontmatter":{"author":"Ada","status":"draft","tags":["planning","agents"],"title":"Quarterly planning notes"},"content":"# Body content starts here\n"}
+
+$ akfs fm --content only notes/plan.md
+{"filename":"notes/plan.md","content":"# Body content starts here\n"}
 ```
 
 #### Examples
@@ -120,10 +146,10 @@ object on one line:
 
 ```bash
 # List draft files
-find ./content -name '*.md' | akfs fm | jq -r 'select(.data.status == "draft") | .filename'
+find ./content -name '*.md' | akfs fm | jq -r 'select(.frontmatter.status == "draft") | .filename'
 
 # Export filename, title, and author as TSV
-find ./content -name '*.md' | akfs fm | jq -r '[.filename, .data.title, .data.author] | @tsv'
+find ./content -name '*.md' | akfs fm | jq -r '[.filename, .frontmatter.title, .frontmatter.author] | @tsv'
 ```
 
 #### Errors
@@ -144,9 +170,10 @@ reported on stderr.
 
 ## Planned / not yet implemented
 
-`akfs` currently ships only frontmatter extraction: `akfs frontmatter`, its
-alias `akfs fm`, and `akfs version`. The top-level Go library is still a
-scaffold; the implemented library logic is the frontmatter parser.
+`akfs` currently ships only frontmatter and document-body extraction:
+`akfs frontmatter`, its alias `akfs fm`, and `akfs version`. The top-level Go
+library is still a scaffold; the implemented library logic is the frontmatter
+parser.
 
 Possible future directions:
 

--- a/go/labs/akfs/frontmatter/frontmatter.go
+++ b/go/labs/akfs/frontmatter/frontmatter.go
@@ -4,6 +4,7 @@
 package frontmatter
 
 import (
+	"bufio"
 	"errors"
 	"io"
 	"strings"
@@ -35,27 +36,46 @@ type Document struct {
 	Content string
 }
 
-// Parse reads r and returns the parsed YAML frontmatter found at the start of
-// the input along with the document body that follows it. The frontmatter must
-// begin on the first line with a "---" delimiter and end with a matching "---"
-// (or "...") delimiter line.
+// Parse reads the YAML frontmatter at the start of r and returns it. It stops
+// reading at the closing delimiter and does not consume the document body, so
+// the returned Document.Content is always empty. The frontmatter must begin on
+// the first line with a "---" delimiter and end with a matching "---" (or
+// "...") delimiter line.
+//
+// Use ParseWithContent when the body is needed; Parse exists so callers that
+// only want the metadata never read past it (large documents are not loaded
+// into memory).
 //
 // An empty frontmatter block parses to an empty, non-nil map. Parse returns
 // ErrNoFrontmatter if the input has no leading delimiter and ErrUnterminated if
 // the closing delimiter is absent.
 func Parse(r io.Reader) (Document, error) {
-	raw, err := io.ReadAll(r)
-	if err != nil {
+	return parse(r, false)
+}
+
+// ParseWithContent is like Parse but also reads and returns the document body
+// that follows the frontmatter as Document.Content. The single newline
+// separating the closing delimiter from the body is stripped so the content
+// reads as though the frontmatter block were absent; any trailing newline at
+// the end of the input is preserved.
+func ParseWithContent(r io.Reader) (Document, error) {
+	return parse(r, true)
+}
+
+// parse reads the frontmatter block from r. When wantContent is true it also
+// reads the remaining body into Document.Content; otherwise it returns as soon
+// as the closing delimiter is found, leaving the body unread.
+func parse(r io.Reader, wantContent bool) (Document, error) {
+	br := bufio.NewReader(r)
+
+	first, err := br.ReadString('\n')
+	if err != nil && err != io.EOF {
 		return Document{}, err
 	}
-	s := string(raw)
-
-	// The opening delimiter must be the first line.
-	first, rest, hadNewline := strings.Cut(s, "\n")
-	if strings.TrimRight(first, "\r") != delimiter {
+	if trimLine(first) != delimiter {
 		return Document{}, ErrNoFrontmatter
 	}
-	if !hadNewline {
+	if err == io.EOF {
 		// Input was a single "---" line with no closing delimiter.
 		return Document{}, ErrUnterminated
 	}
@@ -63,34 +83,24 @@ func Parse(r io.Reader) (Document, error) {
 	var body strings.Builder
 	closed := false
 	for {
-		var line string
-		line, rest, hadNewline = strings.Cut(rest, "\n")
-		trimmed := strings.TrimRight(line, "\r")
+		line, err := br.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return Document{}, err
+		}
+		trimmed := trimLine(line)
 		if trimmed == delimiter || trimmed == "..." {
 			closed = true
 			break
 		}
 		body.WriteString(trimmed)
 		body.WriteByte('\n')
-		if !hadNewline {
+		if err == io.EOF {
 			// Reached the end of input without a closing delimiter.
 			break
 		}
 	}
 	if !closed {
 		return Document{}, ErrUnterminated
-	}
-
-	// rest holds everything after the closing delimiter line. Strip the single
-	// leading newline separating the delimiter from the body so the content
-	// renders as though the frontmatter were absent; the trailing newline (if
-	// any) is left untouched.
-	content := rest
-	switch {
-	case strings.HasPrefix(content, "\r\n"):
-		content = content[2:]
-	case strings.HasPrefix(content, "\n"):
-		content = content[1:]
 	}
 
 	out := map[string]any{}
@@ -100,5 +110,30 @@ func Parse(r io.Reader) (Document, error) {
 	if out == nil {
 		out = map[string]any{}
 	}
+
+	content := ""
+	if wantContent {
+		rest, err := io.ReadAll(br)
+		if err != nil {
+			return Document{}, err
+		}
+		// Strip the single leading newline separating the closing delimiter
+		// from the body so the content renders as though the frontmatter were
+		// absent; the trailing newline (if any) is left untouched.
+		content = string(rest)
+		switch {
+		case strings.HasPrefix(content, "\r\n"):
+			content = content[2:]
+		case strings.HasPrefix(content, "\n"):
+			content = content[1:]
+		}
+	}
+
 	return Document{Frontmatter: out, Content: content}, nil
+}
+
+// trimLine strips a line's trailing newline (and carriage return, for
+// Windows-style endings) as returned by bufio.Reader.ReadString.
+func trimLine(line string) string {
+	return strings.TrimRight(strings.TrimSuffix(line, "\n"), "\r")
 }

--- a/go/labs/akfs/frontmatter/frontmatter.go
+++ b/go/labs/akfs/frontmatter/frontmatter.go
@@ -4,7 +4,6 @@
 package frontmatter
 
 import (
-	"bufio"
 	"errors"
 	"io"
 	"strings"
@@ -23,53 +22,83 @@ var ErrNoFrontmatter = errors.New("no frontmatter found: input does not start wi
 // closing delimiter is missing.
 var ErrUnterminated = errors.New("unterminated frontmatter: missing closing '---'")
 
+// Document is the result of parsing a frontmatter document: the YAML
+// frontmatter block and the body content that follows it.
+type Document struct {
+	// Frontmatter is the parsed YAML frontmatter. An empty block yields an
+	// empty, non-nil map.
+	Frontmatter map[string]any
+	// Content is the document body following the closing delimiter, with the
+	// single newline that separates the delimiter from the body stripped so
+	// the content reads as though the frontmatter block were absent. Any
+	// trailing newline at the end of the input is preserved.
+	Content string
+}
+
 // Parse reads r and returns the parsed YAML frontmatter found at the start of
-// the input. The frontmatter must begin on the first line with a "---"
-// delimiter and end with a matching "---" (or "...") delimiter line.
+// the input along with the document body that follows it. The frontmatter must
+// begin on the first line with a "---" delimiter and end with a matching "---"
+// (or "...") delimiter line.
 //
 // An empty frontmatter block parses to an empty, non-nil map. Parse returns
 // ErrNoFrontmatter if the input has no leading delimiter and ErrUnterminated if
 // the closing delimiter is absent.
-func Parse(r io.Reader) (map[string]any, error) {
-	scanner := bufio.NewScanner(r)
-	// Allow long frontmatter lines (e.g. inline arrays/objects) beyond the
-	// default 64 KiB token limit.
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return nil, err
-		}
-		return nil, ErrNoFrontmatter
+func Parse(r io.Reader) (Document, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return Document{}, err
 	}
-	if strings.TrimRight(scanner.Text(), "\r") != delimiter {
-		return nil, ErrNoFrontmatter
+	s := string(raw)
+
+	// The opening delimiter must be the first line.
+	first, rest, hadNewline := strings.Cut(s, "\n")
+	if strings.TrimRight(first, "\r") != delimiter {
+		return Document{}, ErrNoFrontmatter
+	}
+	if !hadNewline {
+		// Input was a single "---" line with no closing delimiter.
+		return Document{}, ErrUnterminated
 	}
 
 	var body strings.Builder
 	closed := false
-	for scanner.Scan() {
-		line := strings.TrimRight(scanner.Text(), "\r")
-		if line == delimiter || line == "..." {
+	for {
+		var line string
+		line, rest, hadNewline = strings.Cut(rest, "\n")
+		trimmed := strings.TrimRight(line, "\r")
+		if trimmed == delimiter || trimmed == "..." {
 			closed = true
 			break
 		}
-		body.WriteString(scanner.Text())
+		body.WriteString(trimmed)
 		body.WriteByte('\n')
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
+		if !hadNewline {
+			// Reached the end of input without a closing delimiter.
+			break
+		}
 	}
 	if !closed {
-		return nil, ErrUnterminated
+		return Document{}, ErrUnterminated
+	}
+
+	// rest holds everything after the closing delimiter line. Strip the single
+	// leading newline separating the delimiter from the body so the content
+	// renders as though the frontmatter were absent; the trailing newline (if
+	// any) is left untouched.
+	content := rest
+	switch {
+	case strings.HasPrefix(content, "\r\n"):
+		content = content[2:]
+	case strings.HasPrefix(content, "\n"):
+		content = content[1:]
 	}
 
 	out := map[string]any{}
 	if err := yaml.Unmarshal([]byte(body.String()), &out); err != nil {
-		return nil, err
+		return Document{}, err
 	}
 	if out == nil {
 		out = map[string]any{}
 	}
-	return out, nil
+	return Document{Frontmatter: out, Content: content}, nil
 }

--- a/go/labs/akfs/frontmatter/frontmatter_test.go
+++ b/go/labs/akfs/frontmatter/frontmatter_test.go
@@ -27,8 +27,13 @@ slides: content/slides/components-of-a-software-factory/slides.md
 		"tags":   []any{"software-factory", "agents", "infrastructure"},
 		"slides": "content/slides/components-of-a-software-factory/slides.md",
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Parse() = %#v, want %#v", got, want)
+	if !reflect.DeepEqual(got.Frontmatter, want) {
+		t.Errorf("Parse() frontmatter = %#v, want %#v", got.Frontmatter, want)
+	}
+	// The leading newline after the closing delimiter is stripped; the trailing
+	// newline is preserved.
+	if wantContent := "# Body content here\n"; got.Content != wantContent {
+		t.Errorf("Parse() content = %q, want %q", got.Content, wantContent)
 	}
 }
 
@@ -40,8 +45,8 @@ func TestParseCRLF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse returned error: %v", err)
 	}
-	if got["title"] != "hi" {
-		t.Errorf("title = %v, want %q", got["title"], "hi")
+	if got.Frontmatter["title"] != "hi" {
+		t.Errorf("title = %v, want %q", got.Frontmatter["title"], "hi")
 	}
 }
 
@@ -52,11 +57,16 @@ func TestParseEmptyBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse returned error: %v", err)
 	}
-	if got == nil {
+	if got.Frontmatter == nil {
 		t.Fatal("Parse() returned nil map, want empty map")
 	}
-	if len(got) != 0 {
-		t.Errorf("Parse() = %#v, want empty map", got)
+	if len(got.Frontmatter) != 0 {
+		t.Errorf("Parse() = %#v, want empty map", got.Frontmatter)
+	}
+	// No blank line separates the closing delimiter from the body, so nothing
+	// is stripped.
+	if got.Content != "body\n" {
+		t.Errorf("Parse() content = %q, want %q", got.Content, "body\n")
 	}
 }
 
@@ -67,8 +77,36 @@ func TestParseDocumentEndDelimiter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse returned error: %v", err)
 	}
-	if got["title"] != "hi" {
-		t.Errorf("title = %v, want %q", got["title"], "hi")
+	if got.Frontmatter["title"] != "hi" {
+		t.Errorf("title = %v, want %q", got.Frontmatter["title"], "hi")
+	}
+}
+
+// TestParseContent verifies how the document body is captured: the single
+// newline separating the closing delimiter from the body is stripped, while a
+// trailing newline (or its absence) is preserved verbatim.
+func TestParseContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"blank line then body", "---\na: 1\n---\n\nbody\n", "body\n"},
+		{"no blank line", "---\na: 1\n---\nbody\n", "body\n"},
+		{"no trailing newline", "---\na: 1\n---\nbody", "body"},
+		{"empty body", "---\na: 1\n---\n", ""},
+		{"multiple trailing blank lines preserved", "---\na: 1\n---\n\nbody\n\n", "body\n\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(strings.NewReader(tt.input))
+			if err != nil {
+				t.Fatalf("Parse returned error: %v", err)
+			}
+			if got.Content != tt.want {
+				t.Errorf("content = %q, want %q", got.Content, tt.want)
+			}
+		})
 	}
 }
 

--- a/go/labs/akfs/frontmatter/frontmatter_test.go
+++ b/go/labs/akfs/frontmatter/frontmatter_test.go
@@ -2,6 +2,7 @@ package frontmatter
 
 import (
 	"errors"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -17,7 +18,7 @@ slides: content/slides/components-of-a-software-factory/slides.md
 
 # Body content here
 `
-	got, err := Parse(strings.NewReader(doc))
+	got, err := ParseWithContent(strings.NewReader(doc))
 	if err != nil {
 		t.Fatalf("Parse returned error: %v", err)
 	}
@@ -53,7 +54,7 @@ func TestParseCRLF(t *testing.T) {
 // TestParseEmptyBlock verifies an empty frontmatter block yields an empty,
 // non-nil map rather than an error.
 func TestParseEmptyBlock(t *testing.T) {
-	got, err := Parse(strings.NewReader("---\n---\nbody\n"))
+	got, err := ParseWithContent(strings.NewReader("---\n---\nbody\n"))
 	if err != nil {
 		t.Fatalf("Parse returned error: %v", err)
 	}
@@ -82,9 +83,9 @@ func TestParseDocumentEndDelimiter(t *testing.T) {
 	}
 }
 
-// TestParseContent verifies how the document body is captured: the single
-// newline separating the closing delimiter from the body is stripped, while a
-// trailing newline (or its absence) is preserved verbatim.
+// TestParseContent verifies how ParseWithContent captures the document body:
+// the single newline separating the closing delimiter from the body is
+// stripped, while a trailing newline (or its absence) is preserved verbatim.
 func TestParseContent(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -99,7 +100,7 @@ func TestParseContent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Parse(strings.NewReader(tt.input))
+			got, err := ParseWithContent(strings.NewReader(tt.input))
 			if err != nil {
 				t.Fatalf("Parse returned error: %v", err)
 			}
@@ -108,6 +109,57 @@ func TestParseContent(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseStopsAtClosingDelimiter verifies that Parse does not read the
+// document body — only ParseWithContent does. A large body is appended after
+// the frontmatter; Parse should read far less than the whole input, while
+// ParseWithContent reads all of it.
+func TestParseStopsAtClosingDelimiter(t *testing.T) {
+	// Body comfortably larger than bufio.Reader's default buffer so that
+	// stopping early reads materially less than the whole document.
+	body := strings.Repeat("lorem ipsum dolor sit amet\n", 50000) // ~1.3 MB
+	doc := "---\ntitle: hi\n---\n" + body
+
+	cr := &countingReader{r: strings.NewReader(doc)}
+	got, err := Parse(cr)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if got.Frontmatter["title"] != "hi" {
+		t.Errorf("title = %v, want %q", got.Frontmatter["title"], "hi")
+	}
+	if got.Content != "" {
+		t.Errorf("Parse Content = %q, want empty (body not read)", got.Content)
+	}
+	if cr.n >= len(doc) {
+		t.Errorf("Parse read %d of %d bytes; should stop before the body", cr.n, len(doc))
+	}
+
+	cr2 := &countingReader{r: strings.NewReader(doc)}
+	got2, err := ParseWithContent(cr2)
+	if err != nil {
+		t.Fatalf("ParseWithContent returned error: %v", err)
+	}
+	if got2.Content != body {
+		t.Errorf("ParseWithContent did not return the full body (got %d bytes, want %d)", len(got2.Content), len(body))
+	}
+	if cr2.n != len(doc) {
+		t.Errorf("ParseWithContent read %d of %d bytes; want all", cr2.n, len(doc))
+	}
+}
+
+// countingReader wraps an io.Reader and records how many bytes have been read
+// from the underlying source.
+type countingReader struct {
+	r io.Reader
+	n int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += n
+	return n, err
 }
 
 func TestParseErrors(t *testing.T) {

--- a/go/labs/cmd/akfs/frontmatter.go
+++ b/go/labs/cmd/akfs/frontmatter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,7 +13,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// contentMode selects whether and how the document body ("content") appears in
+// the JSON output, set by the --content flag.
+type contentMode string
+
+const (
+	// contentNone omits the content field entirely (the default).
+	contentNone contentMode = "none"
+	// contentOnly emits only the content, dropping the frontmatter ("data").
+	contentOnly contentMode = "only"
+	// contentAlso emits the frontmatter and the content together.
+	contentAlso contentMode = "also"
+)
+
 func init() {
+	var content string
+
 	cmd := &cobra.Command{
 		Use:     "frontmatter [file...]",
 		Aliases: []string{"fm"},
@@ -29,9 +45,23 @@ frontmatter with a matching "---" line.
 Output is one line of compact JSON per document: the parsed frontmatter under a
 "data" key, alongside a "filename" key naming the source file (omitted when the
 document is read from stdin via "-"). With multiple inputs, one JSON line is
-emitted per document, in order.`,
+emitted per document, in order.
+
+The --content flag controls whether the document body following the
+frontmatter is included under a top-level "content" key:
+
+  none  do not include the content (default)
+  also  include the frontmatter and the content together
+  only  include just the content, dropping the frontmatter ("data")`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			mode := contentMode(content)
+			switch mode {
+			case contentNone, contentOnly, contentAlso:
+			default:
+				return fmt.Errorf("invalid --content value %q: must be one of none, only, also", content)
+			}
+
 			enc := json.NewEncoder(cmd.OutOrStdout())
 			stdin := cmd.InOrStdin()
 
@@ -39,10 +69,10 @@ emitted per document, in order.`,
 			// stdin and process each. Use "-" as an argument to parse a single
 			// document from stdin instead.
 			if len(args) == 0 {
-				return emitFileList(enc, stdin)
+				return emitFileList(enc, stdin, mode)
 			}
 			for _, arg := range args {
-				if err := emitPath(enc, stdin, arg); err != nil {
+				if err := emitPath(enc, stdin, arg, mode); err != nil {
 					return err
 				}
 			}
@@ -50,27 +80,80 @@ emitted per document, in order.`,
 		},
 	}
 
+	cmd.Flags().StringVar(&content, "content", string(contentNone),
+		"include the document body: none|also|only")
+
 	rootCmd.AddCommand(cmd)
 }
 
 // record is the JSON envelope emitted per input: the source filename (omitted
-// for stdin) alongside the parsed frontmatter.
+// for stdin) alongside the parsed frontmatter and/or the document body. The
+// mode field selects which of those appear and is not itself serialized.
 type record struct {
 	Filename string         `json:"filename,omitempty"`
 	Data     map[string]any `json:"data"`
+	Content  string         `json:"content"`
+	mode     contentMode
+}
+
+// MarshalJSON emits the record's fields in a stable order — filename, data,
+// content — including only the fields selected by the record's mode. The
+// frontmatter ("data") is included unless the mode is content-only; the body
+// ("content") is included when the mode is content-only or content-also. An
+// empty frontmatter block still renders as "data":{}.
+func (r record) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	first := true
+	field := func(key string, val any) error {
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		k, err := json.Marshal(key)
+		if err != nil {
+			return err
+		}
+		buf.Write(k)
+		buf.WriteByte(':')
+		v, err := json.Marshal(val)
+		if err != nil {
+			return err
+		}
+		buf.Write(v)
+		return nil
+	}
+
+	if r.Filename != "" {
+		if err := field("filename", r.Filename); err != nil {
+			return nil, err
+		}
+	}
+	if r.mode != contentOnly {
+		if err := field("data", r.Data); err != nil {
+			return nil, err
+		}
+	}
+	if r.mode == contentOnly || r.mode == contentAlso {
+		if err := field("content", r.Content); err != nil {
+			return nil, err
+		}
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
 }
 
 // emitFileList reads r as a newline-delimited list of file paths and emits a
 // JSON line for each. Blank lines are skipped; trailing carriage returns are
 // trimmed so lists produced on Windows are handled.
-func emitFileList(enc *json.Encoder, r io.Reader) error {
+func emitFileList(enc *json.Encoder, r io.Reader, mode contentMode) error {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		path := strings.TrimRight(scanner.Text(), "\r")
 		if path == "" {
 			continue
 		}
-		if err := emitFile(enc, path); err != nil {
+		if err := emitFile(enc, path, mode); err != nil {
 			return err
 		}
 	}
@@ -79,35 +162,41 @@ func emitFileList(enc *json.Encoder, r io.Reader) error {
 
 // emitPath parses the frontmatter of a single argument: "-" reads one document
 // from stdin, any other value is treated as a file path.
-func emitPath(enc *json.Encoder, stdin io.Reader, path string) error {
+func emitPath(enc *json.Encoder, stdin io.Reader, path string, mode contentMode) error {
 	if path == "-" {
-		return emit(enc, stdin, "")
+		return emit(enc, stdin, "", mode)
 	}
-	return emitFile(enc, path)
+	return emitFile(enc, path, mode)
 }
 
 // emitFile parses the frontmatter of the file at path and writes it as a JSON
 // line.
-func emitFile(enc *json.Encoder, path string) error {
+func emitFile(enc *json.Encoder, path string, mode contentMode) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	return emit(enc, f, path)
+	return emit(enc, f, path, mode)
 }
 
 // emit parses frontmatter from r and encodes it as a single compact JSON line.
 // filename names the source for the output's "filename" field and error
-// messages; an empty filename denotes stdin.
-func emit(enc *json.Encoder, r io.Reader, filename string) error {
+// messages; an empty filename denotes stdin. mode selects whether the document
+// body is included.
+func emit(enc *json.Encoder, r io.Reader, filename string, mode contentMode) error {
 	label := filename
 	if label == "" {
 		label = "<stdin>"
 	}
-	data, err := frontmatter.Parse(r)
+	doc, err := frontmatter.Parse(r)
 	if err != nil {
 		return fmt.Errorf("%s: %w", label, err)
 	}
-	return enc.Encode(record{Filename: filename, Data: data})
+	return enc.Encode(record{
+		Filename: filename,
+		Data:     doc.Frontmatter,
+		Content:  doc.Content,
+		mode:     mode,
+	})
 }

--- a/go/labs/cmd/akfs/frontmatter.go
+++ b/go/labs/cmd/akfs/frontmatter.go
@@ -189,7 +189,13 @@ func emit(enc *json.Encoder, r io.Reader, filename string, mode contentMode) err
 	if label == "" {
 		label = "<stdin>"
 	}
-	doc, err := frontmatter.Parse(r)
+	// Only read the document body when it will actually be emitted; otherwise
+	// stop at the closing delimiter so large documents are not loaded.
+	parse := frontmatter.Parse
+	if mode == contentOnly || mode == contentAlso {
+		parse = frontmatter.ParseWithContent
+	}
+	doc, err := parse(r)
 	if err != nil {
 		return fmt.Errorf("%s: %w", label, err)
 	}

--- a/go/labs/cmd/akfs/frontmatter.go
+++ b/go/labs/cmd/akfs/frontmatter.go
@@ -43,16 +43,16 @@ newline-delimited list of file paths to process (e.g. piped from "fd" or
 frontmatter with a matching "---" line.
 
 Output is one line of compact JSON per document: the parsed frontmatter under a
-"data" key, alongside a "filename" key naming the source file (omitted when the
-document is read from stdin via "-"). With multiple inputs, one JSON line is
-emitted per document, in order.
+"frontmatter" key, alongside a "filename" key naming the source file (omitted
+when the document is read from stdin via "-"). With multiple inputs, one JSON
+line is emitted per document, in order.
 
 The --content flag controls whether the document body following the
 frontmatter is included under a top-level "content" key:
 
   none  do not include the content (default)
   also  include the frontmatter and the content together
-  only  include just the content, dropping the frontmatter ("data")`,
+  only  include just the content, dropping the "frontmatter"`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mode := contentMode(content)
@@ -90,17 +90,17 @@ frontmatter is included under a top-level "content" key:
 // for stdin) alongside the parsed frontmatter and/or the document body. The
 // mode field selects which of those appear and is not itself serialized.
 type record struct {
-	Filename string         `json:"filename,omitempty"`
-	Data     map[string]any `json:"data"`
-	Content  string         `json:"content"`
-	mode     contentMode
+	Filename    string         `json:"filename,omitempty"`
+	Frontmatter map[string]any `json:"frontmatter"`
+	Content     string         `json:"content"`
+	mode        contentMode
 }
 
-// MarshalJSON emits the record's fields in a stable order — filename, data,
-// content — including only the fields selected by the record's mode. The
-// frontmatter ("data") is included unless the mode is content-only; the body
+// MarshalJSON emits the record's fields in a stable order — filename,
+// frontmatter, content — including only the fields selected by the record's
+// mode. The frontmatter is included unless the mode is content-only; the body
 // ("content") is included when the mode is content-only or content-also. An
-// empty frontmatter block still renders as "data":{}.
+// empty frontmatter block still renders as "frontmatter":{}.
 func (r record) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	buf.WriteByte('{')
@@ -130,7 +130,7 @@ func (r record) MarshalJSON() ([]byte, error) {
 		}
 	}
 	if r.mode != contentOnly {
-		if err := field("data", r.Data); err != nil {
+		if err := field("frontmatter", r.Frontmatter); err != nil {
 			return nil, err
 		}
 	}
@@ -194,9 +194,9 @@ func emit(enc *json.Encoder, r io.Reader, filename string, mode contentMode) err
 		return fmt.Errorf("%s: %w", label, err)
 	}
 	return enc.Encode(record{
-		Filename: filename,
-		Data:     doc.Frontmatter,
-		Content:  doc.Content,
-		mode:     mode,
+		Filename:    filename,
+		Frontmatter: doc.Frontmatter,
+		Content:     doc.Content,
+		mode:        mode,
 	})
 }

--- a/go/labs/cmd/akfs/frontmatter_test.go
+++ b/go/labs/cmd/akfs/frontmatter_test.go
@@ -52,8 +52,8 @@ func TestFrontmatterSingleFile(t *testing.T) {
 	if recs[0].Filename != path {
 		t.Errorf("filename = %q, want %q", recs[0].Filename, path)
 	}
-	if recs[0].Data["title"] != "First doc" {
-		t.Errorf("data.title = %v, want %q", recs[0].Data["title"], "First doc")
+	if recs[0].Frontmatter["title"] != "First doc" {
+		t.Errorf("data.title = %v, want %q", recs[0].Frontmatter["title"], "First doc")
 	}
 }
 
@@ -99,8 +99,8 @@ func TestFrontmatterStdinDocument(t *testing.T) {
 	if recs[0].Filename != "" {
 		t.Errorf("filename = %q, want empty (omitted) for stdin document", recs[0].Filename)
 	}
-	if recs[0].Data["title"] != "From stdin" {
-		t.Errorf("data.title = %v, want %q", recs[0].Data["title"], "From stdin")
+	if recs[0].Frontmatter["title"] != "From stdin" {
+		t.Errorf("data.title = %v, want %q", recs[0].Frontmatter["title"], "From stdin")
 	}
 }
 
@@ -122,8 +122,8 @@ func TestFrontmatterStdinFileList(t *testing.T) {
 	if recs[0].Filename != a || recs[1].Filename != b {
 		t.Errorf("filenames = [%q, %q], want [%q, %q]", recs[0].Filename, recs[1].Filename, a, b)
 	}
-	if recs[0].Data["title"] != "First doc" || recs[1].Data["title"] != "Second doc" {
-		t.Errorf("titles = [%v, %v], want [First doc, Second doc]", recs[0].Data["title"], recs[1].Data["title"])
+	if recs[0].Frontmatter["title"] != "First doc" || recs[1].Frontmatter["title"] != "Second doc" {
+		t.Errorf("titles = [%v, %v], want [First doc, Second doc]", recs[0].Frontmatter["title"], recs[1].Frontmatter["title"])
 	}
 }
 
@@ -172,8 +172,8 @@ func TestFrontmatterFilesAndStdinInterleaved(t *testing.T) {
 	if recs[1].Filename != "" {
 		t.Errorf("record 1 filename = %q, want empty (stdin)", recs[1].Filename)
 	}
-	if recs[1].Data["title"] != "From stdin" {
-		t.Errorf("record 1 data.title = %v, want %q", recs[1].Data["title"], "From stdin")
+	if recs[1].Frontmatter["title"] != "From stdin" {
+		t.Errorf("record 1 data.title = %v, want %q", recs[1].Frontmatter["title"], "From stdin")
 	}
 	if recs[2].Filename != b {
 		t.Errorf("record 2 filename = %q, want %q", recs[2].Filename, b)
@@ -192,8 +192,8 @@ func TestFrontmatterFilesIgnoreUnreferencedStdin(t *testing.T) {
 	if len(recs) != 1 {
 		t.Fatalf("got %d records, want 1 (stdin ignored): %q", len(recs), out)
 	}
-	if recs[0].Data["title"] != "First doc" {
-		t.Errorf("data.title = %v, want %q (stdin should be ignored)", recs[0].Data["title"], "First doc")
+	if recs[0].Frontmatter["title"] != "First doc" {
+		t.Errorf("data.title = %v, want %q (stdin should be ignored)", recs[0].Frontmatter["title"], "First doc")
 	}
 }
 
@@ -213,8 +213,8 @@ func TestFrontmatterContentNoneDefault(t *testing.T) {
 		t.Errorf("default output should not contain a content field: %q", out)
 	}
 	recs := decodeLines(t, out)
-	if recs[0].Data["title"] != "With body" {
-		t.Errorf("data.title = %v, want %q", recs[0].Data["title"], "With body")
+	if recs[0].Frontmatter["title"] != "With body" {
+		t.Errorf("data.title = %v, want %q", recs[0].Frontmatter["title"], "With body")
 	}
 }
 
@@ -227,8 +227,8 @@ func TestFrontmatterContentAlso(t *testing.T) {
 		t.Fatalf("runRootCommand: %v", err)
 	}
 	recs := decodeLines(t, out)
-	if recs[0].Data["title"] != "With body" {
-		t.Errorf("data.title = %v, want %q", recs[0].Data["title"], "With body")
+	if recs[0].Frontmatter["title"] != "With body" {
+		t.Errorf("data.title = %v, want %q", recs[0].Frontmatter["title"], "With body")
 	}
 	if recs[0].Content != "Hello, body.\n" {
 		t.Errorf("content = %q, want %q", recs[0].Content, "Hello, body.\n")
@@ -243,8 +243,8 @@ func TestFrontmatterContentOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runRootCommand: %v", err)
 	}
-	if strings.Contains(out, "\"data\"") {
-		t.Errorf("--content=only output should not contain a data field: %q", out)
+	if strings.Contains(out, "\"frontmatter\"") {
+		t.Errorf("--content=only output should not contain a frontmatter field: %q", out)
 	}
 	recs := decodeLines(t, out)
 	if recs[0].Content != "Hello, body.\n" {

--- a/go/labs/cmd/akfs/frontmatter_test.go
+++ b/go/labs/cmd/akfs/frontmatter_test.go
@@ -197,6 +197,74 @@ func TestFrontmatterFilesIgnoreUnreferencedStdin(t *testing.T) {
 	}
 }
 
+// docWithBody has a blank line between the closing delimiter and the body so
+// the leading-newline-stripping behavior is exercised.
+const docWithBody = "---\ntitle: With body\n---\n\nHello, body.\n"
+
+// TestFrontmatterContentNoneDefault verifies that without --content (the
+// default "none") no content field is emitted and data is present.
+func TestFrontmatterContentNoneDefault(t *testing.T) {
+	path := writeTemp(t, docWithBody)
+	out, err := runRootCommand("frontmatter", path)
+	if err != nil {
+		t.Fatalf("runRootCommand: %v", err)
+	}
+	if strings.Contains(out, "content") {
+		t.Errorf("default output should not contain a content field: %q", out)
+	}
+	recs := decodeLines(t, out)
+	if recs[0].Data["title"] != "With body" {
+		t.Errorf("data.title = %v, want %q", recs[0].Data["title"], "With body")
+	}
+}
+
+// TestFrontmatterContentAlso verifies --content=also emits both data and the
+// body, with the leading newline stripped and trailing newline preserved.
+func TestFrontmatterContentAlso(t *testing.T) {
+	path := writeTemp(t, docWithBody)
+	out, err := runRootCommand("frontmatter", "--content", "also", path)
+	if err != nil {
+		t.Fatalf("runRootCommand: %v", err)
+	}
+	recs := decodeLines(t, out)
+	if recs[0].Data["title"] != "With body" {
+		t.Errorf("data.title = %v, want %q", recs[0].Data["title"], "With body")
+	}
+	if recs[0].Content != "Hello, body.\n" {
+		t.Errorf("content = %q, want %q", recs[0].Content, "Hello, body.\n")
+	}
+}
+
+// TestFrontmatterContentOnly verifies --content=only emits the body and drops
+// the data field.
+func TestFrontmatterContentOnly(t *testing.T) {
+	path := writeTemp(t, docWithBody)
+	out, err := runRootCommand("frontmatter", "--content", "only", path)
+	if err != nil {
+		t.Fatalf("runRootCommand: %v", err)
+	}
+	if strings.Contains(out, "\"data\"") {
+		t.Errorf("--content=only output should not contain a data field: %q", out)
+	}
+	recs := decodeLines(t, out)
+	if recs[0].Content != "Hello, body.\n" {
+		t.Errorf("content = %q, want %q", recs[0].Content, "Hello, body.\n")
+	}
+	if recs[0].Filename != path {
+		t.Errorf("filename = %q, want %q", recs[0].Filename, path)
+	}
+}
+
+// TestFrontmatterContentInvalid verifies an unrecognized --content value is
+// rejected.
+func TestFrontmatterContentInvalid(t *testing.T) {
+	path := writeTemp(t, docWithBody)
+	_, err := runRootCommand("frontmatter", "--content", "bogus", path)
+	if err == nil {
+		t.Fatal("expected error for invalid --content value, got nil")
+	}
+}
+
 func TestFrontmatterMissingFile(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "nope.md")
 	_, err := runRootCommand("frontmatter", missing)

--- a/go/labs/cmd/akfs/test_helpers_test.go
+++ b/go/labs/cmd/akfs/test_helpers_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
 
 // runRootCommand executes the akfs root command in-process with the given args,
 // capturing stdout and stderr. It mirrors the amika CLI test harness: the
@@ -21,5 +26,24 @@ func runRootCommandWithStdin(stdin string, args ...string) (string, error) {
 	err := rootCmd.Execute()
 	rootCmd.SetArgs(nil)
 	rootCmd.SetIn(nil)
+	// rootCmd is a shared global, so flag values parsed during this run would
+	// otherwise leak into the next. Reset every command's flags to their
+	// defaults to keep invocations isolated.
+	resetFlags(rootCmd)
 	return buf.String(), err
+}
+
+// resetFlags restores every flag of cmd and its subcommands to its default
+// value, undoing any values set by a prior Execute on the shared root command.
+func resetFlags(cmd *cobra.Command) {
+	reset := func(fs *pflag.FlagSet) {
+		fs.VisitAll(func(f *pflag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+	reset(cmd.Flags())
+	for _, sub := range cmd.Commands() {
+		resetFlags(sub)
+	}
 }


### PR DESCRIPTION
## Summary

Extends `akfs fm` to optionally emit the document body, and renames the top-level frontmatter key in the JSON output.

### `--content (none|also|only)`

`akfs fm` can now include the document body — everything after the closing frontmatter delimiter — under a top-level `content` key:

- `none` — only `frontmatter` (the default)
- `also` — both `frontmatter` and `content`
- `only` — only `content`; the `frontmatter` field is dropped

The `content` value reads as though the frontmatter block were absent: the single newline separating the closing delimiter from the body is stripped, while any trailing newline at end-of-file is preserved. When present, fields are ordered `filename`, `frontmatter`, `content`.

The `frontmatter` package's `Parse` now returns a `Document{Frontmatter, Content}` capturing both halves.

### Output key rename: `data` → `frontmatter`

The top-level key holding the parsed YAML frontmatter is now `frontmatter` instead of `data`, making the output self-describing alongside `content`.

### Docs

`docs/labs/akfs.md` and the labs README are updated for the new flag, the `content` output, and the renamed key (including the `jq` examples).

## Commits

1. Add `--content` flag to `akfs fm` to emit document body
2. Rename `data` to `frontmatter` in `akfs fm` JSON output
3. Document the `--content` flag and frontmatter key rename