### PR TITLE
Add amika-cli skill documenting the CLI for agents

### DIFF
--- a/.agents/skills/amika-cli/SKILL.md
+++ b/.agents/skills/amika-cli/SKILL.md
@@ -1,82 +1,42 @@
 ---
 name: amika-cli
-description: "Drive the `amika` CLI to create, inspect, and operate Amika sandboxes non-interactively. Use when a task involves `amika sandbox`, `amika auth`, `amika secret`, `amika service`, `amika snapshot`, `amika volume`, or `amika scp` — creating or deleting a sandbox, running a coding agent inside one, SSHing or copying files into one, pushing credentials, or scripting any of the above with JSON output."
+description: "Drive the `amika` CLI to create, inspect, and operate Amika sandboxes non-interactively. Use when a task involves `amika sandbox`, `amika auth`, `amika secret`, `amika service`, `amika snapshot`, or `amika scp` — creating or deleting a sandbox, running a coding agent inside one, SSHing or copying files into one, pushing credentials, or scripting any of the above with JSON output."
 ---
 
 # Using the `amika` CLI
 
 `amika` manages **sandboxes**: containerized dev environments with a git repo
-mounted, credentials injected, and optionally a coding agent (`claude`, `codex`)
-running inside. This skill covers driving it from an agent — that is,
-non-interactively, with parseable output, and without hanging on a prompt.
+checked out, credentials injected, and optionally a coding agent (`claude`,
+`codex`) running inside. Drive it non-interactively, with parseable output, and
+without hanging on a prompt.
 
-`amika <command> --help` is authoritative and always matches the installed
-binary. Read it before relying on a flag from this document. In the
-`gofixpoint/amika` repo, `docs/cli-reference.md` has longer prose on individual
-flags; this skill covers the operating model and the agent-safe usage rules
-that reference does not.
-
-Check what you're driving first:
-
-```bash
-amika version   # prints version, commit, build date
-```
-
-## The one thing to get right: local vs remote
-
-Every sandbox command targets **either** local Docker **or** the remote Amika
-API — never both, and there is no merged view.
-
-| Invocation | Target |
-| ---------- | ------ |
-| *(no flag)* | **Remote** — this is the default |
-| `--remote`  | Remote (explicit; same as the default) |
-| `--local`   | Local Docker daemon on this machine |
-
-The default being remote surprises people. `amika sandbox list` with no flags
-hits the API and requires login; it will not show your local Docker sandboxes.
-Pass `--local` for those. Anything in older docs claiming the default depends on
-login state, or that both are listed at once, is stale — `runmode.Resolve` only
-looks at `--local`.
-
-`--local`/`--remote` are persistent flags on `amika sandbox` and `amika service`,
-so they go anywhere after the subcommand.
-
-### What only works in one mode
-
-| Only remote | Only local |
-| ----------- | ---------- |
-| `sandbox ssh`, `sandbox code`, and `scp` sandbox operands | `sandbox create --no-clean` |
-| `sandbox create --secret`, `--snapshot`, `--github-auth-mode` | |
-| `service create`, `service delete` | |
-| all of `snapshot`, all of `secret` | |
-| `sandbox agent-send --session-id`, `--new-session` | |
-
-`--size` (`xs`/`m`/`l`/`xl`) is accepted everywhere but only meaningful remotely.
+Everything here assumes remote sandboxes on the Amika API, the CLI's default
+target. `amika <command> --help` is authoritative and matches the installed
+binary; read it before relying on a flag from this document. Product docs:
+<https://docs.amika.dev/>.
 
 ## Authentication
 
-Remote commands need credentials. Resolution order, checked per request:
+Credentials resolve per request, in this order:
 
 1. `AMIKA_API_KEY` env var — **use this in CI and other headless contexts**
 2. A stored API key file (written by `amika auth login --api-key-file`)
-3. A WorkOS browser session (written by `amika auth login`)
+3. A browser-authed session (written by `amika auth login`)
 
 ```bash
 amika auth status                          # who am I / which org
-amika auth login                           # device flow, opens a browser — NOT headless-safe
+amika auth login                           # opens a browser — NOT headless-safe
 amika auth login --api-key-file ./key.txt  # store a key instead, no browser
 vault kv get -field=key … | amika auth login --api-key-file -   # from stdin
 amika auth logout
 ```
 
-Missing credentials fail with `not logged in; run "amika auth login" or use --local`.
-If you hit that inside an automated run, either export `AMIKA_API_KEY` or switch
-to `--local` — do not try to run the device flow.
+Without credentials, commands fail with a `not logged in` error. In an
+unattended run, export `AMIKA_API_KEY`; never invoke the browser flow.
 
 ## Running it non-interactively
 
-This is the part that breaks agents. Follow all four rules.
+Four rules.
 
 **1. Ask for JSON.** `-o json` (compact, for `jq`) or `-o json-pretty`. Human
 progress text and subprocess chatter go to stderr, so stdout is pure JSON.
