### PR TITLE
Add claude/codex editors to `sandbox code`

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -222,16 +222,29 @@ amika sandbox ssh my-sandbox --revoke
 
 ### `amika sandbox code`
 
-Open a remote sandbox in an editor via SSH.
+Open a remote sandbox in an editor or coding agent via SSH. All editors connect
+through the same Amika-managed SSH host alias (`amika-<id>`, written to
+`~/.ssh/amika.conf` and included from `~/.ssh/config`):
+
+- `cursor` launches Cursor connected to the sandbox.
+- `claude` registers the sandbox as a Claude Desktop SSH environment (in
+  `~/.claude/settings.json`), then opens Claude Desktop; pick `Amika: <name>`
+  from the environment dropdown.
+- `codex` enables Codex's `remote_connections` feature (in
+  `~/.codex/config.toml`), then opens Codex; enable the host under
+  Settings > Connections.
 
 ```bash
 amika sandbox code my-sandbox
 amika sandbox code my-sandbox --editor=cursor
+amika sandbox code my-sandbox --editor=claude
+amika sandbox code my-sandbox --editor=codex
 ```
 
-| Flag               | Default  | Description                      |
-| ------------------ | -------- | -------------------------------- |
-| `--editor <name>`  | `cursor` | Editor to open (currently only `cursor` is supported) |
+| Flag              | Default  | Description                                              |
+| ----------------- | -------- | -------------------------------------------------------- |
+| `--editor <name>` | `cursor` | Editor or agent to open: `cursor`, `claude`, or `codex`  |
+| `--path <path>`   | —        | Override the remote path to open (absolute, or relative to the sandbox workspace root) |
 
 ### `amika sandbox agent-send`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -234,6 +234,10 @@ through the same Amika-managed SSH host alias (`amika-<id>`, written to
   `~/.codex/config.toml`), then opens Codex; enable the host under
   Settings > Connections.
 
