### PR TITLE
Bump L/XL sandbox disk to 24 GB / 32 GB

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -45,7 +45,7 @@ VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 SIZES=("xs" "m" "l" "xl")
 SIZE_CPUS=("1" "2" "2" "4")
 SIZE_MEMORY=("1" "8" "12" "16")
-SIZE_DISK=("3" "10" "18" "24")
+SIZE_DISK=("3" "10" "24" "32")
 SIZE_ORGS=("amika-prod Fixpoint" "amika-prod Fixpoint" "amika-prod Fixpoint" "amika-prod Fixpoint")
 
 # Daytona *VM* (linux-vm) snapshot sizes, published by --push-daytona-vm as
@@ -68,7 +68,7 @@ SIZE_ORGS=("amika-prod Fixpoint" "amika-prod Fixpoint" "amika-prod Fixpoint" "am
 VM_SIZES=("xs" "m" "l" "xl")
 VM_CPUS=("1" "2" "2" "4")
 VM_MEMORY=("1" "8" "12" "16")
-VM_DISK=("3" "10" "18" "24")
+VM_DISK=("3" "10" "24" "32")
 VM_REGION="${DAYTONA_VM_REGION:-us-west-2}"
 VM_ORGS="${DAYTONA_VM_ORGS:-amika-prod Fixpoint}"
 


### PR DESCRIPTION
## What

Bumps the two larger sandbox tiers' Daytona snapshot disk:

- **L**: 18 GB → 24 GB
- **XL**: 24 GB → 32 GB

Both the container snapshot table (`SIZE_DISK`) and the linux-vm snapshot table (`VM_DISK`) are updated, so a VM sandbox is provisioned identically to its container equivalent.

## Why

More working space for the larger sandboxes.

## Notes

- Mirrors the matching bump to `SANDBOX_SIZE_SPECS` in amika-mono: https://github.com/gofixpoint/amika-mono/pull/675
- Disk is baked into each snapshot at build/push time, so the new sizes only apply to snapshots built and pushed after this lands (`bin/build-docker-images … --push-daytona --push-daytona-vm`).
