### PR TITLE
Bind Ctrl-X Ctrl-E to edit command line in vim

### DIFF
--- a/go/internal/sandbox/presets/.zshrc
+++ b/go/internal/sandbox/presets/.zshrc
@@ -15,6 +15,14 @@ setopt histignorealldups sharehistory
 # Use emacs keybindings even if our EDITOR is set to vi
 bindkey -e
 
+export VISUAL="vim"
+export EDITOR="vim"
+
+# Edit the current command line in $EDITOR with Ctrl-X Ctrl-E
+autoload -U edit-command-line
+zle -N edit-command-line
+bindkey '^X^E' edit-command-line
+
 # Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
 HISTSIZE=1000
 SAVEHIST=1000


### PR DESCRIPTION
## Summary
- Set `VISUAL`/`EDITOR` to `vim` in the sandbox default `.zshrc`
- Wire up zsh's built-in `edit-command-line` widget on `Ctrl-X Ctrl-E`, so the current command line can be opened and edited in vim

## Test plan
- [x] Copied the updated `.zshrc` into a scratch `ZDOTDIR`, launched it in a new tmux window, and confirmed `VISUAL`/`EDITOR` are `vim` and `^X^E` is bound to `edit-command-line`
- [x] Typed `echo hello world`, pressed Ctrl-X Ctrl-E, confirmed vim opened with that text, appended ` EDITED`, saved, and confirmed the command line updated to `echo hello world EDITED` and executed correctly