### PR TITLE
Add --github-auth-mode flag to sandbox create

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -55,7 +55,7 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().Bool("no-setup", false, "Skip the setup script (uses a no-op script instead)")
 	sandboxCreateCmd.Flags().String("branch", "", "Check out this git branch, or create it if it doesn't exist.")
 	sandboxCreateCmd.Flags().String("new-branch", "", "Create a new git branch. With --branch, starts from that branch; otherwise starts from the current checkout.")
-	sandboxCreateCmd.Flags().String("github-auth-mode", "", "GitHub auth mode for the sandbox runtime: pat or app_token (remote only; unset uses server default)")
+	sandboxCreateCmd.Flags().String("github-auth-mode", "", "GitHub auth mode for the sandbox runtime: pat, app_token, or app-token (remote only; unset uses server default)")
 	sandboxListCmd.Flags().BoolP("long", "l", false, "Show additional columns (IMAGE, PORTS)")
 	sandboxDeleteCmd.Flags().Bool("force", false, "Skip confirmation prompt")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -55,6 +55,7 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().Bool("no-setup", false, "Skip the setup script (uses a no-op script instead)")
 	sandboxCreateCmd.Flags().String("branch", "", "Check out this git branch, or create it if it doesn't exist.")
 	sandboxCreateCmd.Flags().String("new-branch", "", "Create a new git branch. With --branch, starts from that branch; otherwise starts from the current checkout.")
+	sandboxCreateCmd.Flags().String("github-auth-mode", "", "GitHub auth mode for the sandbox runtime: pat or app_token (remote only; unset uses server default)")
 	sandboxListCmd.Flags().BoolP("long", "l", false, "Show additional columns (IMAGE, PORTS)")
 	sandboxDeleteCmd.Flags().Bool("force", false, "Skip confirmation prompt")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -295,6 +295,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 	}
 	// Validated in RunE before the auth gate; only the value is read here.
 	githubAuthMode, _ := cmd.Flags().GetString("github-auth-mode")
+	githubAuthMode = sandbox.CanonicalGithubAuthMode(githubAuthMode)
 	setupScript, _ := cmd.Flags().GetString("setup-script")
 	branch, _ := cmd.Flags().GetString("branch")
 	newBranch, _ := cmd.Flags().GetString("new-branch")

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -32,6 +32,14 @@ var sandboxCreateCmd = &cobra.Command{
 		if noSetup && cmd.Flags().Changed("setup-script") {
 			return fmt.Errorf("--no-setup and --setup-script are mutually exclusive")
 		}
+		// Validate before the remote auth gate below so a bad value fails
+		// fast even when the caller is not logged in; otherwise the login
+		// error masks the flag error (and the contract test, which runs
+		// unauthenticated, would never see the validation).
+		githubAuthMode, _ := cmd.Flags().GetString("github-auth-mode")
+		if err := sandbox.ValidateGithubAuthMode(githubAuthMode); err != nil {
+			return err
+		}
 
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -285,10 +293,8 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 	if err := sandbox.ValidateSize(size); err != nil {
 		return err
 	}
+	// Validated in RunE before the auth gate; only the value is read here.
 	githubAuthMode, _ := cmd.Flags().GetString("github-auth-mode")
-	if err := sandbox.ValidateGithubAuthMode(githubAuthMode); err != nil {
-		return err
-	}
 	setupScript, _ := cmd.Flags().GetString("setup-script")
 	branch, _ := cmd.Flags().GetString("branch")
 	newBranch, _ := cmd.Flags().GetString("new-branch")

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -32,6 +32,10 @@ var sandboxCreateCmd = &cobra.Command{
 		if noSetup && cmd.Flags().Changed("setup-script") {
 			return fmt.Errorf("--no-setup and --setup-script are mutually exclusive")
 		}
+		mode := runmode.Resolve(cmd)
+		if mode != runmode.Remote && cmd.Flags().Changed("github-auth-mode") {
+			return fmt.Errorf("--github-auth-mode requires --remote mode")
+		}
 		// Validate before the remote auth gate below so a bad value fails
 		// fast even when the caller is not logged in; otherwise the login
 		// error masks the flag error (and the contract test, which runs
@@ -56,7 +60,6 @@ var sandboxCreateCmd = &cobra.Command{
 			return err
 		}
 
-		mode := runmode.Resolve(cmd)
 		if mode == runmode.Remote && noClean {
 			return fmt.Errorf("--no-clean is only supported for local sandboxes")
 		}

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -285,6 +285,10 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 	if err := sandbox.ValidateSize(size); err != nil {
 		return err
 	}
+	githubAuthMode, _ := cmd.Flags().GetString("github-auth-mode")
+	if err := sandbox.ValidateGithubAuthMode(githubAuthMode); err != nil {
+		return err
+	}
 	setupScript, _ := cmd.Flags().GetString("setup-script")
 	branch, _ := cmd.Flags().GetString("branch")
 	newBranch, _ := cmd.Flags().GetString("new-branch")
@@ -378,6 +382,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 		AgentCredentials: agentCreds,
 		Branch:           branch,
 		NewBranchName:    newBranch,
+		GithubAuthMode:   githubAuthMode,
 	}
 
 	sb, err := client.CreateSandbox(req)

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -54,6 +54,7 @@ type CreateSandboxRequest struct {
 	AgentCredentials   []AgentCredentialRef `json:"agent_credentials,omitempty"`
 	Branch             string               `json:"branch,omitempty"`
 	NewBranchName      string               `json:"new_branch_name,omitempty"`
+	GithubAuthMode     string               `json:"github_auth_mode,omitempty"`
 }
 
 // AgentCredentialRef selects which credential of a given kind the server

--- a/go/internal/apiclient/client_test.go
+++ b/go/internal/apiclient/client_test.go
@@ -466,3 +466,33 @@ func TestDownloadFromSignedURL_Non2xxIsHTTPError(t *testing.T) {
 		t.Errorf("status = %d, want 404", httpErr.StatusCode)
 	}
 }
