### PR TITLE
Surface agent-send session id via --output flag

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -3,6 +3,7 @@ package sandboxcmd
 // command.go assembles the top-level sandbox command and its flags.
 
 import (
+	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 	"github.com/spf13/cobra"
 )
@@ -72,6 +73,7 @@ func New() *cobra.Command {
 	sandboxAgentSendCmd.Flags().String("agent", "claude", "Agent CLI to use (default \"claude\")")
 	sandboxAgentSendCmd.Flags().String("session-id", "", "Resume an existing agent session by ID (remote sandboxes only)")
 	sandboxAgentSendCmd.Flags().Bool("new-session", false, "Start a new agent session (remote sandboxes only)")
+	output.AddFlag(sandboxAgentSendCmd)
 
 	return sandboxCmd
 }

--- a/go/cmd/amika/sandbox/sandbox_agent.go
+++ b/go/cmd/amika/sandbox/sandbox_agent.go
@@ -3,6 +3,7 @@ package sandboxcmd
 // sandbox_agent.go implements agent-send command wiring and agent CLI helpers.
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/config"
+	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 	"github.com/gofixpoint/amika/go/internal/ssh"
@@ -125,7 +127,34 @@ func buildRemoteAgentShellCmd(message string, noWait bool, workdir string, agent
 	return cmd
 }
 