@@ -86,22 +46,24 @@ name=$(amika sandbox create --no-git -o json | jq -r .name)
 amika sandbox list -o json | jq -r '.[].name'
 ```
 
-Most list commands emit a bare JSON array (`[]` when empty, never `null`).
-`snapshot list` is the exception: it emits `{"items": [...]}`, matching the API
-schema. Batch mutations (`start`/`stop`/`delete` over several names) emit an
-array of `{name, status, error?}` — a per-item failure shows up there, so check
-it rather than trusting the exit code alone.
+Output shapes:
 
-**2. Pass the confirmation flag.** In JSON mode the CLI never prompts, so a
-command that would have asked errors out instead. Supply the flag up front:
+- Most list commands: a bare JSON array (`[]` when empty, never `null`).
+- `snapshot list`: `{"items": [...]}`, matching the API schema.
+- Batch mutations (`start`/`stop`/`delete` over several names): an array of
+  `{name, status, error?}`. Check it for per-item failures rather than trusting
+  the exit code alone.
 
-| Command | Flag |
-| ------- | ---- |
-| `sandbox create` (with mounts) | `--yes` |
-| `sandbox delete` | `--force` |
-| `snapshot delete`, `service delete` | `--force` / `-f` |
+**2. Pass the confirmation flag** on commands that prompt. JSON mode never
+prompts, so such a command errors instead of asking. Supply it up front:
+
+| Command           | Flag                                                         |
+|-------------------|--------------------------------------------------------------|
 | `snapshot create` | `--no-interactive` (then `--mode` and `--name` are required) |
-| `volume delete` (when referenced) | `--force` |
+| `snapshot delete` | `--force` / `-f`                                             |
+| `service delete`  | `--force` / `-f`                                             |
+
+`sandbox create` and `sandbox delete` do not prompt.
 
 **3. Don't ask for JSON from commands that can't produce it.** These reject
 `-o json`/`-o json-pretty` outright:
@@ -111,78 +73,76 @@ command that would have asked errors out instead. Supply the flag up front:
 - `auth login` without `--api-key-file` — browser flow
 - `secret extract`, `secret push` — they print a masked credential table and prompt
 
-`sandbox ssh` and `scp` reject `--output` entirely, in any mode: both delegate to
-the system `ssh`/`scp`, which stream their own output. (`scp` still forwards its
-own short `-o` for `ssh_config` overrides.)
+`sandbox ssh` and `scp` reject `--output` entirely: both delegate to the system
+`ssh`/`scp`, which stream their own output. (`scp` still forwards its own short
+`-o` for `ssh_config` overrides.)
 
-**4. Never launch an interactive session.** `sandbox connect`, `sandbox code`,
-and bare `sandbox ssh <name>` will hang forever with no TTY. Use
-`amika sandbox ssh <name> -- <command>` to run something and get output back.
+`secret push` and `secret extract --push` always ask `[y/N]` on stdin and have
+no bypass flag, so pipe the answer in: `echo y | amika secret push KEY=value`.
+
+**4. Don't launch an interactive session you can't steer.** `sandbox connect`,
+`sandbox code`, and bare `sandbox ssh <name>` block on a TTY and hang forever in
+a plain tool call. Use `amika sandbox ssh <name> -- <command>` to run something
+and get output back.
+
+Exception: if you can drive a terminal — a tmux session or pane you can send
+keys to and capture from — an interactive session is fine, and is how to use a
+REPL or a long-running TUI in the sandbox. Launch it into that pane, not into a
+blocking call.
 
 Errors go to stderr and exit non-zero (`1`).
 
 ## Command map
 
-| Command | What it does |
-| ------- | ------------ |
-| `sandbox create` | Create a sandbox; auto-detects the git repo containing the cwd |
-| `sandbox list` (`ls`) | List sandboxes; `-l` adds IMAGE and PORTS columns |
-| `sandbox start` / `stop` | Resume / halt without deleting; both take multiple names |
-| `sandbox delete` (`rm`) | Delete sandboxes and their containers; multiple names |
-| `sandbox agent-send` | Send a prompt to a coding agent running inside a sandbox |
-| `sandbox ssh` | SSH in, or run one command; `--print` emits the connection string; `--revoke` revokes access |
-| `sandbox connect` | Interactive shell (`--shell`, default `zsh`), starting at `/home/amika` |
-| `sandbox code` | Open the sandbox in Cursor / Claude Desktop / Codex over SSH |
-| `scp` | Copy files to/from sandboxes; wraps the system `scp` |
-| `secret push` / `extract` | Push arbitrary secrets, or discover local credentials |
-| `secret claude` / `secret codex` | `push` / `list` / `delete` agent credentials for injection |
-| `service create` / `list` / `delete` | Manage named port-backed services on remote sandboxes |
-| `snapshot create` / `list` / `delete` | Capture a running sandbox to fork later |
-| `volume list` / `delete` | Manage tracked Docker volumes |
-| `auth login` / `status` / `logout` | Authentication |
-| `version` | Version, commit, build date |
-
-`materialize` also exists (run a script in an ephemeral container, copy outputs
-out) but is a hidden command — treat it as unsupported unless asked for by name.
+| Command                               | What it does                                                                                 |
+|---------------------------------------|----------------------------------------------------------------------------------------------|
+| `sandbox create`                      | Create a sandbox; auto-detects the git repo containing the cwd                               |
+| `sandbox list` (`ls`)                 | List sandboxes; `-l` adds columns                                                            |
+| `sandbox start` / `stop`              | Resume / halt without deleting; both take multiple names                                     |
+| `sandbox delete` (`rm`)               | Delete sandboxes; multiple names                                                             |
+| `sandbox agent-send`                  | Send a prompt to a coding agent running inside a sandbox                                     |
+| `sandbox ssh`                         | SSH in, or run one command; `--print` emits the connection string; `--revoke` revokes access |
+| `sandbox connect`                     | Interactive shell (`--shell`, default `zsh`), starting at `/home/amika`                      |
+| `sandbox code`                        | Open the sandbox in Cursor / Claude Desktop / Codex over SSH                                 |
+| `scp`                                 | Copy files to/from sandboxes; wraps the system `scp`                                         |
+| `secret push` / `extract`             | Push arbitrary secrets, or discover local credentials                                        |
+| `secret claude` / `secret codex`      | `push` / `list` / `delete` agent credentials for injection                                   |
+| `service create` / `list` / `delete`  | Manage named port-backed services on a sandbox                                               |
+| `snapshot create` / `list` / `delete` | Capture a running sandbox to fork later                                                      |
+| `auth login` / `status` / `logout`    | Authentication                                                                               |
 
 ## Creating a sandbox
 
-Git is auto-detected: with no `--git`/`--no-git`, the repo containing the cwd is
-mounted at `/home/amika/workspace/<repo>` as a **clean clone** (uncommitted work
-is not carried over). Be deliberate about this — an agent running from inside a
-repo will silently get that repo unless it says otherwise.
+With no `--git`/`--no-git`, the repo containing the cwd is auto-detected and
+checked out at `/home/amika/workspace/<repo>` as a **clean clone** (uncommitted
+work is not carried over). An agent running from inside a repo silently gets
+that repo unless it says otherwise.
 
 ```bash
 # Bare sandbox, no repo, scriptable
