### PR TITLE
Match VM snapshot sizes to container sizes; add XL

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -53,10 +53,15 @@ SIZE_ORGS=("amika-prod Fixpoint" "amika-prod Fixpoint" "amika-prod Fixpoint" "am
 # VM snapshots must live in a region with linux-vm runners
 # (DAYTONA_VM_REGION, default "experimental"); the default region has only
 # container runners.
-VM_SIZES=("small" "medium" "large")
-VM_CPUS=("1" "2" "4")
-VM_MEMORY=("1" "4" "8")
-VM_DISK=("3" "8" "10")
+#
+# Sizes mirror the container `SIZE_*` table (same tiers, same dimensions) so a
+# `linux-vm` sandbox is provisioned identically to its container equivalent —
+# the app advertises one size table for both. Keep these in sync with `SIZE_*`
+# above (and with `SANDBOX_SIZE_SPECS` in amika-mono).
+VM_SIZES=("xs" "m" "l" "xl")
+VM_CPUS=("1" "2" "2" "4")
+VM_MEMORY=("1" "8" "12" "16")
+VM_DISK=("3" "10" "18" "24")
 VM_REGION="${DAYTONA_VM_REGION:-experimental}"
 VM_ORGS="${DAYTONA_VM_ORGS:-amika-prod Fixpoint}"
 
@@ -396,7 +401,7 @@ for preset in "${PRESETS[@]}"; do
         disk="${VM_DISK[$i]}"
         # `snapshot create` rejects both a `:tag` and a `/` in the snapshot NAME
         # (empirically — despite the error text claiming slashes are allowed, a
-        # slashed name like `amika/daytona-vm-small` is rejected, while a plain one
+        # slashed name like `amika/daytona-vm-xs` is rejected, while a plain one
         # is accepted). So the VM snapshots are unversioned and slash-free:
         # `<vm_name_base>-<size>` (amika-daytona-vm-<size> or
         # amika-daytona-vm-dind-<size>). That matches the app's default config, so

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -25,7 +25,7 @@ set -euo pipefail
 #/   --push-daytona-vm    Also publish linux-vm snapshots (amika-daytona-vm-<size>):
 #/                        uploads the coder image into Daytona's registry, then
 #/                        `daytona snapshot create --image … --sandbox-class linux-vm`
-#/                        in the VM region (DAYTONA_VM_REGION, default "experimental").
+#/                        in the VM region (DAYTONA_VM_REGION, default "us-west-2").
 #/                        Pair with amika/daytona-coder. Requires linux/amd64.
 #/   --ci                 Authenticate via DAYTONA_PROD_API_KEY (amika-prod) and DAYTONA_STAGING_API_KEY (Fixpoint)
 #/                        before each org switch instead of relying on existing daytona login state.
@@ -51,7 +51,7 @@ SIZE_ORGS=("amika-prod Fixpoint" "amika-prod Fixpoint" "amika-prod Fixpoint" "am
 # --image … --sandbox-class linux-vm`. Built for `daytona-coder`
 # (amika-daytona-vm-<size>) and `daytona-coder-dind` (amika-daytona-vm-dind-<size>).
 # VM snapshots must live in a region with linux-vm runners
-# (DAYTONA_VM_REGION, default "experimental"); the default region has only
+# (DAYTONA_VM_REGION, default "us-west-2"); Daytona's default region has only
 # container runners.
 #
 # Sizes mirror the container `SIZE_*` table (same tiers, same dimensions) so a
@@ -62,7 +62,7 @@ VM_SIZES=("xs" "m" "l" "xl")
 VM_CPUS=("1" "2" "2" "4")
 VM_MEMORY=("1" "8" "12" "16")
 VM_DISK=("3" "10" "18" "24")
-VM_REGION="${DAYTONA_VM_REGION:-experimental}"
+VM_REGION="${DAYTONA_VM_REGION:-us-west-2}"
 VM_ORGS="${DAYTONA_VM_ORGS:-amika-prod Fixpoint}"
 
 VALID_IMAGES="amika/base, amika/coder, amika/claude, amika/daytona-coder, amika/daytona-claude, amika/dind, amika/coder-dind, amika/daytona-coder-dind, all"

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -27,6 +27,8 @@ set -euo pipefail
 #/                        `daytona snapshot create --image … --sandbox-class linux-vm`
 #/                        in the VM region (DAYTONA_VM_REGION, default "us-west-2").
 #/                        Pair with amika/daytona-coder. Requires linux/amd64.
+#/                        DAYTONA_VM_ORGS limits target orgs (space-separated);
+#/                        DAYTONA_VM_SIZES limits sizes (e.g. "l xl").
 #/   --ci                 Authenticate via DAYTONA_PROD_API_KEY (amika-prod) and DAYTONA_STAGING_API_KEY (Fixpoint)
 #/                        before each org switch instead of relying on existing daytona login state.
 #/                        Requires --push-daytona.
@@ -64,6 +66,25 @@ VM_MEMORY=("1" "8" "12" "16")
 VM_DISK=("3" "10" "18" "24")
 VM_REGION="${DAYTONA_VM_REGION:-us-west-2}"
 VM_ORGS="${DAYTONA_VM_ORGS:-amika-prod Fixpoint}"
+
+# Optional space-separated subset of VM sizes to publish (e.g. "l xl"), for
+# retrying a partial run without touching sizes that already succeeded. Empty
+# (default) publishes every size in VM_SIZES. Each value must name a size in
+# VM_SIZES. Only affects the linux-vm snapshots; the container --push-daytona
+# path always publishes all sizes.
+VM_SIZES_FILTER="${DAYTONA_VM_SIZES:-}"
+if [ -n "$VM_SIZES_FILTER" ]; then
+  for requested in $VM_SIZES_FILTER; do
+    known=false
+    for size in "${VM_SIZES[@]}"; do
+      [ "$requested" = "$size" ] && { known=true; break; }
+    done
+    if [ "$known" = false ]; then
+      echo "Error: DAYTONA_VM_SIZES contains unknown size '${requested}'. Valid sizes: ${VM_SIZES[*]}" >&2
+      exit 1
+    fi
+  done
+fi
 
 VALID_IMAGES="amika/base, amika/coder, amika/claude, amika/daytona-coder, amika/daytona-claude, amika/dind, amika/coder-dind, amika/daytona-coder-dind, all"
 
@@ -396,6 +417,13 @@ for preset in "${PRESETS[@]}"; do
       # Step 2: create a linux-vm snapshot per size from the uploaded image.
       for i in "${!VM_SIZES[@]}"; do
         vm_size="${VM_SIZES[$i]}"
+        # Honor the optional DAYTONA_VM_SIZES subset: skip sizes not requested.
+        if [ -n "$VM_SIZES_FILTER" ]; then
+          case " $VM_SIZES_FILTER " in
+            *" $vm_size "*) ;;
+            *) continue ;;
+          esac
+        fi
         cpu="${VM_CPUS[$i]}"
         mem="${VM_MEMORY[$i]}"
         disk="${VM_DISK[$i]}"


