### PR TITLE
Bump install.sh DEFAULT_AMIKALOG_VERSION to 0.2.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -eu
 INSTALL_DIR="${AMIKA_INSTALL_DIR:-/usr/local/bin}"
 GITHUB_REPO="gofixpoint/amika"
 DEFAULT_VERSION="0.11.2"
-DEFAULT_AMIKALOG_VERSION="0.1.0"
+DEFAULT_AMIKALOG_VERSION="0.2.0"
 COMPONENT="amika"
 INSTALL_VERSION=""
 DRY_RUN=false
@@ -31,7 +31,7 @@ Environment variables:
 Examples:
   curl -fsSL https://raw.githubusercontent.com/gofixpoint/amika/main/install.sh | sh
   sh install.sh --install-version 0.1.0-rc.1
-  sh install.sh --component amikalog --install-version 0.1.0
+  sh install.sh --component amikalog --install-version 0.2.0
   AMIKA_INSTALL_DIR=~/.local/bin sh install.sh
 EOF
 }


### PR DESCRIPTION
amikalog 0.2.0 changelog (amikalog@v0.1.0..amikalog@v0.2.0):

- amikalog: store one JSONL file per session and parallelize sync (#248) Capture now appends one compact JSON line per event to a per-session file under the existing cross-process lock. Push uploads each changed session file in a bounded parallel pool, tracking uploaded byte size so only sessions that grew are re-sent. Fetch downloads objects in a bounded parallel pool. Backward compatible with legacy per-event files.