### PR TITLE
Derive WorkOS client ID from API URL for staging

### DIFF
--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/gofixpoint/amika/go/internal/basedir"
 )
@@ -57,10 +58,14 @@ func WorkOSClientID() string {
 }
 
 // workOSClientIDForURL maps a known API URL to its WorkOS client ID, falling
-// back to the production default for unrecognized hosts.
+// back to the production default for unrecognized or unparsable hosts. Host
+// comparison ignores case and any port so that variants like a trailing slash,
+// an explicit :443, or mixed-case hosts still resolve to staging.
 func workOSClientIDForURL(apiURL string) string {
-	if u, err := url.Parse(apiURL); err == nil && u.Host == StagingHost {
-		return StagingWorkOSClientID
+	if u, err := url.Parse(apiURL); err == nil {
+		if strings.EqualFold(u.Hostname(), StagingHost) {
+			return StagingWorkOSClientID
+		}
 	}
 	return DefaultWorkOSClientID
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"net/url"
 	"os"
 
 	"github.com/gofixpoint/amika/go/internal/basedir"
@@ -21,7 +22,17 @@ const (
 	// DefaultAPIURL is the default remote API base URL.
 	DefaultAPIURL = "https://app.amika.dev"
 	// DefaultWorkOSClientID is the default WorkOS client ID for device auth.
+	// It matches the production API at DefaultAPIURL.
 	DefaultWorkOSClientID = "client_01KHA495MJS1KT6QBRTYJ239DY"
+
+	// StagingHost is the host of the staging API. Requests against it must be
+	// authenticated with the staging WorkOS environment, not production.
+	StagingHost = "app.staging-amika.dev"
+	// StagingWorkOSClientID is the WorkOS client ID for the staging
+	// environment. The staging API verifies bearer tokens against this
+	// client's issuer, so a token minted by DefaultWorkOSClientID
+	// (production) is rejected with "Invalid bearer token".
+	StagingWorkOSClientID = "client_01KHA4957S0742NKPKGAHV0JZE"
 )
 
 // APIURL returns the API base URL, checking AMIKA_API_URL first.
@@ -32,10 +43,24 @@ func APIURL() string {
 	return DefaultAPIURL
 }
 
-// WorkOSClientID returns the WorkOS client ID, checking AMIKA_WORKOS_CLIENT_ID first.
+// WorkOSClientID returns the WorkOS client ID used for device auth and token
+// verification. An explicit AMIKA_WORKOS_CLIENT_ID always wins. Otherwise the
+// client ID is derived from the API URL so that pointing AMIKA_API_URL at a
+// known environment (e.g. staging) authenticates against the matching WorkOS
+// environment automatically. Without this, logging in against staging mints a
+// production token that staging rejects with a 401 "Invalid bearer token".
 func WorkOSClientID() string {
 	if id := os.Getenv(EnvWorkOSClientID); id != "" {
 		return id
+	}
+	return workOSClientIDForURL(APIURL())
+}
+
+// workOSClientIDForURL maps a known API URL to its WorkOS client ID, falling
+// back to the production default for unrecognized hosts.
+func workOSClientIDForURL(apiURL string) string {
+	if u, err := url.Parse(apiURL); err == nil && u.Host == StagingHost {
+		return StagingWorkOSClientID
 	}
 	return DefaultWorkOSClientID
 }

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -258,6 +258,30 @@ func TestWorkOSClientID_UnknownURLDefaultsToProduction(t *testing.T) {
 	}
 }
 
+func TestWorkOSClientIDForURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiURL string
+		want   string
+	}{
+		{"production default", DefaultAPIURL, DefaultWorkOSClientID},
+		{"staging", "https://" + StagingHost, StagingWorkOSClientID},
+		{"staging trailing slash", "https://" + StagingHost + "/", StagingWorkOSClientID},
+		{"staging with path", "https://" + StagingHost + "/api/v0beta1", StagingWorkOSClientID},
+		{"staging explicit port", "https://" + StagingHost + ":443", StagingWorkOSClientID},
+		{"staging uppercase host", "https://APP.STAGING-AMIKA.DEV", StagingWorkOSClientID},
+		{"unknown host", "https://app.example.com", DefaultWorkOSClientID},
+		{"empty url", "", DefaultWorkOSClientID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workOSClientIDForURL(tt.apiURL); got != tt.want {
+				t.Errorf("workOSClientIDForURL(%q) = %q, want %q", tt.apiURL, got, tt.want)
+			}
+		})
+	}
+}
+
 // setEnv sets an environment variable for the duration of the test, restoring
 // the previous value on cleanup.
 func setEnv(t *testing.T, key, value string) {

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -219,3 +219,73 @@ func TestVolumesStateFile_EnvOverride(t *testing.T) {
 		t.Errorf("VolumesStateFile() = %q, want %q", got, want)
 	}
 }
