### PR TITLE
Bind opencode web to 0.0.0.0 explicitly

### DIFF
--- a/go/internal/sandbox/presets/opencode-setup.sh
+++ b/go/internal/sandbox/presets/opencode-setup.sh
@@ -11,4 +11,4 @@ amika_agent_cwd="$1"
 opencode_web_port="$2"
 
 cd "$amika_agent_cwd"
-exec opencode web --port "$opencode_web_port" --mdns
+exec opencode web --port "$opencode_web_port" --hostname 0.0.0.0


### PR DESCRIPTION
## Change

`opencode-setup.sh`: replace `--mdns` with an explicit `--hostname 0.0.0.0`.

OpenCode web is reached through the sandbox's signed external preview URL, so it must bind to all interfaces. Previously `--mdns` was the only thing setting the bind host to `0.0.0.0` — as a side effect of also advertising the server as `opencode.local` over multicast DNS.

That mDNS advertisement is useless for external-URL access and relies on multicast that is typically unavailable/noisy in a cloud VM, so we bind the host directly and drop mDNS.

## Note

Per the OpenCode 1.18.4 investigation, the "create session does nothing / no filesystem" symptom traced to the missing `auth_token` URL param, not reachability (the server was already bound to `0.0.0.0` via `--mdns`). This change is correct hygiene and removes reliance on the mDNS side-effect, but the auth-param work (deferred) is what will restore session creation and filesystem visibility.