-amika sandbox create --no-git --yes -o json
+amika sandbox create --no-git -o json
 
 # Named, from an explicit repo and branch
 amika sandbox create --name dev --git https://github.com/octocat/Hello-World.git \
-  --branch develop --yes
+  --branch develop
 
 # New branch off an existing one
-amika sandbox create --branch main --new-branch bugfix-1 --yes
+amika sandbox create --branch main --new-branch bugfix-1
 
-# Local, including uncommitted/untracked files
-amika sandbox create --local --no-clean --yes
-
-# Remote, with an injected secret and forked from a snapshot
-amika sandbox create --remote --secret env:ANTHROPIC_API_KEY=my-claude-key \
-  --snapshot amika-mono-base --yes
+# Inject a secret and fork from a snapshot
+amika sandbox create --secret env:ANTHROPIC_API_KEY=my-claude-key \
+  --snapshot amika-mono-base
 ```
 
-Key flags: `--name` (auto-generates a `{color}-{city}` name if omitted),
-`--image` / `--preset` (`coder` or `coder-dind`; mutually exclusive),
-`--mount source:target[:mode]`, `--volume name:target[:mode]`,
-`--port host:container[/proto]` with `--port-host-ip`, `--env KEY=VALUE`,
-`--setup-script` / `--no-setup`, `--size`, `--provider` (only `docker` today).
+Create flags: `--name` (auto-generates a `{color}-{city}` name if omitted),
+`--preset`, `--size` (`xs`/`m`/`l`/`xl`, default `m`), `--env KEY=VALUE`,
+`--secret env:FOO=SECRET_NAME`, `--snapshot`, `--branch` / `--new-branch`,
+`--setup-script` / `--no-setup`, `--github-auth-mode`, and the
+`--agent-credential*` flags below.
 
-Mount modes: `ro`, `rw` (writes sync to host), `rwcopy` (default for `--mount` —
-a Docker-volume snapshot; **writes do not reach the host**).
-
-Mutually exclusive pairs that error: `--git`/`--no-git`, `--no-clean`/`--no-git`,
-`--no-setup`/`--setup-script`, `--image`/`--preset`,
-`--agent-credential[-type]`/`--no-agent-credential` for the same kind.
+Mutually exclusive pairs that error: `--git`/`--no-git`,
+`--no-setup`/`--setup-script`, and `--agent-credential[-type]` against
+`--no-agent-credential` for the same kind.
 
 ### Credential injection
 
@@ -191,10 +151,44 @@ with `amika secret claude push` / `amika secret codex push`, then pin per
 sandbox:
 
 ```bash
-amika sandbox create --agent-credential claude=personal-oauth --yes
-amika sandbox create --agent-credential-type claude=oauth --yes   # by type: oauth | api-key
-amika sandbox create --no-agent-credential codex --yes            # inject nothing for this kind
+amika sandbox create --agent-credential claude=personal-oauth
+amika sandbox create --agent-credential-type claude=oauth   # by type: oauth | api-key
+amika sandbox create --no-agent-credential codex            # inject nothing for this kind
 ```
+
+## Repo configuration: `.amika/config.toml`
+
+`.amika/config.toml` at the repo root declares sandbox defaults, so
+collaborators get the same environment without passing flags. Settings resolve
+by first non-empty value: **CLI flags > UI settings > this file > built-in
+defaults**. In a multi-repo sandbox only the primary repo's config applies.
+
+```toml
+[lifecycle]
+setup_script = ".amika/setup.sh"
+
+[services.web]
+port = 3000
+url_scheme = "http"
+
+[sandbox]
+preset = "coder"
+size = "m"
+
+[env]
+NODE_ENV = "development"
+API_KEY = { secret = "my-api-key" }
+```
+
+Sections: `[lifecycle]` (setup/start scripts), `[services.<name>]` (ports and
+URL scheme), `[sandbox]` (preset, size, snapshot), `[env]` (variables and
+secret references), `[filesystem]` (extra repos to clone), and
+`[agent_credentials]` (per-agent defaults).
+
+Prefer editing this file over one-off flags — it is version-controlled and
+reviewable in a PR. Full reference:
+<https://docs.amika.dev/guides/config-toml> and
+<https://docs.amika.dev/guides/configuration>.
 
 ## Driving an agent inside a sandbox
 
@@ -215,8 +209,8 @@ amika sandbox agent-send my-sandbox "Refactor the API layer" --no-wait
 amika sandbox agent-send my-sandbox "Summarize this repo" -o json
 ```
 
