### PR TITLE
Drop user@host line from sandbox shell prompt

### DIFF
--- a/go/internal/sandbox/presets/.bashrc
+++ b/go/internal/sandbox/presets/.bashrc
@@ -3,9 +3,11 @@ if [ -z "$TMUX" ] && [ "$TERM" = "linux" -o "$TERM" = "dumb" ]; then
   export TERM=xterm-256color
 fi
 
-# Set up the prompt (works on both light and dark terminals)
+# Set up the prompt (works on both light and dark terminals). Just the working
+# directory: the user@host line is dropped because the host is an opaque,
+# per-sandbox container id that only adds noise to SSH sessions and command output.
 
-PS1='\[\e[1;34m\]\u@\h\[\e[0m\]\n\[\e[1;35m\]\w\[\e[0m\]\$ '
+PS1='\[\e[1;35m\]\w\[\e[0m\]\$ '
 
 # History settings
 HISTCONTROL=ignoredups:erasedups


### PR DESCRIPTION
## Problem

The preset `.bashrc` (`go/internal/sandbox/presets/.bashrc`) sets a two-line prompt whose first line is `\u@\h`:

```
vercel-sandbox@9d24f4a9-d21
~$
```

The host portion is an opaque, per-sandbox container id. It carries no useful information and clutters interactive SSH sessions and captured command output.

## Fix

Reduce the prompt to just the colored working directory:

```
PS1='\[\e[1;35m\]\w\[\e[0m\]\$ '
```

So a session now reads:

```
~$ ls
workspace
~$
```

Still light/dark-terminal friendly; only the `user@<container-id>` header line is removed.

## Notes

- Baked into the snapshot at image-build time, so it applies to sandboxes created from a **newly built** snapshot. Existing sandboxes can drop the line by editing the `PS1=` line in `~/.bashrc`.