### PR TITLE
Clear stale dockerd pidfile before starting daemon

### DIFF
--- a/go/internal/sandbox/presets/docker-setup.sh
+++ b/go/internal/sandbox/presets/docker-setup.sh
@@ -9,15 +9,20 @@ DOCKERD_LOG="/var/log/amikad/dockerd.log"
 DOCKERD_PID_FILE="/run/amikad/dockerd.pid"
 DOCKER_READY_TIMEOUT=30
 
-# A persistent-sandbox snapshot can capture dockerd's own pidfile while the
-# daemon is running. On a fresh boot from that snapshot dockerd is not running,
-# but the pidfile survives pointing at a PID that is no longer dockerd (often
-# reused by another process), so a fresh dockerd refuses to start ("ensure
-# docker is not running or delete /var/run/docker.pid: process with PID N is
-# still running") — wedging the pre-setup hook on every boot from such a
-# snapshot. When no live dockerd is running the pidfile is stale, so remove it.
+# A persistent-sandbox snapshot can capture the Docker and containerd pidfiles
+# while the daemons are running. On a fresh boot from that snapshot neither is
+# running, but the pidfiles survive pointing at PIDs that are no longer theirs
+# (often reused by another process). A fresh dockerd then refuses to start
+# ("ensure docker is not running or delete /var/run/docker.pid: process with PID
+# N is still running"); and even past that, its managed containerd pidfile at
+# /run/docker/containerd/containerd.pid would look alive, so dockerd times out on
+# the dead socket — wedging the pre-setup hook on every boot from such a
+# snapshot. Remove each stale pidfile when its daemon is not actually running.
 if [ -f /var/run/docker.pid ] && ! pgrep -x dockerd >/dev/null 2>&1; then
   rm -f /var/run/docker.pid
+fi
+if [ -f /run/docker/containerd/containerd.pid ] && ! pgrep -x containerd >/dev/null 2>&1; then
+  rm -f /run/docker/containerd/containerd.pid
 fi
 
 # Start dockerd in a new session so it survives process group cleanup

--- a/go/internal/sandbox/presets/docker-setup.sh
+++ b/go/internal/sandbox/presets/docker-setup.sh
@@ -9,6 +9,17 @@ DOCKERD_LOG="/var/log/amikad/dockerd.log"
 DOCKERD_PID_FILE="/run/amikad/dockerd.pid"
 DOCKER_READY_TIMEOUT=30
 
+# A persistent-sandbox snapshot can capture dockerd's own pidfile while the
+# daemon is running. On a fresh boot from that snapshot dockerd is not running,
+# but the pidfile survives pointing at a PID that is no longer dockerd (often
+# reused by another process), so a fresh dockerd refuses to start ("ensure
+# docker is not running or delete /var/run/docker.pid: process with PID N is
+# still running") — wedging the pre-setup hook on every boot from such a
+# snapshot. When no live dockerd is running the pidfile is stale, so remove it.
+if [ -f /var/run/docker.pid ] && ! pgrep -x dockerd >/dev/null 2>&1; then
+  rm -f /var/run/docker.pid
+fi
+
 # Start dockerd in a new session so it survives process group cleanup
 # when the calling hook (pre-setup.sh) exits.
 setsid dockerd > "$DOCKERD_LOG" 2>&1 &


### PR DESCRIPTION
## Problem

On a Vercel (persistent) sandbox, booting from a snapshot that was captured while `dockerd` was running fails the pre-setup hook every time:

```
ERROR: dockerd did not become ready within 30s
# /var/log/amikad/dockerd.log:
failed to start daemon, ensure docker is not running or delete /var/run/docker.pid: process with PID 162 is still running
```

The snapshot captures dockerd's own `/var/run/docker.pid`. On a fresh boot dockerd isn't running, but the pidfile survives pointing at a PID that's since been reused by another process, so `dockerd` refuses to start — and `docker-setup.sh` just lets it fail and times out.

## Fix

Before starting `dockerd`, if there's no live `dockerd` process, treat the pidfile as stale and remove it:

```bash
if [ -f /var/run/docker.pid ] && ! pgrep -x dockerd >/dev/null 2>&1; then
  rm -f /var/run/docker.pid
fi
```

This makes the dind hook survive the snapshot/resume lifecycle instead of wedging on every boot from a snapshot taken with Docker up. No effect on a normal fresh boot (no pidfile present).

## Notes

- Scoped to `dockerd`'s pidfile, matching the observed failure. If containerd's pidfile shows the same symptom on resume, we can extend the same guard in a follow-up.
- Takes effect once the preset image/snapshot is rebuilt.