-In **text** mode the session id goes to stderr as `session_id: <id>` *before* the
-response, keeping stdout the pure agent output. In **JSON** mode you get one
+In **text** mode the session id goes to stderr as `session_id: <id>` *before*
+the response, keeping stdout the pure agent output. In **JSON** mode you get one
 object on stdout:
 
 ```json
@@ -227,16 +221,16 @@ object on stdout:
 
 `status` is `"sent"` for `--no-wait` and `"completed"` otherwise. **Check
 `is_error`** — a `completed` send whose agent errored sets it true and exits
-non-zero. Resume a remote session with `--session-id <id>`, or force a fresh one
-with `--new-session`.
+non-zero. Resume a session with `--session-id <id>`, or force a fresh one with
+`--new-session`.
 
 `--workdir` defaults to `$AMIKA_AGENT_CWD`, which `sandbox create` sets to the
-mounted repo path.
+checked-out repo path.
 
 The agent CLIs run with permission prompts disabled inside the sandbox
 (`--dangerously-skip-permissions` for Claude,
-`--dangerously-bypass-approvals-and-sandbox` for Codex). That is the point of the
-sandbox, but it means anything you send executes unsupervised in there.
+`--dangerously-bypass-approvals-and-sandbox` for Codex). That is the point of
+the sandbox, but anything you send executes unsupervised in there.
 
 ## Running commands and copying files
 
@@ -250,15 +244,15 @@ amika sandbox ssh my-sandbox --revoke           # revoke SSH access
 `amika scp` forwards every argument to the system `scp`, so `-r`, `-p`, `-C`,
 `-v`, `-o Option=value` all work. Path forms:
 
-| Form | Meaning |
-| ---- | ------- |
-| `PATH` | Local path |
-| `NAME[:PATH]` | Path in sandbox `NAME`; relative is under `/home/amika`, absolute is verbatim |
-| `sbox://NAME[/PATH]` | Same, URI form; `PATH` is absolute, `~` is home, a `/` in `NAME` must be `%2F` |
-| `scp://[user@]host[:port][/path]` | An arbitrary SSH host |
+| Form                              | Meaning                                                                        |
+|-----------------------------------|--------------------------------------------------------------------------------|
+| `PATH`                            | Local path                                                                     |
+| `NAME[:PATH]`                     | Path in sandbox `NAME`; relative is under `/home/amika`, absolute is verbatim  |
+| `sbox://NAME[/PATH]`              | Same, URI form; `PATH` is absolute, `~` is home, a `/` in `NAME` must be `%2F` |
+| `scp://[user@]host[:port][/path]` | An arbitrary SSH host                                                          |
 
-A bare `host:path` **always** names a sandbox — reach a real SSH host only via an
-`scp://` URI.
+A bare `host:path` **always** names a sandbox — reach a real SSH host only via
+an `scp://` URI.
 
 ```bash
 amika scp ./local.txt my-sandbox:local.txt
@@ -270,7 +264,7 @@ amika scp --print ./a.txt my-sandbox:a.txt      # show the resolved scp command
 Sandbox↔sandbox and sandbox↔external copies are not supported yet; go through
 the local machine in two steps.
 
-## Snapshots, services, volumes
+## Snapshots and services
 
 ```bash
 # Capture a sandbox to fork from later
@@ -279,45 +273,33 @@ amika snapshot create --sandbox my-sandbox --no-interactive \
 amika snapshot list -o json | jq -r '.items[].name'   # note the envelope
 amika snapshot delete my-base --force
 
-# Expose a port on a remote sandbox as a named service
+# Expose a port as a named service
 amika service create --sandbox my-sandbox --name web --port 3000 --url-scheme https
 amika service list --sandbox-name my-sandbox
 amika service delete --sandbox my-sandbox --name web -f