-func runRemoteAgentSend(client *apiclient.Client, name, message string, noWait bool, workdir string, agent agentConfig, opts agentRunOpts, stdout io.Writer) error {
+// agentSendJSON is the JSON rendering of a synchronous agent-send result,
+// emitted to stdout when --output json is set.
+type agentSendJSON struct {
+	SessionID      string `json:"session_id"`
+	AgentSessionID string `json:"agent_session_id,omitempty"`
+	Response       string `json:"response"`
+	IsError        bool   `json:"is_error"`
+}
+
+// checkAgentSendOutputMode rejects JSON output for agent-send modes that stream
+// raw agent output rather than a structured result. Only synchronous remote
+// sends buffer the response into the JSON object, so --local and --no-wait
+// cannot honor --output json and must fail fast instead of silently emitting
+// non-JSON text.
+func checkAgentSendOutputMode(format output.Format, mode runmode.Mode, noWait bool) error {
+	if format != output.JSON {
+		return nil
+	}
+	if mode == runmode.Local {
+		return fmt.Errorf("--output json is not supported with --local; only synchronous remote sends produce structured output")
+	}
+	if noWait {
+		return fmt.Errorf("--output json is not supported with --no-wait; only synchronous sends produce structured output")
+	}
+	return nil
+}
+
+func runRemoteAgentSend(client *apiclient.Client, name, message string, noWait bool, workdir string, agent agentConfig, opts agentRunOpts, format output.Format, stdout, stderr io.Writer) error {
 	if noWait {
 		shellCmd := buildRemoteAgentShellCmd(message, noWait, workdir, agent, opts)
 		return ssh.ExecSSH(client, name, false, []string{shellCmd})
@@ -143,13 +172,41 @@ func runRemoteAgentSend(client *apiclient.Client, name, message string, noWait b
 		return fmt.Errorf("agent-send failed for sandbox %q: %w", name, err)
 	}
 
-	fmt.Fprint(stdout, resp.Result)
-	if resp.Result != "" && !strings.HasSuffix(resp.Result, "\n") {
-		fmt.Fprintln(stdout)
+	if err := writeAgentSendResult(resp, format, stdout, stderr); err != nil {
+		return err
 	}
 
 	if resp.IsError {
 		return fmt.Errorf("agent returned an error in sandbox %q", name)
+	}
+	return nil
+}
+
+// writeAgentSendResult renders a synchronous agent-send response. In text mode
+// the agent response goes to stdout and the session id (if any) to stderr,
+// keeping stdout the pure agent output. In JSON mode a single object with the
+// session id, response, and error status is written to stdout.
+func writeAgentSendResult(resp *apiclient.AgentSendResponse, format output.Format, stdout, stderr io.Writer) error {
+	if format == output.JSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(agentSendJSON{
+			SessionID:      resp.SessionID,
+			AgentSessionID: resp.AgentSessionID,
+			Response:       resp.Result,
+			IsError:        resp.IsError,
+		}); err != nil {
+			return fmt.Errorf("failed to encode agent-send response as JSON: %w", err)
+		}
+		return nil
+	}
+
+	fmt.Fprint(stdout, resp.Result)
+	if resp.Result != "" && !strings.HasSuffix(resp.Result, "\n") {
+		fmt.Fprintln(stdout)
+	}
+	if resp.SessionID != "" {
+		fmt.Fprintf(stderr, "session_id: %s\n", resp.SessionID)
 	}
 	return nil
 }
@@ -173,7 +230,15 @@ var sandboxAgentSendCmd = &cobra.Command{
 	Long: `Send a prompt to an AI agent CLI running inside a sandbox container.
 The message can be provided as a positional argument or piped via stdin.
 By default the command waits for the agent to finish and streams the response.
-Use --no-wait to send the message and return immediately.`,
+Use --no-wait to send the message and return immediately.
+
+For synchronous remote sends, the agent session id is surfaced so the session
+can be resumed with --session-id. In text output (the default) the response is
+written to stdout and "session_id: <id>" to stderr, keeping stdout the pure
+agent response. With --output json, the session id, response, and error status
+are written to stdout as a single JSON object instead. --output json requires a
+synchronous remote send; it is rejected with --local or --no-wait, which stream
+raw agent output and produce no structured result.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
@@ -200,12 +265,20 @@ Use --no-wait to send the message and return immediately.`,
 			return err
 		}
 
+		format, err := output.Resolve(cmd)
+		if err != nil {
+			return err
+		}
+
 		target, err := getRemoteTarget(cmd)
 		if err != nil {
 			return err
 		}
 
 		mode := runmode.Resolve(cmd)
+		if err := checkAgentSendOutputMode(format, mode, noWait); err != nil {
+			return err
+		}
 		if err := runmode.RequireAuth(mode, runmode.DefaultAuthChecker); err != nil {
 			return err
 		}
@@ -244,7 +317,7 @@ Use --no-wait to send the message and return immediately.`,
 		newSession, _ := cmd.Flags().GetBool("new-session")
 		opts := agentRunOpts{SessionID: sessionID, NewSession: newSession}
 
-		if err := runRemoteAgentSend(client, name, message, noWait, workdir, agent, opts, os.Stdout); err != nil {
+		if err := runRemoteAgentSend(client, name, message, noWait, workdir, agent, opts, format, os.Stdout, os.Stderr); err != nil {
 			return err
 		}
 		if noWait {

--- a/go/cmd/amika/sandbox/sandbox_agent_test.go
+++ b/go/cmd/amika/sandbox/sandbox_agent_test.go
@@ -1,9 +1,15 @@
 package sandboxcmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/output"
+	"github.com/gofixpoint/amika/go/internal/runmode"
 )
 
 func TestBuildSandboxConnectArgs(t *testing.T) {
@@ -182,6 +188,104 @@ func TestAgentCmdPartsWithOpts(t *testing.T) {
 			t.Fatalf("got %v, want %v", got, want)
 		}
 	})
+}
+
+func TestWriteAgentSendResult(t *testing.T) {
+	t.Run("text mode writes response to stdout and session id to stderr", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		resp := &apiclient.AgentSendResponse{Result: "hello there", SessionID: "sess-42"}
+		if err := writeAgentSendResult(resp, output.Text, &stdout, &stderr); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if stdout.String() != "hello there\n" {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), "hello there\n")
+		}
+		if stderr.String() != "session_id: sess-42\n" {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), "session_id: sess-42\n")
+		}
+	})
+
+	t.Run("text mode keeps stdout pure when session id absent", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		resp := &apiclient.AgentSendResponse{Result: "just text\n"}
+		if err := writeAgentSendResult(resp, output.Text, &stdout, &stderr); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if stdout.String() != "just text\n" {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), "just text\n")
+		}
+		if stderr.String() != "" {
+			t.Fatalf("stderr = %q, want empty", stderr.String())
+		}
+	})
+
+	t.Run("json mode writes structured object to stdout only", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		resp := &apiclient.AgentSendResponse{
+			Result:         "the answer",
+			SessionID:      "sess-42",
+			AgentSessionID: "claude-abc",
+			IsError:        false,
+		}
+		if err := writeAgentSendResult(resp, output.JSON, &stdout, &stderr); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if stderr.String() != "" {
+			t.Fatalf("stderr = %q, want empty in json mode", stderr.String())
+		}
+		var got agentSendJSON
+		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+			t.Fatalf("stdout is not valid JSON: %v (%q)", err, stdout.String())
+		}
+		want := agentSendJSON{
+			SessionID:      "sess-42",
+			AgentSessionID: "claude-abc",
+			Response:       "the answer",
+			IsError:        false,
+		}
+		if got != want {
+			t.Fatalf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("json mode omits agent_session_id when empty", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		resp := &apiclient.AgentSendResponse{Result: "x", SessionID: "sess-1"}
+		if err := writeAgentSendResult(resp, output.JSON, &stdout, &stderr); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(stdout.String(), "agent_session_id") {
+			t.Fatalf("stdout = %q, should omit agent_session_id when empty", stdout.String())
+		}
+	})
+}
+
+func TestCheckAgentSendOutputMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		format  output.Format
+		mode    runmode.Mode
+		noWait  bool
+		wantErr bool
+	}{
+		{name: "text remote wait ok", format: output.Text, mode: runmode.Remote, noWait: false},
+		{name: "text local ok", format: output.Text, mode: runmode.Local, noWait: false},
+		{name: "text remote no-wait ok", format: output.Text, mode: runmode.Remote, noWait: true},
+		{name: "json remote wait ok", format: output.JSON, mode: runmode.Remote, noWait: false},
+		{name: "json local rejected", format: output.JSON, mode: runmode.Local, noWait: false, wantErr: true},
+		{name: "json remote no-wait rejected", format: output.JSON, mode: runmode.Remote, noWait: true, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkAgentSendOutputMode(tc.format, tc.mode, tc.noWait)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
 }
 
 func TestBuildRemoteAgentShellCmd(t *testing.T) {

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -475,9 +475,10 @@ type AgentSendRequest struct {
 
 // AgentSendResponse is the response from POST /api/v0beta1/sandboxes/{id}/agent-send.
 type AgentSendResponse struct {
-	Result    string `json:"response"`
-	SessionID string `json:"session_id"`
-	IsError   bool   `json:"is_error"`
+	Result         string `json:"response"`
+	SessionID      string `json:"session_id"`
+	AgentSessionID string `json:"agent_session_id"`
+	IsError        bool   `json:"is_error"`
 }
 
 // AgentSend sends a message to an agent inside a remote sandbox.

--- a/go/internal/output/output.go
+++ b/go/internal/output/output.go
@@ -1,0 +1,58 @@
+// Package output resolves the --output flag that selects how a CLI command
+// renders its result: human-readable text or machine-readable JSON. The flag
+// is registered only on commands that actually implement it (via AddFlag), so
+// commands that do not support it reject --output with an unknown-flag error
+// rather than silently emitting text.
+package output
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Format is the rendering format selected by the --output flag.
+type Format int
+
+const (
+	// Text renders human-readable output. It is the default.
+	Text Format = iota
+	// JSON renders machine-readable JSON.
+	JSON
+)
+
+// String returns the flag value that selects the format.
+func (f Format) String() string {
+	switch f {
+	case Text:
+		return "text"
+	case JSON:
+		return "json"
+	default:
+		return "unknown"
+	}
+}
+
+// FlagName is the name of the output-format flag.
+const FlagName = "output"
+
+// AddFlag registers the --output/-o flag on a command that implements it.
+// Register it only on commands that honor the flag; leaving it off other
+// commands makes Cobra reject --output there automatically.
+func AddFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP(FlagName, "o", "text", "Output format: \"text\" or \"json\"")
+}
+
+// Resolve reads the --output flag from cmd and returns the selected Format.
+// An unrecognized value is an error.
+func Resolve(cmd *cobra.Command) (Format, error) {
+	value, _ := cmd.Flags().GetString(FlagName)
+	switch value {
+	case "", "text":
+		return Text, nil
+	case "json":
+		return JSON, nil
+	default:
+		return Text, fmt.Errorf("invalid --output value %q: expected \"text\" or \"json\"", value)
+	}
+}

--- a/go/internal/output/output_test.go
+++ b/go/internal/output/output_test.go
@@ -1,0 +1,63 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newCmdWithFlag(value string, set bool) *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	AddFlag(cmd)
+	if set {
+		_ = cmd.Flags().Set(FlagName, value)
+	}
+	return cmd
+}
+
+func TestResolve(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		set     bool
+		want    Format
+		wantErr bool
+	}{
+		{name: "default is text", set: false, want: Text},
+		{name: "explicit text", value: "text", set: true, want: Text},
+		{name: "json", value: "json", set: true, want: JSON},
+		{name: "invalid value errors", value: "yaml", set: true, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Resolve(newCmdWithFlag(tc.value, tc.set))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for value %q, got nil", tc.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("Resolve() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAddFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	AddFlag(cmd)
+	f := cmd.Flags().Lookup(FlagName)
+	if f == nil {
+		t.Fatal("expected --output flag to be registered")
+	}
+	if f.Shorthand != "o" {
+		t.Fatalf("shorthand = %q, want %q", f.Shorthand, "o")
+	}
+	if f.DefValue != "text" {
+		t.Fatalf("default = %q, want %q", f.DefValue, "text")
+	}
+}


### PR DESCRIPTION
## What

`amika sandbox agent-send` received the `session_id` from the synchronous API response but silently discarded it, so callers had no way to learn the id needed to resume a session with `--session-id`.

This adds an `--output`/`-o` flag (`text` or `json`) to `agent-send` and surfaces the session id:

- **text** (default): the agent response stays the sole content of **stdout**, and `session_id: <id>` is written to **stderr** — preserving the existing workflow where stdout is the raw agent text and can be piped.
- **json**: a single object with `session_id`, `agent_session_id`, `response`, and `is_error` is written to stdout.

The flag can be placed after the positional args, e.g. `amika sandbox agent-send my-box "hi" -o json`.

## Scoping / contract

`--output` is registered **only on commands that implement it** (via `output.AddFlag`), currently just `agent-send`. Other commands (`version`, `sandbox list`, …) therefore reject `--output` with a plain unknown-flag error instead of advertising a machine-readable mode they don't honor. New commands opt in by calling `output.AddFlag` when they add JSON support.

Within `agent-send`, JSON output is additionally rejected for `--local` and `--no-wait` sends: those paths stream raw agent/Docker output and produce no structured result, so `--output json` there fails fast with a clear error rather than emitting non-JSON.

## Why no service change

The endpoint `POST /api/v0beta1/sandboxes/{id}/agent-send` already returns `session_id`; the CLI just wasn't surfacing it.

## Testing

- Unit tests for the text/json renderer (`writeAgentSendResult`), the flag parser and registration (`output.Resolve` / `output.AddFlag`), and the local/no-wait guard (`checkAgentSendOutputMode`).
- `go vet`, `gofmt`, and `revive` clean on the changed packages.
- Manually verified: `-o json` produces the structured object on a sync remote send; text mode keeps stdout pure with `session_id` on stderr; `--output` is rejected on unsupported commands and on `--local`/`--no-wait`; the flag parses after positional args.