### PR TITLE
Unhide --github-auth-mode after staged rollout

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -57,8 +57,6 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().String("branch", "", "Check out this git branch, or create it if it doesn't exist.")
 	sandboxCreateCmd.Flags().String("new-branch", "", "Create a new git branch. With --branch, starts from that branch; otherwise starts from the current checkout.")
 	sandboxCreateCmd.Flags().String("github-auth-mode", "", "GitHub auth mode for the sandbox runtime: pat, app_token, or app-token (remote only; unset uses server default)")
-	// TODO(KAPRO-518): Unhide --github-auth-mode once the staged rollout is complete.
-	sandboxCreateCmd.Flags().MarkHidden("github-auth-mode")
 	sandboxListCmd.Flags().BoolP("long", "l", false, "Show additional columns (IMAGE, PORTS)")
 	sandboxDeleteCmd.Flags().Bool("force", false, "Skip confirmation prompt")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")


### PR DESCRIPTION
## Context

PR #270 added `amika sandbox create --github-auth-mode` for selecting the GitHub auth mode used by remote sandbox runtime setup. The flag accepts `pat`, `app_token`, and `app-token`, but was intentionally hidden while the staged rollout settled.

## Changes

The server behavior and docs are now ready for users to discover the flag normally, so this PR:

- Removes the `MarkHidden("github-auth-mode")` call in `go/cmd/amika/sandbox/command.go`.
- Removes the `TODO(KAPRO-518)` comment tracking the unhide.

## Verification

- `amika sandbox create --help` now lists `--github-auth-mode` with its existing description text.
- `go test ./cmd/amika/...` passes (`cmd/amika`, `cmd/amika/sandbox`, `cmd/amika/scp`).