### PR TITLE
Support Vercel WebSocket-tunneled SSH in the CLI

### DIFF
--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -78,6 +78,12 @@ Examples:
 			if info.SSHDestination == "" {
 				return fmt.Errorf("server returned empty SSH destination")
 			}
+			// A WebSocket-tunneled sandbox (Vercel) has no plain destination to
+			// print — connecting requires a websocat ProxyCommand + a per-session
+			// key that `amika sandbox ssh` sets up.
+			if info.WebSocketProxyURL != "" {
+				return fmt.Errorf("this sandbox's SSH is tunneled over a WebSocket and has no plain destination to print; run `amika sandbox ssh %s` to connect", name)
+			}
 			fmt.Fprintln(cmd.OutOrStdout(), info.SSHDestination)
 			return nil
 		}
@@ -162,6 +168,13 @@ func prepareCursorSSHTarget(client *apiclient.Client, paths basedir.Paths, name 
 	}
 	if info.SSHDestination == "" {
 		return cursorSSHTarget{}, fmt.Errorf("server returned empty SSH destination")
+	}
+	// The editor path writes a static `~/.ssh/amika.conf` Host block, which can't
+	// yet express the websocat ProxyCommand + per-session identity a
+	// WebSocket-tunneled sandbox (Vercel) needs. Fail clearly rather than write a
+	// Host block that can't connect. `amika sandbox ssh` handles the tunnel.
+	if info.WebSocketProxyURL != "" {
+		return cursorSSHTarget{}, fmt.Errorf("opening a WebSocket-tunneled sandbox (e.g. Vercel) in an editor over SSH is not supported yet; use `amika sandbox ssh %s` for a shell", name)
 	}
 
 	sandboxID := info.SandboxID

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -170,6 +170,14 @@ type SSHInfo struct {
 	SandboxID   string `json:"sandbox_id"`
 	SandboxName string `json:"sandbox_name"`
 	RepoName    string `json:"repo_name"`
+	// WebSocketProxyURL and PrivateKey are set only by providers whose SSH is
+	// tunneled over a WebSocket rather than reached at a routable host (Vercel).
+	// When present, `ssh_destination` is just a "user@label" for display: the
+	// real connection dials `sshd` inside the sandbox through a local `websocat`
+	// ProxyCommand to this wss URL, authenticating with this per-access PEM
+	// private key. Both are empty for gateway providers (Daytona/Freestyle).
+	WebSocketProxyURL string `json:"web_socket_proxy_url"`
+	PrivateKey        string `json:"private_key"`
 }
 
 // GetSSH retrieves SSH connection details for a remote sandbox.

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -180,8 +180,17 @@ type SSHInfo struct {
 	PrivateKey        string `json:"private_key"`
 }
 
-// GetSSH retrieves SSH connection details for a remote sandbox.
+// GetSSH retrieves (mints) SSH connection details for a remote sandbox.
+// Minting is synchronous and can be slow: it may resume a stopped sandbox and,
+// for WebSocket-tunneled providers (Vercel), generate a keypair and start the
+// in-sandbox sshd/websocat bridge — each an internal round-trip. A longer HTTP
+// timeout (5 minutes) is used instead of the default 30 seconds so a cold mint
+// doesn't fail spuriously.
 func (c *Client) GetSSH(name string) (*SSHInfo, error) {
+	saved := c.HTTP.Timeout
+	c.HTTP.Timeout = 5 * time.Minute
+	defer func() { c.HTTP.Timeout = saved }()
+
 	var result SSHInfo
 	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/ssh", nil, &result); err != nil {
 		return nil, fmt.Errorf("remote ssh: %w", err)

--- a/go/internal/ssh/ssh.go
+++ b/go/internal/ssh/ssh.go
@@ -4,9 +4,11 @@
 package ssh
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"syscall"
 
@@ -78,9 +80,39 @@ func execTunneledSSH(info *apiclient.SSHInfo, forcePTY bool, extraArgs []string)
 	}
 	sshArgs = append(sshArgs, extraArgs...)
 
+	// A Ctrl-C on a non-interactive tunneled command (no PTY, so the terminal is
+	// in cooked mode) delivers SIGINT to our whole process group: ssh, our child,
+	// gets it and exits. Without trapping it here the default action would kill
+	// this wrapper first, skipping the deferred cleanup and leaking the minted
+	// PEM key into /tmp. Trap SIGINT/SIGTERM so we stay alive until c.Run returns
+	// (letting the deferred cleanup run) and remove the key eagerly in case we're
+	// killed anyway. We do NOT forward the signal to ssh: it already received the
+	// group signal, and an interactive session puts the terminal in raw mode
+	// (Ctrl-C is delivered to the remote, not to us), so we must never tear that
+	// session down ourselves.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		for range sigCh {
+			cleanup()
+		}
+	}()
+
 	c := exec.Command(sshBin, sshArgs...)
 	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