-
-amika volume list
-amika volume delete my-volume --force
 ```
 
 `--mode` is `scrub_and_delete` (removes injected secrets) or `full`. Prefer
-`scrub_and_delete` unless you have a reason not to bake credentials into an
-image others can fork.
+`scrub_and_delete` unless you have a reason to bake credentials into an image
+others can fork.
+
+Services declared in `.amika/config.toml` are created with the sandbox; use
+`service create` for ones you add afterward.
 
 ## Environment variables
 
-| Variable | Effect |
-| -------- | ------ |
-| `AMIKA_API_KEY` | Bearer token for the remote API; beats stored key and session. The headless auth path |
-| `AMIKA_API_URL` | Remote API base URL (default `https://app.amika.dev`) |
-| `AMIKA_WORKOS_CLIENT_ID` | WorkOS client id for device login; change it alongside `AMIKA_API_URL` |
-| `AMIKA_STATE_DIRECTORY` | State dir (default `$XDG_STATE_HOME/amika`, else `~/.local/state/amika`) — holds sandbox/volume/mount state, session, and API key |
-| `AMIKA_SANDBOX_PROVIDER` | Override the sandbox provider |
-| `AMIKA_PRESET_IMAGE_PREFIX` | Docker image name prefix for presets |
-| `AMIKA_AGENT_CWD` | Set inside the sandbox to the mounted repo; the default `agent-send --workdir` |
-| `AMIKA_OPEN_CLAUDE_CODEX_SUPPORT` | Set `true` to unlock `sandbox code --editor=claude\|codex` |
-
-Point a whole session at a dev stack by exporting `AMIKA_API_URL` and
-`AMIKA_WORKOS_CLIENT_ID` together — there is no config-file equivalent yet.
+| Variable                          | Effect                                                                                                              |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `AMIKA_API_KEY`                   | Bearer token for the API; beats the stored key and session. The headless auth path                                  |
+| `AMIKA_API_URL`                   | API base URL (default `https://app.amika.dev`)                                                                      |
+| `AMIKA_STATE_DIRECTORY`           | CLI state dir (default `$XDG_STATE_HOME/amika`, else `~/.local/state/amika`) — holds the session and stored API key |
+| `AMIKA_AGENT_CWD`                 | Set inside the sandbox to the checked-out repo; the default `agent-send --workdir`                                  |
+| `AMIKA_OPEN_CLAUDE_CODEX_SUPPORT` | Set `true` to unlock `sandbox code --editor=claude\|codex`                                                           |
 
 ## Gotchas
 
-- **Remote is the default.** `--local` is the only thing that switches it.
-- **`--yes` and `--force` are not optional** in automation; without them a
-  prompt either blocks or (in JSON mode) errors.
-- **`rwcopy` writes never reach the host.** Use `rw` if you need them to.
-- **Git auto-detection is on by default** and clones clean. `--no-git` to opt
-  out, `--no-clean` (local only) to carry uncommitted work.
-- **An `agent-send` failure is reported twice.** The JSON with
-  `"is_error": true` is written to stdout first, *then* the command exits
-  non-zero. Read the object rather than only checking the exit code.
-- **`snapshot list` returns `{"items": []}`**, unlike every other list command.
-- Local sandboxes must use the `docker` provider; other providers error.
+- Git auto-detection is on by default and clones clean; pass `--no-git` to opt out.
+- An `agent-send` failure is reported twice: the JSON with `"is_error": true`
+  goes to stdout first, *then* the command exits non-zero. Read the object.
+- `snapshot list` returns `{"items": []}`, unlike every other list command.
+- `--secret` takes a secret *name*, not a value — push it with `amika secret push` first.

