### PR TITLE
Bust agent CLI Docker layer cache on every rebuild

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -16,6 +16,7 @@ set -euo pipefail
 #/
 #/ Options:
 #/   --platform <plat>    Override build platform (linux/amd64 or linux/arm64)
+#/   --no-cache           Pass --no-cache to docker build (disable layer cache entirely)
 #/   --ignore-unstaged    Continue even if there are unstaged changes
 #/   --push-daytona       Push built images to Daytona orgs amika-prod and Fixpoint (requires linux/amd64)
 #/   --ci                 Authenticate via DAYTONA_PROD_API_KEY (amika-prod) and DAYTONA_STAGING_API_KEY (Fixpoint)
@@ -61,6 +62,7 @@ image_presets() {
 # Parse arguments
 IMAGES=()
 PLATFORM=""
+NO_CACHE=false
 IGNORE_UNSTAGED=false
 PUSH_DAYTONA=false
 CI_AUTH=false
@@ -72,6 +74,7 @@ while [ $# -gt 0 ]; do
         echo "Error: --platform requires a value" >&2; exit 1
       fi
       PLATFORM="$2"; shift 2 ;;
+    --no-cache)        NO_CACHE=true; shift ;;
     --ignore-unstaged) IGNORE_UNSTAGED=true; shift ;;
     --push-daytona)    PUSH_DAYTONA=true; shift ;;
     --ci)              CI_AUTH=true; shift ;;
@@ -171,6 +174,9 @@ for preset in "${PRESETS[@]}"; do
   dockerfile="$REPO_ROOT/go/internal/sandbox/presets/${preset}/Dockerfile"
 
   docker_args=(build)
+  if [ "$NO_CACHE" = true ]; then
+    docker_args+=(--no-cache)
+  fi
   if [ -n "$PLATFORM" ]; then
     docker_args+=(--platform "$PLATFORM")
     echo "Building ${image_tag} and ${latest_tag} (platform: ${PLATFORM}) from ${dockerfile}..."

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -213,6 +213,9 @@ for preset in "${PRESETS[@]}"; do
       ;;
     coder-dind)
       docker_args+=(--build-arg "DIND_IMAGE=amika/dind:${VERSION}")
+      if [ "$UPDATE_AGENT_CLIS" = true ]; then
+        docker_args+=(--build-arg "AGENT_CLI_CACHE_BUST=${AGENT_CLI_CACHE_BUST}")
+      fi
       ;;
     daytona-coder-dind)
       docker_args+=(--build-arg "CODER_DIND_IMAGE=amika/coder-dind:${VERSION}")

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -16,8 +16,11 @@ set -euo pipefail
 #/
 #/ Options:
 #/   --platform <plat>    Override build platform (linux/amd64 or linux/arm64)
-#/   --no-cache           Pass --no-cache to docker build (disable layer cache entirely)
-#/   --ignore-unstaged    Continue even if there are unstaged changes
+#/   --no-cache              Pass --no-cache to docker build (disable layer cache entirely)
+#/   --no-update-agent-clis  Skip reinstall of agent CLI packages (@anthropic-ai/claude-code,
+#/                           @openai/codex, opencode-ai); reuses the cached layer instead of
+#/                           fetching the latest versions (cache-busted by default)
+#/   --ignore-unstaged       Continue even if there are unstaged changes
 #/   --push-daytona       Push built images to Daytona orgs amika-prod and Fixpoint (requires linux/amd64)
 #/   --ci                 Authenticate via DAYTONA_PROD_API_KEY (amika-prod) and DAYTONA_STAGING_API_KEY (Fixpoint)
 #/                        before each org switch instead of relying on existing daytona login state.
@@ -63,6 +66,7 @@ image_presets() {
 IMAGES=()
 PLATFORM=""
 NO_CACHE=false
+UPDATE_AGENT_CLIS=true
 IGNORE_UNSTAGED=false
 PUSH_DAYTONA=false
 CI_AUTH=false
@@ -74,8 +78,9 @@ while [ $# -gt 0 ]; do
         echo "Error: --platform requires a value" >&2; exit 1
       fi
       PLATFORM="$2"; shift 2 ;;
-    --no-cache)        NO_CACHE=true; shift ;;
-    --ignore-unstaged) IGNORE_UNSTAGED=true; shift ;;
+    --no-cache)           NO_CACHE=true; shift ;;
+    --no-update-agent-clis) UPDATE_AGENT_CLIS=false; shift ;;
+    --ignore-unstaged)    IGNORE_UNSTAGED=true; shift ;;
     --push-daytona)    PUSH_DAYTONA=true; shift ;;
     --ci)              CI_AUTH=true; shift ;;
     --help)            usage; exit 0 ;;
