### PR TITLE
Add release checklist docs and speed up functional release tests

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,115 @@
+# Release Checklist
+
+Run these checks against the staging environment before promoting a release to production.
+
+## Prerequisites
+
+- An `AMIKA_API_KEY` with sufficient permissions for the target environment
+- Docker running locally (required by the Go e2e suite to build the `amika` binary)
+- Node.js / pnpm installed (required by the TypeScript SDK functional suite)
+
+## 1. Go E2E Tests
+
+The e2e suite is a black-box runner that exercises the compiled `dist/amika` binary against a real API. It has two tiers:
+
+- **Offline cases** (no `api-` prefix): no network, no credentials required.
+- **Real-API cases** (`api-*.yaml`): talk to `AMIKA_API_URL` and may create billable resources; require `AMIKA_RUN_E2E_API=1`.
+
+Run both offline and real-API cases against staging:
+
+```bash
+AMIKA_RUN_E2E=1 \
+AMIKA_RUN_E2E_API=1 \
+AMIKA_API_URL=https://app.staging-amika.dev/ \
+AMIKA_API_KEY=<your-api-key> \
+  make test-e2e-api
+```
+
+Or invoke Go directly from the repo root:
+
+```bash
+AMIKA_RUN_E2E=1 \
+AMIKA_RUN_E2E_API=1 \
+AMIKA_API_URL=https://app.staging-amika.dev/ \
+AMIKA_API_KEY=<your-api-key> \
+  go -C go test -v -timeout 20m ./test/e2e/...
+```
+
+To run offline cases only (no credentials needed):
+
+```bash
+make test-e2e
+```
+
+The suite builds the `amika` binary fresh before running, so `dist/amika` does not need to exist beforehand.
+
+**Expected result:** all subtests under `TestE2ECases` pass, including `api-auth-status`, `api-sandbox-lifecycle`, `api-sandbox-list`, `api-secret-list`, `api-service-lifecycle`, `api-snapshot-lifecycle`, and `api-snapshot-list`.
+
+## 2. TypeScript SDK Functional Tests
+
+The functional suite exercises the TypeScript SDK client against a live server. It is separate from the default `pnpm test` run (which is offline-only) and uses `vitest.functional.config.ts`.
+
+The suite includes a production-host guard that fails fast if `AMIKA_API_URL` points at the production host.
+
+```bash
+AMIKA_API_URL=https://app.staging-amika.dev/ \
+AMIKA_API_TOKEN=<your-api-key> \
+  pnpm --dir sdk/typescript test:functional -- --reporter=verbose
+```
+
+Pass `--reporter=verbose` so vitest prints each test as it completes instead of buffering all output until the run finishes. This makes it clear which test is running — useful because `sandbox.functional.test.ts` provisions a real sandbox on staging and can take several minutes (the suite's timeout is 15 minutes).
+
+Individual test files:
+
+| File | What it covers |
+|---|---|
+| `sandbox.functional.test.ts` | Sandbox create / list / delete lifecycle |
+| `secrets.functional.test.ts` | Secret create / update / list, provider secrets |
+| `release.functional.test.ts` | Release pipeline read operations |
+
+**Expected result:** all tests pass (some may be skipped if the account lacks the relevant resources).
+
+## Running both suites together
+
+```bash
+API_KEY=<your-api-key>
+STAGING=https://app.staging-amika.dev/
+
+# Go e2e
+AMIKA_RUN_E2E=1 AMIKA_RUN_E2E_API=1 \
+AMIKA_API_URL="$STAGING" AMIKA_API_KEY="$API_KEY" \
+  make test-e2e-api
+
+# TypeScript SDK functional
+AMIKA_API_URL="$STAGING" AMIKA_API_TOKEN="$API_KEY" \
+  pnpm --dir sdk/typescript test:functional -- --reporter=verbose
+```
+
+## Saving results
+
+Redirect output to `scratch/test-results/` for comparison across runs:
+
+```bash
+API_KEY=<your-api-key>
+STAGING=https://app.staging-amika.dev/
+
+AMIKA_RUN_E2E=1 AMIKA_RUN_E2E_API=1 \
+AMIKA_API_URL="$STAGING" AMIKA_API_KEY="$API_KEY" \
+  go -C go test -v -timeout 20m ./test/e2e/... \
+  2>&1 | tee scratch/test-results/e2e-go.txt
+
+AMIKA_API_URL="$STAGING" AMIKA_API_TOKEN="$API_KEY" \
+  pnpm --dir sdk/typescript test:functional -- --reporter=verbose \
+  2>&1 | tee scratch/test-results/ts-sdk-functional.txt
+```
+
+## After staging passes
+
+Promote the release and re-run if desired against production (`https://app.amika.dev/`), omitting `AMIKA_RUN_E2E_API=1` if you want to avoid creating billable resources:
+
+```bash
+AMIKA_RUN_E2E=1 \
+AMIKA_API_URL=https://app.amika.dev/ \
+AMIKA_API_KEY=<your-api-key> \
+  make test-e2e
+```

--- a/sdk/typescript/test/functional/release.functional.test.ts
+++ b/sdk/typescript/test/functional/release.functional.test.ts
@@ -35,18 +35,18 @@ const SENTINEL_VALUE = "hello-snapshot";
 /**
  * Run a command inside a sandbox via SSH, return trimmed stdout.
  * Retries on exit 255 (transport-level failure: SSH daemon not yet ready)
- * with exponential backoff.
+ * with capped exponential backoff (2s, 4s, 8s, 10s — ~24s total over 5 attempts).
  */
 function sshRun(
   sshDestination: string,
   command: string,
-  { maxAttempts = 6, baseDelayMs = 5_000 } = {},
+  { maxAttempts = 5, baseDelayMs = 2_000, maxDelayMs = 10_000 } = {},
 ): string {
   const args = sshDestination.trim().split(/\s+/);
   let lastErr: Error | undefined;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     if (attempt > 0) {
-      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      const delay = Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs);
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay);
     }
     const result = spawnSync(
@@ -78,7 +78,7 @@ async function waitForSnapshot(
   client: AmikaClient,
   slug: string,
   targetState = "active",
-  timeoutMs = 5 * 60 * 1000,
+  timeoutMs = 2 * 60 * 1000,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary

- Add `docs/release-checklist.md` documenting how to run the Go e2e suite and the TypeScript SDK functional suite against staging before a release, including credentials, env vars, the `--reporter=verbose` flag for legible per-test output, and how to save results.
- Shorten the SSH retry backoff and snapshot wait in `release.functional.test.ts` so a failing staging run surfaces failures far faster.

## Details

The SSH helper (`sshRun`) retried transport failures (exit 255) with uncapped exponential backoff over 6 attempts (~155s per SSH call). It now uses 5 attempts with a 2s base capped at 10s per attempt (~24s total).

`waitForSnapshot` polled for up to 5 minutes for a snapshot to reach `active`. It now waits up to 2 minutes. This matters when a snapshot fails server-side (e.g. the `/etc/environment` scrub abort tracked in KAPRO-711): the helper doesn't short-circuit on the `failed` state, so a shorter cap keeps a doomed poll from dragging on.