+The `claude` and `codex` editors are gated behind a feature flag: set
+`AMIKA_OPEN_CLAUDE_CODEX_SUPPORT=true` to enable them (`cursor` is always
+available).
+
 ```bash
 amika sandbox code my-sandbox
 amika sandbox code my-sandbox --editor=cursor

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -66,7 +66,7 @@ func New() *cobra.Command {
 	sandboxSSHCmd.Flags().BoolP("t", "t", false, "Force pseudo-terminal allocation (like ssh -t)")
 	sandboxSSHCmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
 	sandboxSSHCmd.Flags().Bool("print", false, "Print the SSH connection string instead of connecting")
-	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor to open (currently only \"cursor\" is supported)")
+	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor or agent to open: \"cursor\", \"claude\", or \"codex\"")
 	sandboxCodeCmd.Flags().String("path", "", "Override the remote path to open (absolute, or relative to the sandbox workspace root)")
 	sandboxAgentSendCmd.Flags().Bool("no-wait", false, "Send the instruction and return immediately without waiting for a response")
 	sandboxAgentSendCmd.Flags().String("workdir", "$AMIKA_AGENT_CWD", "Working directory inside the container (default: $AMIKA_AGENT_CWD)")

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/appcfg"
 	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/ssh"
@@ -92,21 +94,35 @@ Examples:
 	},
 }
 
+// supportedEditors lists the values accepted by `sandbox code --editor`.
+var supportedEditors = []string{"cursor", "claude", "codex"}
+
 var sandboxCodeCmd = &cobra.Command{
 	Use:   "code <name>",
-	Short: "Open a remote sandbox in an editor via SSH",
-	Long: `Open a remote sandbox in an editor (e.g. Cursor) using SSH remote access.
+	Short: "Open a remote sandbox in an editor or agent via SSH",
+	Long: `Open a remote sandbox in an editor or coding agent using SSH remote access.
+
+Supported --editor values:
+  cursor   launch Cursor connected to the sandbox (default)
+  claude   register the sandbox as a Claude Desktop SSH environment
+  codex    expose the sandbox to Codex as an SSH connection
+
+For claude and codex, the command writes the local app config so the sandbox
+appears as a remote environment; select it in the app to start the session.
 
 Examples:
   amika sandbox code my-sandbox
-  amika sandbox code my-sandbox --editor=cursor`,
+  amika sandbox code my-sandbox --editor=cursor
+  amika sandbox code my-sandbox --editor=claude
+  amika sandbox code my-sandbox --editor=codex`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		editor, _ := cmd.Flags().GetString("editor")
-
-		if editor != "cursor" {
-			return fmt.Errorf("unsupported editor %q; currently only \"cursor\" is supported", editor)
+		switch editor {
+		case "cursor", "claude", "codex":
+		default:
+			return fmt.Errorf("unsupported editor %q; supported editors are %q", editor, supportedEditors)
 		}
 
 		mode := runmode.Resolve(cmd)
@@ -115,10 +131,6 @@ Examples:
 		}
 		if err := runmode.RequireAuth(mode, runmode.DefaultAuthChecker); err != nil {
 			return err
-		}
-
-		if _, err := exec.LookPath("cursor"); err != nil {
-			return fmt.Errorf("cursor CLI is not installed or not in PATH; install it from Cursor > Settings > Extensions > cursor-cli")
 		}
 
 		target, err := getRemoteTarget(cmd)
@@ -132,44 +144,44 @@ Examples:
 		}
 
 		pathOverride, _ := cmd.Flags().GetString("path")
-		cursorTarget, err := prepareCursorSSHTarget(client, basedir.New(""), name, pathOverride)
-		if err != nil {
-			return err
-		}
+		paths := basedir.New("")
 
-		cursorCmd := exec.Command("cursor", "--remote", "ssh-remote+"+cursorTarget.alias, cursorTarget.remotePath)
-		cursorCmd.Stdin = os.Stdin
-		cursorCmd.Stdout = os.Stdout
-		cursorCmd.Stderr = os.Stderr
-
-		fmt.Fprintf(cmd.OutOrStdout(), "Opening sandbox %q in Cursor via SSH (%s)...\n", name, cursorTarget.alias)
-		fmt.Fprintf(cmd.OutOrStdout(), "Running: cursor --remote ssh-remote+%s %s\n", cursorTarget.alias, cursorTarget.remotePath)
-		fmt.Fprintf(cmd.OutOrStdout(), "Hint: if the file explorer is not visible, press Cmd+Shift+E in Cursor to open it.\n")
-		if err := cursorCmd.Run(); err != nil {
-			return fmt.Errorf("cursor failed: %w\n\nMake sure the \"Remote - SSH\" extension is installed in Cursor", err)
+		switch editor {
+		case "cursor":
+			return openSandboxInCursor(cmd, client, paths, name, pathOverride)
+		case "claude":
+			return openSandboxInClaude(cmd, client, paths, name, pathOverride)
+		case "codex":
+			return openSandboxInCodex(cmd, client, paths, name, pathOverride)
 		}
 		return nil
 	},
 }
 
-type cursorSSHTarget struct {
-	alias      string
-	remotePath string
+// sandboxSSHAlias is the stable Amika-managed SSH alias for a sandbox plus the
+// identity needed to label and locate it, shared by every `code` editor.
+type sandboxSSHAlias struct {
+	alias       string
+	sandboxName string
+	repoName    string
 }
 
-// sshInfoClient is the subset of apiclient.Client used by prepareCursorSSHTarget.
+// sshInfoClient is the subset of apiclient.Client used to resolve SSH aliases.
 type sshInfoClient interface {
 	GetSSH(name string) (*apiclient.SSHInfo, error)
 	GetSandbox(name string) (*apiclient.RemoteSandbox, error)
 }
 
-func prepareCursorSSHTarget(client sshInfoClient, paths basedir.Paths, name string, pathOverride string) (cursorSSHTarget, error) {
+// resolveSandboxSSHAlias mints SSH access for the sandbox and upserts it into
+// the Amika-managed SSH config, returning the stable `amika-<id>` Host alias.
+// Every `code` editor connects through this single alias.
+func resolveSandboxSSHAlias(client sshInfoClient, paths basedir.Paths, name string) (sandboxSSHAlias, error) {
 	info, err := client.GetSSH(name)
 	if err != nil {
-		return cursorSSHTarget{}, err
+		return sandboxSSHAlias{}, err
 	}
 	if info.SSHDestination == "" {
-		return cursorSSHTarget{}, fmt.Errorf("server returned empty SSH destination")
+		return sandboxSSHAlias{}, fmt.Errorf("server returned empty SSH destination")
 	}
 
 	sandboxID := info.SandboxID
@@ -177,7 +189,7 @@ func prepareCursorSSHTarget(client sshInfoClient, paths basedir.Paths, name stri
 	if sandboxID == "" {
 		sb, err := client.GetSandbox(name)
 		if err != nil {
-			return cursorSSHTarget{}, fmt.Errorf("look up sandbox id: %w", err)
+			return sandboxSSHAlias{}, fmt.Errorf("look up sandbox id: %w", err)
 		}
 		sandboxID = sb.ID
 		sandboxName = sb.Name
@@ -188,22 +200,120 @@ func prepareCursorSSHTarget(client sshInfoClient, paths basedir.Paths, name stri
 
 	entry, err := ssh.NewHostEntry(sandboxID, sandboxName, info.SSHDestination, info.ExpiresAt)
 	if err != nil {
-		return cursorSSHTarget{}, err
+		return sandboxSSHAlias{}, err
 	}
 	alias, err := ssh.UpsertHost(paths, entry)
 	if err != nil {
-		return cursorSSHTarget{}, fmt.Errorf("write managed SSH config: %w", err)
+		return sandboxSSHAlias{}, fmt.Errorf("write managed SSH config: %w", err)
 	}
 
-	return cursorSSHTarget{alias: alias, remotePath: resolveCursorRemotePath(info.RepoName, pathOverride)}, nil
+	return sandboxSSHAlias{alias: alias, sandboxName: sandboxName, repoName: info.RepoName}, nil
 }
 
-// resolveCursorRemotePath computes the remote path to open in the editor.
+// openSandboxInCursor launches Cursor connected to the sandbox over SSH.
+func openSandboxInCursor(cmd *cobra.Command, client sshInfoClient, paths basedir.Paths, name, pathOverride string) error {
+	if _, err := exec.LookPath("cursor"); err != nil {
+		return fmt.Errorf("cursor CLI is not installed or not in PATH; install it from Cursor > Settings > Extensions > cursor-cli")
+	}
+
+	target, err := prepareCursorSSHTarget(client, paths, name, pathOverride)
+	if err != nil {
+		return err
+	}
+
+	cursorCmd := exec.Command("cursor", "--remote", "ssh-remote+"+target.alias, target.remotePath)
+	cursorCmd.Stdin = os.Stdin
+	cursorCmd.Stdout = os.Stdout
+	cursorCmd.Stderr = os.Stderr
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Opening sandbox %q in Cursor via SSH (%s)...\n", name, target.alias)
+	fmt.Fprintf(cmd.OutOrStdout(), "Running: cursor --remote ssh-remote+%s %s\n", target.alias, target.remotePath)
+	fmt.Fprintf(cmd.OutOrStdout(), "Hint: if the file explorer is not visible, press Cmd+Shift+E in Cursor to open it.\n")
+	if err := cursorCmd.Run(); err != nil {
+		return fmt.Errorf("cursor failed: %w\n\nMake sure the \"Remote - SSH\" extension is installed in Cursor", err)
+	}
+	return nil
+}
+
+// openSandboxInClaude registers the sandbox as an SSH environment in Claude
+// Desktop's settings and opens the app so the user can select it. Claude
+// Desktop cannot be pointed at an SSH environment via a deep link, so the user
+// picks it from the environment dropdown to start the remote session.
+func openSandboxInClaude(cmd *cobra.Command, client sshInfoClient, paths basedir.Paths, name, pathOverride string) error {
+	target, err := resolveSandboxSSHAlias(client, paths, name)
+	if err != nil {
+		return err
+	}
+
+	host := appcfg.ClaudeSSHHost{
+		ID:             target.alias,
+		Name:           "Amika: " + target.sandboxName,
+		SSHHost:        target.alias,
+		StartDirectory: resolveRemoteWorkspacePath(target.repoName, pathOverride),
+	}
+	if _, err := appcfg.UpsertClaudeSSHConfig(paths, host); err != nil {
+		return fmt.Errorf("write Claude settings: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Registered SSH environment %q for sandbox %q in Claude Desktop.\n", host.Name, name)
+	if err := openApp("claude://code/new"); err != nil {
+		fmt.Fprintf(out, "Could not launch Claude Desktop automatically (%v); open it yourself.\n", err)
+	} else {
+		fmt.Fprintf(out, "Opening Claude Desktop...\n")
+	}
+	fmt.Fprintf(out, "In the Code tab, choose %q from the environment dropdown to start the remote session.\n", host.Name)
+	return nil
+}
+
+// openSandboxInCodex enables Codex's remote-connections feature (the SSH alias
+// is already in ~/.ssh/config via the Amika include) and opens the app. Codex
+// has no deep link to connect to a host, so the user enables the alias under
+// Settings > Connections.
+func openSandboxInCodex(cmd *cobra.Command, client sshInfoClient, paths basedir.Paths, name, pathOverride string) error {
+	target, err := resolveSandboxSSHAlias(client, paths, name)
+	if err != nil {
+		return err
+	}
+
+	if _, err := appcfg.EnableCodexRemoteConnections(paths); err != nil {
+		return fmt.Errorf("enable Codex remote connections: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Enabled Codex remote connections; SSH host %q for sandbox %q is available from ~/.ssh/config.\n", target.alias, name)
+	if err := openApp("codex://"); err != nil {
+		fmt.Fprintf(out, "Could not launch Codex automatically (%v); open it yourself.\n", err)
+	} else {
+		fmt.Fprintf(out, "Opening Codex...\n")
+	}
+	fmt.Fprintf(out, "In Codex, open Settings > Connections, enable host %q, and choose a remote folder (e.g. %s).\n",
+		target.alias, resolveRemoteWorkspacePath(target.repoName, pathOverride))
+	return nil
+}
+
+type cursorSSHTarget struct {
+	alias      string
+	remotePath string
+}
+
+func prepareCursorSSHTarget(client sshInfoClient, paths basedir.Paths, name string, pathOverride string) (cursorSSHTarget, error) {
+	target, err := resolveSandboxSSHAlias(client, paths, name)
+	if err != nil {
+		return cursorSSHTarget{}, err
+	}
+	return cursorSSHTarget{
+		alias:      target.alias,
+		remotePath: resolveRemoteWorkspacePath(target.repoName, pathOverride),
+	}, nil
+}
+
+// resolveRemoteWorkspacePath computes the remote path to open in the editor.
 // An absolute pathOverride is used verbatim; a relative one is joined onto
 // /home/amika so that e.g. "workspace/biz" → "/home/amika/workspace/biz".
 // When pathOverride is empty the default workspace path is used, optionally
 // extended with the repo name.
-func resolveCursorRemotePath(repoName, pathOverride string) string {
+func resolveRemoteWorkspacePath(repoName, pathOverride string) string {
 	if pathOverride != "" {
 		if path.IsAbs(pathOverride) {
 			return pathOverride
@@ -215,4 +325,24 @@ func resolveCursorRemotePath(repoName, pathOverride string) string {
 		remotePath = remotePath + "/" + repoName
 	}
 	return remotePath
+}
+
+// openApp hands a URL scheme to the OS so the associated desktop app launches
+// (or focuses). Best-effort: it returns once the opener starts, not when the
+// app is ready. It is a var so tests can stub out the real launch.
+var openApp = func(url string) error {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		c = exec.Command("open", url)
+	case "linux":
+		c = exec.Command("xdg-open", url)
+	case "windows":
+		// `start` treats its first quoted argument as the window title, so pass
+		// an empty title before the URL.
+		c = exec.Command("cmd", "/c", "start", "", url)
+	default:
+		return fmt.Errorf("unsupported platform %q", runtime.GOOS)
+	}
+	return c.Start()
 }

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
+	"strings"
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/appcfg"
@@ -16,6 +17,31 @@ import (
 	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/spf13/cobra"
 )
+
+// claudeCodexSupportEnv gates the claude/codex editors. They stay off until it
+// is set to "true", mirroring the webapp's NEXT_PUBLIC_OPEN_CLAUDE_CODEX_SUPPORT
+// flag so the two roll out together.
+const claudeCodexSupportEnv = "AMIKA_OPEN_CLAUDE_CODEX_SUPPORT"
+
+func claudeCodexEditorsEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(claudeCodexSupportEnv)), "true")
+}
+
+// validateEditor checks that the requested editor is known and enabled. cursor
+// is always available; claude and codex require claudeCodexSupportEnv.
+func validateEditor(editor string) error {
+	switch editor {
+	case "cursor":
+		return nil
+	case "claude", "codex":
+		if !claudeCodexEditorsEnabled() {
+			return fmt.Errorf("editor %q is not enabled; set %s=true to enable it", editor, claudeCodexSupportEnv)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported editor %q; supported editors are %q", editor, supportedEditors)
+	}
+}
 
 var sandboxSSHCmd = &cobra.Command{
 	Use:   "ssh [flags] <name> [-- <command>...]",
@@ -109,6 +135,8 @@ Supported --editor values:
 
 For claude and codex, the command writes the local app config so the sandbox
 appears as a remote environment; select it in the app to start the session.
+These two editors are gated: set AMIKA_OPEN_CLAUDE_CODEX_SUPPORT=true to enable
+them.
 
 Examples:
   amika sandbox code my-sandbox
@@ -119,10 +147,8 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		editor, _ := cmd.Flags().GetString("editor")
-		switch editor {
-		case "cursor", "claude", "codex":
-		default:
-			return fmt.Errorf("unsupported editor %q; supported editors are %q", editor, supportedEditors)
+		if err := validateEditor(editor); err != nil {
+			return err
 		}
 
 		mode := runmode.Resolve(cmd)

--- a/go/cmd/amika/sandbox/sandbox_ssh_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_test.go
@@ -106,6 +106,43 @@ func testSSHPaths(t *testing.T) (basedir.Paths, string) {
 	return basedir.New(home), home
 }
 
+func TestValidateEditor(t *testing.T) {
+	t.Run("cursor is always allowed", func(t *testing.T) {
+		t.Setenv(claudeCodexSupportEnv, "")
+		if err := validateEditor("cursor"); err != nil {
+			t.Fatalf("cursor should be allowed: %v", err)
+		}
+	})
+
+	t.Run("unknown editor is rejected", func(t *testing.T) {
+		t.Setenv(claudeCodexSupportEnv, "true")
+		if err := validateEditor("vim"); err == nil {
+			t.Fatalf("expected unknown editor to be rejected")
+		}
+	})
+
+	for _, editor := range []string{"claude", "codex"} {
+		t.Run(editor+" gated off by default", func(t *testing.T) {
+			t.Setenv(claudeCodexSupportEnv, "")
+			if err := validateEditor(editor); err == nil {
+				t.Fatalf("expected %q to be gated when the flag is unset", editor)
+			}
+		})
+		t.Run(editor+" enabled when flag is true", func(t *testing.T) {
+			t.Setenv(claudeCodexSupportEnv, "true")
+			if err := validateEditor(editor); err != nil {
+				t.Fatalf("expected %q to be allowed when flag is set: %v", editor, err)
+			}
+		})
+		t.Run(editor+" gated when flag is a non-true value", func(t *testing.T) {
+			t.Setenv(claudeCodexSupportEnv, "1")
+			if err := validateEditor(editor); err == nil {
+				t.Fatalf("expected %q to be gated when flag is %q", editor, "1")
+			}
+		})
+	}
+}
+
 func daytonaInfo() *apiclient.SSHInfo {
 	return &apiclient.SSHInfo{
 		SSHDestination: "-p 2222 tok@ssh.app.daytona.io",

--- a/go/cmd/amika/sandbox/sandbox_ssh_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_test.go
@@ -1,14 +1,33 @@
 package sandboxcmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/spf13/cobra"
 )
 
-func TestResolveCursorRemotePath(t *testing.T) {
+// stubOpenApp replaces openApp with a recorder for the duration of a test so
+// no real desktop app is launched.
+func stubOpenApp(t *testing.T) *[]string {
+	t.Helper()
+	var opened []string
+	prev := openApp
+	openApp = func(url string) error {
+		opened = append(opened, url)
+		return nil
+	}
+	t.Cleanup(func() { openApp = prev })
+	return &opened
+}
+
+func TestResolveRemoteWorkspacePath(t *testing.T) {
 	tests := []struct {
 		name         string
 		repoName     string
@@ -57,9 +76,9 @@ func TestResolveCursorRemotePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveCursorRemotePath(tt.repoName, tt.pathOverride)
+			got := resolveRemoteWorkspacePath(tt.repoName, tt.pathOverride)
 			if got != tt.want {
-				t.Errorf("resolveCursorRemotePath(%q, %q) = %q, want %q",
+				t.Errorf("resolveRemoteWorkspacePath(%q, %q) = %q, want %q",
 					tt.repoName, tt.pathOverride, got, tt.want)
 			}
 		})
@@ -80,11 +99,110 @@ func (s *stubSSHClient) GetSandbox(_ string) (*apiclient.RemoteSandbox, error) {
 	return s.sandbox, nil
 }
 
-func testSSHPaths(t *testing.T) basedir.Paths {
+func testSSHPaths(t *testing.T) (basedir.Paths, string) {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", filepath.Join(t.TempDir(), "state"))
-	return basedir.New(home)
+	return basedir.New(home), home
+}
+
+func daytonaInfo() *apiclient.SSHInfo {
+	return &apiclient.SSHInfo{
+		SSHDestination: "-p 2222 tok@ssh.app.daytona.io",
+		SandboxID:      "sb_abc",
+		SandboxName:    "my-sandbox",
+		RepoName:       "biz",
+	}
+}
+
+func TestOpenSandboxInClaude(t *testing.T) {
+	opened := stubOpenApp(t)
+	paths, home := testSSHPaths(t)
+	client := &stubSSHClient{info: daytonaInfo()}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	if err := openSandboxInClaude(cmd, client, paths, "my-sandbox", ""); err != nil {
+		t.Fatalf("openSandboxInClaude: %v", err)
+	}
+
+	// The stable alias landed in the managed SSH config.
+	amikaConf, err := os.ReadFile(filepath.Join(home, ".ssh", "amika.conf"))
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	if !bytes.Contains(amikaConf, []byte("Host amika-sb_abc")) {
+		t.Fatalf("amika.conf missing alias:\n%s", amikaConf)
+	}
+
+	// The Claude environment was registered against that alias.
+	var doc struct {
+		SSHConfigs []struct {
+			ID             string `json:"id"`
+			Name           string `json:"name"`
+			SSHHost        string `json:"sshHost"`
+			StartDirectory string `json:"startDirectory"`
+		} `json:"sshConfigs"`
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read claude settings: %v", err)
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse claude settings: %v", err)
+	}
+	if len(doc.SSHConfigs) != 1 {
+		t.Fatalf("expected 1 sshConfigs entry, got %d", len(doc.SSHConfigs))
+	}
+	got := doc.SSHConfigs[0]
+	if got.ID != "amika-sb_abc" || got.SSHHost != "amika-sb_abc" || got.Name != "Amika: my-sandbox" {
+		t.Fatalf("unexpected entry: %+v", got)
+	}
+	if got.StartDirectory != "/home/amika/workspace/biz" {
+		t.Fatalf("startDirectory = %q, want /home/amika/workspace/biz", got.StartDirectory)
+	}
+	if len(*opened) != 1 || (*opened)[0] != "claude://code/new" {
+		t.Fatalf("expected claude deep link to be opened, got %v", *opened)
+	}
+}
+
+func TestOpenSandboxInCodex(t *testing.T) {
+	opened := stubOpenApp(t)
+	paths, home := testSSHPaths(t)
+	client := &stubSSHClient{info: daytonaInfo()}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	if err := openSandboxInCodex(cmd, client, paths, "my-sandbox", ""); err != nil {
+		t.Fatalf("openSandboxInCodex: %v", err)
+	}
+
+	amikaConf, err := os.ReadFile(filepath.Join(home, ".ssh", "amika.conf"))
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	if !bytes.Contains(amikaConf, []byte("Host amika-sb_abc")) {
+		t.Fatalf("amika.conf missing alias:\n%s", amikaConf)
+	}
+
+	var cfg struct {
+		Features struct {
+			RemoteConnections bool `toml:"remote_connections"`
+		} `toml:"features"`
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read codex config: %v", err)
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse codex config: %v", err)
+	}
+	if !cfg.Features.RemoteConnections {
+		t.Fatalf("expected features.remote_connections=true, got %s", data)
+	}
+	if len(*opened) != 1 || (*opened)[0] != "codex://" {
+		t.Fatalf("expected codex deep link to be opened, got %v", *opened)
+	}
 }
 
 func TestPrepareCursorSSHTarget(t *testing.T) {
@@ -145,7 +263,8 @@ func TestPrepareCursorSSHTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := &stubSSHClient{info: tt.info}
-			got, err := prepareCursorSSHTarget(client, testSSHPaths(t), "my-sandbox", tt.pathOverride)
+			paths, _ := testSSHPaths(t)
+			got, err := prepareCursorSSHTarget(client, paths, "my-sandbox", tt.pathOverride)
 			if err != nil {
 				t.Fatalf("prepareCursorSSHTarget: %v", err)
 			}

--- a/go/internal/appcfg/appcfg.go
+++ b/go/internal/appcfg/appcfg.go
@@ -1,0 +1,64 @@
+// Package appcfg writes local configuration for third-party coding apps
+// (Claude Desktop, Codex) so they can open Amika sandboxes over SSH.
+//
+// The SSH connection itself is defined once in the Amika-managed SSH config
+// (see internal/ssh): a stable `amika-<id>` Host alias in ~/.ssh/amika.conf,
+// pulled into ~/.ssh/config via an Include. Both Claude Desktop and Codex read
+// ~/.ssh/config, so all this package does is make each app aware of that alias:
+//
+//   - Claude Desktop keeps SSH environments in ~/.claude/settings.json under
+//     `sshConfigs`; we upsert an entry whose `sshHost` is the alias.
+//   - Codex reads host aliases straight from ~/.ssh/config once the
+//     `remote_connections` feature is enabled in ~/.codex/config.toml.
+package appcfg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic writes data to path via a temp file + rename so a concurrent
+// reader never observes a partially written file. The parent directory is
+// created 0700 and the file is written 0600, matching how the SSH config and
+// other Amika-managed dotfiles are persisted.
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".amika-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file to %s: %w", path, err)
+	}
+	return nil
+}
+
+// readFileOrEmpty returns the file contents, or nil if the file does not exist.
+func readFileOrEmpty(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/go/internal/appcfg/appcfg_test.go
+++ b/go/internal/appcfg/appcfg_test.go
@@ -1,0 +1,207 @@
+package appcfg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gofixpoint/amika/go/internal/basedir"
+)
+
+func newPaths(t *testing.T) (basedir.Paths, string) {
+	t.Helper()
+	home := t.TempDir()
+	return basedir.New(home), home
+}
+
+func TestUpsertClaudeSSHConfigCreatesFile(t *testing.T) {
+	paths, home := newPaths(t)
+	host := ClaudeSSHHost{ID: "amika-abc", Name: "Amika: my-sandbox", SSHHost: "amika-abc", StartDirectory: "/home/amika/workspace/repo"}
+
+	changed, err := UpsertClaudeSSHConfig(paths, host)
+	if err != nil {
+		t.Fatalf("UpsertClaudeSSHConfig: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true when creating the file")
+	}
+
+	var doc struct {
+		SSHConfigs []claudeSSHConfigEntry `json:"sshConfigs"`
+	}
+	readJSON(t, filepath.Join(home, ".claude", "settings.json"), &doc)
+	if len(doc.SSHConfigs) != 1 {
+		t.Fatalf("expected 1 sshConfigs entry, got %d", len(doc.SSHConfigs))
+	}
+	got := doc.SSHConfigs[0]
+	if got != host.entry() {
+		t.Fatalf("entry mismatch: got %+v want %+v", got, host.entry())
+	}
+}
+
+func TestUpsertClaudeSSHConfigPreservesOtherKeysAndEntries(t *testing.T) {
+	paths, home := newPaths(t)
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-existing settings with an unrelated top-level key and a foreign
+	// sshConfigs entry that carries a field Amika does not model.
+	seed := `{
+  "model": "opus",
+  "sshConfigs": [
+    {"id": "other", "name": "Other", "sshHost": "other@host", "sshPort": 2222}
+  ]
+}`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	host := ClaudeSSHHost{ID: "amika-abc", Name: "Amika: sb", SSHHost: "amika-abc"}
+	if _, err := UpsertClaudeSSHConfig(paths, host); err != nil {
+		t.Fatalf("UpsertClaudeSSHConfig: %v", err)
+	}
+
+	doc := map[string]json.RawMessage{}
+	readJSON(t, path, &doc)
+	if _, ok := doc["model"]; !ok {
+		t.Fatalf("unrelated top-level key 'model' was dropped")
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal(doc["sshConfigs"], &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (foreign + amika), got %d", len(entries))
+	}
+	// The foreign entry keeps its unmodeled sshPort field.
+	var foreignKept bool
+	for _, e := range entries {
+		if e["id"] == "other" && e["sshPort"] != nil {
+			foreignKept = true
+		}
+	}
+	if !foreignKept {
+		t.Fatalf("foreign entry's sshPort field was dropped: %+v", entries)
+	}
+}
+
+func TestUpsertClaudeSSHConfigIdempotent(t *testing.T) {
+	paths, _ := newPaths(t)
+	host := ClaudeSSHHost{ID: "amika-abc", Name: "Amika: sb", SSHHost: "amika-abc"}
+
+	if _, err := UpsertClaudeSSHConfig(paths, host); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := UpsertClaudeSSHConfig(paths, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatalf("expected changed=false on a no-op re-run")
+	}
+}
+
+func TestUpsertClaudeSSHConfigUpdatesExisting(t *testing.T) {
+	paths, home := newPaths(t)
+	host := ClaudeSSHHost{ID: "amika-abc", Name: "Amika: sb", SSHHost: "amika-abc", StartDirectory: "/home/amika/workspace/a"}
+	if _, err := UpsertClaudeSSHConfig(paths, host); err != nil {
+		t.Fatal(err)
+	}
+
+	host.StartDirectory = "/home/amika/workspace/b"
+	changed, err := UpsertClaudeSSHConfig(paths, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true when start directory changes")
+	}
+	var doc struct {
+		SSHConfigs []claudeSSHConfigEntry `json:"sshConfigs"`
+	}
+	readJSON(t, filepath.Join(home, ".claude", "settings.json"), &doc)
+	if len(doc.SSHConfigs) != 1 || doc.SSHConfigs[0].StartDirectory != "/home/amika/workspace/b" {
+		t.Fatalf("expected single updated entry, got %+v", doc.SSHConfigs)
+	}
+}
+
+func TestEnableCodexRemoteConnections(t *testing.T) {
+	paths, home := newPaths(t)
+	changed, err := EnableCodexRemoteConnections(paths)
+	if err != nil {
+		t.Fatalf("EnableCodexRemoteConnections: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true when creating the file")
+	}
+
+	doc := map[string]any{}
+	readTOML(t, filepath.Join(home, ".codex", "config.toml"), &doc)
+	features, _ := doc["features"].(map[string]any)
+	if enabled, _ := features["remote_connections"].(bool); !enabled {
+		t.Fatalf("expected features.remote_connections=true, got %+v", doc)
+	}
+
+	// Second run is a no-op.
+	changed, err = EnableCodexRemoteConnections(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatalf("expected changed=false on a no-op re-run")
+	}
+}
+
+func TestEnableCodexRemoteConnectionsPreservesOtherKeys(t *testing.T) {
+	paths, home := newPaths(t)
+	path := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	seed := "model = \"gpt-5\"\n\n[features]\nother_flag = true\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnableCodexRemoteConnections(paths); err != nil {
+		t.Fatalf("EnableCodexRemoteConnections: %v", err)
+	}
+
+	doc := map[string]any{}
+	readTOML(t, path, &doc)
+	if doc["model"] != "gpt-5" {
+		t.Fatalf("unrelated key 'model' was dropped: %+v", doc)
+	}
+	features, _ := doc["features"].(map[string]any)
+	if enabled, _ := features["remote_connections"].(bool); !enabled {
+		t.Fatalf("remote_connections not enabled: %+v", doc)
+	}
+	if kept, _ := features["other_flag"].(bool); !kept {
+		t.Fatalf("existing features.other_flag was dropped: %+v", doc)
+	}
+}
+
+func readJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+}
+
+func readTOML(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := toml.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+}

--- a/go/internal/appcfg/claude.go
+++ b/go/internal/appcfg/claude.go
@@ -1,0 +1,119 @@
+package appcfg
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gofixpoint/amika/go/internal/basedir"
+)
+
+// ClaudeSSHHost describes an SSH environment to register in Claude Desktop's
+// settings under `sshConfigs`. SSHHost is a ~/.ssh/config Host alias (the
+// Amika-managed `amika-<id>`), so port/user/auth come from the SSH config
+// rather than being duplicated here.
+type ClaudeSSHHost struct {
+	ID             string
+	Name           string
+	SSHHost        string
+	StartDirectory string
+}
+
+// claudeSSHConfigEntry is the on-disk JSON shape of a Claude `sshConfigs` entry.
+// Only the fields Amika manages are modeled; the entry is fully owned by Amika
+// (keyed by its `id`), so re-marshaling it is lossless for our purposes.
+type claudeSSHConfigEntry struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	SSHHost        string `json:"sshHost"`
+	StartDirectory string `json:"startDirectory,omitempty"`
+}
+
+func (h ClaudeSSHHost) entry() claudeSSHConfigEntry {
+	return claudeSSHConfigEntry{
+		ID:             h.ID,
+		Name:           h.Name,
+		SSHHost:        h.SSHHost,
+		StartDirectory: h.StartDirectory,
+	}
+}
+
+// UpsertClaudeSSHConfig adds or updates an SSH environment in
+// ~/.claude/settings.json. Every other setting in the file is preserved, as are
+// all other `sshConfigs` entries (including any fields Amika does not model);
+// only the entry whose `id` matches host.ID is replaced. It reports whether the
+// file was changed, so callers can stay quiet when the environment is already
+// registered. A missing settings file is created.
+func UpsertClaudeSSHConfig(paths basedir.Paths, host ClaudeSSHHost) (bool, error) {
+	path, err := paths.ClaudeSettingsFile()
+	if err != nil {
+		return false, err
+	}
+	raw, err := readFileOrEmpty(path)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	// Preserve every top-level key by decoding into raw messages and only
+	// touching `sshConfigs`.
+	doc := map[string]json.RawMessage{}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return false, fmt.Errorf("parse %s (is it valid JSON?): %w", path, err)
+		}
+	}
+
+	// Preserve unknown fields on other entries by keeping them as raw messages.
+	var entries []json.RawMessage
+	if existing, ok := doc["sshConfigs"]; ok && len(bytes.TrimSpace(existing)) > 0 {
+		if err := json.Unmarshal(existing, &entries); err != nil {
+			return false, fmt.Errorf("parse sshConfigs in %s: %w", path, err)
+		}
+	}
+
+	desired := host.entry()
+	desiredRaw, err := json.Marshal(desired)
+	if err != nil {
+		return false, err
+	}
+
+	found := false
+	for i, e := range entries {
+		var probe struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(e, &probe); err != nil {
+			continue
+		}
+		if probe.ID != host.ID {
+			continue
+		}
+		found = true
+		// Already registered identically: nothing to do.
+		var current claudeSSHConfigEntry
+		if json.Unmarshal(e, &current) == nil && current == desired {
+			return false, nil
+		}
+		entries[i] = desiredRaw
+		break
+	}
+	if !found {
+		entries = append(entries, desiredRaw)
+	}
+
+	newList, err := json.Marshal(entries)
+	if err != nil {
+		return false, err
+	}
+	doc["sshConfigs"] = newList
+
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	out = append(out, '\n')
+	if err := writeFileAtomic(path, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/go/internal/appcfg/codex.go
+++ b/go/internal/appcfg/codex.go
@@ -1,0 +1,58 @@
+package appcfg
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gofixpoint/amika/go/internal/basedir"
+)
+
+// EnableCodexRemoteConnections ensures ~/.codex/config.toml enables the
+// `remote_connections` feature, which lets the Codex app pick up SSH host
+// aliases from ~/.ssh/config:
+//
+//	[features]
+//	remote_connections = true
+//
+// Every other key in the file is preserved. It reports whether the file was
+// changed, so callers stay quiet when the feature is already on, and only
+// rewrites the file when the flag actually needs flipping (a rewrite drops TOML
+// comments and reorders keys, so we avoid it otherwise). A missing file is
+// created.
+func EnableCodexRemoteConnections(paths basedir.Paths) (bool, error) {
+	path, err := paths.CodexConfigFile()
+	if err != nil {
+		return false, err
+	}
+	raw, err := readFileOrEmpty(path)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	doc := map[string]any{}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		if err := toml.Unmarshal(raw, &doc); err != nil {
+			return false, fmt.Errorf("parse %s (is it valid TOML?): %w", path, err)
+		}
+	}
+
+	features, _ := doc["features"].(map[string]any)
+	if features == nil {
+		features = map[string]any{}
+	}
+	if enabled, ok := features["remote_connections"].(bool); ok && enabled {
+		return false, nil
+	}
+	features["remote_connections"] = true
+	doc["features"] = features
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
+		return false, fmt.Errorf("encode %s: %w", path, err)
+	}
+	if err := writeFileAtomic(path, buf.Bytes()); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/go/internal/basedir/basedir.go
+++ b/go/internal/basedir/basedir.go
@@ -23,6 +23,10 @@ const (
 	sshDirName          = ".ssh"
 	sshConfigFile       = "config"
 	sshAmikaConfigFile  = "amika.conf"
+	claudeDirName       = ".claude"
+	claudeSettingsFile  = "settings.json"
+	codexDirName        = ".codex"
+	codexConfigFile     = "config.toml"
 	envXDGConfigHome    = "XDG_CONFIG_HOME"
 	envXDGDataHome      = "XDG_DATA_HOME"
 	envXDGCacheHome     = "XDG_CACHE_HOME"
@@ -57,6 +61,9 @@ type Paths interface {
 	SSHDir() (string, error)
 	SSHConfigFile() (string, error)
 	SSHAmikaConfigFile() (string, error)
+
+	ClaudeSettingsFile() (string, error)
+	CodexConfigFile() (string, error)
 }
 
 type xdgPaths struct {
@@ -272,6 +279,26 @@ func (p *xdgPaths) SSHAmikaConfigFile() (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, sshAmikaConfigFile), nil
+}
+
+// ClaudeSettingsFile returns the Claude Desktop / Claude Code settings file at
+// ~/.claude/settings.json, where SSH environments live under `sshConfigs`.
+func (p *xdgPaths) ClaudeSettingsFile() (string, error) {
+	home, err := p.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, claudeDirName, claudeSettingsFile), nil
+}
+
+// CodexConfigFile returns the Codex config file at ~/.codex/config.toml, where
+// the `remote_connections` feature flag is set.
+func (p *xdgPaths) CodexConfigFile() (string, error) {
+	home, err := p.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, codexDirName, codexConfigFile), nil
 }
 
 // MountsStateFileIn returns the mounts state file path under the given state directory.


### PR DESCRIPTION
## What

Extends `amika sandbox code --editor` (previously cursor-only) with **`claude`** and **`codex`**, so a sandbox can be opened in Claude Desktop or Codex over SSH — modeled on the existing Cursor flow.

```bash
amika sandbox code my-sandbox --editor=claude
amika sandbox code my-sandbox --editor=codex
```

## How

All three editors connect through the **same** Amika-managed SSH host alias (`amika-<id>`, written to `~/.ssh/amika.conf` and included from `~/.ssh/config` by the existing `ssh.UpsertHost`). Each editor then does its app-specific glue:

| Editor   | Extra local config                                                                 | Launch |
| -------- | ---------------------------------------------------------------------------------- | ------ |
| `cursor` | none (existing behavior)                                                           | `cursor --remote ssh-remote+<alias>` |
| `claude` | upsert an `sshConfigs` entry in `~/.claude/settings.json` (`sshHost` = alias)       | open `claude://code/new`; user picks `Amika: <name>` from the environment dropdown |
| `codex`  | enable `remote_connections` in `~/.codex/config.toml` (alias already in `~/.ssh/config`) | open `codex://`; user enables the host under Settings → Connections |

