### PR TITLE
Route `amika sandbox ssh` through the managed host alias

### DIFF
--- a/go/cmd/amika/sandbox/sandbox_agent.go
+++ b/go/cmd/amika/sandbox/sandbox_agent.go
@@ -128,7 +128,7 @@ func buildRemoteAgentShellCmd(message string, noWait bool, workdir string, agent
 func runRemoteAgentSend(client *apiclient.Client, name, message string, noWait bool, workdir string, agent agentConfig, opts agentRunOpts, stdout io.Writer) error {
 	if noWait {
 		shellCmd := buildRemoteAgentShellCmd(message, noWait, workdir, agent, opts)
-		return ssh.ExecSSH(client, name, false, []string{shellCmd})
+		return ssh.ExecSSH(client, config.SSHPaths(), name, false, []string{shellCmd})
 	}
 
 	req := apiclient.AgentSendRequest{

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -423,7 +423,7 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 
 	connect, _ := cmd.Flags().GetBool("connect")
 	if connect {
-		return ssh.ExecSSH(client, sb.Name, false, nil)
+		return ssh.ExecSSH(client, config.SSHPaths(), sb.Name, false, nil)
 	}
 
 	return nil

--- a/go/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/go/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -364,7 +364,7 @@ var sandboxConnectCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return ssh.ExecSSH(client, name, false, nil)
+		return ssh.ExecSSH(client, config.SSHPaths(), name, false, nil)
 	},
 }
 

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 	"path"
 
-	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/gofixpoint/amika/go/internal/config"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/spf13/cobra"
@@ -88,7 +88,7 @@ Examples:
 		if len(args) > 1 {
 			extraArgs = args[1:]
 		}
-		return ssh.ExecSSH(client, name, forcePTY, extraArgs)
+		return ssh.ExecSSH(client, config.SSHPaths(), name, forcePTY, extraArgs)
 	},
 }
 
@@ -132,7 +132,7 @@ Examples:
 		}
 
 		pathOverride, _ := cmd.Flags().GetString("path")
-		cursorTarget, err := prepareCursorSSHTarget(client, basedir.New(""), name, pathOverride)
+		cursorTarget, err := prepareCursorSSHTarget(client, config.SSHPaths(), name, pathOverride)
 		if err != nil {
 			return err
 		}
@@ -157,44 +157,21 @@ type cursorSSHTarget struct {
 	remotePath string
 }
 
