### PR TITLE
Fix stale API route paths in CLI client comments

### DIFF
--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -129,7 +129,7 @@ func (c *Client) GetSandbox(name string) (*RemoteSandbox, error) {
 	return &result, nil
 }
 
-// waitForSandboxState polls GET /api/sandboxes/{name} every 3 seconds until
+// waitForSandboxState polls GET /api/v0beta1/sandboxes/{name} every 3 seconds until
 // the sandbox state matches one of readyStates or "failed".
 func (c *Client) waitForSandboxState(name string, readyStates []string, failMsg string) (*RemoteSandbox, error) {
 	for {
@@ -152,7 +152,7 @@ func (c *Client) waitForSandboxState(name string, readyStates []string, failMsg 
 	}
 }
 
-// WaitForSandbox polls GET /api/sandboxes/{name} until the sandbox reaches
+// WaitForSandbox polls GET /api/v0beta1/sandboxes/{name} until the sandbox reaches
 // a ready or terminal state. It polls every 3 seconds.
 func (c *Client) WaitForSandbox(name string) (*RemoteSandbox, error) {
 	return c.waitForSandboxState(name, []string{"active", "running", "started"}, "sandbox provisioning failed")
@@ -205,7 +205,7 @@ func (c *Client) StartSandbox(name string) error {
 	return nil
 }
 
-// WaitForSandboxStart polls GET /api/sandboxes/{name} until the sandbox
+// WaitForSandboxStart polls GET /api/v0beta1/sandboxes/{name} until the sandbox
 // transitions out of "initializing" state. It polls every 3 seconds.
 func (c *Client) WaitForSandboxStart(name string) (*RemoteSandbox, error) {
 	return c.waitForSandboxState(name, []string{"active", "running", "started"}, "sandbox start failed")
@@ -221,7 +221,7 @@ func (c *Client) StopSandbox(name string) error {
 	return nil
 }
 
-// WaitForSandboxStop polls GET /api/sandboxes/{name} until the sandbox
+// WaitForSandboxStop polls GET /api/v0beta1/sandboxes/{name} until the sandbox
 // transitions out of "stopping" state. It polls every 3 seconds.
 func (c *Client) WaitForSandboxStop(name string) (*RemoteSandbox, error) {
 	return c.waitForSandboxState(name, []string{"stopped"}, "sandbox stop failed")


### PR DESCRIPTION
## Summary

The sandbox-polling doc comments in `go/internal/apiclient/client.go` referenced the pre-versioning `/api/sandboxes/{name}` path. The client already targets the versioned API (`apiBasePath = "/api/v0beta1"`), so this updates the four comments to match the actual requests.

Comment-only change; no behavior change.

## Context

Companion to the amika-mono PR that deletes the deprecated `app/api` routes duplicated in `src/server`. The Go CLI was already migrated to `/api/v0beta1`; only these doc comments were stale.

## Test plan

- `go build ./...`, `go vet ./internal/apiclient/`, and `go test ./internal/apiclient/` pass.
- Pre-commit hooks (go vet, revive) pass.