+
+func TestWorkOSClientID_EnvOverrideWins(t *testing.T) {
+	// An explicit AMIKA_WORKOS_CLIENT_ID overrides everything, including any
+	// value that would otherwise be derived from the API URL.
+	setEnv(t, EnvWorkOSClientID, "client_custom")
+	setEnv(t, EnvAPIURL, "https://"+StagingHost)
+
+	if got := WorkOSClientID(); got != "client_custom" {
+		t.Errorf("WorkOSClientID() = %q, want %q", got, "client_custom")
+	}
+}
+
+func TestWorkOSClientID_DefaultsToProduction(t *testing.T) {
+	unsetEnv(t, EnvWorkOSClientID)
+	unsetEnv(t, EnvAPIURL)
+
+	if got := WorkOSClientID(); got != DefaultWorkOSClientID {
+		t.Errorf("WorkOSClientID() = %q, want %q", got, DefaultWorkOSClientID)
+	}
+}
+
+func TestWorkOSClientID_DerivedFromStagingURL(t *testing.T) {
+	unsetEnv(t, EnvWorkOSClientID)
+	setEnv(t, EnvAPIURL, "https://"+StagingHost)
+
+	if got := WorkOSClientID(); got != StagingWorkOSClientID {
+		t.Errorf("WorkOSClientID() = %q, want %q", got, StagingWorkOSClientID)
+	}
+}
+
+func TestWorkOSClientID_UnknownURLDefaultsToProduction(t *testing.T) {
+	unsetEnv(t, EnvWorkOSClientID)
+	setEnv(t, EnvAPIURL, "https://app.example.com")
+
+	if got := WorkOSClientID(); got != DefaultWorkOSClientID {
+		t.Errorf("WorkOSClientID() = %q, want %q", got, DefaultWorkOSClientID)
+	}
+}
+
+// setEnv sets an environment variable for the duration of the test, restoring
+// the previous value on cleanup.
+func setEnv(t *testing.T, key, value string) {
+	t.Helper()
+	orig, had := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("Setenv(%q): %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, orig)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+// unsetEnv unsets an environment variable for the duration of the test,
+// restoring the previous value on cleanup.
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	orig, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("Unsetenv(%q): %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, orig)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Pointing the CLI at the staging API with `AMIKA_API_URL=https://app.staging-amika.dev` (and no `AMIKA_WORKOS_CLIENT_ID`) makes every authenticated request fail with:

```
$ amika secrets codex push --type oauth --name 'personal-codex-oauth'
remote create codex secret: HTTP 401: {"error":"Invalid bearer token"}
```

The failure is not specific to `secrets codex push` — `secrets ... list`, `sandbox list`, etc. all return the same 401. Confusingly, `amika auth login` and `amika auth status` both report a *successful* login, so the failure only surfaces later as an opaque 401.

## Root cause

`amika auth login` runs a WorkOS device flow keyed on `config.WorkOSClientID()`, which defaulted to the **production** client ID (`client_01KHA495MJS1KT6QBRTYJ239DY`) regardless of `AMIKA_API_URL`. That mints a production-issued bearer token.

The staging API verifies bearer tokens against its **own** WorkOS client (`client_01KHA4957S0742NKPKGAHV0JZE`), checking the issuer `https://api.workos.com/user_management/${WORKOS_CLIENT_ID}`. A production token has a mismatched issuer, so verification fails and the request is rejected with `401 "Invalid bearer token"`.

In other words: `AMIKA_API_URL` and `AMIKA_WORKOS_CLIENT_ID` were independent, and nothing linked them. A user targeting staging had to know to also set `AMIKA_WORKOS_CLIENT_ID` to the staging value — otherwise auth silently used the wrong environment.

I confirmed this by decoding the stored session token (issuer = prod client), reading the server's `verifyWorkOSToken` (issuer built from staging's `WORKOS_CLIENT_ID`), and observing the login verification URL switch from `auth.amika.dev` (prod) to `soothing-song-80-staging.authkit.app` (staging) once the correct client ID is used.

## Fix

Derive the WorkOS client ID from the resolved API URL when `AMIKA_WORKOS_CLIENT_ID` is not set: the staging host resolves to the staging client ID, everything else falls back to the production default. An explicit `AMIKA_WORKOS_CLIENT_ID` still wins. Host matching is case- and port-insensitive so URL variants (trailing slash, `:443`, mixed case) still resolve correctly.

After the fix, `AMIKA_API_URL=https://app.staging-amika.dev amika auth login` routes to the staging AuthKit automatically, and authenticated requests succeed.

## Testing

- `go test ./internal/config/` — new table + behavior tests (env override precedence, staging derivation, unknown-host fallback, trailing slash, path, explicit port, uppercase host, empty URL)
- `make lint`, `go vet ./...`, `go build ./...` all pass
- Verified end-to-end that login now targets the staging WorkOS environment with only `AMIKA_API_URL` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)