### PR DESCRIPTION
The `--push-daytona-vm` snapshots used a separate, smaller size table (`VM_CPUS`/`VM_MEMORY`/`VM_DISK`, tiers small/medium/large), so a `linux-vm` sandbox was provisioned with different vCPU/RAM/disk than the container equivalent — and the amika-mono UI advertises a single size table for both.

## Change
Align the VM sizes to the container `SIZE_*` table and rename the tiers small/medium/large → xs/m/l to match, plus add the missing **xl** tier:

| tier | vCPU | RAM   | Disk  |
|------|------|-------|-------|
| xs   | 1    | 1 GB  | 3 GB  |
| m    | 2    | 8 GB  | 10 GB |
| l    | 2    | 12 GB | 18 GB |
| xl   | 4    | 16 GB | 24 GB |

VM snapshots are now `amika-daytona-vm-{xs,m,l,xl}` (+ `-dind-` variants), matching the container image dimensions 1:1. The amika-mono side (config defaults + the removal of the VM-specific size table) is a companion PR.

## Follow-up
Rebuild/republish the VM snapshots so the live snapshots carry the new sizes and the new xl:
`DAYTONA_VM_ORGS=… bin/build-docker-images amika/daytona-coder amika/daytona-coder-dind --push-daytona-vm`

The old `amika-daytona-vm-{small,medium,large}` snapshots become orphaned after the rename — delete them once nothing references them.