-	return c.Run()
+	runErr := c.Run()
+
+	// Preserve ssh's own exit status the way the direct syscall.Exec path does,
+	// so a remote command's exit code (2, 127, 130, …) survives instead of being
+	// collapsed into Cobra's generic exit 1. os.Exit skips deferred funcs, so
+	// remove the key first.
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		cleanup()
+		os.Exit(exitErr.ExitCode())
+	}
+	return runErr
 }
 
 // tunnelSSHArgs builds the `ssh` arguments for a WebSocket-tunneled sandbox: an
@@ -102,12 +134,32 @@ func tunnelSSHArgs(info *apiclient.SSHInfo, keyPath string, forcePTY bool) ([]st
 		"-o", "IdentitiesOnly=yes",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "ProxyCommand=websocat --binary - " + info.WebSocketProxyURL,
+		"-o", "ProxyCommand=" + proxyCommand(info.WebSocketProxyURL),
 	}
 	if forcePTY {
 		args = append(args, "-t")
 	}
 	return append(args, dest), nil
+}
+
+// proxyCommand builds the ssh ProxyCommand that bridges to the sandbox's sshd
+// over the WebSocket. ssh executes ProxyCommand through the user's shell, after
+// first expanding its own `%` tokens, so a signed wss URL — which routinely
+// contains `%2F`, `&`, `?`, etc. — must be both shell-quoted (so the shell
+// treats it literally) and have every `%` doubled (so ssh's token pass leaves a
+// single literal `%`). Skipping either silently breaks the tunnel.
+func proxyCommand(wsURL string) string {
+	quoted := shellQuote(wsURL)
+	escaped := strings.ReplaceAll(quoted, "%", "%%")
+	return "websocat --binary - " + escaped
+}
+
+// shellQuote wraps s in single quotes so /bin/sh treats every character
+// literally, escaping any embedded single quote by ending the quoted run,
+// inserting an escaped quote, and reopening it. Used for values interpolated
+// into ssh's shell-executed ProxyCommand.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // writeTempIdentity writes a PEM private key to a fresh 0600 temp file and

--- a/go/internal/ssh/ssh.go
+++ b/go/internal/ssh/ssh.go
@@ -25,6 +25,12 @@ func ExecSSH(client *apiclient.Client, name string, forcePTY bool, extraArgs []s
 		return fmt.Errorf("server returned empty SSH destination")
 	}
 
+	// Providers whose SSH is tunneled over a WebSocket (Vercel) have no routable
+	// host: connect through a local `websocat` ProxyCommand using the minted key.
+	if info.WebSocketProxyURL != "" {
+		return execTunneledSSH(info, forcePTY, extraArgs)
+	}
+
 	sshArgs := strings.Fields(info.SSHDestination)
 
 	if forcePTY {
@@ -41,4 +47,95 @@ func ExecSSH(client *apiclient.Client, name string, forcePTY bool, extraArgs []s
 		return fmt.Errorf("ssh not found: %w", err)
 	}
 	return syscall.Exec(sshBin, append([]string{"ssh"}, sshArgs...), os.Environ())
+}
+
+// execTunneledSSH connects to a sandbox whose sshd is only reachable through a
+// WebSocket bridge (Vercel). There is no routable host, so ssh dials the bridge
+// via a local `websocat` ProxyCommand and authenticates with the minted PEM key.
+// Unlike the direct path this does NOT `syscall.Exec` (which never returns), so
+// the temporary key file can be cleaned up after the interactive session ends.
+func execTunneledSSH(info *apiclient.SSHInfo, forcePTY bool, extraArgs []string) error {
+	if info.PrivateKey == "" {
+		return fmt.Errorf("server returned a WebSocket SSH proxy URL but no private key")
+	}
+	if _, err := exec.LookPath("websocat"); err != nil {
+		return fmt.Errorf("websocat is required to connect to this sandbox's SSH tunnel but was not found on PATH; install it from https://github.com/vi/websocat")
+	}
+	sshBin, err := exec.LookPath("ssh")
+	if err != nil {
+		return fmt.Errorf("ssh not found: %w", err)
+	}
+
+	keyPath, cleanup, err := writeTempIdentity(info.PrivateKey)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	sshArgs, err := tunnelSSHArgs(info, keyPath, forcePTY)
+	if err != nil {
+		return err
+	}
+	sshArgs = append(sshArgs, extraArgs...)
+
+	c := exec.Command(sshBin, sshArgs...)
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return c.Run()
+}
+
+// tunnelSSHArgs builds the `ssh` arguments for a WebSocket-tunneled sandbox: an
+// identity file, a `websocat` ProxyCommand to the wss URL, and the parsed
+// user@host from the (non-routable) destination label. Host-key checking is set
+// to accept-new against /dev/null because each sandbox is ephemeral and the
+// "host" is only a label.
+func tunnelSSHArgs(info *apiclient.SSHInfo, keyPath string, forcePTY bool) ([]string, error) {
+	d, err := ParseDestination(info.SSHDestination)
+	if err != nil {
+		return nil, err
+	}
+	dest := d.Host
+	if d.User != "" {
+		dest = d.User + "@" + d.Host
+	}
+	args := []string{
+		"-i", keyPath,
+		"-o", "IdentitiesOnly=yes",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "ProxyCommand=websocat --binary - " + info.WebSocketProxyURL,
+	}
+	if forcePTY {
+		args = append(args, "-t")
+	}
+	return append(args, dest), nil
+}
+
+// writeTempIdentity writes a PEM private key to a fresh 0600 temp file and
+// returns its path plus a cleanup func. ssh requires the key to end with a
+// newline, so one is appended if absent.
+func writeTempIdentity(pem string) (string, func(), error) {
+	f, err := os.CreateTemp("", "amika-ssh-*.key")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp identity file: %w", err)
+	}
+	name := f.Name()
+	cleanup := func() { _ = os.Remove(name) }
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("chmod identity file: %w", err)
+	}
+	if !strings.HasSuffix(pem, "\n") {
+		pem += "\n"
+	}
+	if _, err := f.WriteString(pem); err != nil {
+		f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("write identity file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close identity file: %w", err)
+	}
+	return name, cleanup, nil
 }

