### PR TITLE
Add --path flag to amika sandbox code

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -68,6 +68,7 @@ func New() *cobra.Command {
 	sandboxSSHCmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
 	sandboxSSHCmd.Flags().Bool("print", false, "Print the SSH connection string instead of connecting")
 	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor to open (currently only \"cursor\" is supported)")
+	sandboxCodeCmd.Flags().String("path", "", "Override the remote path to open (absolute, or relative to the sandbox workspace root)")
 	sandboxAgentSendCmd.Flags().Bool("no-wait", false, "Send the instruction and return immediately without waiting for a response")
 	sandboxAgentSendCmd.Flags().String("workdir", "$AMIKA_AGENT_CWD", "Working directory inside the container (default: $AMIKA_AGENT_CWD)")
 	sandboxAgentSendCmd.Flags().String("agent", "claude", "Agent CLI to use (default \"claude\")")

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/basedir"
@@ -130,7 +131,8 @@ Examples:
 			return err
 		}
 
-		cursorTarget, err := prepareCursorSSHTarget(client, basedir.New(""), name)
+		pathOverride, _ := cmd.Flags().GetString("path")
+		cursorTarget, err := prepareCursorSSHTarget(client, basedir.New(""), name, pathOverride)
 		if err != nil {
 			return err
 		}
@@ -155,7 +157,13 @@ type cursorSSHTarget struct {
 	remotePath string
 }
 
