### PR TITLE
docs: correct minimum Go version to 1.25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
 
 ## Development Notes
 
-- Requires Go 1.21 or later
+- Requires Go 1.25 or later
 - Linting uses [revive](https://github.com/mgechev/revive) — config in `go/revive.toml`
 - All exported symbols must have doc comments (enforced by the `exported` rule)
 - No external dependencies need to be installed for linting; `make lint` uses `go run`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Go 1.21 or later
+- Go 1.25 or later
 - Docker (required for `materialize`, `sandbox`, and `volume` commands)
 - macOS (the only supported platform currently)
 - rsync (usually pre-installed on macOS)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Want it fully managed? [Amika Cloud](https://amika.dev) runs the same agents in 
 
 ## Quick Start
 
-**Prerequisites:** Docker, macOS or Linux (Go 1.21+ only needed to build from source)
+**Prerequisites:** Docker, macOS or Linux (Go 1.25+ only needed to build from source)
 
 ### Install
 
@@ -62,7 +62,7 @@ Once installed, the `amika` binary is on your `PATH` — run commands directly (
 <details>
 <summary>Build from source instead</summary>
 
-Requires Go 1.21+. Build outputs land in `dist/`:
+Requires Go 1.25+. Build outputs land in `dist/`:
 
 ```bash
 git clone https://github.com/gofixpoint/amika.git && cd amika
@@ -216,7 +216,7 @@ curl -fsSL https://raw.githubusercontent.com/gofixpoint/amika/main/install.sh | 
 <details>
 <summary>Build from source instead</summary>
 
-Requires Go 1.21+. Build outputs land in `dist/`:
+Requires Go 1.25+. Build outputs land in `dist/`:
 
 ```bash
 git clone https://github.com/gofixpoint/amika.git && cd amika


### PR DESCRIPTION
## What

`go/go.mod` declares `go 1.25.3`, so the Go toolchain refuses to build with anything older than 1.25.x. However, the docs claimed **Go 1.21+** in several places, which would mislead a contributor on Go 1.21–1.24 into a build failure on the very first step.

This PR updates the documented minimum Go version to **1.25** to match `go.mod`.

## Changes

- `README.md` — Quick Start prerequisites and both "Build from source" sections (1.21+ → 1.25+)
- `CONTRIBUTING.md` — Prerequisites (Go 1.21 or later → Go 1.25 or later)
- `AGENTS.md` — Development Notes (Requires Go 1.21 or later → Go 1.25 or later)

## Verification

Docs-only change. Confirmed the four references were the only `1.21` mentions:

```
$ grep -rn "1.21" README.md CONTRIBUTING.md AGENTS.md
(no matches after change)
```