### PR TITLE
Auto-install amikalog hooks in sandbox images

### DIFF
--- a/go/internal/sandbox/presets/base/Dockerfile
+++ b/go/internal/sandbox/presets/base/Dockerfile
@@ -140,3 +140,13 @@ RUN mkdir -p /home/amika/workspace
 COPY --chown=amika:amika .zshrc /home/amika/.zshrc
 COPY --chown=amika:amika .bashrc /home/amika/.bashrc
 COPY --chown=amika:amika .tmux.conf /home/amika/.tmux.conf
+
+# Pre-register the amikalog hooks so every sandbox records Claude Code and Codex
+# activity from first boot, without the user having to run `amikalog start`.
+# This runs as the amika user (see USER above) so it writes the per-user hook
+# configs into this home -- ~/.claude/settings.json and ~/.codex/hooks.json --
+# owned by amika, with the hook command pinned to the absolute installed binary
+# path (/usr/local/bin/amikalog). It only writes those config files (no network),
+# and is idempotent, so it is safe across rebuilds. All presets derive from this
+# base, so installing here covers container and Daytona VM sandboxes alike.
+RUN amikalog start


### PR DESCRIPTION
## What

Add a `RUN amikalog start` step to the base preset `Dockerfile` (after `USER amika`) so every sandbox ships with the Claude Code and Codex hooks pre-registered. Users no longer need to run `amikalog start` themselves for the sandbox to begin capturing agent activity.

## Why

The `amikalog` binary was recently baked into the base image (#280), but the hooks it installs still had to be turned on manually per sandbox. Registering them at image-build time makes capture work out of the box.

## How it works

`amikalog start` (v0.2.0, the pinned `AMIKALOG_VERSION`) runs `eventlog.Init`, which in one pass:

- writes `~/.claude/settings.json` — the `amikalog hook --source claude` command for all 18 Claude hook events (match-all);
- writes `~/.codex/hooks.json` — the `amikalog hook --source codex` command for all 10 Codex events (matcher `.*`), honoring `$CODEX_HOME`;
- strips any obsolete managed `notify` from `~/.codex/config.toml`.

The step runs as the `amika` user, so both files are written into `/home/amika` owned by amika, with the hook command pinned to the absolute installed path `/usr/local/bin/amikalog`. It only writes config files (no network) and is idempotent. Every preset (`coder`, `claude`, `dind`, `coder-dind`, `daytona-*`) derives from `base`, so this covers container and Daytona VM sandboxes in one place.

## Testing

Fetched the exact pinned release (`amikalog@v0.2.0`, via `install.sh`) and ran `amikalog start` against a throwaway `HOME`:

- exit 0; wrote both `~/.claude/settings.json` (18 events) and `~/.codex/hooks.json` (10 events, matcher `.*`);
- hook command used the absolute binary path (→ `/usr/local/bin/amikalog` in the image);
- second run reported "already present" and exited 0 (idempotent).

## Note

amika-mono's Freestyle/Vercel snapshot builders reproduce the preset image independently and don't install the `amikalog` binary yet, so they're unaffected by this change. Extending the hooks to those providers is a separate follow-up.