-// sshInfoClient is the subset of apiclient.Client used by prepareCursorSSHTarget.
-type sshInfoClient interface {
-	GetSSH(name string) (*apiclient.SSHInfo, error)
-	GetSandbox(name string) (*apiclient.RemoteSandbox, error)
-}
-
-func prepareCursorSSHTarget(client sshInfoClient, paths basedir.Paths, name string, pathOverride string) (cursorSSHTarget, error) {
-	info, err := client.GetSSH(name)
+func prepareCursorSSHTarget(client ssh.InfoClient, paths basedir.Paths, name string, pathOverride string) (cursorSSHTarget, error) {
+	alias, info, options, err := ssh.ResolveHost(client, paths, name)
 	if err != nil {
 		return cursorSSHTarget{}, err
 	}
-	if info.SSHDestination == "" {
-		return cursorSSHTarget{}, fmt.Errorf("server returned empty SSH destination")
+	// Cursor connects via the alias through its own Remote-SSH machinery, which
+	// takes no extra ssh command-line options, and the managed Host block does
+	// not render arbitrary options. If the server requires any (e.g. -i or
+	// -o ProxyCommand), fail clearly instead of launching Cursor without them
+	// and letting it fail obscurely; `amika sandbox ssh` forwards them and
+	// still works. No current provider emits options, so this is unreachable
+	// today.
+	if len(options) > 0 {
+		return cursorSSHTarget{}, fmt.Errorf("sandbox %q requires ssh options %v that `amika sandbox code` cannot pass to Cursor; connect with `amika sandbox ssh %s` instead", name, options, name)
 	}
-
-	sandboxID := info.SandboxID
-	sandboxName := info.SandboxName
-	if sandboxID == "" {
-		sb, err := client.GetSandbox(name)
-		if err != nil {
-			return cursorSSHTarget{}, fmt.Errorf("look up sandbox id: %w", err)
-		}
-		sandboxID = sb.ID
-		sandboxName = sb.Name
-	}
-	if sandboxName == "" {
-		sandboxName = name
-	}
-
-	entry, err := ssh.NewHostEntry(sandboxID, sandboxName, info.SSHDestination, info.ExpiresAt)
-	if err != nil {
-		return cursorSSHTarget{}, err
-	}
-	alias, err := ssh.UpsertHost(paths, entry)
-	if err != nil {
-		return cursorSSHTarget{}, fmt.Errorf("write managed SSH config: %w", err)
-	}
-
 	return cursorSSHTarget{alias: alias, remotePath: resolveCursorRemotePath(info.RepoName, pathOverride)}, nil
 }
 

--- a/go/cmd/amika/sandbox/sandbox_ssh_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_test.go
@@ -158,3 +158,17 @@ func TestPrepareCursorSSHTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestPrepareCursorSSHTargetRejectsOptions(t *testing.T) {
+	// Cursor cannot receive ssh command-line options and the managed block does
+	// not render them, so a destination that carries options must fail clearly
+	// rather than launch Cursor without them.
+	client := &stubSSHClient{info: &apiclient.SSHInfo{
+		SSHDestination: "-i /key -o ProxyCommand=pc tok@ssh.app.daytona.io",
+		SandboxID:      "sb_abc",
+		SandboxName:    "my-sandbox",
+	}}
+	if _, err := prepareCursorSSHTarget(client, testSSHPaths(t), "my-sandbox", ""); err == nil {
+		t.Fatal("expected error when the destination requires ssh options")
+	}
+}

--- a/go/internal/basedir/basedir.go
+++ b/go/internal/basedir/basedir.go
@@ -60,13 +60,22 @@ type Paths interface {
 }
 
 type xdgPaths struct {
-	homeOverride string
+	homeOverride     string
+	stateDirOverride string
 }
 
 // New returns a Paths resolver. If homeOverride is non-empty, XDG fallback
 // directories are resolved relative to that home directory.
 func New(homeOverride string) Paths {
 	return &xdgPaths{homeOverride: homeOverride}
+}
+
+// NewWithStateDir returns a Paths resolver like New but with the Amika state
+// directory forced to stateDirOverride when it is non-empty. Callers use this
+// to honor AMIKA_STATE_DIRECTORY (read by the config package) without teaching
+// this package about that env var; an empty stateDirOverride behaves like New.
+func NewWithStateDir(homeOverride, stateDirOverride string) Paths {
+	return &xdgPaths{homeOverride: homeOverride, stateDirOverride: stateDirOverride}
 }
 
 func (p *xdgPaths) HomeDir() (string, error) {
@@ -149,6 +158,9 @@ func (p *xdgPaths) AmikaCacheDir() (string, error) {
 }
 
 func (p *xdgPaths) AmikaStateDir() (string, error) {
+	if p.stateDirOverride != "" {
+		return p.stateDirOverride, nil
+	}
 	base, err := p.StateHome()
 	if err != nil {
 		return "", err

--- a/go/internal/basedir/basedir_test.go
+++ b/go/internal/basedir/basedir_test.go
@@ -98,6 +98,39 @@ func TestPaths_SSHPaths(t *testing.T) {
 	}
 }
 
+func TestNewWithStateDir(t *testing.T) {
+	home := t.TempDir()
+	stateOverride := filepath.Join(t.TempDir(), "custom-state")
+	// XDG_STATE_HOME must be ignored in favor of the explicit override.
+	setEnv(t, envXDGStateHome, filepath.Join(t.TempDir(), "xdg"))
+
+	p := NewWithStateDir(home, stateOverride)
+
+	if got, _ := p.AmikaStateDir(); got != stateOverride {
+		t.Fatalf("AmikaStateDir = %q, want %q", got, stateOverride)
+	}
+	if got, _ := p.SSHHostsStateFile(); got != filepath.Join(stateOverride, "ssh-hosts.json") {
+		t.Fatalf("SSHHostsStateFile = %q", got)
+	}
+	// Home-relative locations are unaffected by the state override.
+	if got, _ := p.SSHConfigFile(); got != filepath.Join(home, ".ssh", "config") {
+		t.Fatalf("SSHConfigFile = %q", got)
+	}
+}
+
+func TestNewWithStateDirEmptyMatchesNew(t *testing.T) {
+	home := t.TempDir()
+	state := filepath.Join(t.TempDir(), "state")
+	setEnv(t, envXDGStateHome, state)
+
+	// An empty override must resolve exactly like New.
+	got, _ := NewWithStateDir(home, "").SSHHostsStateFile()
+	want, _ := New(home).SSHHostsStateFile()
+	if got != want {
+		t.Fatalf("SSHHostsStateFile with empty override = %q, want %q", got, want)
+	}
+}
+
 func TestSSHAmikaConfigName(t *testing.T) {
 	if got := SSHAmikaConfigName(); got != "amika.conf" {
 		t.Fatalf("SSHAmikaConfigName = %q", got)

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -50,6 +50,14 @@ func StateDir() (string, error) {
 	return basedir.New("").AmikaStateDir()
 }
 
+// SSHPaths returns a Paths resolver for the SSH commands that honors
+// AMIKA_STATE_DIRECTORY for state files (e.g. the managed SSH hosts state),
+// matching the other state-file helpers here. The managed ~/.ssh files
+// (config, amika.conf) stay at their home-relative locations.
+func SSHPaths() basedir.Paths {
+	return basedir.NewWithStateDir("", os.Getenv(EnvStateDirectory))
+}
+
 // MountsStateFile returns the resolved mounts state file path.
 func MountsStateFile() (string, error) {
 	if dir := os.Getenv(EnvStateDirectory); dir != "" {

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -85,6 +85,61 @@ func TestStateDir_XDGOverride(t *testing.T) {
 	}
 }
 
+func TestSSHPaths_Default(t *testing.T) {
+	orig := os.Getenv(EnvStateDirectory)
+	_ = os.Unsetenv(EnvStateDirectory)
+	defer func() {
+		if orig != "" {
+			_ = os.Setenv(EnvStateDirectory, orig)
+		}
+	}()
+
+	got, err := SSHPaths().SSHHostsStateFile()
+	if err != nil {
+		t.Fatalf("SSHHostsStateFile() error: %v", err)
+	}
+	want, err := basedir.New("").SSHHostsStateFile()
+	if err != nil {
+		t.Fatalf("basedir SSHHostsStateFile() error: %v", err)
+	}
+	if got != want {
+		t.Errorf("SSHPaths().SSHHostsStateFile() = %q, want %q", got, want)
+	}
+}
+
+func TestSSHPaths_EnvOverride(t *testing.T) {
+	override := t.TempDir()
+	orig := os.Getenv(EnvStateDirectory)
+	_ = os.Setenv(EnvStateDirectory, override)
+	defer func() {
+		if orig != "" {
+			_ = os.Setenv(EnvStateDirectory, orig)
+		} else {
+			_ = os.Unsetenv(EnvStateDirectory)
+		}
+	}()
+
+	p := SSHPaths()
+
+	// The SSH hosts state file follows the override...
+	got, err := p.SSHHostsStateFile()
+	if err != nil {
+		t.Fatalf("SSHHostsStateFile() error: %v", err)
+	}
+	if want := basedir.SSHHostsStateFileIn(override); got != want {
+		t.Errorf("SSHHostsStateFile() = %q, want %q", got, want)
+	}
+
+	// ...but the managed ~/.ssh files do not move under the state dir.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	if got, _ := p.SSHConfigFile(); got != filepath.Join(home, ".ssh", "config") {
+		t.Errorf("SSHConfigFile() = %q, want it under ~/.ssh", got)
+	}
+}
+
 func TestMountsStateFile_Default(t *testing.T) {
 	orig := os.Getenv(EnvStateDirectory)
 	_ = os.Unsetenv(EnvStateDirectory)

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -167,10 +167,15 @@ func isAllDigits(s string) bool {
 // NewHostEntry builds a managed host entry for a sandbox from its ssh
 // destination string and identity. The destination is parsed (rather than
 // split on whitespace) so an explicit port survives into the rendered config.
-func NewHostEntry(sandboxID, sandboxName, destination, expiresAt string) (HostEntry, error) {
+// Any extra ssh options the server includes (beyond user/host/port, e.g. -i or
+// -o ProxyCommand) are returned separately: the alias block cannot express them
+// as ssh_config directives, so a caller execing ssh must forward them on the
+// command line (as scp does; see resolveSandboxDestination in
+// cmd/amika/scp/scp.go).
+func NewHostEntry(sandboxID, sandboxName, destination, expiresAt string) (HostEntry, []string, error) {
 	d, err := ParseDestination(destination)
 	if err != nil {
-		return HostEntry{}, err
+		return HostEntry{}, nil, err
 	}
 	return HostEntry{
 		SandboxID:   sandboxID,
@@ -179,7 +184,7 @@ func NewHostEntry(sandboxID, sandboxName, destination, expiresAt string) (HostEn
 		User:        d.User,
 		Port:        d.Port,
 		ExpiresAt:   expiresAt,
-	}, nil
+	}, d.Options, nil
 }
 
 // Upsert adds or replaces the entry for a sandbox id, keeping entries sorted by
@@ -200,15 +205,40 @@ func (s *HostsState) Upsert(entry HostEntry) {
 // Render produces the contents of ~/.ssh/amika.conf from the state. Each block
 // is a stable `Host amika-<id>` alias preceded by the sandbox name as a comment
 // so the file stays human-readable even though it is keyed by id.
-func Render(state HostsState) string {
+//
+// HostKeyAlias pins host-key lookup/storage to the stable alias rather than the
+// rotating HostName. Without it OpenSSH keys known_hosts by the real HostName,
+// so `accept-new` would silently accept a fresh key whenever the gateway
+// hostname rotates (no real verification) and would flag a changed key when
+// several sandboxes share one gateway hostname. Keying by the alias makes the
+// first connection record the sandbox's key and every reconnect verify it.
+//
+// Render fails closed if any interpolated field contains a control character:
+// an embedded newline would let a value inject arbitrary ssh_config directives
+// (e.g. ProxyCommand) into a file that ~/.ssh/config includes. Upstream schemas
+// already forbid such characters, so this only guards against a future
+// regression rather than any reachable input today.
+func Render(state HostsState) (string, error) {
 	var b strings.Builder
 	b.WriteString(managedHeader)
 	for _, h := range state.Hosts {
+		alias := Alias(h.SandboxID)
+		for _, f := range []struct{ name, value string }{
+			{"sandbox id", h.SandboxID},
+			{"sandbox name", h.SandboxName},
+			{"host name", h.HostName},
+			{"user", h.User},
+		} {
+			if i := strings.IndexFunc(f.value, isControlChar); i >= 0 {
+				return "", fmt.Errorf("refusing to render ssh config: %s %q for %s contains a control character at offset %d", f.name, f.value, alias, i)
+			}
+		}
+
 		b.WriteString("\n")
 		if h.SandboxName != "" {
 			fmt.Fprintf(&b, "# %s\n", h.SandboxName)
 		}
-		fmt.Fprintf(&b, "Host %s\n", Alias(h.SandboxID))
+		fmt.Fprintf(&b, "Host %s\n", alias)
 		fmt.Fprintf(&b, "  HostName %s\n", h.HostName)
 		if h.User != "" {
 			fmt.Fprintf(&b, "  User %s\n", h.User)
@@ -216,9 +246,17 @@ func Render(state HostsState) string {
 		if h.Port != 0 {
 			fmt.Fprintf(&b, "  Port %d\n", h.Port)
 		}
+		fmt.Fprintf(&b, "  HostKeyAlias %s\n", alias)
 		b.WriteString("  StrictHostKeyChecking accept-new\n")
 	}
-	return b.String()
+	return b.String(), nil
+}
+
+// isControlChar reports whether r is an ASCII/Unicode control character. Any of
+// these in a rendered field (most dangerously a newline) could break out of its
+// directive line in the generated ssh config.
+func isControlChar(r rune) bool {
+	return r == 0x7f || r < 0x20
 }
 
 // LoadState reads the SSH hosts state, returning an empty state if the file does
@@ -258,13 +296,15 @@ func SaveState(paths basedir.Paths, state HostsState) error {
 	return writeFileAtomic(path, append(data, '\n'), 0o600)
 }
 
-// WriteAmikaConfig renders the state to ~/.ssh/amika.conf atomically.
-func WriteAmikaConfig(paths basedir.Paths, state HostsState) error {
+// WriteAmikaConfig writes already-rendered amika.conf content to
+// ~/.ssh/amika.conf atomically. Callers Render first so an invalid state is
+// rejected before any file (or the state file) is touched.
+func WriteAmikaConfig(paths basedir.Paths, rendered string) error {
 	path, err := paths.SSHAmikaConfigFile()
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(path, []byte(Render(state)), 0o600)
+	return writeFileAtomic(path, []byte(rendered), 0o600)
 }
 
 // EnsureInclude makes sure ~/.ssh/config pulls in the managed amika.conf via an
@@ -320,10 +360,17 @@ func UpsertHost(paths basedir.Paths, entry HostEntry) (string, error) {
 		return "", err
 	}
 	state.Upsert(entry)
+	// Render (and thus validate) before persisting. If the new entry is
+	// unrenderable, failing here avoids writing it to the state file, where it
+	// would otherwise wedge every later regeneration for all sandboxes.
+	rendered, err := Render(state)
+	if err != nil {
+		return "", err
+	}
 	if err := SaveState(paths, state); err != nil {
 		return "", err
 	}
-	if err := WriteAmikaConfig(paths, state); err != nil {
+	if err := WriteAmikaConfig(paths, rendered); err != nil {
 		return "", err
 	}
 	if err := EnsureInclude(paths); err != nil {

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -67,7 +67,7 @@ func TestParseDestination(t *testing.T) {
 }
 
 func TestNewHostEntry(t *testing.T) {
-	entry, err := NewHostEntry("sb_1", "my-sandbox", "-p 2222 token@ssh.app.daytona.io", "2026-06-04T18:30:00.000Z")
+	entry, options, err := NewHostEntry("sb_1", "my-sandbox", "-i /key -o ProxyCommand=pc -p 2222 token@ssh.app.daytona.io", "2026-06-04T18:30:00.000Z")
 	if err != nil {
 		t.Fatalf("NewHostEntry: %v", err)
 	}
@@ -82,10 +82,16 @@ func TestNewHostEntry(t *testing.T) {
 	if entry != want {
 		t.Fatalf("entry = %+v, want %+v", entry, want)
 	}
+	// Options beyond user/host/port cannot live in the alias block, so they are
+	// surfaced separately for the caller to forward on the ssh command line.
+	wantOptions := []string{"-i", "/key", "-o", "ProxyCommand=pc"}
+	if !reflect.DeepEqual(options, wantOptions) {
+		t.Fatalf("options = %v, want %v", options, wantOptions)
+	}
 }
 
 func TestNewHostEntryRejectsEmptyDestination(t *testing.T) {
-	if _, err := NewHostEntry("sb_1", "n", "", ""); err == nil {
+	if _, _, err := NewHostEntry("sb_1", "n", "", ""); err == nil {
 		t.Fatal("expected error for empty destination")
 	}
 }
@@ -94,8 +100,12 @@ func TestRender(t *testing.T) {
 	state := HostsState{Hosts: []HostEntry{
 		{SandboxID: "sb_1", SandboxName: "my-sandbox", HostName: "ssh.app.daytona.io", User: "token"},
 	}}
-	want := managedHeader + "\n# my-sandbox\nHost amika-sb_1\n  HostName ssh.app.daytona.io\n  User token\n  StrictHostKeyChecking accept-new\n"
-	if got := Render(state); got != want {
+	want := managedHeader + "\n# my-sandbox\nHost amika-sb_1\n  HostName ssh.app.daytona.io\n  User token\n  HostKeyAlias amika-sb_1\n  StrictHostKeyChecking accept-new\n"
+	got, err := Render(state)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if got != want {
 		t.Fatalf("Render mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
 }
@@ -104,7 +114,10 @@ func TestRenderIncludesPortAndNameComment(t *testing.T) {
 	state := HostsState{Hosts: []HostEntry{
 		{SandboxID: "sb_2", SandboxName: "named", HostName: "h", User: "u", Port: 2222},
 	}}
-	got := Render(state)
+	got, err := Render(state)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
 	if !strings.Contains(got, "  Port 2222\n") {
 		t.Errorf("expected Port line, got:\n%s", got)
 	}
@@ -112,6 +125,28 @@ func TestRenderIncludesPortAndNameComment(t *testing.T) {
 	hostIdx := strings.Index(got, "Host amika-sb_2")
 	if nameIdx < 0 || hostIdx < 0 || nameIdx > hostIdx {
 		t.Errorf("name comment should precede the Host line, got:\n%s", got)
+	}
+}
+
+func TestRenderRejectsControlCharacters(t *testing.T) {
+	// A newline in any interpolated field must be refused: it could otherwise
+	// inject arbitrary ssh_config directives (e.g. ProxyCommand) into a file
+	// that ~/.ssh/config includes.
+	fields := []HostEntry{
+		{SandboxID: "sb_1", SandboxName: "ok\n  ProxyCommand touch /tmp/pwned", HostName: "h", User: "u"},
+		{SandboxID: "sb_1", HostName: "h\n  ProxyCommand evil", User: "u"},
+		{SandboxID: "sb_1", HostName: "h", User: "u\n  ProxyCommand evil"},
+		{SandboxID: "sb_1\n  ProxyCommand evil", HostName: "h", User: "u"},
+	}
+	for _, h := range fields {
+		state := HostsState{Hosts: []HostEntry{h}}
+		got, err := Render(state)
+		if err == nil {
+			t.Errorf("Render(%+v) = %q, want error", h, got)
+		}
+		if got != "" {
+			t.Errorf("Render(%+v) returned %q on error, want empty", h, got)
+		}
 	}
 }
 

--- a/go/internal/ssh/ssh.go
+++ b/go/internal/ssh/ssh.go
@@ -11,34 +11,130 @@ import (
 	"syscall"
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/basedir"
 )
 
-// ExecSSH replaces the current process with an interactive ssh session to the
-// named sandbox. It fetches fresh connection details from the API and execs the
-// system ssh binary directly, forwarding any extra args (e.g. a remote command).
-func ExecSSH(client *apiclient.Client, name string, forcePTY bool, extraArgs []string) error {
+// InfoClient is the subset of apiclient.Client needed to resolve a sandbox's
+// managed SSH host: its rotating connection details plus, as a fallback, its
+// immutable id.
+type InfoClient interface {
+	GetSSH(name string) (*apiclient.SSHInfo, error)
+	GetSandbox(name string) (*apiclient.RemoteSandbox, error)
+}
+
+// ResolveHost fetches fresh SSH connection details for a sandbox, records (or
+// refreshes) its managed entry in ~/.ssh/amika.conf, ensures ~/.ssh/config
+// includes that file, and returns the stable alias to connect through, the raw
+// info, and any extra ssh options the server included beyond user/host/port.
+// Connecting via the alias (rather than the raw destination) is what applies
+// `StrictHostKeyChecking accept-new`, so callers avoid a "Host key verification
+// failed" error on first connect to a fresh host. The alias block cannot carry
+// options such as -i or -o ProxyCommand, so a caller execing ssh must forward
+// the returned options on the command line.
+func ResolveHost(client InfoClient, paths basedir.Paths, name string) (string, *apiclient.SSHInfo, []string, error) {
 	info, err := client.GetSSH(name)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if info.SSHDestination == "" {
+		return "", nil, nil, fmt.Errorf("server returned empty SSH destination")
+	}
+
+	sandboxID := info.SandboxID
+	sandboxName := info.SandboxName
+	if sandboxID == "" {
+		sb, err := client.GetSandbox(name)
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("look up sandbox id: %w", err)
+		}
+		sandboxID = sb.ID
+		sandboxName = sb.Name
+	}
+	if sandboxName == "" {
+		sandboxName = name
+	}
+
+	entry, options, err := NewHostEntry(sandboxID, sandboxName, info.SSHDestination, info.ExpiresAt)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	// -F replaces (rather than supplements) the config file ssh reads, so
+	// forwarding it would make ssh ignore the managed block we just wrote and
+	// try to dial the literal alias as a host. It is fundamentally incompatible
+	// with connecting through the alias, so reject it rather than silently fail
+	// to connect. No current provider emits it; this guards a future one.
+	if opt, ok := configFileOption(options); ok {
+		return "", nil, nil, fmt.Errorf("server-provided SSH option %q selects an alternate config file, which is incompatible with amika's managed host alias", opt)
+	}
+	alias, err := UpsertHost(paths, entry)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("write managed SSH config: %w", err)
+	}
+	return alias, info, options, nil
+}
+
+// configFileOption reports whether options select an alternate ssh config file
+// via -F — in any getopt spelling: "-F", attached "-Ffile", or bundled after
+// boolean flags like "-4F" — and returns the offending token. It scans each
+// option cluster the way consumesFollowingArg does rather than matching a "-F"
+// prefix: a letter that itself takes an argument ends the cluster, so an 'F'
+// after it belongs to that argument, not a config-file flag.
+//
+// -F replaces (rather than supplements) the config file ssh reads, so it is the
+// one forwarded option that defeats alias resolution outright. Other options
+// (e.g. -o) merge with the managed block; a hostile -o could still override an
+// individual directive, but the destination comes from the trusted,
+// authenticated API — the same trust the pre-existing scp forwarding assumes.
+func configFileOption(options []string) (string, bool) {
+	for _, opt := range options {
+		if len(opt) < 2 || opt[0] != '-' || opt[1] == '-' {
+			continue
+		}
+		for i := 1; i < len(opt); i++ {
+			if opt[i] == 'F' {
+				return opt, true
+			}
+			// A non-F option that consumes an argument ends the cluster; the
+			// remainder of the token is its value, not further option letters.
+			if strings.IndexByte(argTakingOptions, opt[i]) >= 0 {
+				break
+			}
+		}
+	}
+	return "", false
+}
+
+// ExecSSH replaces the current process with an interactive ssh session to the
+// named sandbox. It resolves the sandbox's managed host alias (writing the
+// managed SSH config as a side effect) and execs the system ssh binary against
+// that alias, forwarding any server-provided ssh options plus any extra args
+// (e.g. a remote command).
+func ExecSSH(client InfoClient, paths basedir.Paths, name string, forcePTY bool, extraArgs []string) error {
+	alias, _, options, err := ResolveHost(client, paths, name)
 	if err != nil {
 		return err
 	}
-	if info.SSHDestination == "" {
-		return fmt.Errorf("server returned empty SSH destination")
-	}
 
-	sshArgs := strings.Fields(info.SSHDestination)
-
-	if forcePTY {
-		dest := sshArgs[len(sshArgs)-1]
-		sshArgs = append(sshArgs[:len(sshArgs)-1], "-t", dest)
-	}
-
-	if len(extraArgs) > 0 {
-		sshArgs = append(sshArgs, extraArgs...)
-	}
+	sshArgs := buildSSHArgs(alias, options, forcePTY, extraArgs)
 
 	sshBin, err := exec.LookPath("ssh")
 	if err != nil {
 		return fmt.Errorf("ssh not found: %w", err)
 	}
 	return syscall.Exec(sshBin, append([]string{"ssh"}, sshArgs...), os.Environ())
+}
+
+// buildSSHArgs assembles the argument list for `ssh <alias>`, placing the
+// server-provided options and -t before the destination (as ssh requires) and
+// any remote command after it. The alias supplies HostName/User/Port from the
+// managed config; the options carry anything that block cannot express.
+func buildSSHArgs(alias string, options []string, forcePTY bool, extraArgs []string) []string {
+	var sshArgs []string
+	sshArgs = append(sshArgs, options...)
+	if forcePTY {
+		sshArgs = append(sshArgs, "-t")
+	}
+	sshArgs = append(sshArgs, alias)
+	sshArgs = append(sshArgs, extraArgs...)
+	return sshArgs
 }

--- a/go/internal/ssh/ssh_test.go
+++ b/go/internal/ssh/ssh_test.go
@@ -1,0 +1,188 @@
+package ssh
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+)
+
+func TestBuildSSHArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		alias     string
+		options   []string
+		forcePTY  bool
+		extraArgs []string
+		want      []string
+	}{
+		{
+			name:  "interactive session connects via alias",
+			alias: "amika-sb_abc",
+			want:  []string{"amika-sb_abc"},
+		},
+		{
+			name:      "remote command follows the destination",
+			alias:     "amika-sb_abc",
+			extraArgs: []string{"ls", "-la"},
+			want:      []string{"amika-sb_abc", "ls", "-la"},
+		},
+		{
+			name:      "forcePTY places -t before the destination",
+			alias:     "amika-sb_abc",
+			forcePTY:  true,
+			extraArgs: []string{"top"},
+			want:      []string{"-t", "amika-sb_abc", "top"},
+		},
+		{
+			name:      "server options precede the destination",
+			alias:     "amika-sb_abc",
+			options:   []string{"-i", "/key", "-o", "ProxyCommand=pc"},
+			forcePTY:  true,
+			extraArgs: []string{"top"},
+			want:      []string{"-i", "/key", "-o", "ProxyCommand=pc", "-t", "amika-sb_abc", "top"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSSHArgs(tt.alias, tt.options, tt.forcePTY, tt.extraArgs)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildSSHArgs(%q, %v, %v, %v) = %v, want %v",
+					tt.alias, tt.options, tt.forcePTY, tt.extraArgs, got, tt.want)
+			}
+		})
+	}
+}
+
+// stubInfoClient implements InfoClient for testing.
+type stubInfoClient struct {
+	info    *apiclient.SSHInfo
+	sandbox *apiclient.RemoteSandbox
+}
+
+func (s *stubInfoClient) GetSSH(_ string) (*apiclient.SSHInfo, error) {
+	return s.info, nil
+}
+
+func (s *stubInfoClient) GetSandbox(_ string) (*apiclient.RemoteSandbox, error) {
+	return s.sandbox, nil
+}
+
+func TestResolveHostWritesManagedConfig(t *testing.T) {
+	client := &stubInfoClient{info: &apiclient.SSHInfo{
+		SSHDestination: "-i /key -p 2222 tok@ssh.app.daytona.io",
+		SandboxID:      "sb_abc",
+		SandboxName:    "my-sandbox",
+	}}
+	paths := testPaths(t)
+
+	alias, info, options, err := ResolveHost(client, paths, "my-sandbox")
+	if err != nil {
+		t.Fatalf("ResolveHost: %v", err)
+	}
+	if alias != "amika-sb_abc" {
+		t.Errorf("alias = %q, want %q", alias, "amika-sb_abc")
+	}
+	if info.SSHDestination != client.info.SSHDestination {
+		t.Errorf("info.SSHDestination = %q, want %q", info.SSHDestination, client.info.SSHDestination)
+	}
+	// Options the alias block cannot express must be surfaced for forwarding.
+	if want := []string{"-i", "/key"}; !reflect.DeepEqual(options, want) {
+		t.Errorf("options = %v, want %v", options, want)
+	}
+
+	// The managed config must carry the alias block and accept-new so the first
+	// connection to a fresh host does not fail host key verification.
+	confPath, err := paths.SSHAmikaConfigFile()
+	if err != nil {
+		t.Fatalf("SSHAmikaConfigFile: %v", err)
+	}
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	if !strings.Contains(string(conf), "Host amika-sb_abc") {
+		t.Errorf("amika.conf missing alias block:\n%s", conf)
+	}
+	if !strings.Contains(string(conf), "StrictHostKeyChecking accept-new") {
+		t.Errorf("amika.conf missing accept-new:\n%s", conf)
+	}
+	// HostKeyAlias keys known_hosts by the stable alias so accept-new verifies
+	// the sandbox's key on reconnect even when the gateway HostName rotates.
+	if !strings.Contains(string(conf), "HostKeyAlias amika-sb_abc") {
+		t.Errorf("amika.conf missing HostKeyAlias:\n%s", conf)
+	}
+}
+
+func TestResolveHostFallsBackToSandboxID(t *testing.T) {
+	client := &stubInfoClient{
+		info: &apiclient.SSHInfo{
+			SSHDestination: "-p 2222 tok@ssh.app.daytona.io",
+			// SandboxID empty: an older server that predates the field.
+		},
+		sandbox: &apiclient.RemoteSandbox{ID: "sb_xyz", Name: "fallback-name"},
+	}
+
+	alias, _, _, err := ResolveHost(client, testPaths(t), "my-sandbox")
+	if err != nil {
+		t.Fatalf("ResolveHost: %v", err)
+	}
+	if alias != "amika-sb_xyz" {
+		t.Errorf("alias = %q, want %q", alias, "amika-sb_xyz")
+	}
+}
+
+func TestResolveHostEmptyDestination(t *testing.T) {
+	client := &stubInfoClient{info: &apiclient.SSHInfo{SSHDestination: ""}}
+	if _, _, _, err := ResolveHost(client, testPaths(t), "my-sandbox"); err == nil {
+		t.Fatal("expected error for empty SSH destination")
+	}
+}
+
+func TestResolveHostRejectsConfigFileOption(t *testing.T) {
+	// -F selects an alternate config file, so ssh would never see the managed
+	// alias block; reject it rather than silently fail to connect. Covers the
+	// standalone, attached, and bundled-after-a-boolean-flag getopt spellings.
+	for _, dest := range []string{
+		"-F /etc/ssh/other tok@ssh.app.daytona.io",
+		"-F/etc/ssh/other tok@ssh.app.daytona.io",
+		"-4F /etc/ssh/other tok@ssh.app.daytona.io",
+	} {
+		client := &stubInfoClient{info: &apiclient.SSHInfo{
+			SSHDestination: dest,
+			SandboxID:      "sb_abc",
+			SandboxName:    "my-sandbox",
+		}}
+		if _, _, _, err := ResolveHost(client, testPaths(t), "my-sandbox"); err == nil {
+			t.Errorf("ResolveHost(%q): expected error for -F option", dest)
+		}
+	}
+}
+
+func TestConfigFileOption(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []string
+		want    bool
+	}{
+		{name: "standalone -F", options: []string{"-F", "/etc/other"}, want: true},
+		{name: "attached -Ffile", options: []string{"-F/etc/other"}, want: true},
+		{name: "bundled after boolean flag", options: []string{"-4F", "/etc/other"}, want: true},
+		{name: "bundled with attached file", options: []string{"-4F/etc/other"}, want: true},
+		{name: "no options", options: nil, want: false},
+		{name: "identity only", options: []string{"-i", "/key"}, want: false},
+		{name: "option value ends cluster before F", options: []string{"-o", "SendEnv=FOO"}, want: false},
+		{name: "F inside another option's attached value", options: []string{"-iF"}, want: false},
+		{name: "jump host", options: []string{"-J", "gw@host"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, got := configFileOption(tt.options); got != tt.want {
+				t.Errorf("configFileOption(%v) = %v, want %v", tt.options, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`amika sandbox ssh` fails with **"Host key verification failed"** on first connect to a fresh sandbox host ([KAPRO-561](https://linear.app/fixpoint/issue/KAPRO-561/amika-sandbox-ssh-fails-with-host-key-verification-failed-on-first-use)).

`ExecSSH` execed `ssh` against the raw connection string from the API (e.g. `tok@ssh.app.daytona.io`). That destination never matched the `Host amika-<id>` block in `~/.ssh/amika.conf`, so the block's `StrictHostKeyChecking accept-new` was never applied. With no `known_hosts` entry, ssh falls back to prompting — and in non-interactive use (a remote command, piped stdin, CI) the prompt can't be answered, so the connection fails.

`amika sandbox code` was unaffected because it connects via the stable alias `amika-<id>`, which does carry `accept-new`.

Note: simply calling `EnsureInclude()` from the ssh path — as the issue originally proposed — would not have fixed it, because the raw destination still wouldn't match the alias block.

## Fix

**Core change** — route `amika sandbox ssh` through the managed alias:

- Extract the "resolve sandbox id → upsert managed host → return alias" logic (previously inline in `prepareCursorSSHTarget`) into a shared `ssh.ResolveHost` helper.
- Route `ExecSSH` through the alias `amika-<id>` instead of the raw destination, so `StrictHostKeyChecking accept-new` applies and first connect no longer fails.
- All `ExecSSH` call sites (`ssh`, `agent --no-wait`, `create --connect`, `attach`) now pass base-dir paths and benefit from the fix.

**Correctness / robustness follow-ups** (surfaced by review):

- **Forward server-provided ssh options.** The raw destination may carry options beyond user/host/port (e.g. `-i`, `-o …`) that the alias block cannot express. `ResolveHost` now surfaces them and `ExecSSH` forwards them on the command line ahead of the alias, mirroring how `scp` already forwards them.
- **Render `HostKeyAlias <alias>`.** OpenSSH keys `known_hosts` by the real `HostName`, not the alias, unless `HostKeyAlias` is set. Without it, `accept-new` would silently accept a fresh key whenever the gateway hostname rotates and would flag changed keys when sandboxes share a gateway. With it, the first connect records the sandbox's key under its stable id and every reconnect verifies against it.
- **Reject `-F` in forwarded options.** Unlike other options, `-F` *replaces* the config file ssh reads, so forwarding it would make ssh ignore the managed block and dial the literal alias as a host. `ResolveHost` rejects it (all getopt spellings) with a clear error.

**Security hardening:**

- **Fail closed on control characters in `Render`.** `~/.ssh/amika.conf` is `Include`d by `~/.ssh/config`; an embedded newline in an interpolated field (sandbox name/id, host, user) could inject arbitrary ssh_config directives (e.g. `ProxyCommand`). Upstream schemas already forbid such characters, so this is unreachable today, but the render seam now enforces it itself rather than trusting distant invariants. Validation runs before the state file is persisted so a bad entry can't wedge later regenerations.

No current provider (Daytona, Freestyle, Vercel) emits options in `ssh_destination`, so the option-forwarding, `-F`, and injection paths are defense-in-depth against a future provider rather than live bugs.

## Testing

- `go build ./...`, `go vet ./internal/ssh/... ./cmd/amika/sandbox/...` — clean
- `go test ./internal/ssh/... ./cmd/amika/sandbox/...` — pass
- `gofmt` clean
- New/updated tests cover: `buildSSHArgs` arg ordering (options / `-t` / alias / command); `ResolveHost` (writes alias block + `accept-new` + `HostKeyAlias`, surfaces options, sandbox-id fallback, empty-destination error, `-F` rejection in all forms); `configFileOption` getopt-cluster matching; and `Render` rejecting control characters in every interpolated field.

## Review

Cleared Codex review (P1 option forwarding + two P2s: `HostKeyAlias`, `-F`) and an independent review pass (bundled-`-F` guard hole, validate-before-persist ordering), all addressed.