--- a/go/internal/ssh/ssh_test.go
+++ b/go/internal/ssh/ssh_test.go
@@ -1,0 +1,77 @@
+package ssh
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+)
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "''"},
+		{"plain", "'plain'"},
+		{"a b&c?d", "'a b&c?d'"},
+		{"has'quote", `'has'\''quote'`},
+	}
+	for _, c := range cases {
+		if got := shellQuote(c.in); got != c.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestProxyCommandEscapesURL(t *testing.T) {
+	// A signed wss URL with %-encoded bytes and shell metacharacters must survive
+	// both ssh's %-token expansion (each literal % doubled) and the shell (whole
+	// URL single-quoted), or the tunnel breaks.
+	url := "wss://host-2222.vercel.run/?token=a%2Fb&sig=c%3Dd"
+	got := proxyCommand(url)
+	want := "websocat --binary - 'wss://host-2222.vercel.run/?token=a%%2Fb&sig=c%%3Dd'"
+	if got != want {
+		t.Fatalf("proxyCommand(%q) = %q, want %q", url, got, want)
+	}
+	// Every literal % in the source URL must be doubled: an odd count would mean a
+	// token leaked through ssh's %-expansion unescaped.
+	if n := strings.Count(got, "%"); n%2 != 0 {
+		t.Errorf("proxyCommand left an odd number of %% (%d): %q", n, got)
+	}
+}
+
+func TestTunnelSSHArgs(t *testing.T) {
+	info := &apiclient.SSHInfo{
+		SSHDestination:    "vercel-sandbox@crimson-luanda",
+		WebSocketProxyURL: "wss://crimson-luanda-2222.vercel.run/",
+	}
+	args, err := tunnelSSHArgs(info, "/tmp/key", true)
+	if err != nil {
+		t.Fatalf("tunnelSSHArgs: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"-i /tmp/key",
+		"IdentitiesOnly=yes",
+		"StrictHostKeyChecking=accept-new",
+		"ProxyCommand=websocat --binary - 'wss://crimson-luanda-2222.vercel.run/'",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("tunnelSSHArgs missing %q in %q", want, joined)
+		}
+	}
+	// forcePTY=true adds -t, and the destination must be the final argument.
+	if args[len(args)-1] != "vercel-sandbox@crimson-luanda" {
+		t.Errorf("last arg = %q, want destination", args[len(args)-1])
+	}
+	sawPTY := false
+	for _, a := range args {
+		if a == "-t" {
+			sawPTY = true
+		}
+	}
+	if !sawPTY {
+		t.Errorf("forcePTY did not add -t: %q", joined)
+	}
+}


### PR DESCRIPTION
Vercel sandboxes expose `sshd` only through a WebSocket bridge (the e2b pattern), so the `/ssh` mint returns `web_socket_proxy_url` + `private_key` and a **non-routable** `ssh_destination` label. The CLI previously ran plain `ssh <dest>`, which works for Daytona/Freestyle but cannot reach a Vercel sandbox.

## Changes
- **`apiclient.SSHInfo`** — parse the two new fields `web_socket_proxy_url` and `private_key`.
- **`internal/ssh` (`ExecSSH`)** — when `web_socket_proxy_url` is set, connect through a local `websocat` `ProxyCommand` to the `wss://` URL, authenticating with the minted PEM key (written to a temp `0600` file and removed after the session). Uses `exec.Command` (not `syscall.Exec`) on this path so the temp key is cleaned up. Gateway providers keep the existing direct `syscall.Exec` path unchanged.
- **`sandbox_ssh.go`** — `--print` and `amika sandbox code` (editor Remote-SSH) can’t express a tunneled connection yet, so they fail with a clear message pointing at `amika sandbox ssh`.

## Requirements / follow-ups
- Requires **`websocat`** on the client `PATH` for tunneled sandboxes (checked with a clear error).
- **Editor Remote-SSH (`amika sandbox code`) for Vercel is a follow-up**: it needs the managed `~/.ssh/amika.conf` Host block to carry a `ProxyCommand` + persisted `IdentityFile`, which this PR does not add.

## Testing
`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/ssh/... ./internal/apiclient/...` all pass (built against go 1.25.3). No `go.mod`/`go.sum` changes.

The server side (mint/tunnel/key-auth) is already merged in `amika-mono`; this is the client half.