+
+func TestCreateSandboxRequest_JSONOmitsGithubAuthModeWhenEmpty(t *testing.T) {
+	req := CreateSandboxRequest{Name: "my-sandbox"}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "github_auth_mode") {
+		t.Errorf("expected github_auth_mode to be omitted when empty, got: %s", string(data))
+	}
+}
+
+func TestCreateSandboxRequest_JSONIncludesGithubAuthModeWhenSet(t *testing.T) {
+	req := CreateSandboxRequest{Name: "my-sandbox", GithubAuthMode: "pat"}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	got, ok := m["github_auth_mode"]
+	if !ok {
+		t.Fatalf("expected github_auth_mode in JSON, got: %s", string(data))
+	}
+	if got != "pat" {
+		t.Errorf("github_auth_mode = %q, want %q", got, "pat")
+	}
+}

--- a/go/internal/sandbox/github_auth_mode.go
+++ b/go/internal/sandbox/github_auth_mode.go
@@ -7,16 +7,32 @@ import (
 
 // AllowedGithubAuthModes lists the GitHub auth mode names available for user
 // selection via --github-auth-mode.
-var AllowedGithubAuthModes = []string{"pat", "app_token"}
+var AllowedGithubAuthModes = []string{"pat", "app_token", "app-token"}
+
+// canonicalGithubAuthModeAliases maps accepted aliases to the canonical value
+// sent to the remote API.
+var canonicalGithubAuthModeAliases = map[string]string{
+	"app-token": "app_token",
+}
+
+// CanonicalGithubAuthMode converts accepted aliases to the canonical value
+// expected by the API. Unknown values are returned unchanged.
+func CanonicalGithubAuthMode(mode string) string {
+	if canonical, ok := canonicalGithubAuthModeAliases[mode]; ok {
+		return canonical
+	}
+	return mode
+}
 
 // ValidateGithubAuthMode returns an error if mode is non-empty and not in
 // AllowedGithubAuthModes. An empty string is accepted (server default).
 func ValidateGithubAuthMode(mode string) error {
+	mode = CanonicalGithubAuthMode(mode)
 	if mode == "" {
 		return nil
 	}
 	for _, m := range AllowedGithubAuthModes {
-		if mode == m {
+		if mode == CanonicalGithubAuthMode(m) {
 			return nil
 		}
 	}

--- a/go/internal/sandbox/github_auth_mode.go
+++ b/go/internal/sandbox/github_auth_mode.go
@@ -1,0 +1,24 @@
+package sandbox
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AllowedGithubAuthModes lists the GitHub auth mode names available for user
+// selection via --github-auth-mode.
+var AllowedGithubAuthModes = []string{"pat", "app_token"}
+
+// ValidateGithubAuthMode returns an error if mode is non-empty and not in
+// AllowedGithubAuthModes. An empty string is accepted (server default).
+func ValidateGithubAuthMode(mode string) error {
+	if mode == "" {
+		return nil
+	}
+	for _, m := range AllowedGithubAuthModes {
+		if mode == m {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown github-auth-mode %q; allowed modes: %s", mode, strings.Join(AllowedGithubAuthModes, ", "))
+}

--- a/go/internal/sandbox/github_auth_mode_test.go
+++ b/go/internal/sandbox/github_auth_mode_test.go
@@ -1,0 +1,55 @@
+package sandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateGithubAuthMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		wantErr string
+	}{
+		{
+			name: "empty is ok (server default)",
+			mode: "",
+		},
+		{
+			name: "pat is allowed",
+			mode: "pat",
+		},
+		{
+			name: "app_token is allowed",
+			mode: "app_token",
+		},
+		{
+			name:    "unknown value is rejected",
+			mode:    "oauth",
+			wantErr: "unknown github-auth-mode",
+		},
+		{
+			name:    "junk value is rejected",
+			mode:    "junk",
+			wantErr: "unknown github-auth-mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGithubAuthMode(tt.mode)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/go/internal/sandbox/github_auth_mode_test.go
+++ b/go/internal/sandbox/github_auth_mode_test.go
@@ -24,6 +24,10 @@ func TestValidateGithubAuthMode(t *testing.T) {
 			mode: "app_token",
 		},
 		{
+			name: "app-token alias is allowed",
+			mode: "app-token",
+		},
+		{
 			name:    "unknown value is rejected",
 			mode:    "oauth",
 			wantErr: "unknown github-auth-mode",
@@ -49,6 +53,39 @@ func TestValidateGithubAuthMode(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCanonicalGithubAuthMode(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "app-token alias normalizes",
+			in:   "app-token",
+			want: "app_token",
+		},
+		{
+			name: "app_token stays unchanged",
+			in:   "app_token",
+			want: "app_token",
+		},
+		{
+			name: "pat stays unchanged",
+			in:   "pat",
+			want: "pat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanonicalGithubAuthMode(tt.in)
+			if got != tt.want {
+				t.Fatalf("CanonicalGithubAuthMode(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/go/test/contract/cli_contract_test.go
+++ b/go/test/contract/cli_contract_test.go
@@ -80,3 +80,16 @@ func TestSecretPushHelpContract(t *testing.T) {
 		t.Fatalf("expected help output to include --from-env flag, got:\n%s", text)
 	}
 }
+
+func TestSandboxCreateInvalidGithubAuthModeFailsEarly(t *testing.T) {
+	bin := testutil.BuildAmikaBinary(t)
+
+	cmd := exec.Command(bin, "sandbox", "create", "--remote", "--github-auth-mode", "invalid", "--no-git")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected sandbox create to fail, output:\n%s", string(out))
+	}
+	if !strings.Contains(string(out), "unknown github-auth-mode") {
+		t.Fatalf("expected unknown github-auth-mode error, got:\n%s", string(out))
+	}
+}

--- a/go/test/contract/cli_contract_test.go
+++ b/go/test/contract/cli_contract_test.go
@@ -93,3 +93,16 @@ func TestSandboxCreateInvalidGithubAuthModeFailsEarly(t *testing.T) {
 		t.Fatalf("expected unknown github-auth-mode error, got:\n%s", string(out))
 	}
 }
+
+func TestSandboxCreateGithubAuthModeRequiresRemote(t *testing.T) {
+	bin := testutil.BuildAmikaBinary(t)
+
+	cmd := exec.Command(bin, "sandbox", "create", "--local", "--github-auth-mode", "pat", "--no-git")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected sandbox create to fail, output:\n%s", string(out))
+	}
+	if !strings.Contains(string(out), "--github-auth-mode requires --remote mode") {
+		t.Fatalf("expected --github-auth-mode remote-only error, got:\n%s", string(out))
+	}
+}


### PR DESCRIPTION
## Summary

Adds \`--github-auth-mode <pat|app_token>\` to \`amika sandbox create\` (remote creation), matching the new \`github_auth_mode\` field on the create-sandbox API (amika-mono spec 015: sandbox GitHub runtime auth via GitHub App tokens).

- Unset omits the field from the request body (\`omitempty\`), so the server default (\`pat\`) applies.
- Invalid values fail client-side before any request, following the \`ValidateSize\`/\`ValidatePreset\` pattern.
- Silently ignored on the local creation path, matching \`--size\`.

## Testing

- Table-driven unit tests for \`ValidateGithubAuthMode\` (empty/pat/app_token accepted, junk rejected)
- JSON marshalling tests: field omitted when empty, included when set
- Contract test: \`--github-auth-mode invalid\` fails early with \`unknown github-auth-mode\`
- \`make test-unit\` and \`make test-contract\` pass