### PR TITLE
Add --scope to agent credential push and make --force scope-aware

### DIFF
--- a/go/cmd/amika/secrets.go
+++ b/go/cmd/amika/secrets.go
@@ -519,6 +519,7 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 			}
 
 			force, _ := cmd.Flags().GetBool("force")
+			scope, _ := cmd.Flags().GetString("scope")
 
 			client, err := getSecretsClient()
 			if err != nil {
@@ -550,6 +551,7 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 				Name:  name,
 				Value: credValue,
 				Type:  credType,
+				Scope: scope,
 			})
 			if err != nil {
 				return err
@@ -568,6 +570,7 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 	cmd.Flags().String("value", "", "Credential value (skips interactive discovery)")
 	cmd.Flags().String("from-file", "", "Path to a credentials file (skips interactive discovery)")
 	cmd.Flags().String("type", "oauth", "Credential type: \"oauth\" (default) or \"api_key\"")
+	cmd.Flags().String("scope", "user", "Credential scope: \"user\" (default, private) or \"org\" (visible to org members)")
 	cmd.Flags().Bool("force", false, fmt.Sprintf("Overwrite an existing %s credential with the same name", p.ShortName))
 
 	return cmd

--- a/go/cmd/amika/secrets.go
+++ b/go/cmd/amika/secrets.go
@@ -527,9 +527,18 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 			}
 
 			// Provider secrets have no update endpoint, so --force overwrites by
-			// deleting any same-named credential before creating the new one.
+			// deleting the conflicting credential before creating the new one.
 			// This is not atomic: if the create below fails, the old credential
 			// is already gone.