@@ -162,6 +167,12 @@ for img in "${IMAGES[@]}"; do
   done
 done
 
+# Capture a single timestamp for AGENT_CLI_CACHE_BUST so all presets in this
+# run share the same value (consistent cache behavior across coder and claude).
+if [ "$UPDATE_AGENT_CLIS" = true ]; then
+  AGENT_CLI_CACHE_BUST="$(date +%s)"
+fi
+
 # Track what we built/pushed for the summary
 BUILT_IMAGES=()
 PUSHED_SNAPSHOTS=()
@@ -187,6 +198,9 @@ for preset in "${PRESETS[@]}"; do
   case "$preset" in
     coder|claude)
       docker_args+=(--build-arg "BASE_IMAGE=amika/base:${VERSION}")
+      if [ "$UPDATE_AGENT_CLIS" = true ]; then
+        docker_args+=(--build-arg "AGENT_CLI_CACHE_BUST=${AGENT_CLI_CACHE_BUST}")
+      fi
       ;;
     daytona-coder)
       docker_args+=(--build-arg "CODER_IMAGE=amika/coder:${VERSION}")

--- a/go/internal/sandbox/presets/claude/Dockerfile
+++ b/go/internal/sandbox/presets/claude/Dockerfile
@@ -17,7 +17,8 @@ RUN npm install -g pnpm typescript tsx
 # Reset ownership before switching users so the image is consistent regardless
 # of postinstall behavior.
 ARG AGENT_CLI_CACHE_BUST=
-RUN npm install -g @anthropic-ai/claude-code \
+RUN echo "agent-cli-cache-bust: $AGENT_CLI_CACHE_BUST" \
+    && npm install -g @anthropic-ai/claude-code \
     && chown -R amika:amika /home/amika
 
 USER amika

--- a/go/internal/sandbox/presets/claude/Dockerfile
+++ b/go/internal/sandbox/presets/claude/Dockerfile
@@ -5,13 +5,19 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# Install pnpm, TypeScript, and Claude Code CLI. Some packages' postinstall
-# scripts write into /home/amika (e.g. creating /home/amika/.config) while
-# running as root, which leaves those paths root-owned and breaks
-# user-facing hooks that try to write under ~/.config. Reset ownership
-# before switching users so the image is consistent regardless of
-# postinstall behavior.
-RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code \
+# Install stable coding toolchain packages.
+RUN npm install -g pnpm typescript tsx
+
+# Install agent CLI packages separately so this layer can be cache-busted
+# independently (pass --build-arg AGENT_CLI_CACHE_BUST=<timestamp>) without
+# reinstalling the stable toolchain above.
+# Some packages' postinstall scripts write into /home/amika (e.g. creating
+# /home/amika/.config) while running as root, which leaves those paths
+# root-owned and breaks user-facing hooks that try to write under ~/.config.
+# Reset ownership before switching users so the image is consistent regardless
+# of postinstall behavior.
+ARG AGENT_CLI_CACHE_BUST=
+RUN npm install -g @anthropic-ai/claude-code \
     && chown -R amika:amika /home/amika
 
 USER amika

--- a/go/internal/sandbox/presets/coder-dind/Dockerfile
+++ b/go/internal/sandbox/presets/coder-dind/Dockerfile
@@ -5,12 +5,19 @@ FROM ${DIND_IMAGE}
 
 USER root
 
