### PR TITLE
Add `--snapshot` flag to `amika sandbox create`

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -85,6 +85,9 @@ amika sandbox create --branch main --new-branch bugfix-1
 # Inject remote secrets (remote sandboxes only)
 amika sandbox create --name dev-sandbox --remote \
   --secret env:ANTHROPIC_API_KEY=my-claude-key
+
+# Fork from a captured snapshot (remote sandboxes only)
+amika sandbox create --name dev-sandbox --remote --snapshot amika-mono-base
 ```
 
 #### Flags
@@ -109,6 +112,7 @@ amika sandbox create --name dev-sandbox --remote \
 | `--branch <name>`       |                      | Check out this branch, or create it if it doesn't exist. Requires a git repo (auto-detected or via `--git`)                          |
 | `--new-branch <name>`  |                      | Create a new branch (errors if it already exists). Starts from `--branch` if set, otherwise from the base branch. Requires a git repo (auto-detected or via `--git`)  |
 | `--secret <spec>`       |                      | Inject a remote secret (`env:FOO=SECRET_NAME` or `env:SECRET_NAME`). Repeatable. Requires `--remote`. See [secrets.md](secrets.md)   |
+| `--snapshot <slug>`     |                      | Fork the new sandbox from a captured snapshot slug (capture with `amika snapshot create`). Requires `--remote`                       |
 
 #### Mount modes
 

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -44,6 +44,7 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().Bool("no-git", false, "Skip git repo auto-detection; create a sandbox without mounting any repo.")
 	sandboxCreateCmd.Flags().Bool("no-clean", false, "With a local-path git source, include untracked files from the working tree instead of a clean clone. Local sandboxes only.")
 	sandboxCreateCmd.Flags().String("size", "", "Sandbox size: \"xs\", \"m\", \"l\", or \"xl\" (default \"m\", remote only)")
+	sandboxCreateCmd.Flags().String("snapshot", "", "Fork the sandbox from a captured snapshot slug (remote only)")
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().StringArray("secret", nil, "Inject a remote secret (env:FOO=SECRET_NAME or env:SECRET_NAME)")
 	sandboxCreateCmd.Flags().StringArray("agent-credential", nil, "Pin an agent credential by name (KIND=NAME, e.g. claude=personal-oauth). Repeatable per kind.")

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -36,6 +36,9 @@ var sandboxCreateCmd = &cobra.Command{
 		if mode != runmode.Remote && cmd.Flags().Changed("github-auth-mode") {
 			return fmt.Errorf("--github-auth-mode requires --remote mode")
 		}
+		if mode != runmode.Remote && cmd.Flags().Changed("snapshot") {
+			return fmt.Errorf("--snapshot requires --remote mode")
+		}
 		// Validate before the remote auth gate below so a bad value fails
 		// fast even when the caller is not logged in; otherwise the login
 		// error masks the flag error (and the contract test, which runs
@@ -302,6 +305,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 	setupScript, _ := cmd.Flags().GetString("setup-script")
 	branch, _ := cmd.Flags().GetString("branch")
 	newBranch, _ := cmd.Flags().GetString("new-branch")
+	snapshot, _ := cmd.Flags().GetString("snapshot")
 
 	if name == "" {
 		name = sandbox.GenerateName()
@@ -393,6 +397,11 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 		Branch:           branch,
 		NewBranchName:    newBranch,
 		GithubAuthMode:   githubAuthMode,
+	}
+	// Only set Snapshot when a slug was given; an unset flag leaves the field
+	// nil so the server applies its default snapshot chain.
+	if snapshot != "" {
+		req.Snapshot = &snapshot
 	}
 
 	sb, err := client.CreateSandbox(req)

--- a/go/cmd/amika/sandbox_commands_test.go
+++ b/go/cmd/amika/sandbox_commands_test.go
@@ -51,6 +51,28 @@ func TestSandboxCreateHasConnectFlag(t *testing.T) {
 	}
 }
 
+func TestSandboxCreateHasSnapshotFlag(t *testing.T) {
+	sandboxCmd := findSubcommand(t, rootCmd, "sandbox")
+	createCmd := findSubcommand(t, sandboxCmd, "create")
+	flag := createCmd.Flags().Lookup("snapshot")
+	if flag == nil {
+		t.Fatal("sandbox create command must define --snapshot")
+	}
+	if flag.Value.Type() != "string" {
+		t.Fatalf("snapshot flag type = %q, want string", flag.Value.Type())
+	}
+}
+
+func TestSandboxCreateSnapshotRequiresRemote(t *testing.T) {
+	_, err := runRootCommand("sandbox", "create", "--local", "--snapshot", "amika-mono-base")
+	if err == nil {
+		t.Fatal("expected an error when --snapshot is used without --remote")
+	}
+	if !strings.Contains(err.Error(), "--snapshot requires --remote mode") {
+		t.Fatalf("error = %v, want it to mention --snapshot requires --remote mode", err)
+	}
+}
+
 func TestSandboxListCommand_PrintsRows(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("AMIKA_STATE_DIRECTORY", dir)

--- a/go/cmd/amika/sandbox_commands_test.go
+++ b/go/cmd/amika/sandbox_commands_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func findSubcommand(t *testing.T, parent *cobra.Command, name string) *cobra.Command {
@@ -64,6 +65,17 @@ func TestSandboxCreateHasSnapshotFlag(t *testing.T) {
 }
 
 func TestSandboxCreateSnapshotRequiresRemote(t *testing.T) {
+	// runRootCommand shares the package-global rootCmd, and cobra carries flag
+	// values and their Changed state across Execute calls. Reset what this test
+	// sets so it can't leak --local/--snapshot onto later sandbox tests.
+	sandboxCmd := findSubcommand(t, rootCmd, "sandbox")
+	createCmd := findSubcommand(t, sandboxCmd, "create")
+	t.Cleanup(func() {
+		resetFlag(t, sandboxCmd.PersistentFlags().Lookup("local"))
+		resetFlag(t, sandboxCmd.PersistentFlags().Lookup("remote"))
+		resetFlag(t, createCmd.Flags().Lookup("snapshot"))
+	})
+
 	_, err := runRootCommand("sandbox", "create", "--local", "--snapshot", "amika-mono-base")
 	if err == nil {
 		t.Fatal("expected an error when --snapshot is used without --remote")
@@ -71,6 +83,20 @@ func TestSandboxCreateSnapshotRequiresRemote(t *testing.T) {
 	if !strings.Contains(err.Error(), "--snapshot requires --remote mode") {
 		t.Fatalf("error = %v, want it to mention --snapshot requires --remote mode", err)
 	}
+}
+
+// resetFlag restores a cobra/pflag flag to its declared default and clears its
+// Changed state, undoing what a runRootCommand call leaves on the shared
+// rootCmd (cobra never resets flags between Execute calls).
+func resetFlag(t *testing.T, flag *pflag.Flag) {
+	t.Helper()
+	if flag == nil {
+		return
+	}
+	if err := flag.Value.Set(flag.DefValue); err != nil {
+		t.Fatalf("reset flag %q: %v", flag.Name, err)
+	}
+	flag.Changed = false
 }
 
 func TestSandboxListCommand_PrintsRows(t *testing.T) {

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -55,6 +55,13 @@ type CreateSandboxRequest struct {
 	Branch             string               `json:"branch,omitempty"`
 	NewBranchName      string               `json:"new_branch_name,omitempty"`
 	GithubAuthMode     string               `json:"github_auth_mode,omitempty"`
+	// Snapshot forks the new sandbox from a captured snapshot slug (remote
+	// only). nil omits the field so the server applies its default snapshot
+	// chain (repo default, else preset/size); a non-nil value boots from that
+	// snapshot. The server also accepts an explicit JSON null to opt out of the
+	// repo-level default, but a *string with omitempty cannot encode that (nil
+	// omits rather than nulls), so the opt-out is not reachable from here.
+	Snapshot *string `json:"snapshot,omitempty"`
 }
 
 // AgentCredentialRef selects which credential of a given kind the server

--- a/go/internal/apiclient/client_test.go
+++ b/go/internal/apiclient/client_test.go
@@ -102,6 +102,45 @@ func TestPathEscapesSandboxName(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxSnapshotField(t *testing.T) {
+	slug := "amika-mono-base"
+	setPtr := &slug
+	tests := []struct {
+		name        string
+		snapshot    *string
+		wantPresent bool
+	}{
+		{name: "slug is sent", snapshot: setPtr, wantPresent: true},
+		{name: "nil is omitted", snapshot: nil, wantPresent: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]string{"id": "1", "name": "dev", "state": "active"})
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL, "test-token")
+			if _, err := c.CreateSandbox(CreateSandboxRequest{Name: "dev", Snapshot: tt.snapshot}); err != nil {
+				t.Fatalf("CreateSandbox: %v", err)
+			}
+
+			raw, present := body["snapshot"]
+			if present != tt.wantPresent {
+				t.Fatalf("snapshot present = %v, want %v (body=%v)", present, tt.wantPresent, body)
+			}
+			if tt.wantPresent {
+				if got, _ := raw.(string); got != slug {
+					t.Errorf("snapshot = %q, want %q", got, slug)
+				}
+			}
+		})
+	}
+}
+
 func TestGetSSHParsesResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

Brings the Go CLI to parity with the TypeScript SDK (#284) on
fork-from-snapshot: `amika sandbox create --snapshot <slug>` now boots a
remote sandbox from a captured snapshot. Part of the parity audit
(KAPRO-570).

## Changes

- **`apiclient.CreateSandboxRequest`** — new `Snapshot *string` field
  (`json:"snapshot,omitempty"`). nil omits the field (server keeps its
  default snapshot chain); a slug forks the new sandbox from that
  snapshot.
- **`--snapshot` flag** on `sandbox create`, gated to `--remote` mode
  (mirrors the existing `--github-auth-mode` guard) — the local Docker /
  OSS `/v1` path has no cloud-snapshot store.
- Docs (`cli-reference.md`) + tests.

## Testing

Ran with Go 1.25.3 against the affected packages:

- `gofmt -l` clean · `go build ./...` OK · `go vet` OK
- `go test ./internal/apiclient/... ./cmd/amika/...` — pass
- New tests: `TestCreateSandboxSnapshotField` (slug sent / nil omitted),
  `TestSandboxCreateHasSnapshotFlag`, `TestSandboxCreateSnapshotRequiresRemote`

## Known limitation

`*string` + `omitempty` can't encode the server's explicit-`null`
opt-out (the repo-default bypass the TS SDK's `snapshot: null` exposes):
nil omits the field rather than sending `null`. Supporting it would need
a custom nullable type — out of scope here, since the CLI's need is
"fork from a slug." Called out in a comment on the field.