--- a/.agents/skills/amika-cli/SKILL.md
+++ b/.agents/skills/amika-cli/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: amika-cli
+description: "Drive the `amika` CLI to create, inspect, and operate Amika sandboxes non-interactively. Use when a task involves `amika sandbox`, `amika auth`, `amika secret`, `amika service`, `amika snapshot`, `amika volume`, or `amika scp` — creating or deleting a sandbox, running a coding agent inside one, SSHing or copying files into one, pushing credentials, or scripting any of the above with JSON output."
+---
+
+# Using the `amika` CLI
+
+`amika` manages **sandboxes**: containerized dev environments with a git repo
+mounted, credentials injected, and optionally a coding agent (`claude`, `codex`)
+running inside. This skill covers driving it from an agent — that is,
+non-interactively, with parseable output, and without hanging on a prompt.
+
+`amika <command> --help` is authoritative and always matches the installed
+binary. Read it before relying on a flag from this document. In the
+`gofixpoint/amika` repo, `docs/cli-reference.md` has longer prose on individual
+flags; this skill covers the operating model and the agent-safe usage rules
+that reference does not.
+
+Check what you're driving first:
+
+```bash
+amika version   # prints version, commit, build date
+```
+
+## The one thing to get right: local vs remote
+
+Every sandbox command targets **either** local Docker **or** the remote Amika
+API — never both, and there is no merged view.
+
+| Invocation | Target |
+| ---------- | ------ |
+| *(no flag)* | **Remote** — this is the default |
+| `--remote`  | Remote (explicit; same as the default) |
+| `--local`   | Local Docker daemon on this machine |
+
+The default being remote surprises people. `amika sandbox list` with no flags
+hits the API and requires login; it will not show your local Docker sandboxes.
+Pass `--local` for those. Anything in older docs claiming the default depends on
+login state, or that both are listed at once, is stale — `runmode.Resolve` only
+looks at `--local`.
+
+`--local`/`--remote` are persistent flags on `amika sandbox` and `amika service`,
+so they go anywhere after the subcommand.
+
+### What only works in one mode
+
+| Only remote | Only local |
+| ----------- | ---------- |
+| `sandbox ssh`, `sandbox code`, and `scp` sandbox operands | `sandbox create --no-clean` |
+| `sandbox create --secret`, `--snapshot`, `--github-auth-mode` | |
+| `service create`, `service delete` | |
+| all of `snapshot`, all of `secret` | |
+| `sandbox agent-send --session-id`, `--new-session` | |
+
+`--size` (`xs`/`m`/`l`/`xl`) is accepted everywhere but only meaningful remotely.
+
+## Authentication
+
+Remote commands need credentials. Resolution order, checked per request:
+
+1. `AMIKA_API_KEY` env var — **use this in CI and other headless contexts**
+2. A stored API key file (written by `amika auth login --api-key-file`)
+3. A WorkOS browser session (written by `amika auth login`)
+
+```bash
+amika auth status                          # who am I / which org
+amika auth login                           # device flow, opens a browser — NOT headless-safe
+amika auth login --api-key-file ./key.txt  # store a key instead, no browser
+vault kv get -field=key … | amika auth login --api-key-file -   # from stdin
+amika auth logout
+```
+
+Missing credentials fail with `not logged in; run "amika auth login" or use --local`.
+If you hit that inside an automated run, either export `AMIKA_API_KEY` or switch
+to `--local` — do not try to run the device flow.
+
+## Running it non-interactively
+
+This is the part that breaks agents. Follow all four rules.
+
+**1. Ask for JSON.** `-o json` (compact, for `jq`) or `-o json-pretty`. Human
+progress text and subprocess chatter go to stderr, so stdout is pure JSON.
+
+```bash
+name=$(amika sandbox create --no-git -o json | jq -r .name)
+amika sandbox list -o json | jq -r '.[].name'
+```
+
+Most list commands emit a bare JSON array (`[]` when empty, never `null`).
+`snapshot list` is the exception: it emits `{"items": [...]}`, matching the API
+schema. Batch mutations (`start`/`stop`/`delete` over several names) emit an
+array of `{name, status, error?}` — a per-item failure shows up there, so check
+it rather than trusting the exit code alone.
+
+**2. Pass the confirmation flag.** In JSON mode the CLI never prompts, so a
+command that would have asked errors out instead. Supply the flag up front:
+
+| Command | Flag |
+| ------- | ---- |
+| `sandbox create` (with mounts) | `--yes` |
+| `sandbox delete` | `--force` |
+| `snapshot delete`, `service delete` | `--force` / `-f` |
+| `snapshot create` | `--no-interactive` (then `--mode` and `--name` are required) |
+| `volume delete` (when referenced) | `--force` |
+
+**3. Don't ask for JSON from commands that can't produce it.** These reject
+`-o json`/`-o json-pretty` outright:
+
+- `sandbox connect`, `sandbox code`, `sandbox create --connect` — they open a shell or editor
+- `sandbox ssh` without `-- <command>` — interactive session
+- `auth login` without `--api-key-file` — browser flow
+- `secret extract`, `secret push` — they print a masked credential table and prompt
+
+`sandbox ssh` and `scp` reject `--output` entirely, in any mode: both delegate to
+the system `ssh`/`scp`, which stream their own output. (`scp` still forwards its
+own short `-o` for `ssh_config` overrides.)
+
+**4. Never launch an interactive session.** `sandbox connect`, `sandbox code`,
+and bare `sandbox ssh <name>` will hang forever with no TTY. Use
+`amika sandbox ssh <name> -- <command>` to run something and get output back.
+
+Errors go to stderr and exit non-zero (`1`).
+
+## Command map
+
+| Command | What it does |
+| ------- | ------------ |
+| `sandbox create` | Create a sandbox; auto-detects the git repo containing the cwd |
+| `sandbox list` (`ls`) | List sandboxes; `-l` adds IMAGE and PORTS columns |
+| `sandbox start` / `stop` | Resume / halt without deleting; both take multiple names |
+| `sandbox delete` (`rm`) | Delete sandboxes and their containers; multiple names |
+| `sandbox agent-send` | Send a prompt to a coding agent running inside a sandbox |
+| `sandbox ssh` | SSH in, or run one command; `--print` emits the connection string; `--revoke` revokes access |
+| `sandbox connect` | Interactive shell (`--shell`, default `zsh`), starting at `/home/amika` |
+| `sandbox code` | Open the sandbox in Cursor / Claude Desktop / Codex over SSH |
+| `scp` | Copy files to/from sandboxes; wraps the system `scp` |
+| `secret push` / `extract` | Push arbitrary secrets, or discover local credentials |
+| `secret claude` / `secret codex` | `push` / `list` / `delete` agent credentials for injection |
+| `service create` / `list` / `delete` | Manage named port-backed services on remote sandboxes |
+| `snapshot create` / `list` / `delete` | Capture a running sandbox to fork later |
+| `volume list` / `delete` | Manage tracked Docker volumes |
+| `auth login` / `status` / `logout` | Authentication |
+| `version` | Version, commit, build date |
+
+`materialize` also exists (run a script in an ephemeral container, copy outputs
+out) but is a hidden command — treat it as unsupported unless asked for by name.
+
+## Creating a sandbox
+
+Git is auto-detected: with no `--git`/`--no-git`, the repo containing the cwd is
+mounted at `/home/amika/workspace/<repo>` as a **clean clone** (uncommitted work
+is not carried over). Be deliberate about this — an agent running from inside a
+repo will silently get that repo unless it says otherwise.
+
+```bash
+# Bare sandbox, no repo, scriptable
+amika sandbox create --no-git --yes -o json
+
+# Named, from an explicit repo and branch
+amika sandbox create --name dev --git https://github.com/octocat/Hello-World.git \
+  --branch develop --yes
+
+# New branch off an existing one
+amika sandbox create --branch main --new-branch bugfix-1 --yes
+
+# Local, including uncommitted/untracked files
+amika sandbox create --local --no-clean --yes
+
+# Remote, with an injected secret and forked from a snapshot
+amika sandbox create --remote --secret env:ANTHROPIC_API_KEY=my-claude-key \
+  --snapshot amika-mono-base --yes
+```
+
+Key flags: `--name` (auto-generates a `{color}-{city}` name if omitted),
+`--image` / `--preset` (`coder` or `coder-dind`; mutually exclusive),
+`--mount source:target[:mode]`, `--volume name:target[:mode]`,
+`--port host:container[/proto]` with `--port-host-ip`, `--env KEY=VALUE`,
+`--setup-script` / `--no-setup`, `--size`, `--provider` (only `docker` today).
+
+Mount modes: `ro`, `rw` (writes sync to host), `rwcopy` (default for `--mount` —
+a Docker-volume snapshot; **writes do not reach the host**).
+
+Mutually exclusive pairs that error: `--git`/`--no-git`, `--no-clean`/`--no-git`,
+`--no-setup`/`--setup-script`, `--image`/`--preset`,
+`--agent-credential[-type]`/`--no-agent-credential` for the same kind.
+
+### Credential injection
+
+Sandboxes get agent credentials from the remote secrets store. Push them first
+with `amika secret claude push` / `amika secret codex push`, then pin per
+sandbox:
+
+```bash
+amika sandbox create --agent-credential claude=personal-oauth --yes
+amika sandbox create --agent-credential-type claude=oauth --yes   # by type: oauth | api-key
+amika sandbox create --no-agent-credential codex --yes            # inject nothing for this kind
+```
+
+## Driving an agent inside a sandbox
+
+`sandbox agent-send` is the main programmatic entry point. `--agent` accepts
+`claude` (default) or `codex` — nothing else.
+
+```bash
+# Synchronous: waits, streams the response
+amika sandbox agent-send my-sandbox "Add unit tests for the auth module"
+
+# From stdin
+echo "Fix the failing tests" | amika sandbox agent-send my-sandbox
+
+# Fire and forget
+amika sandbox agent-send my-sandbox "Refactor the API layer" --no-wait
+
+# Structured, for a script
+amika sandbox agent-send my-sandbox "Summarize this repo" -o json
+```
+
+In **text** mode the session id goes to stderr as `session_id: <id>` *before* the
+response, keeping stdout the pure agent output. In **JSON** mode you get one
+object on stdout:
+
+```json
+{ "sandbox": "...", "agent": "claude", "status": "completed",
+  "response": "...", "session_id": "...", "agent_session_id": "...",
+  "is_error": false, "is_new_session": true, "cost_usd": 0.01 }
+```
+
+`status` is `"sent"` for `--no-wait` and `"completed"` otherwise. **Check
+`is_error`** — a `completed` send whose agent errored sets it true and exits
+non-zero. Resume a remote session with `--session-id <id>`, or force a fresh one
+with `--new-session`.
+
+`--workdir` defaults to `$AMIKA_AGENT_CWD`, which `sandbox create` sets to the
+mounted repo path.
+
+The agent CLIs run with permission prompts disabled inside the sandbox
+(`--dangerously-skip-permissions` for Claude,
+`--dangerously-bypass-approvals-and-sandbox` for Codex). That is the point of the
+sandbox, but it means anything you send executes unsupervised in there.
+
+## Running commands and copying files
+
+```bash
+amika sandbox ssh my-sandbox -- ls -la          # run a command, get output
+amika sandbox ssh -t my-sandbox -- top          # force a PTY
+amika sandbox ssh --print my-sandbox            # print the connection string
+amika sandbox ssh my-sandbox --revoke           # revoke SSH access
+```
+
+`amika scp` forwards every argument to the system `scp`, so `-r`, `-p`, `-C`,
+`-v`, `-o Option=value` all work. Path forms:
+
+| Form | Meaning |
+| ---- | ------- |
+| `PATH` | Local path |
+| `NAME[:PATH]` | Path in sandbox `NAME`; relative is under `/home/amika`, absolute is verbatim |
+| `sbox://NAME[/PATH]` | Same, URI form; `PATH` is absolute, `~` is home, a `/` in `NAME` must be `%2F` |
+| `scp://[user@]host[:port][/path]` | An arbitrary SSH host |
+
+A bare `host:path` **always** names a sandbox — reach a real SSH host only via an
+`scp://` URI.
+
+```bash
+amika scp ./local.txt my-sandbox:local.txt
+amika scp -r my-sandbox:/srv/out ./out
+amika scp my-sandbox:/data.csv scp://user@host:22/tmp/data.csv
+amika scp --print ./a.txt my-sandbox:a.txt      # show the resolved scp command
+```
+
+Sandbox↔sandbox and sandbox↔external copies are not supported yet; go through
+the local machine in two steps.
+
+## Snapshots, services, volumes
+
+```bash
+# Capture a sandbox to fork from later
+amika snapshot create --sandbox my-sandbox --no-interactive \
+  --mode scrub_and_delete --name my-base
+amika snapshot list -o json | jq -r '.items[].name'   # note the envelope
+amika snapshot delete my-base --force
+
+# Expose a port on a remote sandbox as a named service
+amika service create --sandbox my-sandbox --name web --port 3000 --url-scheme https
+amika service list --sandbox-name my-sandbox
+amika service delete --sandbox my-sandbox --name web -f
+
+amika volume list
+amika volume delete my-volume --force
+```
+
+`--mode` is `scrub_and_delete` (removes injected secrets) or `full`. Prefer
+`scrub_and_delete` unless you have a reason not to bake credentials into an
+image others can fork.
+
+## Environment variables
+
+| Variable | Effect |
+| -------- | ------ |
+| `AMIKA_API_KEY` | Bearer token for the remote API; beats stored key and session. The headless auth path |
+| `AMIKA_API_URL` | Remote API base URL (default `https://app.amika.dev`) |
+| `AMIKA_WORKOS_CLIENT_ID` | WorkOS client id for device login; change it alongside `AMIKA_API_URL` |
+| `AMIKA_STATE_DIRECTORY` | State dir (default `$XDG_STATE_HOME/amika`, else `~/.local/state/amika`) — holds sandbox/volume/mount state, session, and API key |
+| `AMIKA_SANDBOX_PROVIDER` | Override the sandbox provider |
+| `AMIKA_PRESET_IMAGE_PREFIX` | Docker image name prefix for presets |
+| `AMIKA_AGENT_CWD` | Set inside the sandbox to the mounted repo; the default `agent-send --workdir` |
+| `AMIKA_OPEN_CLAUDE_CODEX_SUPPORT` | Set `true` to unlock `sandbox code --editor=claude\|codex` |
+
+Point a whole session at a dev stack by exporting `AMIKA_API_URL` and
+`AMIKA_WORKOS_CLIENT_ID` together — there is no config-file equivalent yet.
+
+## Gotchas
+
+- **Remote is the default.** `--local` is the only thing that switches it.
+- **`--yes` and `--force` are not optional** in automation; without them a
+  prompt either blocks or (in JSON mode) errors.
+- **`rwcopy` writes never reach the host.** Use `rw` if you need them to.
+- **Git auto-detection is on by default** and clones clean. `--no-git` to opt
+  out, `--no-clean` (local only) to carry uncommitted work.
+- **An `agent-send` failure is reported twice.** The JSON with
+  `"is_error": true` is written to stdout first, *then* the command exits
+  non-zero. Read the object rather than only checking the exit code.
+- **`snapshot list` returns `{"items": []}`**, unlike every other list command.
+- Local sandboxes must use the `docker` provider; other providers error.


