### PR TITLE
Run setup-repo.sh from sandbox setup script

### DIFF
--- a/.amika/scripts/setup.sh
+++ b/.amika/scripts/setup.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+# In the Amika lifecycle this script is not run in place from .amika/scripts:
+# it is uploaded and executed from elsewhere with AMIKA_AGENT_CWD set to the
+# repo root, so resolve the repo from there. Fall back to a $0-relative path
+# for manual runs where AMIKA_AGENT_CWD is unset.
+REPO_ROOT="${AMIKA_AGENT_CWD:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+# Run the repo setup script (configures git hooks, etc.). Amika sandboxes
+# invoke this setup script but never run setup-repo.sh on their own, so do
+# it here to ensure git hooks are active for commits made inside the sandbox.
+"$REPO_ROOT/setup-repo.sh"
+
 # Check if Go is already installed
 if command -v go &>/dev/null; then
     echo "Go is already installed: $(go version)"


### PR DESCRIPTION
## Summary

Amika sandboxes invoke the `setup_script` declared in `.amika/config.toml` (`.amika/scripts/setup.sh`), but that script only installed Go and never ran the repo's `setup-repo.sh`. As a result git hooks were not configured in sandboxes, so commits made inside a sandbox silently skipped the pre-commit hook.

This runs `./setup-repo.sh` (which configures `core.hooksPath`) at the start of `setup.sh`, before the early return that skips the Go install when Go is already present.

Companion change in the `amika-mono` repo: gofixpoint/amika-mono#719

Closes KAPRO-171.

## Test plan

- `bash -n .amika/scripts/setup.sh` passes.
- Git hooks (`core.hooksPath`) are configured after the setup script runs.