-# Install coding agent CLIs. Some packages' postinstall scripts write into
-# /home/amika (e.g. creating /home/amika/.config) while running as root,
-# which leaves those paths root-owned and breaks user-facing hooks that try
-# to write under ~/.config. Reset ownership before switching users so the
-# image is consistent regardless of postinstall behavior.
-RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai \
+# Install stable coding toolchain packages.
+RUN npm install -g pnpm typescript tsx
+
+# Install agent CLI packages separately so this layer can be cache-busted
+# independently (pass --build-arg AGENT_CLI_CACHE_BUST=<timestamp>) without
+# reinstalling the stable toolchain above.
+# Some packages' postinstall scripts write into /home/amika (e.g. creating
+# /home/amika/.config) while running as root, which leaves those paths
+# root-owned and breaks user-facing hooks that try to write under ~/.config.
+# Reset ownership before switching users so the image is consistent regardless
+# of postinstall behavior.
+ARG AGENT_CLI_CACHE_BUST=
+RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
     && chown -R amika:amika /home/amika
 
 USER amika

--- a/go/internal/sandbox/presets/coder-dind/Dockerfile
+++ b/go/internal/sandbox/presets/coder-dind/Dockerfile
@@ -17,7 +17,8 @@ RUN npm install -g pnpm typescript tsx
 # Reset ownership before switching users so the image is consistent regardless
 # of postinstall behavior.
 ARG AGENT_CLI_CACHE_BUST=
-RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
+RUN echo "agent-cli-cache-bust: $AGENT_CLI_CACHE_BUST" \
+    && npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
     && chown -R amika:amika /home/amika
 
 USER amika

--- a/go/internal/sandbox/presets/coder/Dockerfile
+++ b/go/internal/sandbox/presets/coder/Dockerfile
@@ -5,12 +5,19 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# Install coding agent CLIs. Some packages' postinstall scripts write into
-# /home/amika (e.g. creating /home/amika/.config) while running as root,
-# which leaves those paths root-owned and breaks user-facing hooks that try
-# to write under ~/.config. Reset ownership before switching users so the
-# image is consistent regardless of postinstall behavior.
-RUN npm install -g pnpm typescript tsx @anthropic-ai/claude-code @openai/codex opencode-ai \
+# Install stable coding toolchain packages.
+RUN npm install -g pnpm typescript tsx
+
+# Install agent CLI packages separately so this layer can be cache-busted
+# independently (pass --build-arg AGENT_CLI_CACHE_BUST=<timestamp>) without
+# reinstalling the stable toolchain above.
+# Some packages' postinstall scripts write into /home/amika (e.g. creating
+# /home/amika/.config) while running as root, which leaves those paths
+# root-owned and breaks user-facing hooks that try to write under ~/.config.
+# Reset ownership before switching users so the image is consistent regardless
+# of postinstall behavior.
+ARG AGENT_CLI_CACHE_BUST=
+RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
     && chown -R amika:amika /home/amika
 
 USER amika

--- a/go/internal/sandbox/presets/coder/Dockerfile
+++ b/go/internal/sandbox/presets/coder/Dockerfile
@@ -17,7 +17,8 @@ RUN npm install -g pnpm typescript tsx
 # Reset ownership before switching users so the image is consistent regardless
 # of postinstall behavior.
 ARG AGENT_CLI_CACHE_BUST=
-RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
+RUN echo "agent-cli-cache-bust: $AGENT_CLI_CACHE_BUST" \
+    && npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
     && chown -R amika:amika /home/amika
 
 USER amika


### PR DESCRIPTION
## Summary

- Splits `RUN npm install` in the `coder` and `claude` Dockerfiles into two layers: one for stable toolchain packages (`pnpm`, `typescript`, `tsx`) and one for agent CLI packages (`@anthropic-ai/claude-code`, `@openai/codex`, `opencode-ai`), so only the agent CLI layer needs to be invalidated when fetching the latest versions.
- Adds `ARG AGENT_CLI_CACHE_BUST=` before the agent CLI install step; passing a unique value via `--build-arg` busts that layer without touching the stable toolchain layer above it.
- Adds `--no-cache` flag to `bin/build-docker-images` to pass `--no-cache` through to `docker build` when a fully fresh build is needed.
- Adds `--no-update-agent-clis` flag to `bin/build-docker-images`; by default, a timestamp-based `AGENT_CLI_CACHE_BUST` value is passed on every run so agent CLIs are always reinstalled at their latest versions. Pass `--no-update-agent-clis` to reuse the cached layer instead.