### PR TITLE
feat: show command aliases in amika CLI help output

### DIFF
--- a/go/cmd/amika/help.go
+++ b/go/cmd/amika/help.go
@@ -1,0 +1,52 @@
+package main
+
+// help.go customizes the Cobra usage template to show command aliases in the
+// Available Commands list.
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cobra.AddTemplateFunc("cmdAliasesStr", func(cmd *cobra.Command) string {
+		if len(cmd.Aliases) == 0 {
+			return ""
+		}
+		return " (aliases: " + strings.Join(cmd.Aliases, ", ") + ")"
+	})
+
+	// Modified from cobra's defaultUsageTemplate: each subcommand's Short
+	// description is followed by its aliases (if any).
+	rootCmd.SetUsageTemplate(`Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{cmdAliasesStr .}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{cmdAliasesStr .}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{cmdAliasesStr .}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`)
+}

--- a/go/cmd/amika/help_test.go
+++ b/go/cmd/amika/help_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// helpLineContains returns true if any line in output contains all of needles.
+func helpLineContains(output string, needles ...string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		match := true
+		for _, needle := range needles {
+			if !strings.Contains(line, needle) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func TestHelpShowsAliasesForSubcommands(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantLines [][]string // each inner slice is a set of strings that must appear together on one line
+	}{
+		{
+			name: "sandbox delete shows rm and remove aliases",
+			args: []string{"sandbox", "--help"},
+			wantLines: [][]string{
+				{"delete", "(aliases: rm, remove)"},
+				{"list", "(aliases: ls)"},
+			},
+		},
+		{
+			name: "volume delete shows rm and remove aliases",
+			args: []string{"volume", "--help"},
+			wantLines: [][]string{
+				{"delete", "(aliases: rm, remove)"},
+				{"list", "(aliases: ls)"},
+			},
+		},
+		{
+			name: "service list shows ls alias",
+			args: []string{"service", "--help"},
+			wantLines: [][]string{
+				{"list", "(aliases: ls)"},
+			},
+		},
+		{
+			name: "secret claude subcommands show aliases",
+			args: []string{"secret", "claude", "--help"},
+			wantLines: [][]string{
+				{"delete", "(aliases: rm)"},
+				{"list", "(aliases: ls)"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := runRootCommand(tt.args...)
+			for _, lineNeedles := range tt.wantLines {
+				if !helpLineContains(out, lineNeedles...) {
+					t.Errorf("no line in help output contains %v\ngot:\n%s", lineNeedles, out)
+				}
+			}
+		})
+	}
+}
+
+func TestHelpNoAliasesForCommandsWithoutAliases(t *testing.T) {
+	out, _ := runRootCommand("sandbox", "--help")
+	// "create" has no aliases — its line should not contain "(aliases:"
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "create") && strings.Contains(line, "(aliases:") {
+			t.Errorf("create command should not show aliases, but got line: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a custom Cobra usage template that appends `(aliases: rm, remove)` after a subcommand's short description when the command has aliases defined
- Covers sandbox (`delete`, `list`), volume (`delete`, `list`), service (`list`), and secret provider sub-trees (`delete`, `list`)
- Uses `cobra.AddTemplateFunc` to register a `cmdAliasesStr` helper and `rootCmd.SetUsageTemplate` to apply the modified template — child commands inherit it automatically

Closes KAPRO-374.