### PR DESCRIPTION
Adds `.agents/skills/amika-cli/SKILL.md`, an agent-facing guide to driving the
`amika` CLI non-interactively. The same file is going into `amika-mono` (branch
`dylan/amika-cli-skill`) so both repos' agents share one description of the CLI —
the two copies are byte-identical.

The skill covers **remote sandboxes only**, which is what the CLI targets by
default.

## What it covers

Aimed at what agents get wrong on the first try, rather than restating per-flag
detail:

- **Auth resolution order**, with `AMIKA_API_KEY` called out as the headless
  path.
- **Four rules for non-interactive use**: ask for JSON, pass the confirmation
  flag, don't request JSON from commands that can't emit it, and don't launch an
  interactive session you can't steer (with a tmux exception for REPLs and
  TUIs).
- **`.amika/config.toml`** — per-repo sandbox defaults and the
  flags > UI > file > defaults resolution order.
- `sandbox create`, `agent-send`, `ssh`/`scp`, snapshots, services, and
  environment variables.

## Findings from writing it

Scoping the skill to remote surfaced a few things worth knowing independently of
the doc:

- **`createRemoteSandbox` returns before `--mount`, `--volume`, `--port`,
  `--port-host-ip`, `--image`, `--provider`, and `--yes` are read.** On remote
  those flags are silently ignored, not merely unsupported — no error, no
  warning.