-func prepareCursorSSHTarget(client *apiclient.Client, paths basedir.Paths, name string) (cursorSSHTarget, error) {
+// sshInfoClient is the subset of apiclient.Client used by prepareCursorSSHTarget.
+type sshInfoClient interface {
+	GetSSH(name string) (*apiclient.SSHInfo, error)
+	GetSandbox(name string) (*apiclient.RemoteSandbox, error)
+}
+
+func prepareCursorSSHTarget(client sshInfoClient, paths basedir.Paths, name string, pathOverride string) (cursorSSHTarget, error) {
 	info, err := client.GetSSH(name)
 	if err != nil {
 		return cursorSSHTarget{}, err
@@ -187,10 +195,24 @@ func prepareCursorSSHTarget(client *apiclient.Client, paths basedir.Paths, name 
 		return cursorSSHTarget{}, fmt.Errorf("write managed SSH config: %w", err)
 	}
 
-	remotePath := "/home/amika/workspace"
-	if info.RepoName != "" {
-		remotePath = remotePath + "/" + info.RepoName
-	}
+	return cursorSSHTarget{alias: alias, remotePath: resolveCursorRemotePath(info.RepoName, pathOverride)}, nil
+}
 
-	return cursorSSHTarget{alias: alias, remotePath: remotePath}, nil
+// resolveCursorRemotePath computes the remote path to open in the editor.
+// An absolute pathOverride is used verbatim; a relative one is joined onto
+// /home/amika so that e.g. "workspace/biz" → "/home/amika/workspace/biz".
+// When pathOverride is empty the default workspace path is used, optionally
+// extended with the repo name.
+func resolveCursorRemotePath(repoName, pathOverride string) string {
+	if pathOverride != "" {
+		if path.IsAbs(pathOverride) {
+			return pathOverride
+		}
+		return path.Join("/home/amika", pathOverride)
+	}
+	remotePath := "/home/amika/workspace"
+	if repoName != "" {
+		remotePath = remotePath + "/" + repoName
+	}
+	return remotePath
 }

--- a/go/cmd/amika/sandbox/sandbox_ssh_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_test.go
@@ -1,0 +1,160 @@
+package sandboxcmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/basedir"
+)
+
+func TestResolveCursorRemotePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		repoName     string
+		pathOverride string
+		want         string
+	}{
+		{
+			name: "no override no repo",
+			want: "/home/amika/workspace",
+		},
+		{
+			name:     "no override with repo",
+			repoName: "biz",
+			want:     "/home/amika/workspace/biz",
+		},
+		{
+			name:         "relative override resolves against home",
+			repoName:     "biz",
+			pathOverride: "workspace/biz",
+			want:         "/home/amika/workspace/biz",
+		},
+		{
+			name:         "relative override subdirectory",
+			repoName:     "biz",
+			pathOverride: "workspace/biz/src",
+			want:         "/home/amika/workspace/biz/src",
+		},
+		{
+			name:         "relative override ignores repo name",
+			repoName:     "biz",
+			pathOverride: "workspace/other",
+			want:         "/home/amika/workspace/other",
+		},
+		{
+			name:         "absolute override used verbatim",
+			repoName:     "biz",
+			pathOverride: "/custom/path",
+			want:         "/custom/path",
+		},
+		{
+			name:         "absolute override no repo",
+			pathOverride: "/home/amika/workspace/biz",
+			want:         "/home/amika/workspace/biz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveCursorRemotePath(tt.repoName, tt.pathOverride)
+			if got != tt.want {
+				t.Errorf("resolveCursorRemotePath(%q, %q) = %q, want %q",
+					tt.repoName, tt.pathOverride, got, tt.want)
+			}
+		})
+	}
+}
+
+// stubSSHClient implements sshInfoClient for testing.
+type stubSSHClient struct {
+	info    *apiclient.SSHInfo
+	sandbox *apiclient.RemoteSandbox
+}
+
+func (s *stubSSHClient) GetSSH(_ string) (*apiclient.SSHInfo, error) {
+	return s.info, nil
+}
+
+func (s *stubSSHClient) GetSandbox(_ string) (*apiclient.RemoteSandbox, error) {
+	return s.sandbox, nil
+}
+
+func testSSHPaths(t *testing.T) basedir.Paths {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(t.TempDir(), "state"))
+	return basedir.New(home)
+}
+
+func TestPrepareCursorSSHTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		info         *apiclient.SSHInfo
+		pathOverride string
+		wantAlias    string
+		wantPath     string
+	}{
+		{
+			name: "default path with repo",
+			info: &apiclient.SSHInfo{
+				SSHDestination: "-p 2222 tok@ssh.app.daytona.io",
+				SandboxID:      "sb_abc",
+				SandboxName:    "my-sandbox",
+				RepoName:       "biz",
+			},
+			wantAlias: "amika-sb_abc",
+			wantPath:  "/home/amika/workspace/biz",
+		},
+		{
+			name: "default path without repo",
+			info: &apiclient.SSHInfo{
+				SSHDestination: "-p 2222 tok@ssh.app.daytona.io",
+				SandboxID:      "sb_abc",
+				SandboxName:    "my-sandbox",
+			},
+			wantAlias: "amika-sb_abc",
+			wantPath:  "/home/amika/workspace",
+		},
+		{
+			name: "relative path override",
+			info: &apiclient.SSHInfo{
+				SSHDestination: "-p 2222 tok@ssh.app.daytona.io",
+				SandboxID:      "sb_abc",
+				SandboxName:    "my-sandbox",
+				RepoName:       "biz",
+			},
+			pathOverride: "workspace/biz",
+			wantAlias:    "amika-sb_abc",
+			wantPath:     "/home/amika/workspace/biz",
+		},
+		{
+			name: "absolute path override",
+			info: &apiclient.SSHInfo{
+				SSHDestination: "-p 2222 tok@ssh.app.daytona.io",
+				SandboxID:      "sb_abc",
+				SandboxName:    "my-sandbox",
+				RepoName:       "biz",
+			},
+			pathOverride: "/custom/path",
+			wantAlias:    "amika-sb_abc",
+			wantPath:     "/custom/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &stubSSHClient{info: tt.info}
+			got, err := prepareCursorSSHTarget(client, testSSHPaths(t), "my-sandbox", tt.pathOverride)
+			if err != nil {
+				t.Fatalf("prepareCursorSSHTarget: %v", err)
+			}
+			if got.alias != tt.wantAlias {
+				t.Errorf("alias = %q, want %q", got.alias, tt.wantAlias)
+			}
+			if got.remotePath != tt.wantPath {
+				t.Errorf("remotePath = %q, want %q", got.remotePath, tt.wantPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--path <dirpath>` flag to `amika sandbox code` that overrides the remote directory opened in Cursor
- Absolute paths are used verbatim; relative paths resolve against `/home/amika` (e.g. `workspace/biz` → `/home/amika/workspace/biz`)
- Extracts `resolveCursorRemotePath` as a pure function and narrows the client dependency to a `sshInfoClient` interface to enable unit tests without network access
- Adds `TestResolveCursorRemotePath` (7 cases) and `TestPrepareCursorSSHTarget` (4 cases) in `sandbox_ssh_test.go`