### PR TITLE
Pin opencode-ai to 1.18.4 in coder images

### DIFF
--- a/go/internal/sandbox/presets/coder-dind/Dockerfile
+++ b/go/internal/sandbox/presets/coder-dind/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install -g pnpm typescript tsx
 # of postinstall behavior.
 ARG AGENT_CLI_CACHE_BUST=
 RUN echo "agent-cli-cache-bust: $AGENT_CLI_CACHE_BUST" \
-    && npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
+    && npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai@1.18.4 \
     && chown -R amika:amika /home/amika
 
 USER amika

--- a/go/internal/sandbox/presets/coder/Dockerfile
+++ b/go/internal/sandbox/presets/coder/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install -g pnpm typescript tsx
 # of postinstall behavior.
 ARG AGENT_CLI_CACHE_BUST=
 RUN echo "agent-cli-cache-bust: $AGENT_CLI_CACHE_BUST" \
-    && npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
+    && npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai@1.18.4 \
     && chown -R amika:amika /home/amika
 
 USER amika


### PR DESCRIPTION
## Problem

`opencode-ai` was installed unpinned in the `coder` and `coder-dind` presets, so every base-snapshot rebuild floated to whatever npm `latest` was at build time. A recent rebuild pulled a newer OpenCode that regressed the sandbox web UI (blank screen from a CSP inline-script hash mismatch, plus auth/session behavior changes).

## Fix

Pin `opencode-ai@1.18.4` (current `latest`, the version now installed) in both `coder/Dockerfile` and `coder-dind/Dockerfile` so snapshot rebuilds are deterministic while we get this version working.

## Note

This pins the install but does not rebuild. The Daytona images build `FROM amika/coder:latest`, so the pin takes effect on the next base-snapshot rebuild. Worth confirming `opencode --version` reports `1.18.4` in the current snapshot.