### PR TITLE
Add amika snapshot create/list/delete commands

### DIFF
--- a/go/cmd/amika/snapshot.go
+++ b/go/cmd/amika/snapshot.go
@@ -1,0 +1,383 @@
+package main
+
+// snapshot.go implements the `amika snapshot` command group: create, list, and
+// delete snapshots captured from running remote sandboxes. Snapshots are a
+// remote-only concept, so every subcommand talks to the API directly.
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var snapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Manage snapshots captured from running sandboxes",
+}
+
+var snapshotCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Capture a snapshot from a running sandbox",
+	Long: `Capture a snapshot from a running sandbox.
+
+By default this is interactive: it prompts for the capture mode and, for
+"scrub and delete", previews the injected secrets that will be removed and asks
+for confirmation. Pass --no-interactive for a non-prompting run (which then
+requires --mode and --name).`,
+	Args: cobra.NoArgs,
+	RunE: runSnapshotCreate,
+}
+
+var snapshotListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List snapshots captured from sandboxes",
+	Args:    cobra.NoArgs,
+	RunE:    runSnapshotList,
+}
+
+var snapshotDeleteCmd = &cobra.Command{
+	Use:     "delete <name-or-id> [<name-or-id>...]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete one or more sandbox snapshots",
+	Args:    cobra.MinimumNArgs(1),
+	RunE:    runSnapshotDelete,
+}
+
+// getSnapshotClient returns an API client authenticated with the current
+// session, resolved per request (AMIKA_API_KEY, stored key, then WorkOS).
+func getSnapshotClient() (*apiclient.Client, error) {
+	return apiclient.NewClientWithTokenSource(config.APIURL(), apiclient.NewResolvedTokenSource(config.WorkOSClientID())), nil
+}
+
+func runSnapshotCreate(cmd *cobra.Command, _ []string) error {
+	sandboxRef, _ := cmd.Flags().GetString("sandbox")
+	name, _ := cmd.Flags().GetString("name")
+	mode, _ := cmd.Flags().GetString("mode")
+	description, _ := cmd.Flags().GetString("description")
+	noInteractive, _ := cmd.Flags().GetBool("no-interactive")
+
+	if strings.TrimSpace(sandboxRef) == "" {
+		return fmt.Errorf("--sandbox is required")
+	}
+
+	client, err := getSnapshotClient()
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+
+	if noInteractive {
+		if mode == "" {
+			return fmt.Errorf("--mode is required with --no-interactive (scrub_and_delete or full)")
+		}
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("--name is required with --no-interactive")
+		}
+	} else {
+		if mode == "" {
+			mode, err = promptSnapshotMode(cmd, reader)
+			if err != nil {
+				return err
+			}
+		}
+		if strings.TrimSpace(name) == "" {
+			name, err = promptLine(cmd, reader, "Snapshot name")
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(name) == "" {
+				return fmt.Errorf("a snapshot name is required")
+			}
+		}
+	}
+
+	if mode != "scrub_and_delete" && mode != "full" {
+		return fmt.Errorf("invalid --mode %q: must be scrub_and_delete or full", mode)
+	}
+
+	// For scrub-and-delete, show what will be removed and confirm before the
+	// destructive capture (interactive runs only).
+	if mode == "scrub_and_delete" && !noInteractive {
+		preview, err := client.GetSandboxScrubPreview(sandboxRef)
+		if err != nil {
+			return err
+		}
+		printScrubPreview(cmd, preview)
+		confirmed, err := confirmAction(
+			"Scrub these secrets, snapshot the sandbox, and delete it?",
+			reader,
+		)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return nil
+		}
+	}
+
+	snap, err := client.CreateSandboxSnapshot(apiclient.CreateSandboxSnapshotRequest{
+		SandboxRef:  sandboxRef,
+		Name:        name,
+		Description: description,
+		Mode:        mode,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"Snapshot %q is %s. Capture runs in the background; check `amika snapshot list`.\n",
+		snap.Snapshot,
+		snap.State,
+	)
+	return nil
+}
+
+func runSnapshotList(cmd *cobra.Command, _ []string) error {
+	long, _ := cmd.Flags().GetBool("long")
+	sandboxRef, _ := cmd.Flags().GetString("sandbox")
+	repoRef, _ := cmd.Flags().GetString("repo")
+
+	client, err := getSnapshotClient()
+	if err != nil {
+		return err
+	}
+
+	var sourceSandboxID, repositoryID string
+	if strings.TrimSpace(sandboxRef) != "" {
+		sourceSandboxID, err = resolveSandboxID(client, sandboxRef)
+		if err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(repoRef) != "" {
+		repositoryID, err = resolveRepositoryID(client, repoRef)
+		if err != nil {
+			return err
+		}
+	}
+
+	snapshots, err := client.ListSandboxSnapshots(repositoryID, sourceSandboxID)
+	if err != nil {
+		return err
+	}
+	if len(snapshots) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No snapshots found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	if long {
+		fmt.Fprintln(w, "NAME\tSTATE\tPROVIDER\tSOURCE\tSIZE\tBASE\tDESCRIPTION\tCREATED\tERROR")
+		for _, s := range snapshots {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				s.Snapshot, s.State, s.Provider, snapshotSource(s),
+				deref(s.SandboxSize), deref(s.BaseSnapshot), deref(s.Description),
+				s.CreatedAt, deref(s.ErrorMessage))
+		}
+	} else {
+		fmt.Fprintln(w, "NAME\tSTATE\tPROVIDER\tSOURCE\tCREATED")
+		for _, s := range snapshots {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				s.Snapshot, s.State, s.Provider, snapshotSource(s), s.CreatedAt)
+		}
+	}
+	w.Flush()
+	return nil
+}
+
+func runSnapshotDelete(cmd *cobra.Command, args []string) error {
+	force, _ := cmd.Flags().GetBool("force")
+
+	if !force {
+		reader := bufio.NewReader(cmd.InOrStdin())
+		confirmed, err := confirmAction(
+			fmt.Sprintf("Delete snapshot(s) %s?", strings.Join(args, ", ")),
+			reader,
+		)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return nil
+		}
+	}
+
+	client, err := getSnapshotClient()
+	if err != nil {
+		return err
+	}
+
+	var errs []string
+	for _, ref := range args {
+		if err := client.DeleteSandboxSnapshot(ref); err != nil {
+			errs = append(errs, fmt.Sprintf("snapshot %q: %v", ref, err))
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Snapshot %q deleted\n", ref)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+// promptSnapshotMode asks the user to choose a capture mode, defaulting to
+// scrub_and_delete on empty input.
+func promptSnapshotMode(cmd *cobra.Command, reader *bufio.Reader) (string, error) {
+	out := cmd.OutOrStdout()
+	for {
+		fmt.Fprintln(out, "Capture mode:")
+		fmt.Fprintln(out, "  [1] scrub_and_delete (default): remove injected secrets, snapshot, then delete the sandbox")
+		fmt.Fprintln(out, "  [2] full: snapshot everything as-is (keeps secrets and the sandbox; unsafe)")
+		fmt.Fprint(out, "Choose [1/2] (default 1): ")
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return "", fmt.Errorf("failed to read choice: %w", err)
+		}
+		switch strings.TrimSpace(strings.ToLower(answer)) {
+		case "", "1", "scrub_and_delete":
+			return "scrub_and_delete", nil
+		case "2", "full":
+			return "full", nil
+		default:
+			fmt.Fprintln(out, "Please enter 1 or 2.")
+		}
+	}
+}
+
+// promptLine prompts for a single line of free-form input.
+func promptLine(cmd *cobra.Command, reader *bufio.Reader, label string) (string, error) {
+	fmt.Fprintf(cmd.OutOrStdout(), "%s: ", label)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", label, err)
+	}
+	return strings.TrimSpace(answer), nil
+}
+
+func printScrubPreview(cmd *cobra.Command, preview *apiclient.SandboxScrubPreview) {
+	out := cmd.OutOrStdout()
+	if len(preview.Files) == 0 && len(preview.EnvVars) == 0 {
+		fmt.Fprintln(out, "No injected secrets detected; nothing will be scrubbed.")
+		return
+	}
+	fmt.Fprintln(out, "The following injected secrets will be removed before the snapshot:")
+	for _, f := range preview.Files {
+		fmt.Fprintf(out, "  file: %s\n", f)
+	}
+	for _, e := range preview.EnvVars {
+		fmt.Fprintf(out, "  env:  %s\n", e)
+	}
+}
+
+// resolveSandboxID resolves a sandbox name-or-id to its id, matching by id
+// first, then by name.
+func resolveSandboxID(client *apiclient.Client, ref string) (string, error) {
+	sandboxes, err := client.ListSandboxes()
+	if err != nil {
+		return "", err
+	}
+	for _, s := range sandboxes {
+		if s.ID == ref {
+			return s.ID, nil
+		}
+	}
+	for _, s := range sandboxes {
+		if s.Name == ref {
+			return s.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no sandbox found matching %q", ref)
+}
+
+// resolveRepositoryID resolves a repository name-or-id to its id, matching by
+// id, then exact repo URL, then repo-name basename (rejecting an ambiguous
+// basename match).
+func resolveRepositoryID(client *apiclient.Client, ref string) (string, error) {
+	repos, err := client.ListRepositories()
+	if err != nil {
+		return "", err
+	}
+	for _, r := range repos {
+		if r.ID == ref {
+			return r.ID, nil
+		}
+	}
+	var matches []string
+	for _, r := range repos {
+		if r.RepoURL == ref || repoBasename(r.RepoURL) == ref {
+			matches = append(matches, r.ID)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("no repository found matching %q", ref)
+	default:
+		return "", fmt.Errorf("%q matches multiple repositories; pass a repository id instead", ref)
+	}
+}
+
+func snapshotSource(s apiclient.SandboxSnapshot) string {
+	if s.SourceSandboxName != nil && *s.SourceSandboxName != "" {
+		return *s.SourceSandboxName
+	}
+	if s.SourceSandboxID != nil && *s.SourceSandboxID != "" {
+		return *s.SourceSandboxID
+	}
+	return "-"
+}
+
+func deref(s *string) string {
+	if s == nil || *s == "" {
+		return "-"
+	}
+	return *s
+}
+
+// repoBasename extracts the repo name from a git URL or path, dropping any
+// ".git" suffix (e.g. "https://github.com/org/repo.git" -> "repo").
+func repoBasename(repoURL string) string {
+	p := strings.TrimRight(strings.TrimSpace(repoURL), "/")
+	if i := strings.LastIndex(p, "://"); i >= 0 {
+		p = p[i+3:]
+	}
+	if i := strings.LastIndex(p, ":"); i >= 0 {
+		p = p[i+1:]
+	}
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		p = p[i+1:]
+	}
+	return strings.TrimSuffix(p, ".git")
+}
+
+func init() {
+	rootCmd.AddCommand(snapshotCmd)
+	snapshotCmd.AddCommand(snapshotCreateCmd)
+	snapshotCmd.AddCommand(snapshotListCmd)
+	snapshotCmd.AddCommand(snapshotDeleteCmd)
+
+	snapshotCreateCmd.Flags().String("sandbox", "", "Source sandbox to snapshot (name or id)")
+	snapshotCreateCmd.Flags().String("name", "", "Name for the snapshot")
+	snapshotCreateCmd.Flags().String("mode", "", "Capture mode: scrub_and_delete or full (required with --no-interactive)")
+	snapshotCreateCmd.Flags().String("description", "", "Optional description shown in the snapshot list")
+	snapshotCreateCmd.Flags().Bool("no-interactive", false, "Do not prompt; requires --mode and --name")
+
+	snapshotListCmd.Flags().BoolP("long", "l", false, "Show additional columns")
+	snapshotListCmd.Flags().String("sandbox", "", "Only show snapshots captured from this sandbox (name or id)")
+	snapshotListCmd.Flags().String("repo", "", "Only show snapshots for this repository (name or id)")
+
+	snapshotDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+}

--- a/go/cmd/amika/snapshot_test.go
+++ b/go/cmd/amika/snapshot_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/spf13/cobra"
+)
+
+func TestRepoBasename(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"https://github.com/org/repo.git", "repo"},
+		{"https://github.com/org/repo", "repo"},
+		{"git@github.com:org/repo.git", "repo"},
+		{"/local/path/to/repo/", "repo"},
+		{"repo", "repo"},
+	}
+	for _, tt := range tests {
+		if got := repoBasename(tt.in); got != tt.want {
+			t.Errorf("repoBasename(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSnapshotSourceAndDeref(t *testing.T) {
+	name := "my-box"
+	id := "sb-123"
+	if got := snapshotSource(apiclient.SandboxSnapshot{SourceSandboxName: &name, SourceSandboxID: &id}); got != "my-box" {
+		t.Errorf("prefers name: got %q", got)
+	}
+	if got := snapshotSource(apiclient.SandboxSnapshot{SourceSandboxID: &id}); got != "sb-123" {
+		t.Errorf("falls back to id: got %q", got)
+	}
+	if got := snapshotSource(apiclient.SandboxSnapshot{}); got != "-" {
+		t.Errorf("empty source: got %q", got)
+	}
+	if deref(nil) != "-" {
+		t.Error("deref(nil) should be -")
+	}
+	if deref(&name) != "my-box" {
+		t.Error("deref(&name) should be my-box")
+	}
+}
+
+func TestResolveSandboxID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "sb-1", "name": "alpha", "state": "active"},
+			{"id": "sb-2", "name": "beta", "state": "active"},
+		})
+	}))
+	defer srv.Close()
+	client := apiclient.NewClient(srv.URL, "tok")
+
+	if id, err := resolveSandboxID(client, "sb-2"); err != nil || id != "sb-2" {
+		t.Errorf("by id: got %q, %v", id, err)
+	}
+	if id, err := resolveSandboxID(client, "alpha"); err != nil || id != "sb-1" {
+		t.Errorf("by name: got %q, %v", id, err)
+	}
+	if _, err := resolveSandboxID(client, "missing"); err == nil {
+		t.Error("expected not-found error")
+	}
+}
+
+func TestResolveRepositoryID(t *testing.T) {
+	repos := []map[string]any{
+		{"id": "repo-1", "repo_url": "https://github.com/org/alpha.git"},
+		{"id": "repo-2", "repo_url": "https://github.com/org/beta.git"},
+		{"id": "repo-3", "repo_url": "https://gitlab.com/other/beta.git"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(repos)
+	}))
+	defer srv.Close()
+	client := apiclient.NewClient(srv.URL, "tok")
+
+	if id, err := resolveRepositoryID(client, "repo-2"); err != nil || id != "repo-2" {
+		t.Errorf("by id: got %q, %v", id, err)
+	}
+	if id, err := resolveRepositoryID(client, "alpha"); err != nil || id != "repo-1" {
+		t.Errorf("by basename: got %q, %v", id, err)
+	}
+	if id, err := resolveRepositoryID(client, "https://github.com/org/beta.git"); err != nil || id != "repo-2" {
+		t.Errorf("by exact url: got %q, %v", id, err)
+	}
+	if _, err := resolveRepositoryID(client, "beta"); err == nil ||
+		!strings.Contains(err.Error(), "multiple") {
+		t.Errorf("ambiguous basename should error: %v", err)
+	}
+	if _, err := resolveRepositoryID(client, "missing"); err == nil {
+		t.Error("expected not-found error")
+	}
+}
+
+// newTestCreateCmd builds a command carrying the create flags so RunE can be
+// exercised directly.
+func newTestCreateCmd() *cobra.Command {
+	c := &cobra.Command{RunE: runSnapshotCreate}
+	c.Flags().String("sandbox", "", "")
+	c.Flags().String("name", "", "")
+	c.Flags().String("mode", "", "")
+	c.Flags().String("description", "", "")
+	c.Flags().Bool("no-interactive", false, "")
+	return c
+}
+
+func TestSnapshotCreateNoInteractiveValidation(t *testing.T) {
+	t.Run("requires sandbox", func(t *testing.T) {
+		c := newTestCreateCmd()
+		if err := runSnapshotCreate(c, nil); err == nil ||
+			!strings.Contains(err.Error(), "--sandbox is required") {
+			t.Errorf("got %v", err)
+		}
+	})
+
+	t.Run("requires mode without interactive", func(t *testing.T) {
+		c := newTestCreateCmd()
+		c.Flags().Set("sandbox", "box")
+		c.Flags().Set("no-interactive", "true")
+		if err := runSnapshotCreate(c, nil); err == nil ||
+			!strings.Contains(err.Error(), "--mode is required") {
+			t.Errorf("got %v", err)
+		}
+	})
+
+	t.Run("requires name without interactive", func(t *testing.T) {
+		c := newTestCreateCmd()
+		c.Flags().Set("sandbox", "box")
+		c.Flags().Set("no-interactive", "true")
+		c.Flags().Set("mode", "full")
+		if err := runSnapshotCreate(c, nil); err == nil ||
+			!strings.Contains(err.Error(), "--name is required") {
+			t.Errorf("got %v", err)
+		}
+	})
+}

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -236,6 +236,115 @@ func (c *Client) DeleteSandbox(name string) error {
 	return nil
 }
 