+			//
+			// What counts as "conflicting" depends on scope, mirroring the
+			// server's uniqueness rules:
+			//   - user scope: unique by (name, scope), so replace only a
+			//     same-named user-scoped credential. A same-named org
+			//     credential legitimately coexists and is left alone.
+			//   - org scope: at most one org-scoped credential per provider
+			//     (any name or type), so replace whatever org-scoped
+			//     credential exists.
 			replaced := false
 			if force {
 				existing, err := client.ListProviderSecrets(p.APIPath)
@@ -537,13 +546,20 @@ func newProviderPushCmd(p providerConfig) *cobra.Command {
 					return err
 				}
 				for _, item := range existing {
-					if item.Name == name {
-						if err := client.DeleteProviderSecret(p.APIPath, item.ID); err != nil {
-							return fmt.Errorf("overwriting existing %s credential %q: %w",
-								p.ShortName, name, err)
-						}
-						replaced = true
+					var conflicts bool
+					if scope == "org" {
+						conflicts = item.Scope == "org"
+					} else {
+						conflicts = item.Scope == scope && item.Name == name
 					}
+					if !conflicts {
+						continue
+					}
+					if err := client.DeleteProviderSecret(p.APIPath, item.ID); err != nil {
+						return fmt.Errorf("overwriting existing %s credential %q: %w",
+							p.ShortName, item.Name, err)
+					}
+					replaced = true
 				}
 			}
 

--- a/go/cmd/amika/secrets_test.go
+++ b/go/cmd/amika/secrets_test.go
@@ -552,8 +552,8 @@ func TestSecretClaudePush_Force(t *testing.T) {
 	var mu sync.Mutex
 	var deletedIDs []string
 	mockEnv := setupMockClaudeAPIRecording(t, &mu, &deletedIDs, []map[string]string{
-		{"id": "cred-existing-1", "name": "Test OAuth", "type": "oauth"},
-		{"id": "cred-other-2", "name": "Other", "type": "oauth"},
+		{"id": "cred-existing-1", "name": "Test OAuth", "type": "oauth", "scope": "user"},
+		{"id": "cred-other-2", "name": "Other", "type": "oauth", "scope": "user"},
 	})
 
 	cmd := exec.Command(bin, "secret", "claude", "push",
@@ -576,13 +576,81 @@ func TestSecretClaudePush_Force(t *testing.T) {
 	}
 }
 
+// TestSecretClaudePush_ForceOrgScope verifies that --force --scope org
+// replaces whatever org-scoped credential exists (the server allows only
+// one per provider, regardless of name), while leaving a same-named
+// user-scoped credential untouched.
+func TestSecretClaudePush_ForceOrgScope(t *testing.T) {
+	bin := buildAmika(t)
+
+	var mu sync.Mutex
+	var deletedIDs []string
+	mockEnv := setupMockClaudeAPIRecording(t, &mu, &deletedIDs, []map[string]string{
+		{"id": "cred-user-1", "name": "Test OAuth", "type": "oauth", "scope": "user"},
+		{"id": "cred-org-2", "name": "Differently Named Org Cred", "type": "oauth", "scope": "org"},
+	})
+
+	cmd := exec.Command(bin, "secret", "claude", "push",
+		"--force",
+		"--scope", "org",
+		"--value", `{"claudeAiOauth":{"accessToken":"test"}}`,
+		"--name", "Test OAuth")
+	cmd.Env = mockEnv
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected success, got error: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Updated") {
+		t.Fatalf("expected 'Updated' in output for forced overwrite, got:\n%s", out)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deletedIDs) != 1 || deletedIDs[0] != "cred-org-2" {
+		t.Fatalf("expected only the org-scoped credential to be deleted regardless of name, got: %v", deletedIDs)
+	}
+}
+
+// TestSecretClaudePush_ForceUserScopeIgnoresOrg verifies that --force at
+// user scope does not delete a same-named org-scoped credential, since the
+// two legitimately coexist.
+func TestSecretClaudePush_ForceUserScopeIgnoresOrg(t *testing.T) {
+	bin := buildAmika(t)
+
+	var mu sync.Mutex
+	var deletedIDs []string
+	mockEnv := setupMockClaudeAPIRecording(t, &mu, &deletedIDs, []map[string]string{
+		{"id": "cred-org-1", "name": "Test OAuth", "type": "oauth", "scope": "org"},
+	})
+
+	cmd := exec.Command(bin, "secret", "claude", "push",
+		"--force",
+		"--scope", "user",
+		"--value", `{"claudeAiOauth":{"accessToken":"test"}}`,
+		"--name", "Test OAuth")
+	cmd.Env = mockEnv
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected success, got error: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Created") {
+		t.Fatalf("expected 'Created' (no overwrite) at user scope, got:\n%s", out)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deletedIDs) != 0 {
+		t.Fatalf("expected no deletes at user scope when only an org cred matches, got: %v", deletedIDs)
+	}
+}
+
 func TestSecretClaudePush_NoForceDoesNotDelete(t *testing.T) {
 	bin := buildAmika(t)
 
 	var mu sync.Mutex
 	var deletedIDs []string
 	mockEnv := setupMockClaudeAPIRecording(t, &mu, &deletedIDs, []map[string]string{
-		{"id": "cred-existing-1", "name": "Test OAuth", "type": "oauth"},
+		{"id": "cred-existing-1", "name": "Test OAuth", "type": "oauth", "scope": "user"},
 	})
 
 	cmd := exec.Command(bin, "secret", "claude", "push",

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -285,7 +285,8 @@ func (c *Client) UpdateSecret(id string, req UpdateSecretRequest) error {
 type CreateProviderSecretRequest struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
-	Type  string `json:"type"` // "oauth" or "api_key" — required by the server
+	Type  string `json:"type"`            // "oauth" or "api_key" — required by the server
+	Scope string `json:"scope,omitempty"` // "user" (default) or "org"; omitted means the server default
 }
 
 // ProviderSecretSummary is the response from POST /api/v0beta1/secrets/<provider>.

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -299,9 +299,10 @@ type ProviderSecretSummary struct {
 // ProviderSecretListItem is an item in the GET /api/v0beta1/secrets/<provider>
 // response.
 type ProviderSecretListItem struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Scope string `json:"scope"` // "user" or "org"
 }
 
 // CreateProviderSecret uploads provider-scoped credentials (e.g. Claude,


### PR DESCRIPTION
## Summary

Adds a `--scope` flag to `amika secret claude push` and `amika secret codex push` so users can create org-scoped agent credentials from the CLI (the remote API already accepts `scope` on `POST /secrets/{claude,codex}`), and updates `--force` to respect scope when deciding what to overwrite.

### `--scope` flag

- Wires a `--scope` flag (default `user`) through the shared provider push command, passed via `CreateProviderSecretRequest.Scope`.
- Mirrors the existing `--scope` on the generic `secret push` / `secret extract` commands.

### Scope-aware `--force`

Previously `--force` deleted any same-named credential regardless of scope, which didn't match the server's uniqueness rules. Now it mirrors them:

- **user scope:** replaces only a same-named *user-scoped* credential, leaving a same-named org credential intact (the two legitimately coexist).
- **org scope:** replaces whatever org-scoped credential exists for the provider. The server permits only one org-scoped credential per provider (`kind`), enforced by the partial unique index `idx_special_secrets_org_singleton`, so a differently-named one would otherwise block the create with a 409 that `--force` couldn't clear.

`ProviderSecretListItem` now captures the `scope` field (already returned by the list endpoint) so the CLI can distinguish the two.

## Follow-up

The one-org-credential-per-provider constraint is an inherited limitation; lifting it for agent providers (while keeping GitHub/OpenCode singletons) is tracked in KAPRO-484.