Neither Claude Desktop nor Codex can be pointed at an SSH host by a deep link, so the command writes the config and prints which environment/host to select.

### Changes
- New `internal/appcfg` package: `UpsertClaudeSSHConfig` (JSON) and `EnableCodexRemoteConnections` (TOML). Both preserve unrelated keys/entries and are idempotent (only write when something changes).
- `internal/basedir`: `ClaudeSettingsFile()` (`~/.claude/settings.json`) and `CodexConfigFile()` (`~/.codex/config.toml`).
- Refactored `sandbox_ssh.go` to share alias resolution (`resolveSandboxSSHAlias`) across all editors; `openApp` is a var so tests can stub the launch.
- Updated `docs/cli-reference.md`.

## Testing
- `go build ./...`, `gofmt -l`, `go vet` — clean.
- New unit tests assert the real files get written: `~/.ssh/amika.conf` alias, the `settings.json` sshConfigs entry, and the `config.toml` flag; plus merge/idempotency for `appcfg`.

## Notes
- For the Codex flow to actually connect, `codex` must be on the sandbox's remote `PATH` (Claude Desktop auto-installs its remote agent; Codex does not). If the coder image doesn't ship `codex`, that's a separate image change.
- Paired with the webapp change (gofixpoint/amika-mono#737), whose buttons copy these commands.

## Feature flag

`--editor=claude` and `--editor=codex` are **gated off by default**. They require `AMIKA_OPEN_CLAUDE_CODEX_SUPPORT=true`; otherwise the command errors with how to enable them. `cursor` is always available. This mirrors the webapp's `NEXT_PUBLIC_OPEN_CLAUDE_CODEX_SUPPORT` flag (gofixpoint/amika-mono#737) so the CLI and UI roll out together.
