### PR TITLE
Treat a missing frontmatter block as empty rather than an error

### DIFF
--- a/docs/labs/akfs.md
+++ b/docs/labs/akfs.md
@@ -50,9 +50,10 @@ make build-akfs          # builds dist/akfs
 Parse the YAML frontmatter block from one or more documents and emit it as JSON.
 Aliased as `akfs fm`.
 
-A document's frontmatter must begin on the first line with a `---` delimiter and
-end with a matching `---` (or `...`) delimiter line; the block between is parsed
-as YAML. For example:
+A document's frontmatter begins on the first line with a `---` delimiter and
+ends with a matching `---` (or `...`) delimiter line; the block between is parsed
+as YAML. A document with no leading `---` is treated as having no frontmatter
+(see [Files without frontmatter](#files-without-frontmatter)). For example:
 
 ```markdown
 ---
@@ -152,16 +153,32 @@ find ./content -name '*.md' | akfs fm | jq -r 'select(.frontmatter.status == "dr
 find ./content -name '*.md' | akfs fm | jq -r '[.filename, .frontmatter.title, .frontmatter.author] | @tsv'
 ```
 
-#### Errors
+#### Files without frontmatter
 
-Parsing fails (non-zero exit) when a document does not start with `---`
-(`no frontmatter found`) or is missing its closing delimiter
-(`unterminated frontmatter`). Errors are prefixed with the source name — the
-file path, or `<stdin>` for a stdin document:
+A document that does not start with a `---` delimiter is **not** an error: it is
+treated as having no frontmatter. The `frontmatter` field is an empty object,
+and (with `--content`) the entire file is returned as the body. This makes it
+safe to run `akfs fm` across a directory that mixes documents with and without
+frontmatter.
 
 ```bash
-$ printf 'no frontmatter here\n' | akfs fm -
-<stdin>: no frontmatter found: input does not start with '---'
+$ printf 'Just some prose.\n' | akfs fm -
+{"frontmatter":{}}
+
+$ printf 'Just some prose.\n' | akfs fm --content also -
+{"frontmatter":{},"content":"Just some prose.\n"}
+```
+
+#### Errors
+
+Parsing fails (non-zero exit) only when a document opens with a `---` delimiter
+but is missing its closing delimiter (`unterminated frontmatter`). Errors are
+prefixed with the source name — the file path, or `<stdin>` for a stdin
+document:
+
+```bash
+$ printf -- '---\ntitle: hi\n' | akfs fm -
+<stdin>: unterminated frontmatter: missing closing '---'
 ```
 
 When processing multiple inputs, the first failing document aborts the run.

--- a/go/labs/akfs/frontmatter/frontmatter.go
+++ b/go/labs/akfs/frontmatter/frontmatter.go
@@ -15,10 +15,6 @@ import (
 // delimiter is the line that opens and closes a YAML frontmatter block.
 const delimiter = "---"
 
-// ErrNoFrontmatter is returned when the input does not begin with a frontmatter
-// block (a line containing only "---").
-var ErrNoFrontmatter = errors.New("no frontmatter found: input does not start with '---'")
-
 // ErrUnterminated is returned when an opening "---" delimiter is found but the
 // closing delimiter is missing.
 var ErrUnterminated = errors.New("unterminated frontmatter: missing closing '---'")
@@ -46,9 +42,12 @@ type Document struct {
 // only want the metadata never read past it (large documents are not loaded
 // into memory).
 //
-// An empty frontmatter block parses to an empty, non-nil map. Parse returns
-// ErrNoFrontmatter if the input has no leading delimiter and ErrUnterminated if
-// the closing delimiter is absent.
+// A document with no leading "---" delimiter is treated as having no
+// frontmatter rather than an error: the returned frontmatter is an empty,
+// non-nil map. (In that case ParseWithContent returns the entire input as the
+// content; Parse leaves Content empty, as always.) An empty frontmatter block
+// likewise parses to an empty, non-nil map. Parse returns ErrUnterminated when
+// an opening delimiter is present but its closing delimiter is absent.
 func Parse(r io.Reader) (Document, error) {
 	return parse(r, false)
 }
@@ -57,7 +56,8 @@ func Parse(r io.Reader) (Document, error) {
 // that follows the frontmatter as Document.Content. The single newline
 // separating the closing delimiter from the body is stripped so the content
 // reads as though the frontmatter block were absent; any trailing newline at
-// the end of the input is preserved.
+// the end of the input is preserved. When the document has no frontmatter at
+// all, the entire input is returned verbatim as the content.
 func ParseWithContent(r io.Reader) (Document, error) {
 	return parse(r, true)
 }
@@ -73,7 +73,18 @@ func parse(r io.Reader, wantContent bool) (Document, error) {
 		return Document{}, err
 	}
 	if trimLine(first) != delimiter {
-		return Document{}, ErrNoFrontmatter
+		// No leading delimiter: the document has no frontmatter. Treat the
+		// whole input as content rather than failing. As with any body, the
+		// content is only materialized when the caller asks for it.
+		content := ""
+		if wantContent {
+			rest, err := io.ReadAll(br)
+			if err != nil {
+				return Document{}, err
+			}
+			content = first + string(rest)
+		}
+		return Document{Frontmatter: map[string]any{}, Content: content}, nil
 	}
 	if err == io.EOF {
 		// Input was a single "---" line with no closing delimiter.

--- a/go/labs/akfs/frontmatter/frontmatter_test.go
+++ b/go/labs/akfs/frontmatter/frontmatter_test.go
@@ -168,15 +168,55 @@ func TestParseErrors(t *testing.T) {
 		input   string
 		wantErr error
 	}{
-		{"empty input", "", ErrNoFrontmatter},
-		{"no leading delimiter", "title: hi\n---\n", ErrNoFrontmatter},
 		{"unterminated", "---\ntitle: hi\n", ErrUnterminated},
+		{"single delimiter line", "---", ErrUnterminated},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := Parse(strings.NewReader(tt.input))
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("Parse() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestParseNoFrontmatter verifies that input without a leading "---" delimiter
+// is not an error: the frontmatter is empty for both entry points, and
+// ParseWithContent returns the entire input as content, verbatim. Parse, like
+// always, leaves Content empty.
+func TestParseNoFrontmatter(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty input", ""},
+		{"plain body", "title: hi\n---\n"},
+		{"prose", "Just some text.\nNo frontmatter here.\n"},
+		{"no trailing newline", "hello"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(strings.NewReader(tt.input))
+			if err != nil {
+				t.Fatalf("Parse returned error: %v", err)
+			}
+			if got.Frontmatter == nil || len(got.Frontmatter) != 0 {
+				t.Errorf("Parse Frontmatter = %#v, want empty non-nil map", got.Frontmatter)
+			}
+			if got.Content != "" {
+				t.Errorf("Parse Content = %q, want empty (body not read)", got.Content)
+			}
+
+			withContent, err := ParseWithContent(strings.NewReader(tt.input))
+			if err != nil {
+				t.Fatalf("ParseWithContent returned error: %v", err)
+			}
+			if withContent.Frontmatter == nil || len(withContent.Frontmatter) != 0 {
+				t.Errorf("ParseWithContent Frontmatter = %#v, want empty non-nil map", withContent.Frontmatter)
+			}
+			if withContent.Content != tt.input {
+				t.Errorf("ParseWithContent Content = %q, want %q (whole input)", withContent.Content, tt.input)
 			}
 		})
 	}

--- a/go/labs/cmd/akfs/frontmatter.go
+++ b/go/labs/cmd/akfs/frontmatter.go
@@ -39,8 +39,9 @@ it as JSON.
 Each argument is a file path; the special argument "-" reads a single document
 from stdin. When no arguments are given, stdin is instead treated as a
 newline-delimited list of file paths to process (e.g. piped from "fd" or
-"find"). Each document must begin with a "---" delimiter line and close the
-frontmatter with a matching "---" line.
+"find"). Frontmatter begins on the first line with a "---" delimiter and closes
+with a matching "---" line. A document with no leading "---" is treated as
+having no frontmatter (an empty "frontmatter" object) rather than an error.
 
 Output is one line of compact JSON per document: the parsed frontmatter under a
 "frontmatter" key, alongside a "filename" key naming the source file (omitted

--- a/go/labs/cmd/akfs/frontmatter_test.go
+++ b/go/labs/cmd/akfs/frontmatter_test.go
@@ -274,12 +274,42 @@ func TestFrontmatterMissingFile(t *testing.T) {
 }
 
 func TestFrontmatterParseErrorNamesSource(t *testing.T) {
-	path := writeTemp(t, "no frontmatter here\n")
+	// An opening delimiter with no closing one is still a parse error; the
+	// message should name the source path.
+	path := writeTemp(t, "---\ntitle: hi\n")
 	_, err := runRootCommand("frontmatter", path)
 	if err == nil {
 		t.Fatal("expected parse error, got nil")
 	}
 	if !strings.Contains(err.Error(), path) {
 		t.Errorf("error %q should mention source path %q", err, path)
+	}
+}
+
+// TestFrontmatterNoFrontmatterIsEmpty verifies that a file with no leading
+// "---" block is not an error: it yields an empty frontmatter object, and with
+// --content the whole file is returned as the body.
+func TestFrontmatterNoFrontmatterIsEmpty(t *testing.T) {
+	path := writeTemp(t, "Just some prose.\nNo frontmatter.\n")
+
+	out, err := runRootCommand("frontmatter", path)
+	if err != nil {
+		t.Fatalf("runRootCommand: %v", err)
+	}
+	recs := decodeLines(t, out)
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1: %q", len(recs), out)
+	}
+	if recs[0].Frontmatter == nil || len(recs[0].Frontmatter) != 0 {
+		t.Errorf("frontmatter = %#v, want empty object", recs[0].Frontmatter)
+	}
+
+	out, err = runRootCommand("frontmatter", "--content", "also", path)
+	if err != nil {
+		t.Fatalf("runRootCommand --content also: %v", err)
+	}
+	recs = decodeLines(t, out)
+	if recs[0].Content != "Just some prose.\nNo frontmatter.\n" {
+		t.Errorf("content = %q, want whole file", recs[0].Content)
 	}
 }


### PR DESCRIPTION
## Summary

Makes `akfs fm` tolerant of files that have no frontmatter at all.

A document with no leading `---` delimiter is no longer a parse error. `frontmatter.Parse` now returns an empty `frontmatter` map with the **entire input as content**, so `akfs fm` emits `{"frontmatter":{}}` — and the whole file under `content` when `--content` is used — instead of failing. This makes it safe to run `akfs fm` across a directory that mixes documents with and without frontmatter.

Only the no-frontmatter case is relaxed: a document that opens with `---` but never closes it still fails with `ErrUnterminated`. The now-unused `ErrNoFrontmatter` is removed.

```
$ printf 'Just prose.\n' | akfs fm -
{"frontmatter":{}}

$ printf 'Just prose.\n' | akfs fm --content also -
{"frontmatter":{},"content":"Just prose.\n"}

$ printf -- '---\ntitle: x\n' | akfs fm -
<stdin>: unterminated frontmatter: missing closing '---'   # still an error
```

Docs updated: the old "no frontmatter found" error section is replaced with a new "Files without frontmatter" section, and the remaining error docs/help text are corrected.

## Note

This PR is **stacked on `dylan/akfs-postmatter`** (#249) and targets that branch. Once #249 merges, this should be retargeted to `main`.