- **Remote `sandbox delete` never prompts**, so `--force` is a no-op on that path
  too. The confirmation-flag table is therefore just `snapshot create`/`snapshot
  delete`/`service delete`.
- **`secret push` always reads `[y/N]` from stdin with no bypass flag**, so
  scripted use needs `echo y | amika secret push …`.

## Verification

Behavioral claims were exercised against the installed `amika` v0.13.0 binary,
whose CLI sources are identical to `main` — every rejection message, the
`[]`-not-`null` empty list, the `unknown agent` error, and default-remote
resolution against an empty `AMIKA_STATE_DIRECTORY`. Remote-path flag handling
was read from `sandbox_create.go` and `sandbox_delete.go` rather than tested,
since exercising it would create and destroy real sandboxes.

## Follow-up, not fixed here

`docs/cli-reference.md` has drifted. I left it alone rather than widen this PR:

- Documents `amika auth extract` with an `--export` flag; that command is gone
  (it is now `amika secret extract`, which has no `--export`).
- No sections for `amika service`, `amika snapshot`, or `secret codex`.
- Missing `auth login --api-key-file`, `AMIKA_API_KEY`, `secret
  --scope`/`--force`, `sandbox create
  --size`/`--github-auth-mode`/`--agent-credential*`, `sandbox ssh --print`,
  `agent-send --session-id`/`--new-session`.
- `--preset` is documented as `coder` or `claude`; the binary accepts `coder` or
  `coder-dind`.
- Claims the local/remote default depends on login state and that both are listed
  at once; `runmode.Resolve` only checks `--local`, and `sandbox list` is
  strictly either/or.
- Documents `--mount`/`--volume`/`--port`/`--yes` on `sandbox create` without
  noting they apply to local sandboxes only.
- The `sandbox list` column is `CREATOR`, not `CREATED BY`.

Happy to take that on in a separate PR if it's wanted.

## Stack

1. `dylan/amika-cli-skill` `#THIS` ← you are here
2. `dylan/ssh-impl-no-relay` #316
3. `dylan/no-ssh-keygen-yet-fix` #321
4. `dylan/ssh-websocket-code-review` #322
