### PR TITLE
Add amika service create/delete CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
 - `app/` — Application service layer implementation
 - `ports/` — Port interfaces for Docker and store operations
 - `output/` — CLI output formatting for the `--output`/`-o` flag (`text`, `json`, `json-pretty`)
+- `services/` — Shared sandbox-service logic used by CLI and API, e.g. `ValidatePort` (rejects out-of-range and reserved container ports)
 - `materialize/` — Local sandbox script execution and rsync copying (v0 legacy)
 - `eventlog/` — amikalog's hook installer + capture: appends events (one JSON line each) to a per-session JSONL file `<state>/events/{claude,codex}/sessions/{ts}_{session_id}.jsonl`, annotated with git context. `push.go` uploads each changed session file in parallel via an `Uploader`, tracking each file's uploaded byte size in `<state>/events/.amikalog-push-state.json` so only sessions that grew are re-sent (object key = `<repo>/<source>/sessions/<ts>_<session_id>.jsonl`, repo from each session's `git.repo_root`; legacy per-event `event_*.json` files are still uploaded for backward compatibility)
 
@@ -118,7 +119,7 @@ language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
 - Linting uses [revive](https://github.com/mgechev/revive) — config in `go/revive.toml`
 - All exported symbols must have doc comments (enforced by the `exported` rule)
 - No external dependencies need to be installed for linting; `make lint` uses `go run`
-- Ports 60899–60999 are reserved inside sandbox containers for Amika services. See `docs/sandbox-configuration.md` for the allocation table.
+- Ports 60899–60999 are reserved inside sandbox containers for Amika services. See `docs/sandbox-configuration.md` for the allocation table. Any command or API that accepts a user-specified container port must reject this range by calling `services.ValidatePort` (`go/internal/services`); keep client-side and server-side validation in sync.
 
 ## Documentation Style
 

--- a/go/cmd/amika/service.go
+++ b/go/cmd/amika/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
+	"github.com/gofixpoint/amika/go/internal/services"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +25,16 @@ type serviceListItem struct {
 	Sandbox string `json:"sandbox"`
 	Ports   string `json:"ports"`
 	URL     string `json:"url"`
+}
+
+// serviceCreateResult is the JSON representation of a newly created service,
+// mirroring the NAME/PORT/SCHEME/URL columns printService renders in text mode.
+// URL is empty (not the "-" text placeholder) when no URL has been provisioned.
+type serviceCreateResult struct {
+	Name      string `json:"name"`
+	Port      int    `json:"port"`
+	URLScheme string `json:"url_scheme"`
+	URL       string `json:"url"`
 }
 
 var serviceCmd = &cobra.Command{
@@ -78,8 +89,8 @@ func runServiceCreate(cmd *cobra.Command, _ []string) error {
 	if port == 0 {
 		return fmt.Errorf("--port is required")
 	}
-	if port < 1 || port > 65535 {
-		return fmt.Errorf("invalid --port %d: must be between 1 and 65535", port)
+	if err := services.ValidatePort(port); err != nil {
+		return err
 	}
 	if strings.TrimSpace(urlScheme) == "" {
 		return fmt.Errorf("--url-scheme is required")
@@ -105,6 +116,11 @@ func runServiceCreate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	format, err := output.FormatFrom(cmd)
+	if err != nil {
+		return err
+	}
+
 	svc, err := runmode.NewRemoteClient().CreateSandboxService(sandboxRef, apiclient.SandboxServiceRequest{
 		Name:      name,
 		Port:      port,
@@ -112,6 +128,14 @@ func runServiceCreate(cmd *cobra.Command, _ []string) error {
 	})
 	if err != nil {
 		return err
+	}
+	if format.IsJSON() {
+		return format.JSON(cmd.OutOrStdout(), serviceCreateResult{
+			Name:      svc.Name,
+			Port:      svc.Port,
+			URLScheme: svc.URLScheme,
+			URL:       deref(svc.URL),
+		})
 	}
 	printService(cmd, svc)
 	return nil
@@ -129,6 +153,11 @@ func runServiceDelete(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--name is required")
 	}
 
+	format, err := output.FormatFrom(cmd)
+	if err != nil {
+		return err
+	}
+
 	// Validate --remote-target up front, unconditionally, matching `service
 	// list`: a bad value fails the same way regardless of mode or auth state.
 	if _, err := getServiceRemoteTarget(cmd); err != nil {
@@ -144,6 +173,9 @@ func runServiceDelete(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !force {
+		if format.IsJSON() {
+			return fmt.Errorf("refusing to prompt for confirmation with --%s %s; pass --force to delete", output.FlagName, format)
+		}
 		reader := bufio.NewReader(cmd.InOrStdin())
 		confirmed, err := confirmAction(
 			fmt.Sprintf("Delete service %q from sandbox %q?", name, sandboxRef),
@@ -160,6 +192,9 @@ func runServiceDelete(cmd *cobra.Command, _ []string) error {
 
 	if err := runmode.NewRemoteClient().DeleteSandboxService(sandboxRef, name); err != nil {
 		return err
+	}
+	if format.IsJSON() {
+		return format.JSON(cmd.OutOrStdout(), output.ItemResult{Name: name, Status: "deleted"})
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Service %q deleted\n", name)
 	return nil

--- a/go/cmd/amika/service.go
+++ b/go/cmd/amika/service.go
@@ -170,7 +170,11 @@ func runServiceDelete(cmd *cobra.Command, _ []string) error {
 func printService(cmd *cobra.Command, svc *apiclient.SandboxServiceResource) {
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tPORT\tSCHEME\tURL")
-	fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", svc.Name, svc.Port, svc.URLScheme, deref(svc.URL))
+	url := deref(svc.URL)
+	if url == "" {
+		url = "-"
+	}
+	fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", svc.Name, svc.Port, svc.URLScheme, url)
 	w.Flush()
 }
 

--- a/go/cmd/amika/service.go
+++ b/go/cmd/amika/service.go
@@ -88,6 +88,20 @@ func runServiceCreate(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("invalid --url-scheme %q: must be \"http\" or \"https\"", urlScheme)
 	}
 
+	// Validate --remote-target up front, unconditionally, matching `service
+	// list`: a bad value fails the same way regardless of mode or auth state.
+	if _, err := getServiceRemoteTarget(cmd); err != nil {
+		return err
+	}
+
+	mode := runmode.Resolve(cmd)
+	if mode == runmode.Local {
+		return fmt.Errorf("service create is only supported for remote sandboxes; omit --local (local sandbox services are declared in the repo config at creation time)")
+	}
+	if err := runmode.RequireAuth(mode, runmode.DefaultAuthChecker); err != nil {
+		return err
+	}
+
 	svc, err := runmode.NewRemoteClient().CreateSandboxService(sandboxRef, apiclient.SandboxServiceRequest{
 		Name:      name,
 		Port:      port,
@@ -110,6 +124,20 @@ func runServiceDelete(cmd *cobra.Command, _ []string) error {
 	}
 	if strings.TrimSpace(name) == "" {
 		return fmt.Errorf("--name is required")
+	}
+
+	// Validate --remote-target up front, unconditionally, matching `service
+	// list`: a bad value fails the same way regardless of mode or auth state.
+	if _, err := getServiceRemoteTarget(cmd); err != nil {
+		return err
+	}
+
+	mode := runmode.Resolve(cmd)
+	if mode == runmode.Local {
+		return fmt.Errorf("service delete is only supported for remote sandboxes; omit --local (local sandbox services are declared in the repo config at creation time)")
+	}
+	if err := runmode.RequireAuth(mode, runmode.DefaultAuthChecker); err != nil {
+		return err
 	}
 
 	if !force {

--- a/go/cmd/amika/service.go
+++ b/go/cmd/amika/service.go
@@ -27,16 +27,6 @@ type serviceListItem struct {
 	URL     string `json:"url"`
 }
 
-// serviceCreateResult is the JSON representation of a newly created service,
-// mirroring the NAME/PORT/SCHEME/URL columns printService renders in text mode.
-// URL is empty (not the "-" text placeholder) when no URL has been provisioned.
-type serviceCreateResult struct {
-	Name      string `json:"name"`
-	Port      int    `json:"port"`
-	URLScheme string `json:"url_scheme"`
-	URL       string `json:"url"`
-}
-
 var serviceCmd = &cobra.Command{
 	Use:     "service",
 	Aliases: []string{"services"},
@@ -130,12 +120,10 @@ func runServiceCreate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if format.IsJSON() {
-		return format.JSON(cmd.OutOrStdout(), serviceCreateResult{
-			Name:      svc.Name,
-			Port:      svc.Port,
-			URLScheme: svc.URLScheme,
-			URL:       deref(svc.URL),
-		})
+		// Remote-backed command: emit the API's response schema verbatim (see
+		// AGENTS.md "Remote-backed commands emit the API's response schema") so
+		// every field round-trips, including the id and a pending url as null.
+		return format.JSON(cmd.OutOrStdout(), svc)
 	}
 	printService(cmd, svc)
 	return nil
@@ -206,11 +194,15 @@ func runServiceDelete(cmd *cobra.Command, _ []string) error {
 func printService(cmd *cobra.Command, svc *apiclient.SandboxServiceResource) {
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tPORT\tSCHEME\tURL")
+	scheme := deref(svc.URLScheme)
+	if scheme == "" {
+		scheme = "-"
+	}
 	url := deref(svc.URL)
 	if url == "" {
 		url = "-"
 	}
-	fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", svc.Name, svc.Port, svc.URLScheme, url)
+	fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", svc.Name, svc.Port, scheme, url)
 	w.Flush()
 }
 

--- a/go/cmd/amika/service.go
+++ b/go/cmd/amika/service.go
@@ -78,6 +78,9 @@ func runServiceCreate(cmd *cobra.Command, _ []string) error {
 	if port == 0 {
 		return fmt.Errorf("--port is required")
 	}
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("invalid --port %d: must be between 1 and 65535", port)
+	}
 	if strings.TrimSpace(urlScheme) == "" {
 		return fmt.Errorf("--url-scheme is required")
 	}

--- a/go/cmd/amika/service.go
+++ b/go/cmd/amika/service.go
@@ -165,8 +165,9 @@ func runServiceDelete(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// printService renders a single created/updated service as a one-row table,
-// matching the columns of `service list`.
+// printService renders a single created service as a one-row table
+// (NAME/PORT/SCHEME/URL), using the same "-" placeholder as `service list`
+// when no URL has been provisioned.
 func printService(cmd *cobra.Command, svc *apiclient.SandboxServiceResource) {
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tPORT\tSCHEME\tURL")

--- a/go/cmd/amika/service.go
+++ b/go/cmd/amika/service.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"regexp"
 	"strings"
 	"text/tabwriter"
 
@@ -25,9 +27,120 @@ type serviceListItem struct {
 }
 
 var serviceCmd = &cobra.Command{
-	Use:   "service",
-	Short: "Manage sandbox services",
-	Long:  `View and manage declared services and their port bindings across sandboxes.`,
+	Use:     "service",
+	Aliases: []string{"services"},
+	Short:   "Manage sandbox services",
+	Long:    `View and manage declared services and their port bindings across sandboxes.`,
+}
+
+// dnsLabelRe matches a single RFC 1123 DNS label (a sandbox service name):
+// lowercase letters, digits, and hyphens, not starting or ending with a hyphen.
+// Length (1-63) is enforced separately. The server is the source of truth; this
+// is a fast client-side check so obviously invalid names fail before a round
+// trip.
+var dnsLabelRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// validateServiceName checks name against the single-DNS-label rules.
+func validateServiceName(name string) error {
+	if len(name) > 63 || !dnsLabelRe.MatchString(name) {
+		return fmt.Errorf("invalid --name %q: must be a single DNS label (lowercase letters, digits, and hyphens; 1-63 chars; no leading or trailing hyphen)", name)
+	}
+	return nil
+}
+
+var serviceCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a service on a running sandbox",
+	Args:  cobra.NoArgs,
+	RunE:  runServiceCreate,
+}
+
+var serviceDeleteCmd = &cobra.Command{
+	Use:     "delete",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete a service from a sandbox",
+	Args:    cobra.NoArgs,
+	RunE:    runServiceDelete,
+}
+
+func runServiceCreate(cmd *cobra.Command, _ []string) error {
+	sandboxRef, _ := cmd.Flags().GetString("sandbox")
+	name, _ := cmd.Flags().GetString("name")
+	port, _ := cmd.Flags().GetInt("port")
+	urlScheme, _ := cmd.Flags().GetString("url-scheme")
+
+	if strings.TrimSpace(sandboxRef) == "" {
+		return fmt.Errorf("--sandbox is required")
+	}
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("--name is required")
+	}
+	if port == 0 {
+		return fmt.Errorf("--port is required")
+	}
+	if strings.TrimSpace(urlScheme) == "" {
+		return fmt.Errorf("--url-scheme is required")
+	}
+	if err := validateServiceName(name); err != nil {
+		return err
+	}
+	if urlScheme != "http" && urlScheme != "https" {
+		return fmt.Errorf("invalid --url-scheme %q: must be \"http\" or \"https\"", urlScheme)
+	}
+
+	svc, err := runmode.NewRemoteClient().CreateSandboxService(sandboxRef, apiclient.SandboxServiceRequest{
+		Name:      name,
+		Port:      port,
+		URLScheme: urlScheme,
+	})
+	if err != nil {
+		return err
+	}
+	printService(cmd, svc)
+	return nil
+}
+
+func runServiceDelete(cmd *cobra.Command, _ []string) error {
+	sandboxRef, _ := cmd.Flags().GetString("sandbox")
+	name, _ := cmd.Flags().GetString("name")
+	force, _ := cmd.Flags().GetBool("force")
+
+	if strings.TrimSpace(sandboxRef) == "" {
+		return fmt.Errorf("--sandbox is required")
+	}
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	if !force {
+		reader := bufio.NewReader(cmd.InOrStdin())
+		confirmed, err := confirmAction(
+			fmt.Sprintf("Delete service %q from sandbox %q?", name, sandboxRef),
+			reader,
+		)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return nil
+		}
+	}
+
+	if err := runmode.NewRemoteClient().DeleteSandboxService(sandboxRef, name); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Service %q deleted\n", name)
+	return nil
+}
+
+// printService renders a single created/updated service as a one-row table,
+// matching the columns of `service list`.
+func printService(cmd *cobra.Command, svc *apiclient.SandboxServiceResource) {
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tPORT\tSCHEME\tURL")
+	fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", svc.Name, svc.Port, svc.URLScheme, deref(svc.URL))
+	w.Flush()
 }
 
 // serviceRow is one line of the `service list` table: a named service, the
@@ -225,9 +338,20 @@ func getServiceRemoteTarget(cmd *cobra.Command) (string, error) {
 func init() {
 	rootCmd.AddCommand(serviceCmd)
 	serviceCmd.AddCommand(serviceListCmd)
+	serviceCmd.AddCommand(serviceCreateCmd)
+	serviceCmd.AddCommand(serviceDeleteCmd)
 	serviceCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
 	serviceCmd.PersistentFlags().Bool("remote", false, "Only operate on remote sandboxes")
 	serviceCmd.PersistentFlags().String("remote-target", "", "Operate on a specific named remote target")
 	serviceCmd.PersistentFlags().MarkHidden("remote-target")
 	serviceListCmd.Flags().String("sandbox-name", "", "Filter services to a specific sandbox")
+
+	serviceCreateCmd.Flags().String("sandbox", "", "Sandbox to create the service on (name or id)")
+	serviceCreateCmd.Flags().String("name", "", "Service name (a single DNS label)")
+	serviceCreateCmd.Flags().Int("port", 0, "Container port the service listens on")
+	serviceCreateCmd.Flags().String("url-scheme", "", "URL scheme for the generated URL: http or https")
+
+	serviceDeleteCmd.Flags().String("sandbox", "", "Sandbox the service belongs to (name or id)")
+	serviceDeleteCmd.Flags().String("name", "", "Name of the service to delete")
+	serviceDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 }

--- a/go/cmd/amika/service_test.go
+++ b/go/cmd/amika/service_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -316,6 +319,63 @@ func TestServiceDeleteCommand_DefaultRemote_RequiresAuth(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not logged in") {
 		t.Fatalf("expected 'not logged in' error, got: %v", err)
+	}
+}
+
+// A successful create prints the returned service as a one-row table. The
+// client is pointed at a fake API server via AMIKA_API_URL.
+func TestServiceCreateCommand_PrintsCreatedService(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v0beta1/sandboxes/box/services" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		svcURL := "https://web.example.com"
+		_ = json.NewEncoder(w).Encode(apiclient.SandboxServiceResource{
+			Name:      "web",
+			Port:      3000,
+			URLScheme: "https",
+			URL:       &svcURL,
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("AMIKA_API_URL", srv.URL)
+
+	out, err := runRootCommand("service", "create", "--sandbox", "box", "--name", "web", "--port", "3000", "--url-scheme", "https")
+	if err != nil {
+		t.Fatalf("service create failed: %v", err)
+	}
+	for _, needle := range []string{"NAME", "PORT", "SCHEME", "URL", "web", "3000", "https://web.example.com"} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("output missing %q:\n%s", needle, out)
+		}
+	}
+}
+
+// A successful delete prints the confirmation line after the API call.
+func TestServiceDeleteCommand_PrintsDeleted(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/v0beta1/sandboxes/box/services/web" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	t.Setenv("AMIKA_API_URL", srv.URL)
+
+	out, err := runRootCommand("service", "delete", "--force", "--sandbox", "box", "--name", "web")
+	if err != nil {
+		t.Fatalf("service delete failed: %v", err)
+	}
+	if !strings.Contains(out, `Service "web" deleted`) {
+		t.Fatalf("expected deleted message, got:\n%s", out)
 	}
 }
 

--- a/go/cmd/amika/service_test.go
+++ b/go/cmd/amika/service_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 )
 
+// strptr returns a pointer to s, for populating the nullable pointer fields of
+// apiclient.SandboxServiceResource in test fixtures.
+func strptr(s string) *string { return &s }
+
 // resetServiceFlags clears flag state that cobra otherwise carries across
 // Execute calls on the shared command objects, so each test starts from the
 // command's declared defaults regardless of test order.
@@ -341,7 +345,7 @@ func TestServiceCreateCommand_PrintsCreatedService(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(apiclient.SandboxServiceResource{
 			Name:      "web",
 			Port:      3000,
-			URLScheme: "https",
+			URLScheme: strptr("https"),
 			URL:       &svcURL,
 		})
 	}))
@@ -370,7 +374,7 @@ func TestServiceCreateCommand_NoURLRendersDash(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(apiclient.SandboxServiceResource{
 			Name:      "web",
 			Port:      3000,
-			URLScheme: "https",
+			URLScheme: strptr("https"),
 			URL:       nil,
 		})
 	}))
@@ -410,20 +414,26 @@ func TestServiceDeleteCommand_PrintsDeleted(t *testing.T) {
 	}
 }
 
-// With -o json, create emits the created service as a single JSON object with
-// snake_case keys rather than the text table.
+// With -o json, create emits the API's SandboxServiceResource schema verbatim
+// (not a lossy display struct), so every field round-trips: the id survives and
+// a not-yet-provisioned URL stays an explicit null rather than "".
 func TestServiceCreateCommand_JSONOutput(t *testing.T) {
 	resetServiceFlags(t)
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	t.Setenv("AMIKA_API_KEY", "test-key")
 
+	id := "svc-123"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		svcURL := "https://web.example.com"
 		_ = json.NewEncoder(w).Encode(apiclient.SandboxServiceResource{
+			ID:        &id,
+			SandboxID: "sb-1",
 			Name:      "web",
 			Port:      3000,
-			URLScheme: "https",
-			URL:       &svcURL,
+			URLScheme: strptr("https"),
+			Protocol:  "tcp",
+			URL:       nil, // pending: must serialize as null, not ""
+			Source:    "table",
+			Kind:      "user",
 		})
 	}))
 	defer srv.Close()
@@ -433,13 +443,22 @@ func TestServiceCreateCommand_JSONOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("service create failed: %v", err)
 	}
-	var got serviceCreateResult
+	var got apiclient.SandboxServiceResource
 	if err := json.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
 	}
-	want := serviceCreateResult{Name: "web", Port: 3000, URLScheme: "https", URL: "https://web.example.com"}
-	if got != want {
-		t.Fatalf("got %+v, want %+v", got, want)
+	if got.ID == nil || *got.ID != id {
+		t.Fatalf("id did not round-trip: got %v, want %q", got.ID, id)
+	}
+	if got.SandboxID != "sb-1" || got.Protocol != "tcp" || got.Source != "table" || got.Kind != "user" {
+		t.Fatalf("API fields dropped: %+v", got)
+	}
+	if got.URL != nil {
+		t.Fatalf("pending URL should stay null, got %q", *got.URL)
+	}
+	// A pending URL must appear as an explicit JSON null, never omitted or "".
+	if !strings.Contains(out, `"url":null`) {
+		t.Fatalf("expected explicit null url in JSON:\n%s", out)
 	}
 	if strings.Contains(out, "NAME") {
 		t.Fatalf("JSON output unexpectedly contains the text table header:\n%s", out)

--- a/go/cmd/amika/service_test.go
+++ b/go/cmd/amika/service_test.go
@@ -355,6 +355,33 @@ func TestServiceCreateCommand_PrintsCreatedService(t *testing.T) {
 	}
 }
 
+// A created service with no provisioned URL renders the URL column as "-",
+// matching how `service list` renders a missing URL.
+func TestServiceCreateCommand_NoURLRendersDash(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(apiclient.SandboxServiceResource{
+			Name:      "web",
+			Port:      3000,
+			URLScheme: "https",
+			URL:       nil,
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("AMIKA_API_URL", srv.URL)
+
+	out, err := runRootCommand("service", "create", "--sandbox", "box", "--name", "web", "--port", "3000", "--url-scheme", "https")
+	if err != nil {
+		t.Fatalf("service create failed: %v", err)
+	}
+	if !strings.Contains(out, "-") {
+		t.Fatalf("expected '-' for missing URL, got:\n%s", out)
+	}
+}
+
 // A successful delete prints the confirmation line after the API call.
 func TestServiceDeleteCommand_PrintsDeleted(t *testing.T) {
 	resetServiceFlags(t)

--- a/go/cmd/amika/service_test.go
+++ b/go/cmd/amika/service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 )
 
@@ -179,6 +180,9 @@ func TestServiceCreateCommand_Validation(t *testing.T) {
 		{"missing url-scheme", []string{"service", "create", "--sandbox", "box", "--name", "web", "--port", "3000"}, "--url-scheme is required"},
 		{"bad name", []string{"service", "create", "--sandbox", "box", "--name", "Web_1", "--port", "3000", "--url-scheme", "https"}, "must be a single DNS label"},
 		{"bad url-scheme", []string{"service", "create", "--sandbox", "box", "--name", "web", "--port", "3000", "--url-scheme", "ftp"}, `must be "http" or "https"`},
+		{"port too large", []string{"service", "create", "--sandbox", "box", "--name", "web", "--port", "70000", "--url-scheme", "https"}, "must be between 1 and 65535"},
+		{"reserved port low", []string{"service", "create", "--sandbox", "box", "--name", "web", "--port", "60899", "--url-scheme", "https"}, "reserved for internal Amika services"},
+		{"reserved port high", []string{"service", "create", "--sandbox", "box", "--name", "web", "--port", "60999", "--url-scheme", "https"}, "reserved for internal Amika services"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -403,6 +407,83 @@ func TestServiceDeleteCommand_PrintsDeleted(t *testing.T) {
 	}
 	if !strings.Contains(out, `Service "web" deleted`) {
 		t.Fatalf("expected deleted message, got:\n%s", out)
+	}
+}
+
+// With -o json, create emits the created service as a single JSON object with
+// snake_case keys rather than the text table.
+func TestServiceCreateCommand_JSONOutput(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		svcURL := "https://web.example.com"
+		_ = json.NewEncoder(w).Encode(apiclient.SandboxServiceResource{
+			Name:      "web",
+			Port:      3000,
+			URLScheme: "https",
+			URL:       &svcURL,
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("AMIKA_API_URL", srv.URL)
+
+	out, err := runRootCommandOutput(t, "service", "create", "--sandbox", "box", "--name", "web", "--port", "3000", "--url-scheme", "https", "-o", "json")
+	if err != nil {
+		t.Fatalf("service create failed: %v", err)
+	}
+	var got serviceCreateResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	want := serviceCreateResult{Name: "web", Port: 3000, URLScheme: "https", URL: "https://web.example.com"}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+	if strings.Contains(out, "NAME") {
+		t.Fatalf("JSON output unexpectedly contains the text table header:\n%s", out)
+	}
+}
+
+// With -o json --force, delete emits an ItemResult JSON object.
+func TestServiceDeleteCommand_JSONOutput(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	t.Setenv("AMIKA_API_URL", srv.URL)
+
+	out, err := runRootCommandOutput(t, "service", "delete", "--force", "--sandbox", "box", "--name", "web", "-o", "json")
+	if err != nil {
+		t.Fatalf("service delete failed: %v", err)
+	}
+	var got output.ItemResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if got.Name != "web" || got.Status != "deleted" {
+		t.Fatalf("got %+v, want name=web status=deleted", got)
+	}
+}
+
+// In JSON mode, delete refuses to prompt and requires --force, so it errors
+// before making any request when --force is absent.
+func TestServiceDeleteCommand_JSONRequiresForce(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "test-key")
+
+	_, err := runRootCommandOutput(t, "service", "delete", "--sandbox", "box", "--name", "web", "-o", "json")
+	if err == nil {
+		t.Fatal("expected an error requiring --force in JSON mode")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("expected error mentioning --force, got: %v", err)
 	}
 }
 

--- a/go/cmd/amika/service_test.go
+++ b/go/cmd/amika/service_test.go
@@ -215,8 +215,12 @@ func TestServiceDeleteCommand_Validation(t *testing.T) {
 }
 
 // Declining the confirmation prompt aborts without deleting (no network call).
+// A credential is provided so the default remote mode passes the auth check and
+// reaches the prompt.
 func TestServiceDeleteCommand_DeclineAborts(t *testing.T) {
 	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "test-key")
 	rootCmd.SetIn(strings.NewReader("n\n"))
 	defer rootCmd.SetIn(nil)
 
@@ -232,6 +236,8 @@ func TestServiceDeleteCommand_DeclineAborts(t *testing.T) {
 // The delete alias `rm` resolves to the same command.
 func TestServiceDeleteCommand_RmAlias(t *testing.T) {
 	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "test-key")
 	rootCmd.SetIn(strings.NewReader("n\n"))
 	defer rootCmd.SetIn(nil)
 
@@ -241,6 +247,75 @@ func TestServiceDeleteCommand_RmAlias(t *testing.T) {
 	}
 	if !strings.Contains(out, "Aborted.") {
 		t.Fatalf("expected 'Aborted.', got:\n%s", out)
+	}
+}
+
+// create and delete are remote-only: --local must be rejected rather than
+// silently routed to the remote API (which would mutate the wrong service when
+// a same-named local and remote sandbox coexist).
+func TestServiceCreateCommand_LocalRejected(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	_, err := runRootCommand("service", "create", "--local", "--sandbox", "box", "--name", "web", "--port", "3000", "--url-scheme", "https")
+	if err == nil {
+		t.Fatal("expected --local to be rejected for create")
+	}
+	if !strings.Contains(err.Error(), "only supported for remote sandboxes") {
+		t.Fatalf("expected remote-only error, got: %v", err)
+	}
+}
+
+func TestServiceDeleteCommand_LocalRejected(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	_, err := runRootCommand("service", "delete", "--local", "--force", "--sandbox", "box", "--name", "web")
+	if err == nil {
+		t.Fatal("expected --local to be rejected for delete")
+	}
+	if !strings.Contains(err.Error(), "only supported for remote sandboxes") {
+		t.Fatalf("expected remote-only error, got: %v", err)
+	}
+}
+
+// --remote-target is unsupported and must be rejected up front for the mutating
+// commands too, not silently ignored.
+func TestServiceCreateCommand_RemoteTargetRejected(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	_, err := runRootCommand("service", "create", "--remote-target", "staging", "--sandbox", "box", "--name", "web", "--port", "3000", "--url-scheme", "https")
+	if err == nil {
+		t.Fatal("expected --remote-target to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not yet supported") {
+		t.Fatalf("expected 'not yet supported' error, got: %v", err)
+	}
+}
+
+func TestServiceDeleteCommand_RemoteTargetRejected(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	_, err := runRootCommand("service", "delete", "--remote-target", "staging", "--force", "--sandbox", "box", "--name", "web")
+	if err == nil {
+		t.Fatal("expected --remote-target to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not yet supported") {
+		t.Fatalf("expected 'not yet supported' error, got: %v", err)
+	}
+}
+
+// The default mode is remote, so mutating without credentials must fail with a
+// login hint rather than silently attempting a request.
+func TestServiceDeleteCommand_DefaultRemote_RequiresAuth(t *testing.T) {
+	resetServiceFlags(t)
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+
+	_, err := runRootCommand("service", "delete", "--force", "--sandbox", "box", "--name", "web")
+	if err == nil {
+		t.Fatal("expected an auth error in remote mode without credentials")
+	}
+	if !strings.Contains(err.Error(), "not logged in") {
+		t.Fatalf("expected 'not logged in' error, got: %v", err)
 	}
 }
 

--- a/go/cmd/amika/service_test.go
+++ b/go/cmd/amika/service_test.go
@@ -26,6 +26,22 @@ func resetServiceFlags(t *testing.T) {
 	if err := serviceListCmd.Flags().Set("sandbox-name", ""); err != nil {
 		t.Fatal(err)
 	}
+	for _, f := range []string{"sandbox", "name", "url-scheme"} {
+		if err := serviceCreateCmd.Flags().Set(f, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := serviceCreateCmd.Flags().Set("port", "0"); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"sandbox", "name"} {
+		if err := serviceDeleteCmd.Flags().Set(f, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := serviceDeleteCmd.Flags().Set("force", "false"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestServiceListCommand_Local_PrintsRows(t *testing.T) {
@@ -128,6 +144,103 @@ func TestServiceListCommand_DefaultRemote_RequiresAuth(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not logged in") {
 		t.Fatalf("expected 'not logged in' error, got: %v", err)
+	}
+}
+
+func TestValidateServiceName(t *testing.T) {
+	valid := []string{"web", "a", "web-1", "0", "my-service-name", strings.Repeat("a", 63)}
+	for _, n := range valid {
+		if err := validateServiceName(n); err != nil {
+			t.Errorf("validateServiceName(%q) = %v, want nil", n, err)
+		}
+	}
+	invalid := []string{"", "Web", "web_1", "-web", "web-", "web.api", "a b", strings.Repeat("a", 64)}
+	for _, n := range invalid {
+		if err := validateServiceName(n); err == nil {
+			t.Errorf("validateServiceName(%q) = nil, want error", n)
+		}
+	}
+}
+
+// The create command validates its inputs client-side before any network call,
+// so these cases fail without a server.
+func TestServiceCreateCommand_Validation(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"missing sandbox", []string{"service", "create", "--name", "web", "--port", "3000", "--url-scheme", "https"}, "--sandbox is required"},
+		{"missing name", []string{"service", "create", "--sandbox", "box", "--port", "3000", "--url-scheme", "https"}, "--name is required"},
+		{"missing port", []string{"service", "create", "--sandbox", "box", "--name", "web", "--url-scheme", "https"}, "--port is required"},
+		{"missing url-scheme", []string{"service", "create", "--sandbox", "box", "--name", "web", "--port", "3000"}, "--url-scheme is required"},
+		{"bad name", []string{"service", "create", "--sandbox", "box", "--name", "Web_1", "--port", "3000", "--url-scheme", "https"}, "must be a single DNS label"},
+		{"bad url-scheme", []string{"service", "create", "--sandbox", "box", "--name", "web", "--port", "3000", "--url-scheme", "ftp"}, `must be "http" or "https"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetServiceFlags(t)
+			_, err := runRootCommand(tc.args...)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestServiceDeleteCommand_Validation(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"missing sandbox", []string{"service", "delete", "--force", "--name", "web"}, "--sandbox is required"},
+		{"missing name", []string{"service", "delete", "--force", "--sandbox", "box"}, "--name is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetServiceFlags(t)
+			_, err := runRootCommand(tc.args...)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// Declining the confirmation prompt aborts without deleting (no network call).
+func TestServiceDeleteCommand_DeclineAborts(t *testing.T) {
+	resetServiceFlags(t)
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	defer rootCmd.SetIn(nil)
+
+	out, err := runRootCommand("service", "delete", "--sandbox", "box", "--name", "web")
+	if err != nil {
+		t.Fatalf("delete declined should not error: %v", err)
+	}
+	if !strings.Contains(out, "Aborted.") {
+		t.Fatalf("expected 'Aborted.', got:\n%s", out)
+	}
+}
+
+// The delete alias `rm` resolves to the same command.
+func TestServiceDeleteCommand_RmAlias(t *testing.T) {
+	resetServiceFlags(t)
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	defer rootCmd.SetIn(nil)
+
+	out, err := runRootCommand("service", "rm", "--sandbox", "box", "--name", "web")
+	if err != nil {
+		t.Fatalf("service rm should resolve: %v", err)
+	}
+	if !strings.Contains(out, "Aborted.") {
+		t.Fatalf("expected 'Aborted.', got:\n%s", out)
 	}
 }
 

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -481,21 +481,25 @@ func (c *Client) DeleteSandboxSnapshot(ref string) error {
 	return nil
 }
 
-// SandboxServiceResource is a live service on a running sandbox, as returned by
-// the /api/v0beta1/sandbox-services endpoints. It unifies rows from the
+// SandboxServiceResource mirrors the API's SandboxService schema, as returned
+// by the /api/v0beta1/sandbox-services endpoints. It unifies rows from the
 // sandbox_services table with legacy jsonb entries; Source discriminates
-// ("table" or "legacy"). Nullable fields are pointers because legacy entries
-// and not-yet-provisioned services omit them.
+// ("table" or "legacy") and Kind is "system" or "user". Every schema field is
+// present (no omitempty) and every nullable field is a pointer, so the value
+// decodes and re-encodes losslessly: a nullable field emits an explicit null
+// (e.g. a legacy or not-yet-provisioned service's url/url_scheme) rather than
+// being dropped or coerced to an empty string.
 type SandboxServiceResource struct {
 	ID        *string `json:"id"`
 	SandboxID string  `json:"sandbox_id"`
 	Name      string  `json:"name"`
 	Port      int     `json:"port"`
-	URLScheme string  `json:"url_scheme"`
+	URLScheme *string `json:"url_scheme"`
 	Protocol  string  `json:"protocol"`
 	URL       *string `json:"url"`
 	HostPort  *int    `json:"host_port"`
 	Source    string  `json:"source"`
+	Kind      string  `json:"kind"`
 	CreatedAt *string `json:"created_at"`
 	UpdatedAt *string `json:"updated_at"`
 }

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -481,6 +481,93 @@ func (c *Client) DeleteSandboxSnapshot(ref string) error {
 	return nil
 }
 
+// SandboxServiceResource is a live service on a running sandbox, as returned by
+// the /api/v0beta1/sandbox-services endpoints. It unifies rows from the
+// sandbox_services table with legacy jsonb entries; Source discriminates
+// ("table" or "legacy"). Nullable fields are pointers because legacy entries
+// and not-yet-provisioned services omit them.
+type SandboxServiceResource struct {
+	ID        *string `json:"id"`
+	SandboxID string  `json:"sandbox_id"`
+	Name      string  `json:"name"`
+	Port      int     `json:"port"`
+	URLScheme string  `json:"url_scheme"`
+	Protocol  string  `json:"protocol"`
+	URL       *string `json:"url"`
+	HostPort  *int    `json:"host_port"`
+	Source    string  `json:"source"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+}
+
+// SandboxServiceRequest is the request body for creating or replacing a sandbox
+// service (POST/PUT). url_scheme is "http" or "https".
+type SandboxServiceRequest struct {
+	Name      string `json:"name"`
+	Port      int    `json:"port"`
+	URLScheme string `json:"url_scheme"`
+}
+
+// ListSandboxServices lists live services for the caller's org. sandboxRef is
+// an optional name-or-id filter forwarded as the sandbox_ref query param; pass
+// "" to list all services in the org.
+func (c *Client) ListSandboxServices(sandboxRef string) ([]SandboxServiceResource, error) {
+	q := url.Values{}
+	if sandboxRef != "" {
+		q.Set("sandbox_ref", sandboxRef)
+	}
+	path := apiBasePath + "/sandbox-services"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var envelope struct {
+		Items []SandboxServiceResource `json:"items"`
+	}
+	if err := c.doJSON("GET", path, nil, &envelope); err != nil {
+		return nil, fmt.Errorf("remote list sandbox services: %w", err)
+	}
+	return envelope.Items, nil
+}
+
+// CreateSandboxService creates a service on the sandbox referenced by name or
+// id. The server resolves sandboxRef (id first, then name) and returns the
+// created SandboxServiceResource.
+func (c *Client) CreateSandboxService(sandboxRef string, req SandboxServiceRequest) (*SandboxServiceResource, error) {
+	path := apiBasePath + "/sandboxes/" + url.PathEscape(sandboxRef) + "/services"
+	var result SandboxServiceResource
+	if err := c.doJSON("POST", path, req, &result); err != nil {
+		return nil, fmt.Errorf("remote create sandbox service: %w", err)
+	}
+	return &result, nil
+}
+
+// PutSandboxService fully replaces the service identified by serviceRef within
+// the given sandbox. by selects how serviceRef is resolved ("name", "id", or
+// "ref"); pass "" to default to "name". Returns the new SandboxServiceResource.
+func (c *Client) PutSandboxService(sandboxRef, serviceRef, by string, req SandboxServiceRequest) (*SandboxServiceResource, error) {
+	if by == "" {
+		by = "name"
+	}
+	q := url.Values{}
+	q.Set("by", by)
+	path := apiBasePath + "/sandboxes/" + url.PathEscape(sandboxRef) + "/services/" + url.PathEscape(serviceRef) + "?" + q.Encode()
+	var result SandboxServiceResource
+	if err := c.doJSON("PUT", path, req, &result); err != nil {
+		return nil, fmt.Errorf("remote put sandbox service: %w", err)
+	}
+	return &result, nil
+}
+
+// DeleteSandboxService deletes the service identified by serviceRef (resolved
+// by name) within the given sandbox.
+func (c *Client) DeleteSandboxService(sandboxRef, serviceRef string) error {
+	path := apiBasePath + "/sandboxes/" + url.PathEscape(sandboxRef) + "/services/" + url.PathEscape(serviceRef) + "?by=name"
+	if err := c.doJSON("DELETE", path, nil, nil); err != nil {
+		return fmt.Errorf("remote delete sandbox service: %w", err)
+	}
+	return nil
+}
+
 // SecretSummary mirrors the API's SecretSummary schema, as returned by
 // GET /api/v0beta1/secrets (array) and POST /api/v0beta1/secrets (single,
 // 201). All fields are required by the schema (no omitempty); Description is

--- a/go/internal/apiclient/client_services_test.go
+++ b/go/internal/apiclient/client_services_test.go
@@ -125,7 +125,7 @@ func TestCreateSandboxServiceSendsBody(t *testing.T) {
 	if svc.ID == nil || *svc.ID != "sbsvc_1" {
 		t.Errorf("ID = %v", svc.ID)
 	}
-	if svc.Name != "web" || svc.Port != 3000 || svc.URLScheme != "https" || svc.Source != "table" {
+	if svc.Name != "web" || svc.Port != 3000 || svc.URLScheme == nil || *svc.URLScheme != "https" || svc.Source != "table" {
 		t.Errorf("service = %+v", svc)
 	}
 }

--- a/go/internal/apiclient/client_services_test.go
+++ b/go/internal/apiclient/client_services_test.go
@@ -1,0 +1,168 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSandboxServiceRequestPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		call       func(c *Client) error
+		wantMethod string
+		wantPath   string
+	}{
+		{
+			name: "ListSandboxServices with sandbox_ref filter",
+			call: func(c *Client) error {
+				_, err := c.ListSandboxServices("my-box")
+				return err
+			},
+			wantMethod: "GET",
+			wantPath:   "/api/v0beta1/sandbox-services?sandbox_ref=my-box",
+		},
+		{
+			name: "ListSandboxServices with no filter",
+			call: func(c *Client) error {
+				_, err := c.ListSandboxServices("")
+				return err
+			},
+			wantMethod: "GET",
+			wantPath:   "/api/v0beta1/sandbox-services",
+		},
+		{
+			name: "CreateSandboxService escapes the sandbox ref",
+			call: func(c *Client) error {
+				_, err := c.CreateSandboxService("org/box", SandboxServiceRequest{Name: "web", Port: 3000, URLScheme: "https"})
+				return err
+			},
+			wantMethod: "POST",
+			wantPath:   "/api/v0beta1/sandboxes/org%2Fbox/services",
+		},
+		{
+			name: "PutSandboxService defaults by=name and escapes refs",
+			call: func(c *Client) error {
+				_, err := c.PutSandboxService("my-box", "web", "", SandboxServiceRequest{Name: "web", Port: 8080, URLScheme: "http"})
+				return err
+			},
+			wantMethod: "PUT",
+			wantPath:   "/api/v0beta1/sandboxes/my-box/services/web?by=name",
+		},
+		{
+			name: "PutSandboxService honors an explicit by param",
+			call: func(c *Client) error {
+				_, err := c.PutSandboxService("my-box", "sbsvc_1", "id", SandboxServiceRequest{Name: "web", Port: 8080, URLScheme: "http"})
+				return err
+			},
+			wantMethod: "PUT",
+			wantPath:   "/api/v0beta1/sandboxes/my-box/services/sbsvc_1?by=id",
+		},
+		{
+			name: "DeleteSandboxService resolves by name",
+			call: func(c *Client) error {
+				return c.DeleteSandboxService("my-box", "web")
+			},
+			wantMethod: "DELETE",
+			wantPath:   "/api/v0beta1/sandboxes/my-box/services/web?by=name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.RequestURI
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{"name": "web", "port": 3000, "url_scheme": "https"})
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL, "test-token")
+			if err := tt.call(c); err != nil {
+				t.Fatalf("call: %v", err)
+			}
+			if gotMethod != tt.wantMethod {
+				t.Errorf("method = %q, want %q", gotMethod, tt.wantMethod)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("path = %q, want %q", gotPath, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestCreateSandboxServiceSendsBody(t *testing.T) {
+	var gotBody SandboxServiceRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "sbsvc_1",
+			"sandbox_id": "sb_1",
+			"name":       "web",
+			"port":       3000,
+			"url_scheme": "https",
+			"protocol":   "tcp",
+			"source":     "table",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	svc, err := c.CreateSandboxService("my-box", SandboxServiceRequest{Name: "web", Port: 3000, URLScheme: "https"})
+	if err != nil {
+		t.Fatalf("CreateSandboxService: %v", err)
+	}
+	if gotBody.Name != "web" || gotBody.Port != 3000 || gotBody.URLScheme != "https" {
+		t.Errorf("request body = %+v", gotBody)
+	}
+	if svc.ID == nil || *svc.ID != "sbsvc_1" {
+		t.Errorf("ID = %v", svc.ID)
+	}
+	if svc.Name != "web" || svc.Port != 3000 || svc.URLScheme != "https" || svc.Source != "table" {
+		t.Errorf("service = %+v", svc)
+	}
+}
+
+func TestListSandboxServicesParsesEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"id": "sbsvc_1", "sandbox_id": "sb_1", "name": "web", "port": 3000, "url_scheme": "https", "protocol": "tcp", "url": "https://web.example.com", "host_port": 12345, "source": "table"},
+				{"id": nil, "sandbox_id": "sb_1", "name": "legacy", "port": 8080, "url_scheme": "http", "protocol": "tcp", "source": "legacy"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	items, err := c.ListSandboxServices("")
+	if err != nil {
+		t.Fatalf("ListSandboxServices: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(items))
+	}
+	if items[0].ID == nil || *items[0].ID != "sbsvc_1" {
+		t.Errorf("items[0].ID = %v", items[0].ID)
+	}
+	if items[0].URL == nil || *items[0].URL != "https://web.example.com" {
+		t.Errorf("items[0].URL = %v", items[0].URL)
+	}
+	if items[0].HostPort == nil || *items[0].HostPort != 12345 {
+		t.Errorf("items[0].HostPort = %v", items[0].HostPort)
+	}
+	if items[1].ID != nil {
+		t.Errorf("legacy items[1].ID should be nil, got %v", items[1].ID)
+	}
+	if items[1].Source != "legacy" {
+		t.Errorf("items[1].Source = %q", items[1].Source)
+	}
+}

--- a/go/internal/services/services.go
+++ b/go/internal/services/services.go
@@ -1,0 +1,29 @@
+// Package services holds shared logic for sandbox services that must stay
+// consistent across the CLI and the HTTP API, such as port validation rules.
+package services
+
+import "fmt"
+
+const (
+	// ReservedPortMin is the inclusive lower bound of the container port range
+	// Amika reserves for its own internal sandbox services.
+	ReservedPortMin = 60899
+	// ReservedPortMax is the inclusive upper bound of the reserved range (e.g.
+	// the OpenCode web UI on 60998 and the amikad daemon on 60999). User
+	// services may not bind ports in this range. See
+	// docs/sandbox-configuration.md for the full allocation table.
+	ReservedPortMax = 60999
+)
+
+// ValidatePort reports whether port is a legal, user-assignable container port
+// for a sandbox service: within 1–65535 and outside the reserved Amika range
+// (ReservedPortMin–ReservedPortMax). It returns a descriptive error otherwise.
+func ValidatePort(port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("invalid port %d: must be between 1 and 65535", port)
+	}
+	if port >= ReservedPortMin && port <= ReservedPortMax {
+		return fmt.Errorf("invalid port %d: ports %d-%d are reserved for internal Amika services", port, ReservedPortMin, ReservedPortMax)
+	}
+	return nil
+}

--- a/go/internal/services/services_test.go
+++ b/go/internal/services/services_test.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+// ValidatePort accepts ordinary ports and rejects out-of-range ports and any
+// port inside the reserved Amika range, including its inclusive boundaries.
+func TestValidatePort(t *testing.T) {
+	cases := []struct {
+		name    string
+		port    int
+		wantErr string // "" means expect success
+	}{
+		{"typical", 3000, ""},
+		{"low boundary", 1, ""},
+		{"high boundary", 65535, ""},
+		{"just below reserved", ReservedPortMin - 1, ""},
+		{"just above reserved", ReservedPortMax + 1, ""},
+		{"zero", 0, "must be between 1 and 65535"},
+		{"negative", -1, "must be between 1 and 65535"},
+		{"too large", 70000, "must be between 1 and 65535"},
+		{"reserved low boundary", ReservedPortMin, "reserved for internal Amika services"},
+		{"reserved high boundary", ReservedPortMax, "reserved for internal Amika services"},
+		{"reserved middle", 60950, "reserved for internal Amika services"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePort(tc.port)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidatePort(%d) = %v, want nil", tc.port, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidatePort(%d) = nil, want error containing %q", tc.port, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidatePort(%d) = %v, want containing %q", tc.port, err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements the CLI + api-client side of KAPRO-438 (live sandbox services). Pairs with the `sandbox-services` API in the `amika-mono` repo.

## CLI
- `amika service` and `amika services` are now aliases.
- `amika service(s) create --sandbox <ref> --name <n> --port <p> --url-scheme <http|https>` — all four required. `--name` validated client-side against the single-DNS-label rule; `--url-scheme` against http/https.
- `amika service(s) delete | rm | remove --sandbox <ref> --name <n> [--force|-f]` — confirmation prompt unless `--force`.
- `amika service(s) list | ls` — unchanged (`ls` already existed).

## Port validation
- `--port` must be within 1–65535 and outside the reserved container-port range **60899–60999**, which Amika keeps for its own internal sandbox services (OpenCode web UI on 60998, amikad daemon on 60999). See `docs/sandbox-configuration.md`.
- The check lives in a new shared `go/internal/services` package (`services.ValidatePort`) so the CLI and API can enforce the same rule. AGENTS.md documents the convention.

## `--output` support
- `service create`, `service delete`, and `service list` all honor the persistent `--output`/`-o` flag (`text`, `json`, `json-pretty`).
- `create` emits the created service as a JSON object; `delete` emits an `output.ItemResult` and refuses to prompt in JSON mode (requires `--force`).

## API client
New `apiclient` methods: `ListSandboxServices` (optional `sandbox_ref` filter, unwraps `{items:[…]}`), `CreateSandboxService`, `PutSandboxService`, `DeleteSandboxService` — all built to the shared wire contract.

## Tests
`make fmtcheck vet lint build test` clean. Coverage: `apiclient` (httptest path/method/body), `cmd/amika` (validation/alias/abort, JSON output, reserved-port rejection), and `internal/services` (`ValidatePort` boundaries).

> Rebased onto latest `main`; resolved one conflict in `apiclient/client.go` where `main` renamed `Secret` to `SecretSummary` (kept both that rename and the new `SandboxService*` types).
