### PR TITLE
Do not specify provider when creating a sandbox

### DIFF
--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -366,8 +366,9 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 	}
 
 	req := apiclient.CreateSandboxRequest{
-		Name:             name,
-		Provider:         "daytona",
+		Name: name,
+		// Provider is intentionally left unset: the remote API falls back to its
+		// configured default provider (SANDBOX_PROVIDER) when none is specified.
 		RepoURL:          gitURL,
 		EnvVars:          envVars,
 		SecretEnvVars:    secretEnvVars,


### PR DESCRIPTION
## Summary

The `amika sandbox create` remote path hardcoded `Provider: "daytona"` in the create request. With Daytona being sunset server-side, that hardcoded value is now rejected for new sandboxes once the server's default provider is switched away from Daytona (`provider_not_supported` / `provider_not_enabled` 400).

This drops the hardcoded provider from the request. The `provider` field is `omitempty`, so leaving it unset omits it from the request body entirely, letting the remote API fall back to its configured default provider (`SANDBOX_PROVIDER`).

## Changes

- Remove the hardcoded `Provider: "daytona"` from the remote create-sandbox request in `go/cmd/amika/sandbox/sandbox_create.go`.

## Notes

Requires the server-side change that makes `provider` optional and resolves the configured default when omitted (gofixpoint/amika-mono#563). The local-docker `--provider` flag is unaffected; it governs the local create path only.
