### PR TITLE
Install amika and amikalog CLIs in sandbox images

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -21,6 +21,7 @@ The default preset, used when no `--image` or `--preset` flag is provided.
 - Claude Code (`@anthropic-ai/claude-code`)
 - Codex (`@openai/codex`)
 - OpenCode (`opencode-ai`)
+- amika CLI, amikalog CLI
 
 ### `claude`
 
@@ -37,6 +38,7 @@ A lighter preset focused on Claude Code only.
 - Node.js 22, pnpm
 - TypeScript, tsx
 - Claude Code (`@anthropic-ai/claude-code`)
+- amika CLI, amikalog CLI
 
 ## Usage
 

--- a/go/internal/sandbox/presets/base/Dockerfile
+++ b/go/internal/sandbox/presets/base/Dockerfile
@@ -45,6 +45,19 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
+# Install the amika and amikalog CLIs from their GitHub releases via the install
+# script documented in the README. Both land in /usr/local/bin (on PATH).
+#   amika:    sandbox / agent management CLI.
+#   amikalog: captures Claude Code / Codex hook activity as append-only events.
+# Fetch the script to a file rather than `curl | sh`: Docker's /bin/sh is dash
+# (no pipefail), so a piped `curl` failure would exit 0 and silently skip the
+# install. Running the downloaded script under `&&` makes a bad fetch or a failed
+# install abort the build instead.
+RUN curl -fsSL https://raw.githubusercontent.com/gofixpoint/amika/main/install.sh -o /tmp/amika-install.sh \
+    && sh /tmp/amika-install.sh \
+    && sh /tmp/amika-install.sh --component amikalog \
+    && rm /tmp/amika-install.sh
+
 # Default no-op user-facing hooks; callers can shadow them via
 # --setup-script / --start-script or by uploading their own.
 # Lifecycle order:

--- a/go/internal/sandbox/presets/base/Dockerfile
+++ b/go/internal/sandbox/presets/base/Dockerfile
@@ -45,17 +45,23 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the amika and amikalog CLIs from their GitHub releases via the install
-# script documented in the README. Both land in /usr/local/bin (on PATH).
+# Install the amika and amikalog CLIs from their GitHub releases, landing in
+# /usr/local/bin (on PATH).
 #   amika:    sandbox / agent management CLI.
 #   amikalog: captures Claude Code / Codex hook activity as append-only events.
-# Fetch the script to a file rather than `curl | sh`: Docker's /bin/sh is dash
-# (no pipefail), so a piped `curl` failure would exit 0 and silently skip the
-# install. Running the downloaded script under `&&` makes a bad fetch or a failed
-# install abort the build instead.
-RUN curl -fsSL https://raw.githubusercontent.com/gofixpoint/amika/main/install.sh -o /tmp/amika-install.sh \
-    && sh /tmp/amika-install.sh \
-    && sh /tmp/amika-install.sh --component amikalog \
+# Pin both the installer and the versions to a release rather than the moving
+# `main` branch, so an image built for any commit is reproducible and never
+# picks up whatever amika/amikalog defaults happen to be on `main` at build time.
+# Passing the versions explicitly also means bumping them changes this RUN and so
+# busts Docker's layer cache (a plain install.sh edit would not). `%40` is the
+# URL-encoded `@` in the release tag `amika@v<version>`. Fetch the script to a
+# file rather than `curl | sh`: Docker's /bin/sh is dash (no pipefail), so a
+# piped curl failure would exit 0 and silently skip the install.
+ARG AMIKA_VERSION=0.11.2
+ARG AMIKALOG_VERSION=0.2.0
+RUN curl -fsSL "https://raw.githubusercontent.com/gofixpoint/amika/amika%40v${AMIKA_VERSION}/install.sh" -o /tmp/amika-install.sh \
+    && sh /tmp/amika-install.sh --install-version "${AMIKA_VERSION}" \
+    && sh /tmp/amika-install.sh --component amikalog --install-version "${AMIKALOG_VERSION}" \
     && rm /tmp/amika-install.sh
 
 # Default no-op user-facing hooks; callers can shadow them via


### PR DESCRIPTION
## What

Bakes the **`amika`** and **`amikalog`** CLIs into the sandbox snapshot images.

They're installed in the **base** preset (`go/internal/sandbox/presets/base/Dockerfile`), which every snapshot derives from — `coder`, `claude`, `dind`, `coder-dind`, and the `daytona-*` variants — so both binaries land on `PATH` (`/usr/local/bin`) in all of them.

## How

Uses the install script the README documents, fetched to a file and run rather than piped into `sh`. Docker's `/bin/sh` is `dash` (no `pipefail`), so a piped `curl` failure would exit `0` and silently ship an image without the tools; running the downloaded script under `&&` aborts the build on a bad fetch or a failed install.

Versions come from the install script's defaults (currently `amika` `0.11.2`, `amikalog` `0.2.0`), matching how the agent CLIs (Claude Code / Codex / OpenCode) are installed unpinned to "latest".

## Verification

Built a throwaway `ubuntu:24.04` image running the exact `RUN` block:

```
amika 0.11.2 installed to /usr/local/bin/amika
amikalog 0.2.0 installed to /usr/local/bin/amikalog
version: v0.11.2   (amika --version)
version: v0.2.0    (amikalog --version)
```

Both download the correct-arch tarball, pass checksum verification, and run.

## Notes

- Also adds the two CLIs to the `docs/presets.md` tool lists.
- The CLIs only appear in snapshots built & pushed after this lands (`bin/build-docker-images … --push-daytona --push-daytona-vm`).