+// RemoteRepository represents a repository returned by
+// GET /api/v0beta1/repositories.
+type RemoteRepository struct {
+	ID      string `json:"id"`
+	RepoURL string `json:"repo_url"`
+}
+
+// ListRepositories fetches the org's repositories from the remote API.
+func (c *Client) ListRepositories() ([]RemoteRepository, error) {
+	var result []RemoteRepository
+	if err := c.doJSON("GET", apiBasePath+"/repositories", nil, &result); err != nil {
+		return nil, fmt.Errorf("remote list repositories: %w", err)
+	}
+	return result, nil
+}
+
+// SandboxSnapshot represents a snapshot captured from a running sandbox, as
+// returned by the /api/v0beta1/sandbox-snapshots endpoints.
+type SandboxSnapshot struct {
+	Snapshot          string  `json:"snapshot"`
+	Provider          string  `json:"provider"`
+	Description       *string `json:"description"`
+	SourceSandboxID   *string `json:"source_sandbox_id"`
+	SourceSandboxName *string `json:"source_sandbox_name"`
+	RepositoryID      *string `json:"repository_id"`
+	BaseSnapshot      *string `json:"base_snapshot"`
+	SandboxPreset     *string `json:"sandbox_preset"`
+	SandboxSize       *string `json:"sandbox_size"`
+	State             string  `json:"state"`
+	ErrorMessage      *string `json:"error_message"`
+	CreatedAt         string  `json:"created_at"`
+	UpdatedAt         string  `json:"updated_at"`
+}
+
+// CreateSandboxSnapshotRequest is the request body for
+// POST /api/v0beta1/sandbox-snapshots. SandboxRef references the source
+// sandbox by name or id; the server resolves it (id first, then name). Mode
+// is "scrub_and_delete" or "full".
+type CreateSandboxSnapshotRequest struct {
+	SandboxRef  string `json:"sandbox_ref"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Mode        string `json:"mode,omitempty"`
+}
+
+// ListSandboxSnapshots lists sandbox-captured snapshots for the caller's org.
+// repositoryID and sourceSandboxID are optional id filters; pass "" to omit.
+func (c *Client) ListSandboxSnapshots(repositoryID, sourceSandboxID string) ([]SandboxSnapshot, error) {
+	q := url.Values{}
+	if repositoryID != "" {
+		q.Set("repository_id", repositoryID)
+	}
+	if sourceSandboxID != "" {
+		q.Set("source_sandbox_id", sourceSandboxID)
+	}
+	path := apiBasePath + "/sandbox-snapshots"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var envelope struct {
+		Items []SandboxSnapshot `json:"items"`
+	}
+	if err := c.doJSON("GET", path, nil, &envelope); err != nil {
+		return nil, fmt.Errorf("remote list sandbox snapshots: %w", err)
+	}
+	return envelope.Items, nil
+}
+
+// CreateSandboxSnapshot starts capturing a snapshot from a running sandbox.
+// The endpoint returns 202 Accepted with the snapshot in the "capturing"
+// state; poll ListSandboxSnapshots until it reaches "active" or "failed".
+func (c *Client) CreateSandboxSnapshot(req CreateSandboxSnapshotRequest) (*SandboxSnapshot, error) {
+	var result SandboxSnapshot
+	if err := c.doJSON("POST", apiBasePath+"/sandbox-snapshots", req, &result); err != nil {
+		return nil, fmt.Errorf("remote create sandbox snapshot: %w", err)
+	}
+	return &result, nil
+}
+
+// SandboxScrubPreview lists the injected secrets a "snapshot and delete" would
+// remove from a sandbox (file paths + env var names only, no values).
+type SandboxScrubPreview struct {
+	Files   []string `json:"files"`
+	EnvVars []string `json:"env_vars"`
+}
+
+// GetSandboxScrubPreview previews which injected secrets a scrub-and-delete
+// snapshot would remove from the given sandbox. sandboxRef is a name or id;
+// the server resolves it (id first, then name).
+func (c *Client) GetSandboxScrubPreview(sandboxRef string) (*SandboxScrubPreview, error) {
+	q := url.Values{}
+	q.Set("sandbox", sandboxRef)
+	q.Set("by", "ref")
+	var result SandboxScrubPreview
+	if err := c.doJSON("GET", apiBasePath+"/sandbox-snapshots/scrub-preview?"+q.Encode(), nil, &result); err != nil {
+		return nil, fmt.Errorf("remote sandbox scrub preview: %w", err)
+	}
+	return &result, nil
+}
+
+// DeleteSandboxSnapshot deletes a sandbox snapshot referenced by name or id.
+// The server resolves the reference (id first, then name).
+func (c *Client) DeleteSandboxSnapshot(ref string) error {
+	if err := c.doJSON("DELETE", apiBasePath+"/sandbox-snapshots/"+url.PathEscape(ref)+"?by=ref", nil, nil); err != nil {
+		return fmt.Errorf("remote delete sandbox snapshot: %w", err)
+	}
+	return nil
+}
+
 // Secret represents a secret returned by the remote API.
 type Secret struct {
 	ID    string `json:"id"`

--- a/go/internal/apiclient/client_snapshots_test.go
+++ b/go/internal/apiclient/client_snapshots_test.go
@@ -1,0 +1,136 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSandboxSnapshotRequestPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		call       func(c *Client) error
+		wantMethod string
+		wantPath   string
+	}{
+		{
+			name: "ListSandboxSnapshots with both filters",
+			call: func(c *Client) error {
+				_, err := c.ListSandboxSnapshots("repo1", "sb1")
+				return err
+			},
+			wantMethod: "GET",
+			wantPath:   "/api/v0beta1/sandbox-snapshots?repository_id=repo1&source_sandbox_id=sb1",
+		},
+		{
+			name: "ListSandboxSnapshots with no filters",
+			call: func(c *Client) error {
+				_, err := c.ListSandboxSnapshots("", "")
+				return err
+			},
+			wantMethod: "GET",
+			wantPath:   "/api/v0beta1/sandbox-snapshots",
+		},
+		{
+			name: "CreateSandboxSnapshot",
+			call: func(c *Client) error {
+				_, err := c.CreateSandboxSnapshot(CreateSandboxSnapshotRequest{
+					SandboxRef: "my-box",
+					Name:       "snap",
+					Mode:       "scrub_and_delete",
+				})
+				return err
+			},
+			wantMethod: "POST",
+			wantPath:   "/api/v0beta1/sandbox-snapshots",
+		},
+		{
+			name: "GetSandboxScrubPreview forwards ref via sandbox+by",
+			call: func(c *Client) error {
+				_, err := c.GetSandboxScrubPreview("my-box")
+				return err
+			},
+			wantMethod: "GET",
+			wantPath:   "/api/v0beta1/sandbox-snapshots/scrub-preview?by=ref&sandbox=my-box",
+		},
+		{
+			name:       "DeleteSandboxSnapshot escapes the reference",
+			call:       func(c *Client) error { return c.DeleteSandboxSnapshot("org/snap") },
+			wantMethod: "DELETE",
+			wantPath:   "/api/v0beta1/sandbox-snapshots/org%2Fsnap?by=ref",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.RequestURI
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{"snapshot": "s", "state": "capturing"})
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL, "test-token")
+			if err := tt.call(c); err != nil {
+				t.Fatalf("call: %v", err)
+			}
+			if gotMethod != tt.wantMethod {
+				t.Errorf("method = %q, want %q", gotMethod, tt.wantMethod)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("path = %q, want %q", gotPath, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestListSandboxSnapshotsParsesEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"snapshot": "org/snap-a", "provider": "daytona", "state": "active"},
+				{"snapshot": "org/snap-b", "provider": "freestyle", "state": "capturing"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	items, err := c.ListSandboxSnapshots("", "")
+	if err != nil {
+		t.Fatalf("ListSandboxSnapshots: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(items))
+	}
+	if items[0].Snapshot != "org/snap-a" || items[0].State != "active" {
+		t.Errorf("items[0] = %+v", items[0])
+	}
+}
+
+func TestGetSandboxScrubPreviewParsesResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"files":    []string{"/home/amika/.claude/.credentials.json"},
+			"env_vars": []string{"ANTHROPIC_API_KEY"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	preview, err := c.GetSandboxScrubPreview("my-box")
+	if err != nil {
+		t.Fatalf("GetSandboxScrubPreview: %v", err)
+	}
+	if len(preview.Files) != 1 || preview.Files[0] != "/home/amika/.claude/.credentials.json" {
+		t.Errorf("Files = %v", preview.Files)
+	}
+	if len(preview.EnvVars) != 1 || preview.EnvVars[0] != "ANTHROPIC_API_KEY" {
+		t.Errorf("EnvVars = %v", preview.EnvVars)
+	}
+}


### PR DESCRIPTION
## What

Adds an `amika snapshot` command group for snapshots captured from running remote sandboxes, backed by the new sandbox-snapshot API.

```
amika snapshot create --sandbox <name-or-id> \
    [--name <n>] [--mode scrub_and_delete|full] \
    [--description <t>] [--no-interactive]
amika snapshot list [-l|--long] \
    [--sandbox <name-or-id>] [--repo <name-or-id>]  # alias: ls
amika snapshot delete <name-or-id> [...] [-f|--force]  # aliases: rm, remove
```

## Behavior

- **create** is interactive by default: prompts for the capture mode, and for `scrub_and_delete` previews the injected secrets that will be removed (via `GET /sandbox-snapshots/scrub-preview`) and confirms before the destructive capture. `--no-interactive` skips prompts and requires `--mode` and `--name`. Capture is async (202); the command points the user at `snapshot list`.
- **list** filters by `--sandbox` and `--repo`, each accepting a name or id. The CLI resolves these to ids client-side (sandbox via the sandboxes list, repo via the repositories list, matching id then repo-name basename) and passes the id-based API filters.
- **delete** forwards each `name-or-id` reference straight to the server (`by=ref`), which resolves it id-first.

## Design note

The CLI never sniffs name-vs-id itself. It forwards the raw user reference as a `ref` (the create request's `sandbox_ref` field, `by=ref` on get/delete/preview), and the API resolves it. This matches the API-side convention (`gofixpoint/amika-mono#682`).

## API client

Adds `ListSandboxSnapshots`, `CreateSandboxSnapshot`, `GetSandboxScrubPreview`, `DeleteSandboxSnapshot`, and `ListRepositories`, with httptest-based path/parse tests.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all green.
- Unit tests: client method paths/parsing, `repoBasename`, source/deref formatting, `--sandbox`/`--repo` resolution (id, name/basename, ambiguous, not-found), and `--no-interactive` validation.