### PR TITLE
Add `amika send` and `amika sessions` commands

### DIFF
--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -189,39 +189,32 @@ func runSendStreaming(
 			fmt.Fprint(os.Stdout, text)
 		},
 	})
-	// End a partial streamed line so anything that follows starts fresh.
-	endStreamedLine := func() {
-		if s := streamed.String(); s != "" && !strings.HasSuffix(s, "\n") {
+	// written tracks everything that has reached stdout, so a partial line can
+	// be closed off exactly once at the end.
+	written := streamed.String()
+	endLine := func() {
+		if written != "" && !strings.HasSuffix(written, "\n") {
 			fmt.Fprintln(os.Stdout)
 		}
 	}
 	if err != nil {
-		endStreamedLine()
+		endLine()
 		return err
 	}
 
-	// The buffered `resp.Response` is authoritative: the server builds it from
-	// the agent's final result object, while deltas come from a separate
-	// incremental parser over the same output, so the two need not agree.
-	// Print it when it would otherwise be lost:
-	//   - nothing streamed (an empty reply, or a provider that only yields a
-	//     final result), so stdout would be empty for a non-empty response;
-	//   - the turn failed, where `response` carries the agent CLI's own message
-	//     (e.g. "Not logged in · Please run /login"), which is derived from the
-	//     result object and so typically never arrived as a delta.
-	// The is-error case is skipped when that text did stream, so a failure is
-	// explained exactly once — and as well as it is on the buffered path.
-	missing := streamed.Len() == 0 ||
-		(resp.IsError && !strings.Contains(streamed.String(), resp.Response))
-	if missing && resp.Response != "" {
-		endStreamedLine()
-		fmt.Fprint(os.Stdout, resp.Response)
-		if !strings.HasSuffix(resp.Response, "\n") {
-			fmt.Fprintln(os.Stdout)
+	extra, continuation := unstreamedRemainder(written, resp.Response)
+	if extra != "" {
+		// A continuation resumes the streamed text mid-word, so it must not be
+		// pushed onto a new line; anything else is separate output and starts
+		// on its own line.
+		if !continuation {
+			endLine()
 		}
-	} else {
-		endStreamedLine()
+		fmt.Fprint(os.Stdout, extra)
+		written += extra
 	}
+	endLine()
+
 	if resp.SessionID != "" {
 		fmt.Fprintf(os.Stderr, "session_id: %s\n", resp.SessionID)
 	}
@@ -229,6 +222,39 @@ func runSendStreaming(
 		return fmt.Errorf("agent returned an error")
 	}
 	return nil
+}
+
+// unstreamedRemainder decides how much of the authoritative response still has
+// to be printed once `streamed` has already gone to stdout, and whether that
+// text continues the streamed run directly rather than starting fresh.
+//
+// The two strings come from different server-side parsers over the same agent
+// output — deltas from the incremental event stream, `response` from the final
+// result object — so they are not guaranteed to match. Showing only the stream
+// can silently drop the authoritative result (most visibly on a failed turn,
+// where `response` carries the agent CLI's own message and no delta ever does);
+// always appending it would duplicate text on the common runs where they agree.
+func unstreamedRemainder(streamed, response string) (extra string, continuation bool) {
+	switch {
+	case streamed == "":
+		// An empty reply, or a provider that only yields a final result;
+		// stdout would otherwise be empty for a non-empty response.
+		return response, false
+	case strings.HasPrefix(response, streamed):
+		// The common case. A stream cut short contributes exactly its missing
+		// tail; identical texts leave nothing to add, and then there is no
+		// run to continue either.
+		remainder := response[len(streamed):]
+		return remainder, remainder != ""
+	case strings.Contains(streamed, response):
+		// The stream carried more than the final message (intermediate text
+		// across tool calls) and already included it — appending would repeat.
+		return "", false
+	default:
+		// Genuinely divergent: the authoritative result wins over showing only
+		// the stream.
+		return response, false
+	}
 }
 
 var sessionsCmd = &cobra.Command{
@@ -254,19 +280,20 @@ func runSessionsList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	limit, _ := cmd.Flags().GetInt("limit")
-	sessions, total, err := runmode.NewRemoteClient().ListAgentSessions(limit)
+	resp, err := runmode.NewRemoteClient().ListAgentSessions(limit)
 	if err != nil {
 		return err
 	}
 
 	if format.IsJSON() {
-		// Emit the API schema verbatim; a nil slice becomes `[]`, not `null`.
-		if sessions == nil {
-			sessions = []apiclient.AgentSessionSummary{}
-		}
-		return format.JSON(cmd.OutOrStdout(), sessions)
+		// Emit the API's {sessions,total} envelope verbatim, as a remote-backed
+		// command must — the same reason `snapshot list` re-emits its
+		// {"items": [...]}. Dropping to a bare array here would both diverge
+		// from the documented schema and discard `total`.
+		return format.JSON(cmd.OutOrStdout(), resp)
 	}
 
+	sessions := resp.Sessions
 	if len(sessions) == 0 {
 		fmt.Fprintln(format.Progress(cmd.OutOrStdout()), "No agent-session chats yet.")
 		return nil
@@ -289,10 +316,10 @@ func runSessionsList(cmd *cobra.Command, _ []string) error {
 	}
 	// Never present a page as the whole list: the server caps the page size, so
 	// say what was withheld and how to see it.
-	if total > len(sessions) {
+	if resp.Total > len(sessions) {
 		fmt.Fprintf(format.Progress(cmd.OutOrStdout()),
 			"\nShowing %d of %d chats; use --limit to see more.\n",
-			len(sessions), total)
+			len(sessions), resp.Total)
 	}
 	return nil
 }

--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -261,9 +261,11 @@ func runSessionsList(cmd *cobra.Command, _ []string) error {
 	for _, s := range sessions {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			s.SessionID,
-			strOrDash(s.Agent),
+			s.Agent,
 			s.Status,
-			strOrDash(s.SandboxID),
+			// Prefer the human-readable sandbox name, falling back to the id
+			// when the sandbox has been deleted and the name can't be resolved.
+			strOrDash(s.SandboxName, s.SandboxID),
 			s.UpdatedAt,
 		)
 	}
@@ -296,8 +298,8 @@ func runSessionsShow(cmd *cobra.Command, args []string) error {
 
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "session:  %s\n", detail.SessionID)
-	fmt.Fprintf(out, "agent:    %s\n", strOrDash(detail.Agent))
-	fmt.Fprintf(out, "sandbox:  %s\n", strOrDash(detail.SandboxID))
+	fmt.Fprintf(out, "agent:    %s\n", detail.Agent)
+	fmt.Fprintf(out, "sandbox:  %s\n", strOrDash(detail.SandboxName, detail.SandboxID))
 	fmt.Fprintf(out, "status:   %s\n", detail.Status)
 	fmt.Fprintln(out)
 	for _, m := range detail.Messages {
@@ -305,18 +307,24 @@ func runSessionsShow(cmd *cobra.Command, args []string) error {
 		if m.IsError {
 			marker = " (error)"
 		}
-		fmt.Fprintf(out, "[%s] %s%s:\n%s\n\n", m.Direction, m.Author, marker, m.Contents)
+		fmt.Fprintf(out, "[%s]%s %s\n%s\n\n", m.Role, marker, m.Timestamp, m.Content)
 	}
 	return nil
 }
 
-// strOrDash renders a nullable string field as "-" when unset, so text tables
-// don't print an empty cell for a chat whose sandbox has been cleaned up.
-func strOrDash(s *string) string {
-	if s == nil || *s == "" {
-		return "-"
+// strOrDash renders a nullable string field, falling back through the given
+// alternatives and finally to "-", so a text table never prints an empty cell
+// for a chat whose sandbox name could not be resolved.
+func strOrDash(s *string, fallbacks ...string) string {
+	if s != nil && *s != "" {
+		return *s
 	}
-	return *s
+	for _, f := range fallbacks {
+		if f != "" {
+			return f
+		}
+	}
+	return "-"
 }
 
 func init() {

--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -1,0 +1,236 @@
+package main
+
+// send.go implements the top-level `send` command and the `sessions` command
+// group, which drive the remote `agent-sessions` API: send a message to a
+// coding agent (creating a sandbox behind the scenes when needed) and
+// list / show the resulting durable chats.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/output"
+	"github.com/gofixpoint/amika/go/internal/runmode"
+	"github.com/spf13/cobra"
+)
+
+// sendStdinPiped reports whether stdin is a pipe/redirect rather than a
+// terminal, so a message can be read from it when no positional arg is given.
+func sendStdinPiped() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) == 0
+}
+
+var sendCmd = &cobra.Command{
+	Use:   "send [message]",
+	Short: "Send a message to a coding agent, creating a sandbox if needed",
+	Long: `Send a message to a coding agent via the remote agent-sessions API.
+
+If neither --session-id nor --sandbox is given, a sandbox is created behind the
+scenes and a new chat is started; the returned session id can be passed back as
+--session-id to continue the conversation. The agent (claude or codex) comes
+from --agent, else the organization's default, else claude.
+
+The message can be provided as a positional argument or piped via stdin. The
+command is synchronous: it blocks until the agent finishes and prints the reply.
+
+In text output (the default) "session_id: <id>" is written to stderr first,
+before the response is written to stdout, keeping stdout the pure agent
+response. With --output json, a single JSON object matching the API's
+AgentSessionSendResponse is written to stdout instead.`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runSend,
+}
+
+func runSend(cmd *cobra.Command, args []string) error {
+	var message string
+	if len(args) > 0 {
+		message = strings.Join(args, " ")
+	} else if sendStdinPiped() {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("failed to read message from stdin: %w", err)
+		}
+		message = strings.TrimSpace(string(data))
+	}
+	if message == "" {
+		return fmt.Errorf("message is required as an argument or via stdin")
+	}
+
+	agent, _ := cmd.Flags().GetString("agent")
+	sessionID, _ := cmd.Flags().GetString("session-id")
+	sandboxRef, _ := cmd.Flags().GetString("sandbox")
+	newSession, _ := cmd.Flags().GetBool("new-session")
+	repo, _ := cmd.Flags().GetString("repo")
+
+	format, err := output.FormatFrom(cmd)
+	if err != nil {
+		return err
+	}
+
+	// The agent-sessions API is remote-only: it provisions sandboxes in the
+	// control plane, so there is no local equivalent.
+	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+		return err
+	}
+
+	resp, err := runmode.NewRemoteClient().SendAgentSession(apiclient.AgentSessionSendRequest{
+		Message:    message,
+		Agent:      agent,
+		SessionID:  sessionID,
+		SandboxID:  sandboxRef,
+		NewSession: newSession,
+		RepoURL:    repo,
+	})
+	if err != nil {
+		return err
+	}
+
+	if format.IsJSON() {
+		if err := format.JSON(cmd.OutOrStdout(), resp); err != nil {
+			return err
+		}
+		if resp.IsError {
+			return fmt.Errorf("agent returned an error")
+		}
+		return nil
+	}
+
+	// Text: identifying metadata goes to stderr so stdout stays the pure reply.
+	if resp.SessionID != "" {
+		fmt.Fprintf(os.Stderr, "session_id: %s\n", resp.SessionID)
+	}
+	if resp.CreatedSandbox {
+		fmt.Fprintf(os.Stderr, "created sandbox: %s\n", resp.SandboxID)
+	}
+	fmt.Fprint(os.Stdout, resp.Response)
+	if resp.Response != "" && !strings.HasSuffix(resp.Response, "\n") {
+		fmt.Fprintln(os.Stdout)
+	}
+	if resp.IsError {
+		return fmt.Errorf("agent returned an error")
+	}
+	return nil
+}
+
+var sessionsCmd = &cobra.Command{
+	Use:     "sessions",
+	Aliases: []string{"session"},
+	Short:   "List and inspect agent-session chats",
+	Long:    `View the durable agent-session chats created by "amika send".`,
+}
+
+var sessionsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the organization's agent-session chats",
+	Args:  cobra.NoArgs,
+	RunE:  runSessionsList,
+}
+
+func runSessionsList(cmd *cobra.Command, _ []string) error {
+	format, err := output.FormatFrom(cmd)
+	if err != nil {
+		return err
+	}
+	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+		return err
+	}
+	sessions, err := runmode.NewRemoteClient().ListAgentSessions()
+	if err != nil {
+		return err
+	}
+
+	if format.IsJSON() {
+		// Emit the API schema verbatim; a nil slice becomes `[]`, not `null`.
+		if sessions == nil {
+			sessions = []apiclient.AgentSessionSummary{}
+		}
+		return format.JSON(cmd.OutOrStdout(), sessions)
+	}
+
+	if len(sessions) == 0 {
+		fmt.Fprintln(format.Progress(cmd.OutOrStdout()), "No agent-session chats yet.")
+		return nil
+	}
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "SESSION ID\tAGENT\tSTATUS\tSANDBOX\tUPDATED")
+	for _, s := range sessions {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			s.SessionID,
+			strOrDash(s.Agent),
+			s.Status,
+			strOrDash(s.SandboxID),
+			s.UpdatedAt,
+		)
+	}
+	return w.Flush()
+}
+
+var sessionsShowCmd = &cobra.Command{
+	Use:   "show <session-id>",
+	Short: "Show an agent-session chat and its messages",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSessionsShow,
+}
+
+func runSessionsShow(cmd *cobra.Command, args []string) error {
+	format, err := output.FormatFrom(cmd)
+	if err != nil {
+		return err
+	}
+	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+		return err
+	}
+	detail, err := runmode.NewRemoteClient().GetAgentSession(args[0])
+	if err != nil {
+		return err
+	}
+
+	if format.IsJSON() {
+		return format.JSON(cmd.OutOrStdout(), detail)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "session:  %s\n", detail.SessionID)
+	fmt.Fprintf(out, "agent:    %s\n", strOrDash(detail.Agent))
+	fmt.Fprintf(out, "sandbox:  %s\n", strOrDash(detail.SandboxID))
+	fmt.Fprintf(out, "status:   %s\n", detail.Status)
+	fmt.Fprintln(out)
+	for _, m := range detail.Messages {
+		marker := ""
+		if m.IsError {
+			marker = " (error)"
+		}
+		fmt.Fprintf(out, "[%s] %s%s:\n%s\n\n", m.Direction, m.Author, marker, m.Contents)
+	}
+	return nil
+}
+
+// strOrDash renders a nullable string field as "-" when unset, so text tables
+// don't print an empty cell for a chat whose sandbox has been cleaned up.
+func strOrDash(s *string) string {
+	if s == nil || *s == "" {
+		return "-"
+	}
+	return *s
+}
+
+func init() {
+	sendCmd.Flags().String("agent", "", "Coding agent to use: claude or codex (default: org setting, else claude)")
+	sendCmd.Flags().String("session-id", "", "Continue an existing chat by its session id")
+	sendCmd.Flags().String("sandbox", "", "Send into a specific sandbox (id or name)")
+	sendCmd.Flags().Bool("new-session", false, "Start a brand-new chat")
+	sendCmd.Flags().String("repo", "", "Repository URL to clone when a sandbox is created")
+	rootCmd.AddCommand(sendCmd)
+
+	sessionsCmd.AddCommand(sessionsListCmd)
+	sessionsCmd.AddCommand(sessionsShowCmd)
+	rootCmd.AddCommand(sessionsCmd)
+}

--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -28,6 +28,18 @@ func sendStdinPiped() bool {
 	return (fi.Mode() & os.ModeCharDevice) == 0
 }
 
+// stdoutIsTerminal reports whether stdout is a terminal (not a pipe/redirect).
+// It drives the default streaming choice: stream to an interactive terminal
+// for a live reply, but buffer when stdout is piped so a script's captured
+// output stays the single final response, not the concatenated deltas.
+func stdoutIsTerminal() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
 var sendCmd = &cobra.Command{
 	Use:   "send [message]",
 	Short: "Send a message to a coding agent, creating a sandbox if needed",
@@ -38,13 +50,17 @@ scenes and a new chat is started; the returned session id can be passed back as
 --session-id to continue the conversation. The agent (claude or codex) comes
 from --agent, else the organization's default, else claude.
 
-The message can be provided as a positional argument or piped via stdin. The
-command is synchronous: it blocks until the agent finishes and prints the reply.
+The message can be provided as a positional argument or piped via stdin.
 
-In text output (the default) "session_id: <id>" is written to stderr first,
-before the response is written to stdout, keeping stdout the pure agent
-response. With --output json, a single JSON object matching the API's
-AgentSessionSendResponse is written to stdout instead.`,
+By default the reply streams in as the agent produces it when stdout is a
+terminal, and is buffered (printed once, whole) when stdout is piped or
+--output json is set. Use --stream / --stream=false to force either mode; JSON
+output is always buffered so the emitted object stays valid.
+
+In text output (the default) identifying metadata ("session_id: <id>", sandbox
+progress) is written to stderr, keeping stdout the pure agent response. With
+--output json, a single JSON object matching the API's AgentSessionSendResponse
+is written to stdout instead.`,
 	Args: cobra.ArbitraryArgs,
 	RunE: runSend,
 }
@@ -75,20 +91,40 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Streaming: default on for an interactive terminal, off when piped, and
+	// always off for JSON (deltas can't be emitted as one valid object). An
+	// explicit --stream / --stream=false overrides the default, except in JSON
+	// mode which stays buffered regardless.
+	stream := false
+	if !format.IsJSON() {
+		if cmd.Flags().Changed("stream") {
+			stream = mustBool(cmd, "stream")
+		} else {
+			stream = stdoutIsTerminal()
+		}
+	}
+
 	// The agent-sessions API is remote-only: it provisions sandboxes in the
 	// control plane, so there is no local equivalent.
 	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
 		return err
 	}
 
-	resp, err := runmode.NewRemoteClient().SendAgentSession(apiclient.AgentSessionSendRequest{
+	req := apiclient.AgentSessionSendRequest{
 		Message:    message,
 		Agent:      agent,
 		SessionID:  sessionID,
 		SandboxID:  sandboxRef,
 		NewSession: newSession,
 		RepoURL:    repo,
-	})
+	}
+	client := runmode.NewRemoteClient()
+
+	if stream {
+		return runSendStreaming(client, req)
+	}
+
+	resp, err := client.SendAgentSession(req)
 	if err != nil {
 		return err
 	}
@@ -113,6 +149,67 @@ func runSend(cmd *cobra.Command, args []string) error {
 	fmt.Fprint(os.Stdout, resp.Response)
 	if resp.Response != "" && !strings.HasSuffix(resp.Response, "\n") {
 		fmt.Fprintln(os.Stdout)
+	}
+	if resp.IsError {
+		return fmt.Errorf("agent returned an error")
+	}
+	return nil
+}
+
+// mustBool reads a bool flag, ignoring the (impossible for a defined flag)
+// lookup error to keep call sites terse.
+func mustBool(cmd *cobra.Command, name string) bool {
+	v, _ := cmd.Flags().GetBool(name)
+	return v
+}
+
+// runSendStreaming drives the SSE transport for text output: sandbox lifecycle
+// progress goes to stderr, the reply streams to stdout as it arrives, and the
+// session id is reported on stderr once known. stdout carries only the agent's
+// text, matching the buffered path.
+func runSendStreaming(
+	client *apiclient.Client,
+	req apiclient.AgentSessionSendRequest,
+) error {
+	printedDelta := false
+	var lastByte byte = '\n'
+
+	resp, err := client.SendAgentSessionStream(req, apiclient.AgentSessionStreamHandlers{
+		OnStatus: func(phase, sandboxID string) {
+			switch phase {
+			case "creating_sandbox":
+				fmt.Fprintln(os.Stderr, "creating sandbox…")
+			case "sandbox_ready":
+				if sandboxID != "" {
+					fmt.Fprintf(os.Stderr, "sandbox ready: %s\n", sandboxID)
+				}
+			}
+		},
+		OnDelta: func(text string) {
+			printedDelta = true
+			fmt.Fprint(os.Stdout, text)
+			lastByte = text[len(text)-1]
+		},
+	})
+	// End a partial streamed line so a following error / prompt starts fresh.
+	if printedDelta && lastByte != '\n' {
+		fmt.Fprintln(os.Stdout)
+	}
+	if err != nil {
+		return err
+	}
+
+	// No deltas arrived (e.g. an empty reply, or a non-streaming provider that
+	// only yielded the final result) — print the buffered reply so stdout is
+	// never empty for a non-empty response.
+	if !printedDelta && resp.Response != "" {
+		fmt.Fprint(os.Stdout, resp.Response)
+		if !strings.HasSuffix(resp.Response, "\n") {
+			fmt.Fprintln(os.Stdout)
+		}
+	}
+	if resp.SessionID != "" {
+		fmt.Fprintf(os.Stderr, "session_id: %s\n", resp.SessionID)
 	}
 	if resp.IsError {
 		return fmt.Errorf("agent returned an error")
@@ -228,6 +325,7 @@ func init() {
 	sendCmd.Flags().String("sandbox", "", "Send into a specific sandbox (id or name)")
 	sendCmd.Flags().Bool("new-session", false, "Start a brand-new chat")
 	sendCmd.Flags().String("repo", "", "Repository URL to clone when a sandbox is created")
+	sendCmd.Flags().Bool("stream", false, "Stream the reply as it is produced (default: on for a terminal, off when piped; always off with --output json)")
 	rootCmd.AddCommand(sendCmd)
 
 	sessionsCmd.AddCommand(sessionsListCmd)

--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -171,8 +171,7 @@ func runSendStreaming(
 	client *apiclient.Client,
 	req apiclient.AgentSessionSendRequest,
 ) error {
-	printedDelta := false
-	var lastByte byte = '\n'
+	var streamed strings.Builder
 
 	resp, err := client.SendAgentSessionStream(req, apiclient.AgentSessionStreamHandlers{
 		OnStatus: func(phase, sandboxID string) {
@@ -186,27 +185,42 @@ func runSendStreaming(
 			}
 		},
 		OnDelta: func(text string) {
-			printedDelta = true
+			streamed.WriteString(text)
 			fmt.Fprint(os.Stdout, text)
-			lastByte = text[len(text)-1]
 		},
 	})
-	// End a partial streamed line so a following error / prompt starts fresh.
-	if printedDelta && lastByte != '\n' {
-		fmt.Fprintln(os.Stdout)
+	// End a partial streamed line so anything that follows starts fresh.
+	endStreamedLine := func() {
+		if s := streamed.String(); s != "" && !strings.HasSuffix(s, "\n") {
+			fmt.Fprintln(os.Stdout)
+		}
 	}
 	if err != nil {
+		endStreamedLine()
 		return err
 	}
 
-	// No deltas arrived (e.g. an empty reply, or a non-streaming provider that
-	// only yielded the final result) — print the buffered reply so stdout is
-	// never empty for a non-empty response.
-	if !printedDelta && resp.Response != "" {
+	// The buffered `resp.Response` is authoritative: the server builds it from
+	// the agent's final result object, while deltas come from a separate
+	// incremental parser over the same output, so the two need not agree.
+	// Print it when it would otherwise be lost:
+	//   - nothing streamed (an empty reply, or a provider that only yields a
+	//     final result), so stdout would be empty for a non-empty response;
+	//   - the turn failed, where `response` carries the agent CLI's own message
+	//     (e.g. "Not logged in · Please run /login"), which is derived from the
+	//     result object and so typically never arrived as a delta.
+	// The is-error case is skipped when that text did stream, so a failure is
+	// explained exactly once — and as well as it is on the buffered path.
+	missing := streamed.Len() == 0 ||
+		(resp.IsError && !strings.Contains(streamed.String(), resp.Response))
+	if missing && resp.Response != "" {
+		endStreamedLine()
 		fmt.Fprint(os.Stdout, resp.Response)
 		if !strings.HasSuffix(resp.Response, "\n") {
 			fmt.Fprintln(os.Stdout)
 		}
+	} else {
+		endStreamedLine()
 	}
 	if resp.SessionID != "" {
 		fmt.Fprintf(os.Stderr, "session_id: %s\n", resp.SessionID)
@@ -239,7 +253,8 @@ func runSessionsList(cmd *cobra.Command, _ []string) error {
 	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
 		return err
 	}
-	sessions, err := runmode.NewRemoteClient().ListAgentSessions()
+	limit, _ := cmd.Flags().GetInt("limit")
+	sessions, total, err := runmode.NewRemoteClient().ListAgentSessions(limit)
 	if err != nil {
 		return err
 	}
@@ -269,7 +284,17 @@ func runSessionsList(cmd *cobra.Command, _ []string) error {
 			s.UpdatedAt,
 		)
 	}
-	return w.Flush()
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	// Never present a page as the whole list: the server caps the page size, so
+	// say what was withheld and how to see it.
+	if total > len(sessions) {
+		fmt.Fprintf(format.Progress(cmd.OutOrStdout()),
+			"\nShowing %d of %d chats; use --limit to see more.\n",
+			len(sessions), total)
+	}
+	return nil
 }
 
 var sessionsShowCmd = &cobra.Command{
@@ -304,7 +329,7 @@ func runSessionsShow(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(out)
 	for _, m := range detail.Messages {
 		marker := ""
-		if m.IsError {
+		if m.IsError != nil && *m.IsError {
 			marker = " (error)"
 		}
 		fmt.Fprintf(out, "[%s]%s %s\n%s\n\n", m.Role, marker, m.Timestamp, m.Content)
@@ -336,6 +361,7 @@ func init() {
 	sendCmd.Flags().Bool("stream", false, "Stream the reply as it is produced (default: on for a terminal, off when piped; always off with --output json)")
 	rootCmd.AddCommand(sendCmd)
 
+	sessionsListCmd.Flags().Int("limit", 0, "Maximum chats to list (default: the server's page size, 50)")
 	sessionsCmd.AddCommand(sessionsListCmd)
 	sessionsCmd.AddCommand(sessionsShowCmd)
 	rootCmd.AddCommand(sessionsCmd)

--- a/go/cmd/amika/send_test.go
+++ b/go/cmd/amika/send_test.go
@@ -22,7 +22,7 @@ func TestSendAndSessionsCommandsRegistered(t *testing.T) {
 	if send == nil {
 		t.Fatal("send command not registered on rootCmd")
 	}
-	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "repo"} {
+	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "repo", "stream"} {
 		if send.Flags().Lookup(name) == nil {
 			t.Errorf("send is missing --%s flag", name)
 		}

--- a/go/cmd/amika/send_test.go
+++ b/go/cmd/amika/send_test.go
@@ -70,3 +70,52 @@ func TestSendRejectsInvalidOutput(t *testing.T) {
 		t.Fatalf("err = %v, want an invalid --output error", err)
 	}
 }
+
+// TestUnstreamedRemainder covers what `amika send --stream` still has to print
+// after the deltas, given that the streamed text and the authoritative
+// `response` come from two different server-side parsers and need not agree.
+func TestUnstreamedRemainder(t *testing.T) {
+	cases := []struct {
+		name         string
+		streamed     string
+		response     string
+		extra        string
+		continuation bool
+	}{{
+		name: "identical adds nothing",
+		// The overwhelmingly common case: every byte already reached stdout.
+		streamed: "Hello", response: "Hello", extra: "", continuation: false,
+	}, {
+		name: "nothing streamed prints the whole response",
+		// An empty reply, or a provider that only yields a final result.
+		streamed: "", response: "Hello", extra: "Hello", continuation: false,
+	}, {
+		name: "truncated stream appends only the missing tail",
+		// A dropped delta must not cost the user the rest of the reply, and
+		// the tail resumes the text mid-word rather than on a new line.
+		streamed: "Hel", response: "Hello", extra: "lo", continuation: true,
+	}, {
+		name: "response already contained in a longer stream adds nothing",
+		// Intermediate text across tool calls streams more than the final
+		// message; appending it again would duplicate the tail.
+		streamed: "thinking...\nHello", response: "Hello", extra: "", continuation: false,
+	}, {
+		name: "divergent response wins",
+		// The failed-turn case: `response` carries the agent CLI's own error,
+		// which never arrives as a delta.
+		streamed: "partial output", response: "Not logged in", extra: "Not logged in", continuation: false,
+	}, {
+		name:     "empty response adds nothing",
+		streamed: "Hello", response: "", extra: "", continuation: false,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			extra, continuation := unstreamedRemainder(tc.streamed, tc.response)
+			if extra != tc.extra || continuation != tc.continuation {
+				t.Errorf("unstreamedRemainder(%q, %q) = (%q, %v), want (%q, %v)",
+					tc.streamed, tc.response, extra, continuation, tc.extra, tc.continuation)
+			}
+		})
+	}
+}

--- a/go/cmd/amika/send_test.go
+++ b/go/cmd/amika/send_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func findChildCommand(root *cobra.Command, name string) *cobra.Command {
+	for _, c := range root.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestSendAndSessionsCommandsRegistered(t *testing.T) {
+	send := findChildCommand(rootCmd, "send")
+	if send == nil {
+		t.Fatal("send command not registered on rootCmd")
+	}
+	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "repo"} {
+		if send.Flags().Lookup(name) == nil {
+			t.Errorf("send is missing --%s flag", name)
+		}
+	}
+
+	sessions := findChildCommand(rootCmd, "sessions")
+	if sessions == nil {
+		t.Fatal("sessions command not registered on rootCmd")
+	}
+	if findChildCommand(sessions, "list") == nil {
+		t.Error("sessions has no list subcommand")
+	}
+	if findChildCommand(sessions, "show") == nil {
+		t.Error("sessions has no show subcommand")
+	}
+}
+
+func TestSendRequiresMessage(t *testing.T) {
+	// Force stdin to an immediate EOF so the no-arg path doesn't read a real
+	// terminal / block: with no message from args or stdin, send must error
+	// before any auth or network work.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Close()
+	old := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = old
+		_ = r.Close()
+		resetChangedFlags(rootCmd)
+	})
+
+	_, err = runRootCommand("send")
+	if err == nil || !strings.Contains(err.Error(), "message is required") {
+		t.Fatalf("err = %v, want a message-required error", err)
+	}
+}
+
+func TestSendRejectsInvalidOutput(t *testing.T) {
+	t.Cleanup(func() { resetChangedFlags(rootCmd) })
+	_, err := runRootCommand("send", "hi", "--output", "bogus")
+	if err == nil || !strings.Contains(err.Error(), "invalid --output") {
+		t.Fatalf("err = %v, want an invalid --output error", err)
+	}
+}

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -1134,24 +1134,35 @@ func readAgentSessionStream(
 	return result, streamErr, nil
 }
 
+// ListAgentSessionsResponse mirrors the API's ListAgentSessionsResponse schema
+// (GET /api/v0beta1/agent-sessions): one page of chats plus the total matching
+// the query. Like ListSandboxSnapshotsResponse, the API wraps the list in an
+// envelope rather than returning a bare array, so this is the single
+// decode/encode type — `sessions list -o json` re-emits it verbatim. Sessions
+// is never omitted, so an empty page encodes as [] rather than null.
+type ListAgentSessionsResponse struct {
+	Sessions []AgentSessionSummary `json:"sessions"`
+	Total    int                   `json:"total"`
+}
+
 // ListAgentSessions lists the org's agent-session chats, newest first. A limit
-// of 0 leaves the server's default page size (50) in place. Total is the count
-// of chats matching the query, which exceeds len(sessions) when the page cuts
-// the list short — callers should report that rather than presenting a
-// truncated list as the whole of it.
-func (c *Client) ListAgentSessions(limit int) (sessions []AgentSessionSummary, total int, err error) {
+// of 0 leaves the server's default page size (50) in place. The response's
+// Total exceeds len(Sessions) when the page cuts the list short — callers
+// should report that rather than presenting a truncated list as the whole of it.
+func (c *Client) ListAgentSessions(limit int) (*ListAgentSessionsResponse, error) {
 	path := apiBasePath + "/agent-sessions"
 	if limit > 0 {
 		path += "?limit=" + strconv.Itoa(limit)
 	}
-	var envelope struct {
-		Sessions []AgentSessionSummary `json:"sessions"`
-		Total    int                   `json:"total"`
+	var result ListAgentSessionsResponse
+	if err := c.doJSON("GET", path, nil, &result); err != nil {
+		return nil, fmt.Errorf("remote list agent-sessions: %w", err)
 	}
-	if err := c.doJSON("GET", path, nil, &envelope); err != nil {
-		return nil, 0, fmt.Errorf("remote list agent-sessions: %w", err)
+	// Normalize here so the one encode type always emits [], never null.
+	if result.Sessions == nil {
+		result.Sessions = []AgentSessionSummary{}
 	}
-	return envelope.Sessions, envelope.Total, nil
+	return &result, nil
 }
 
 // GetAgentSession returns one agent-session chat with its message history.

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -813,6 +813,108 @@ func (c *Client) UpdateSession(sandboxName, sessionID string, req UpdateSessionR
 	return &result, nil
 }
 
+// AgentSessionSendRequest is the request body for POST /api/v0beta1/agent-sessions.
+// Message is required; the rest are optional. SessionID continues an existing
+// chat, SandboxID routes into a specific sandbox, and RepoURL is only used when
+// a sandbox is created behind the scenes.
+type AgentSessionSendRequest struct {
+	Message    string `json:"message"`
+	Agent      string `json:"agent,omitempty"`
+	SessionID  string `json:"session_id,omitempty"`
+	SandboxID  string `json:"sandbox_id,omitempty"`
+	NewSession bool   `json:"new_session,omitempty"`
+	RepoURL    string `json:"repo_url,omitempty"`
+}
+
+// AgentSessionSendResponse mirrors the API's AgentSessionSendResponse schema
+// (POST /api/v0beta1/agent-sessions). SessionID is the durable chat id to pass
+// back as --session-id to continue the chat; CostUSD is the only optional field.
+type AgentSessionSendResponse struct {
+	SessionID      string   `json:"session_id"`
+	SandboxID      string   `json:"sandbox_id"`
+	Agent          string   `json:"agent"`
+	Response       string   `json:"response"`
+	IsError        bool     `json:"is_error"`
+	IsNewSession   bool     `json:"is_new_session"`
+	CreatedSandbox bool     `json:"created_sandbox"`
+	CostUSD        *float64 `json:"cost_usd,omitempty"`
+}
+
+// AgentSessionSummary is one row of the agent-sessions list. SandboxID and
+// Agent are nullable in the schema (a chat can outlive its sandbox), as is
+// LastError.
+type AgentSessionSummary struct {
+	SessionID string  `json:"session_id"`
+	SandboxID *string `json:"sandbox_id"`
+	Agent     *string `json:"agent"`
+	Status    string  `json:"status"`
+	LastError *string `json:"last_error"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
+}
+
+// AgentSessionMessage is one message in an agent-session chat's history.
+type AgentSessionMessage struct {
+	ID         string `json:"id"`
+	Direction  string `json:"direction"`
+	Author     string `json:"author"`
+	Contents   string `json:"contents"`
+	IsError    bool   `json:"is_error"`
+	OccurredAt string `json:"occurred_at"`
+}
+
+// AgentSessionDetail mirrors the API's AgentSessionDetail schema: one
+// agent-session chat with its full message history.
+type AgentSessionDetail struct {
+	SessionID string                `json:"session_id"`
+	SandboxID *string               `json:"sandbox_id"`
+	Agent     *string               `json:"agent"`
+	Status    string                `json:"status"`
+	CreatedAt string                `json:"created_at"`
+	UpdatedAt string                `json:"updated_at"`
+	Messages  []AgentSessionMessage `json:"messages"`
+}
+
+// SendAgentSession sends a message to a coding agent, creating a sandbox behind
+// the scenes when the chat has none, or routing to an existing sandbox/session.
+// The endpoint is synchronous (it blocks until the agent finishes), so a longer
+// HTTP timeout (10 minutes) is used instead of the default 30 seconds.
+func (c *Client) SendAgentSession(req AgentSessionSendRequest) (*AgentSessionSendResponse, error) {
+	saved := c.HTTP.Timeout
+	c.HTTP.Timeout = 10 * time.Minute
+	defer func() { c.HTTP.Timeout = saved }()
+
+	var result AgentSessionSendResponse
+	if err := c.doJSON("POST", apiBasePath+"/agent-sessions", req, &result); err != nil {
+		if authErr := extractAgentAuthError(err); authErr != "" {
+			return nil, fmt.Errorf("remote agent-session send: agent failed to authenticate with its AI provider: %s\n\nthe sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access", authErr)
+		}
+		return nil, fmt.Errorf("remote agent-session send: %w", err)
+	}
+	return &result, nil
+}
+
+// ListAgentSessions lists the org's agent-session chats, newest first.
+func (c *Client) ListAgentSessions() ([]AgentSessionSummary, error) {
+	var envelope struct {
+		Sessions []AgentSessionSummary `json:"sessions"`
+		Total    int                   `json:"total"`
+	}
+	if err := c.doJSON("GET", apiBasePath+"/agent-sessions", nil, &envelope); err != nil {
+		return nil, fmt.Errorf("remote list agent-sessions: %w", err)
+	}
+	return envelope.Sessions, nil
+}
+
+// GetAgentSession returns one agent-session chat with its message history.
+func (c *Client) GetAgentSession(sessionID string) (*AgentSessionDetail, error) {
+	var result AgentSessionDetail
+	if err := c.doJSON("GET", apiBasePath+"/agent-sessions/"+url.PathEscape(sessionID), nil, &result); err != nil {
+		return nil, fmt.Errorf("remote get agent-session: %w", err)
+	}
+	return &result, nil
+}
+
 // UploadFile is one requested file in a CreateUploadBatchRequest.
 type UploadFile struct {
 	// Filename is the object key within the org bucket. Relative paths only;

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -2,6 +2,7 @@
 package apiclient
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -892,6 +893,182 @@ func (c *Client) SendAgentSession(req AgentSessionSendRequest) (*AgentSessionSen
 		return nil, fmt.Errorf("remote agent-session send: %w", err)
 	}
 	return &result, nil
+}
+
+// AgentSessionStreamHandlers receives progress while SendAgentSessionStream
+// reads the SSE stream. Both callbacks are optional and are invoked from the
+// calling goroutine as frames arrive. OnStatus reports lifecycle milestones
+// (`creating_sandbox`/`sandbox_ready`, the latter carrying the sandbox id);
+// OnDelta receives agent reply text as it is produced.
+type AgentSessionStreamHandlers struct {
+	OnStatus func(phase, sandboxID string)
+	OnDelta  func(text string)
+}
+
+// SendAgentSessionStream is the streaming counterpart to SendAgentSession: it
+// POSTs to the `/agent-sessions/stream` SSE endpoint and forwards `status` and
+// `delta` frames to the handlers as they arrive, returning the terminal `done`
+// frame — the same AgentSessionSendResponse the buffered endpoint returns. A
+// mid-stream `error` frame (or a stream that ends without a `done`) becomes an
+// error. Auth/validation failures arrive as a normal JSON error BEFORE the
+// stream opens and are surfaced like the buffered path.
+//
+// As with SendAgentSession the turn can run for minutes, so a 10-minute timeout
+// replaces the client default. Note the server caps its own run well under
+// that; the longer client bound just avoids cutting a valid stream short.
+func (c *Client) SendAgentSessionStream(
+	req AgentSessionSendRequest,
+	h AgentSessionStreamHandlers,
+) (*AgentSessionSendResponse, error) {
+	saved := c.HTTP.Timeout
+	c.HTTP.Timeout = 10 * time.Minute
+	defer func() { c.HTTP.Timeout = saved }()
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling request: %w", err)
+	}
+	httpReq, err := http.NewRequest(
+		"POST",
+		c.BaseURL+apiBasePath+"/agent-sessions/stream",
+		bytes.NewReader(data),
+	)
+	if err != nil {
+		return nil, err
+	}
+	token, err := c.TokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("obtaining auth token: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.HTTP.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("remote agent-session send: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// A rejection (auth/validation) is a normal JSON error emitted before the
+	// stream opens; surface it like the buffered path, including the agent-auth
+	// hint when applicable.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		herr := &HTTPError{StatusCode: resp.StatusCode, Body: string(body)}
+		if authErr := extractAgentAuthError(herr); authErr != "" {
+			return nil, fmt.Errorf("remote agent-session send: agent failed to authenticate with its AI provider: %s\n\nthe sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access", authErr)
+		}
+		return nil, fmt.Errorf("remote agent-session send: %w", herr)
+	}
+
+	result, streamErr, err := readAgentSessionStream(resp.Body, h)
+	if err != nil {
+		return nil, fmt.Errorf("remote agent-session send: %w", err)
+	}
+	if streamErr != "" {
+		return nil, fmt.Errorf("remote agent-session send: %s", streamErr)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("remote agent-session send: stream ended without a result")
+	}
+	return result, nil
+}
+
+// readAgentSessionStream parses the send SSE stream. It returns the parsed
+// `done` result (nil if none arrived), the message from an `error` frame (""
+// if none), or a read/parse error. `status`/`delta` frames are dispatched to
+// the handlers as they are seen.
+func readAgentSessionStream(
+	body io.Reader,
+	h AgentSessionStreamHandlers,
+) (*AgentSessionSendResponse, string, error) {
+	scanner := bufio.NewScanner(body)
+	// A single `data:` line can carry the whole AgentSessionSendResponse; allow
+	// well beyond the default 64 KiB line cap.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var event string
+	var dataBuf strings.Builder
+	var result *AgentSessionSendResponse
+	var streamErr string
+
+	// dispatch handles one complete frame (terminated by a blank line).
+	dispatch := func() error {
+		ev, payload := event, dataBuf.String()
+		event = ""
+		dataBuf.Reset()
+		switch ev {
+		case "status":
+			if h.OnStatus != nil {
+				var s struct {
+					Phase     string `json:"phase"`
+					SandboxID string `json:"sandbox_id"`
+				}
+				if json.Unmarshal([]byte(payload), &s) == nil {
+					h.OnStatus(s.Phase, s.SandboxID)
+				}
+			}
+		case "delta":
+			if h.OnDelta != nil {
+				var d struct {
+					Text string `json:"text"`
+				}
+				if json.Unmarshal([]byte(payload), &d) == nil && d.Text != "" {
+					h.OnDelta(d.Text)
+				}
+			}
+		case "done":
+			var r AgentSessionSendResponse
+			if err := json.Unmarshal([]byte(payload), &r); err != nil {
+				return fmt.Errorf("parsing done frame: %w", err)
+			}
+			result = &r
+		case "error":
+			var e struct {
+				Error string `json:"error"`
+			}
+			_ = json.Unmarshal([]byte(payload), &e)
+			if e.Error != "" {
+				streamErr = e.Error
+			} else {
+				streamErr = "stream error"
+			}
+		}
+		return nil
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			// Blank line terminates a frame.
+			if event != "" {
+				if err := dispatch(); err != nil {
+					return nil, "", err
+				}
+			}
+		case strings.HasPrefix(line, "event: "):
+			event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			// SSE joins multiple data lines with \n; the server emits one line.
+			if dataBuf.Len() > 0 {
+				dataBuf.WriteByte('\n')
+			}
+			dataBuf.WriteString(strings.TrimPrefix(line, "data: "))
+		}
+		// Other lines (`:` comments, `id:`) are ignored.
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, "", fmt.Errorf("reading stream: %w", err)
+	}
+	// Flush a trailing frame not followed by a blank line (defensive).
+	if event != "" {
+		if err := dispatch(); err != nil {
+			return nil, "", err
+		}
+	}
+	return result, streamErr, nil
 }
 
 // ListAgentSessions lists the org's agent-session chats, newest first.

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -827,53 +827,69 @@ type AgentSessionSendRequest struct {
 	RepoURL    string `json:"repo_url,omitempty"`
 }
 
+// AgentSessionUsage mirrors the API's AgentSessionUsage schema: the token and
+// cost accounting for one turn. Every field is optional — Claude reports the
+// full set, Codex currently reports none — so all are pointers and a missing
+// one stays absent when the response is re-emitted as JSON.
+type AgentSessionUsage struct {
+	CostUSD             *float64 `json:"cost_usd,omitempty"`
+	InputTokens         *int64   `json:"input_tokens,omitempty"`
+	OutputTokens        *int64   `json:"output_tokens,omitempty"`
+	CacheReadTokens     *int64   `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens *int64   `json:"cache_creation_tokens,omitempty"`
+	DurationMS          *int64   `json:"duration_ms,omitempty"`
+	NumTurns            *int64   `json:"num_turns,omitempty"`
+}
+
 // AgentSessionSendResponse mirrors the API's AgentSessionSendResponse schema
 // (POST /api/v0beta1/agent-sessions). SessionID is the durable chat id to pass
-// back as --session-id to continue the chat; CostUSD is the only optional field.
+// back as --session-id to continue the chat; Usage is the only optional field
+// (absent for a provider that reports no accounting).
 type AgentSessionSendResponse struct {
-	SessionID      string   `json:"session_id"`
-	SandboxID      string   `json:"sandbox_id"`
-	Agent          string   `json:"agent"`
-	Response       string   `json:"response"`
-	IsError        bool     `json:"is_error"`
-	IsNewSession   bool     `json:"is_new_session"`
-	CreatedSandbox bool     `json:"created_sandbox"`
-	CostUSD        *float64 `json:"cost_usd,omitempty"`
+	SessionID      string             `json:"session_id"`
+	SandboxID      string             `json:"sandbox_id"`
+	Agent          string             `json:"agent"`
+	Response       string             `json:"response"`
+	IsError        bool               `json:"is_error"`
+	IsNewSession   bool               `json:"is_new_session"`
+	CreatedSandbox bool               `json:"created_sandbox"`
+	Usage          *AgentSessionUsage `json:"usage,omitempty"`
 }
 
-// AgentSessionSummary is one row of the agent-sessions list. SandboxID and
-// Agent are nullable in the schema (a chat can outlive its sandbox), as is
-// LastError.
+// AgentSessionSummary is one row of the agent-sessions list. SandboxName,
+// Preview, and EndedAt are nullable in the schema — a chat can outlive the
+// sandbox whose name it shows, carry no user message to preview, and still be
+// running.
 type AgentSessionSummary struct {
-	SessionID string  `json:"session_id"`
-	SandboxID *string `json:"sandbox_id"`
-	Agent     *string `json:"agent"`
-	Status    string  `json:"status"`
-	LastError *string `json:"last_error"`
-	CreatedAt string  `json:"created_at"`
-	UpdatedAt string  `json:"updated_at"`
+	SessionID   string  `json:"session_id"`
+	SandboxID   string  `json:"sandbox_id"`
+	SandboxName *string `json:"sandbox_name"`
+	Agent       string  `json:"agent"`
+	Status      string  `json:"status"`
+	Preview     *string `json:"preview"`
+	StartedAt   string  `json:"started_at"`
+	EndedAt     *string `json:"ended_at"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
 }
 
-// AgentSessionMessage is one message in an agent-session chat's history.
+// AgentSessionMessage is one turn in an agent-session chat's transcript,
+// mirroring the API's AgentSessionMessage schema. Role is a plain string (the
+// API deliberately does not enum it) and IsError marks an assistant turn the
+// agent reported as failed; it is absent for user turns and for transcripts
+// that predate per-turn error tracking.
 type AgentSessionMessage struct {
-	ID         string `json:"id"`
-	Direction  string `json:"direction"`
-	Author     string `json:"author"`
-	Contents   string `json:"contents"`
-	IsError    bool   `json:"is_error"`
-	OccurredAt string `json:"occurred_at"`
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	Timestamp string `json:"timestamp"`
+	IsError   bool   `json:"is_error,omitempty"`
 }
 
-// AgentSessionDetail mirrors the API's AgentSessionDetail schema: one
-// agent-session chat with its full message history.
+// AgentSessionDetail mirrors the API's AgentSessionDetail schema: an
+// AgentSessionSummary plus the chat's full transcript.
 type AgentSessionDetail struct {
-	SessionID string                `json:"session_id"`
-	SandboxID *string               `json:"sandbox_id"`
-	Agent     *string               `json:"agent"`
-	Status    string                `json:"status"`
-	CreatedAt string                `json:"created_at"`
-	UpdatedAt string                `json:"updated_at"`
-	Messages  []AgentSessionMessage `json:"messages"`
+	AgentSessionSummary
+	Messages []AgentSessionMessage `json:"messages"`
 }
 
 // SendAgentSession sends a message to a coding agent, creating a sandbox behind

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -882,7 +883,10 @@ type AgentSessionMessage struct {
 	Role      string `json:"role"`
 	Content   string `json:"content"`
 	Timestamp string `json:"timestamp"`
-	IsError   bool   `json:"is_error,omitempty"`
+	// A pointer, not a bool: the field is genuinely absent on user turns and
+	// on transcripts predating per-turn error tracking, and an explicit
+	// `false` must survive being re-emitted under --output json.
+	IsError *bool `json:"is_error,omitempty"`
 }
 
 // AgentSessionDetail mirrors the API's AgentSessionDetail schema: an
@@ -902,10 +906,11 @@ func (c *Client) SendAgentSession(req AgentSessionSendRequest) (*AgentSessionSen
 	defer func() { c.HTTP.Timeout = saved }()
 
 	var result AgentSessionSendResponse
+	// Note: no extractAgentAuthError branch here, unlike the older
+	// /sandboxes/{}/agent/send route. This endpoint reports a provider auth
+	// failure as a 200 with is_error set and the agent CLI's own message in
+	// `response` — not as an HTTP error — so there is no error body to inspect.
 	if err := c.doJSON("POST", apiBasePath+"/agent-sessions", req, &result); err != nil {
-		if authErr := extractAgentAuthError(err); authErr != "" {
-			return nil, fmt.Errorf("remote agent-session send: agent failed to authenticate with its AI provider: %s\n\nthe sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access", authErr)
-		}
 		return nil, fmt.Errorf("remote agent-session send: %w", err)
 	}
 	return &result, nil
@@ -930,8 +935,10 @@ type AgentSessionStreamHandlers struct {
 // stream opens and are surfaced like the buffered path.
 //
 // As with SendAgentSession the turn can run for minutes, so a 10-minute timeout
-// replaces the client default. Note the server caps its own run well under
-// that; the longer client bound just avoids cutting a valid stream short.
+// replaces the client default. The effective bound is the server's, which is
+// lower (a 300s request ceiling): it ends the stream first, without a `done`
+// frame, and the client timeout only guards against a connection that hangs
+// past even that.
 func (c *Client) SendAgentSessionStream(
 	req AgentSessionSendRequest,
 	h AgentSessionStreamHandlers,
@@ -967,28 +974,34 @@ func (c *Client) SendAgentSessionStream(
 	defer resp.Body.Close()
 
 	// A rejection (auth/validation) is a normal JSON error emitted before the
-	// stream opens; surface it like the buffered path, including the agent-auth
-	// hint when applicable.
+	// stream opens; surface it like the buffered path.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		herr := &HTTPError{StatusCode: resp.StatusCode, Body: string(body)}
-		if authErr := extractAgentAuthError(herr); authErr != "" {
-			return nil, fmt.Errorf("remote agent-session send: agent failed to authenticate with its AI provider: %s\n\nthe sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access", authErr)
-		}
-		return nil, fmt.Errorf("remote agent-session send: %w", herr)
+		return nil, fmt.Errorf("remote agent-session send: %w",
+			&HTTPError{StatusCode: resp.StatusCode, Body: string(body)})
 	}
 
 	result, streamErr, err := readAgentSessionStream(resp.Body, h)
 	if err != nil {
 		return nil, fmt.Errorf("remote agent-session send: %w", err)
 	}
+	// A completed turn wins over an error frame: `done` carries the persisted
+	// result, so if both somehow arrive the send succeeded and reporting the
+	// error would discard a real session id.
+	if result != nil {
+		return result, nil
+	}
 	if streamErr != "" {
 		return nil, fmt.Errorf("remote agent-session send: %s", streamErr)
 	}
-	if result == nil {
-		return nil, fmt.Errorf("remote agent-session send: stream ended without a result")
-	}
-	return result, nil
+	// No terminal frame. The most likely cause is the server's own request
+	// ceiling (300s) cutting the stream mid-turn — the turn may well have
+	// completed and persisted, so point at `amika sessions list` rather than
+	// implying the work was lost.
+	return nil, fmt.Errorf(
+		"remote agent-session send: stream ended without a result " +
+			"(the server may have hit its request time limit; " +
+			"check `amika sessions list` for the session)")
 }
 
 // readAgentSessionStream parses the send SSE stream. It returns the parsed
@@ -999,10 +1012,12 @@ func readAgentSessionStream(
 	body io.Reader,
 	h AgentSessionStreamHandlers,
 ) (*AgentSessionSendResponse, string, error) {
-	scanner := bufio.NewScanner(body)
-	// A single `data:` line can carry the whole AgentSessionSendResponse; allow
-	// well beyond the default 64 KiB line cap.
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	// A single `data:` line carries the whole AgentSessionSendResponse, whose
+	// `response` field is an entire agent turn. bufio.Scanner would impose a
+	// fixed line cap and fail a large-but-valid turn *after* it had run and
+	// been billed; bufio.Reader has no such bound, so the streaming and
+	// buffered transports accept the same responses.
+	reader := bufio.NewReader(body)
 
 	var event string
 	var dataBuf strings.Builder
@@ -1026,13 +1041,18 @@ func readAgentSessionStream(
 				}
 			}
 		case "delta":
-			if h.OnDelta != nil {
-				var d struct {
-					Text string `json:"text"`
-				}
-				if json.Unmarshal([]byte(payload), &d) == nil && d.Text != "" {
-					h.OnDelta(d.Text)
-				}
+			// A delta carries reply text, so an unparseable one is lost output.
+			// Fail loudly rather than silently printing a truncated reply and
+			// exiting 0. (`status` above is only cosmetic progress and carries
+			// no response text, so it stays lenient.)
+			var d struct {
+				Text string `json:"text"`
+			}
+			if err := json.Unmarshal([]byte(payload), &d); err != nil {
+				return fmt.Errorf("parsing delta frame: %w", err)
+			}
+			if d.Text != "" && h.OnDelta != nil {
+				h.OnDelta(d.Text)
 			}
 		case "done":
 			var r AgentSessionSendResponse
@@ -1054,29 +1074,56 @@ func readAgentSessionStream(
 		return nil
 	}
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	// handleLine processes one already-newline-stripped line.
+	handleLine := func(line string) error {
 		switch {
 		case line == "":
-			// Blank line terminates a frame.
+			// A blank line terminates a frame. Dispatch it when it is one we
+			// act on; otherwise drop it — but clear the buffered data either
+			// way. An SSE frame with no `event:` is a `message` event this
+			// protocol never sends, and leaving its payload in the buffer
+			// would glue it onto the front of the next frame and corrupt it.
 			if event != "" {
-				if err := dispatch(); err != nil {
-					return nil, "", err
-				}
+				return dispatch()
 			}
-		case strings.HasPrefix(line, "event: "):
-			event = strings.TrimPrefix(line, "event: ")
-		case strings.HasPrefix(line, "data: "):
+			dataBuf.Reset()
+		case strings.HasPrefix(line, "event:"):
+			// The space after the colon is optional in SSE; exactly one is
+			// stripped when present.
+			event = strings.TrimPrefix(strings.TrimPrefix(line, "event:"), " ")
+		case strings.HasPrefix(line, "data:"):
 			// SSE joins multiple data lines with \n; the server emits one line.
 			if dataBuf.Len() > 0 {
 				dataBuf.WriteByte('\n')
 			}
-			dataBuf.WriteString(strings.TrimPrefix(line, "data: "))
+			dataBuf.WriteString(
+				strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
 		}
 		// Other lines (`:` comments, `id:`) are ignored.
+		return nil
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, "", fmt.Errorf("reading stream: %w", err)
+
+	for {
+		raw, readErr := reader.ReadString('\n')
+		// A final line need not be newline-terminated, so process whatever was
+		// read before acting on the error. Trailing \r is stripped so CRLF
+		// streams parse identically.
+		if len(raw) > 0 {
+			if err := handleLine(strings.TrimRight(raw, "\r\n")); err != nil {
+				return nil, "", err
+			}
+			// `done` is terminal: stop reading so a later frame cannot discard
+			// a completed turn's result.
+			if result != nil {
+				return result, streamErr, nil
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return nil, "", fmt.Errorf("reading stream: %w", readErr)
+		}
 	}
 	// Flush a trailing frame not followed by a blank line (defensive).
 	if event != "" {
@@ -1087,16 +1134,24 @@ func readAgentSessionStream(
 	return result, streamErr, nil
 }
 
-// ListAgentSessions lists the org's agent-session chats, newest first.
-func (c *Client) ListAgentSessions() ([]AgentSessionSummary, error) {
+// ListAgentSessions lists the org's agent-session chats, newest first. A limit
+// of 0 leaves the server's default page size (50) in place. Total is the count
+// of chats matching the query, which exceeds len(sessions) when the page cuts
+// the list short — callers should report that rather than presenting a
+// truncated list as the whole of it.
+func (c *Client) ListAgentSessions(limit int) (sessions []AgentSessionSummary, total int, err error) {
+	path := apiBasePath + "/agent-sessions"
+	if limit > 0 {
+		path += "?limit=" + strconv.Itoa(limit)
+	}
 	var envelope struct {
 		Sessions []AgentSessionSummary `json:"sessions"`
 		Total    int                   `json:"total"`
 	}
-	if err := c.doJSON("GET", apiBasePath+"/agent-sessions", nil, &envelope); err != nil {
-		return nil, fmt.Errorf("remote list agent-sessions: %w", err)
+	if err := c.doJSON("GET", path, nil, &envelope); err != nil {
+		return nil, 0, fmt.Errorf("remote list agent-sessions: %w", err)
 	}
-	return envelope.Sessions, nil
+	return envelope.Sessions, envelope.Total, nil
 }
 
 // GetAgentSession returns one agent-session chat with its message history.

--- a/go/internal/apiclient/client_agent_sessions_stream_test.go
+++ b/go/internal/apiclient/client_agent_sessions_stream_test.go
@@ -1,6 +1,7 @@
 package apiclient
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -127,5 +128,154 @@ func TestSendAgentSessionStream_PreStreamHTTPError(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "Agent session not found") {
 		t.Fatalf("err = %v, want the 404 message", err)
+	}
+}
+
+// TestSendAgentSessionStream_EventlessDataFrameDoesNotCorruptNext checks that a
+// frame carrying data but no `event:` line (a legal SSE `message` event, and a
+// common keepalive idiom) is discarded cleanly. Its payload must not survive in
+// the buffer to be glued onto the front of the following frame, which would
+// fail a send whose turn had already completed and been persisted.
+func TestSendAgentSessionStream_EventlessDataFrameDoesNotCorruptNext(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	body := "data: {\"stray\":1}\n\n" +
+		"event: done\ndata: {\"session_id\":\"chat_1\",\"sandbox_id\":\"sbx_1\"," +
+		"\"agent\":\"claude\",\"response\":\"ok\",\"is_error\":false," +
+		"\"is_new_session\":true,\"created_sandbox\":false}\n\n"
+	srv := sseServer(t, body, &rec)
+	defer srv.Close()
+
+	resp, err := NewClient(srv.URL, "test-token").SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi"},
+		AgentSessionStreamHandlers{},
+	)
+	if err != nil {
+		t.Fatalf("SendAgentSessionStream: %v", err)
+	}
+	if resp.SessionID != "chat_1" || resp.Response != "ok" {
+		t.Errorf("resp = %+v", resp)
+	}
+}
+
+// TestSendAgentSessionStream_MalformedDeltaIsAnError checks that an unparseable
+// delta fails the send rather than being dropped. Silently skipping it would
+// print a truncated reply and still exit 0.
+func TestSendAgentSessionStream_MalformedDeltaIsAnError(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	body := "event: delta\ndata: {\"text\":\"good\"}\n\n" +
+		"event: delta\ndata: not-json\n\n" +
+		"event: done\ndata: {\"session_id\":\"chat_1\",\"sandbox_id\":\"sbx_1\"," +
+		"\"agent\":\"claude\",\"response\":\"goodLOST\",\"is_error\":false," +
+		"\"is_new_session\":true,\"created_sandbox\":false}\n\n"
+	srv := sseServer(t, body, &rec)
+	defer srv.Close()
+
+	_, err := NewClient(srv.URL, "test-token").SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi"},
+		AgentSessionStreamHandlers{OnDelta: func(string) {}},
+	)
+	if err == nil || !strings.Contains(err.Error(), "parsing delta frame") {
+		t.Fatalf("err = %v, want a delta parse error", err)
+	}
+}
+
+// TestSendAgentSessionStream_DataWithoutSpace checks the optional space after
+// `data:` is not required, per the SSE spec.
+func TestSendAgentSessionStream_DataWithoutSpace(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	body := "event:delta\ndata:{\"text\":\"hi\"}\n\n" +
+		"event:done\ndata:{\"session_id\":\"chat_1\",\"sandbox_id\":\"sbx_1\"," +
+		"\"agent\":\"claude\",\"response\":\"hi\",\"is_error\":false," +
+		"\"is_new_session\":true,\"created_sandbox\":false}\n\n"
+	srv := sseServer(t, body, &rec)
+	defer srv.Close()
+
+	var deltas strings.Builder
+	resp, err := NewClient(srv.URL, "test-token").SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi"},
+		AgentSessionStreamHandlers{OnDelta: func(s string) { deltas.WriteString(s) }},
+	)
+	if err != nil {
+		t.Fatalf("SendAgentSessionStream: %v", err)
+	}
+	if deltas.String() != "hi" || resp.SessionID != "chat_1" {
+		t.Errorf("deltas = %q, resp = %+v", deltas.String(), resp)
+	}
+}
+
+// TestSendAgentSessionStream_DoneWinsOverLaterErrorFrame checks that a
+// completed turn's result is returned even if an error frame follows: `done`
+// is terminal, and discarding it would throw away a real session id.
+func TestSendAgentSessionStream_DoneWinsOverLaterErrorFrame(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	body := "event: done\ndata: {\"session_id\":\"chat_1\",\"sandbox_id\":\"sbx_1\"," +
+		"\"agent\":\"claude\",\"response\":\"ok\",\"is_error\":false," +
+		"\"is_new_session\":true,\"created_sandbox\":false}\n\n" +
+		"event: error\ndata: {\"error\":\"late failure\"}\n\n"
+	srv := sseServer(t, body, &rec)
+	defer srv.Close()
+
+	resp, err := NewClient(srv.URL, "test-token").SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi"},
+		AgentSessionStreamHandlers{},
+	)
+	if err != nil {
+		t.Fatalf("SendAgentSessionStream: %v", err)
+	}
+	if resp.SessionID != "chat_1" {
+		t.Errorf("resp = %+v", resp)
+	}
+}
+
+// TestSendAgentSessionStream_LargeResponse checks a response well past the old
+// 4 MiB scanner cap parses, so a large-but-valid turn does not fail after it
+// has already run and been billed.
+func TestSendAgentSessionStream_LargeResponse(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	big := strings.Repeat("x", 8*1024*1024)
+	done, err := json.Marshal(AgentSessionSendResponse{
+		SessionID: "chat_1", SandboxID: "sbx_1", Agent: "claude", Response: big,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	srv := sseServer(t, "event: done\ndata: "+string(done)+"\n\n", &rec)
+	defer srv.Close()
+
+	resp, err := NewClient(srv.URL, "test-token").SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi"},
+		AgentSessionStreamHandlers{},
+	)
+	if err != nil {
+		t.Fatalf("SendAgentSessionStream: %v", err)
+	}
+	if len(resp.Response) != len(big) {
+		t.Errorf("response len = %d, want %d", len(resp.Response), len(big))
+	}
+}
+
+// TestSendAgentSessionStream_CRLFAndHeartbeats checks CRLF framing and `:`
+// comment keepalives, which the server emits to hold an idle connection open.
+func TestSendAgentSessionStream_CRLFAndHeartbeats(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	body := ": heartbeat\r\n\r\n" +
+		"event: delta\r\ndata: {\"text\":\"hi\"}\r\n\r\n" +
+		": heartbeat\r\n\r\n" +
+		"event: done\r\ndata: {\"session_id\":\"chat_1\",\"sandbox_id\":\"sbx_1\"," +
+		"\"agent\":\"claude\",\"response\":\"hi\",\"is_error\":false," +
+		"\"is_new_session\":true,\"created_sandbox\":false}\r\n\r\n"
+	srv := sseServer(t, body, &rec)
+	defer srv.Close()
+
+	var deltas strings.Builder
+	resp, err := NewClient(srv.URL, "test-token").SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi"},
+		AgentSessionStreamHandlers{OnDelta: func(s string) { deltas.WriteString(s) }},
+	)
+	if err != nil {
+		t.Fatalf("SendAgentSessionStream: %v", err)
+	}
+	if deltas.String() != "hi" || resp.SessionID != "chat_1" {
+		t.Errorf("deltas = %q, resp = %+v", deltas.String(), resp)
 	}
 }

--- a/go/internal/apiclient/client_agent_sessions_stream_test.go
+++ b/go/internal/apiclient/client_agent_sessions_stream_test.go
@@ -113,7 +113,7 @@ func TestSendAgentSessionStream_NoDoneFrame(t *testing.T) {
 // TestSendAgentSessionStream_PreStreamHTTPError checks that a rejection before
 // the stream opens (a normal JSON 4xx) surfaces as an error, not a parsed stream.
 func TestSendAgentSessionStream_PreStreamHTTPError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"code":"validation_failed","message":"Agent session not found"}`)

--- a/go/internal/apiclient/client_agent_sessions_stream_test.go
+++ b/go/internal/apiclient/client_agent_sessions_stream_test.go
@@ -1,0 +1,131 @@
+package apiclient
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sseServer returns a test server that replies to the send-stream endpoint with
+// the given raw SSE body, recording the request method, path, and Accept header.
+func sseServer(t *testing.T, body string, rec *struct {
+	method, path, accept string
+}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.method, rec.path, rec.accept = r.Method, r.URL.Path, r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, body)
+	}))
+}
+
+// TestSendAgentSessionStream_ForwardsFramesAndReturnsDone checks that status and
+// delta frames are dispatched in order and the terminal done frame is parsed
+// into the returned response.
+func TestSendAgentSessionStream_ForwardsFramesAndReturnsDone(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	body := strings.Join([]string{
+		"event: status\ndata: {\"phase\":\"creating_sandbox\"}\n\n",
+		"event: status\ndata: {\"phase\":\"sandbox_ready\",\"sandbox_id\":\"sbx_1\"}\n\n",
+		"event: delta\ndata: {\"text\":\"Hel\"}\n\n",
+		"event: delta\ndata: {\"text\":\"lo\"}\n\n",
+		"event: done\ndata: {\"session_id\":\"chat_1\",\"sandbox_id\":\"sbx_1\",\"agent\":\"claude\",\"response\":\"Hello\",\"is_error\":false,\"is_new_session\":true,\"created_sandbox\":true}\n\n",
+	}, "")
+	srv := sseServer(t, body, &rec)
+	defer srv.Close()
+
+	var deltas strings.Builder
+	var statuses []string
+	c := NewClient(srv.URL, "test-token")
+	resp, err := c.SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi", Agent: "claude"},
+		AgentSessionStreamHandlers{
+			OnStatus: func(phase, sandboxID string) {
+				statuses = append(statuses, phase+":"+sandboxID)
+			},
+			OnDelta: func(text string) { deltas.WriteString(text) },
+		},
+	)
+	if err != nil {
+		t.Fatalf("SendAgentSessionStream: %v", err)
+	}
+
+	if rec.method != http.MethodPost ||
+		rec.path != "/api/v0beta1/agent-sessions/stream" {
+		t.Errorf("request = %s %s", rec.method, rec.path)
+	}
+	if rec.accept != "text/event-stream" {
+		t.Errorf("Accept = %q, want text/event-stream", rec.accept)
+	}
+	if deltas.String() != "Hello" {
+		t.Errorf("deltas = %q, want %q", deltas.String(), "Hello")
+	}
+	if len(statuses) != 2 ||
+		statuses[0] != "creating_sandbox:" ||
+		statuses[1] != "sandbox_ready:sbx_1" {
+		t.Errorf("statuses = %v", statuses)
+	}
+	if resp.SessionID != "chat_1" || resp.Response != "Hello" ||
+		!resp.IsNewSession || !resp.CreatedSandbox {
+		t.Errorf("resp = %+v", resp)
+	}
+}
+
+// TestSendAgentSessionStream_ErrorFrame checks a mid-stream error frame becomes
+// a returned error carrying the frame's message.
+func TestSendAgentSessionStream_ErrorFrame(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	body := "event: delta\ndata: {\"text\":\"partial\"}\n\n" +
+		"event: error\ndata: {\"error\":\"sandbox blew up\"}\n\n"
+	srv := sseServer(t, body, &rec)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	_, err := c.SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi"},
+		AgentSessionStreamHandlers{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "sandbox blew up") {
+		t.Fatalf("err = %v, want the error-frame message", err)
+	}
+}
+
+// TestSendAgentSessionStream_NoDoneFrame checks that a stream ending without a
+// done (or error) frame is reported rather than silently returning nil.
+func TestSendAgentSessionStream_NoDoneFrame(t *testing.T) {
+	var rec struct{ method, path, accept string }
+	srv := sseServer(t, "event: delta\ndata: {\"text\":\"hi\"}\n\n", &rec)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	_, err := c.SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi"},
+		AgentSessionStreamHandlers{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "without a result") {
+		t.Fatalf("err = %v, want a no-result error", err)
+	}
+}
+
+// TestSendAgentSessionStream_PreStreamHTTPError checks that a rejection before
+// the stream opens (a normal JSON 4xx) surfaces as an error, not a parsed stream.
+func TestSendAgentSessionStream_PreStreamHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"code":"validation_failed","message":"Agent session not found"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	_, err := c.SendAgentSessionStream(
+		AgentSessionSendRequest{Message: "hi", SessionID: "nope"},
+		AgentSessionStreamHandlers{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "Agent session not found") {
+		t.Fatalf("err = %v, want the 404 message", err)
+	}
+}

--- a/go/internal/apiclient/client_agent_sessions_test.go
+++ b/go/internal/apiclient/client_agent_sessions_test.go
@@ -123,15 +123,16 @@ func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClient(srv.URL, "test-token")
-	sessions, total, err := c.ListAgentSessions(0)
+	resp, err := c.ListAgentSessions(0)
 	if err != nil {
 		t.Fatalf("ListAgentSessions: %v", err)
 	}
+	sessions := resp.Sessions
 	if len(sessions) != 2 {
 		t.Fatalf("len = %d, want 2", len(sessions))
 	}
-	if total != 2 {
-		t.Errorf("total = %d, want 2", total)
+	if resp.Total != 2 {
+		t.Errorf("total = %d, want 2", resp.Total)
 	}
 	if sessions[0].SandboxID != "sbx_1" || sessions[0].Agent != "claude" {
 		t.Errorf("sessions[0] = %+v", sessions[0])
@@ -212,5 +213,58 @@ func TestGetAgentSession_EscapesIDAndParsesMessages(t *testing.T) {
 	}
 	if !strings.Contains(string(out), `"is_error":false`) {
 		t.Errorf("re-emitted message = %s, want an explicit is_error:false", out)
+	}
+}
+
+// TestListAgentSessions_ReEmitsEnvelope checks the response round-trips as the
+// API's {sessions,total} envelope, which `sessions list -o json` emits verbatim
+// (remote-backed commands mirror the API response schema). An empty page must
+// encode as [] rather than null.
+func TestListAgentSessions_ReEmitsEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"sessions":[],"total":7}`)
+	}))
+	defer srv.Close()
+
+	resp, err := NewClient(srv.URL, "test-token").ListAgentSessions(0)
+	if err != nil {
+		t.Fatalf("ListAgentSessions: %v", err)
+	}
+	if resp.Total != 7 {
+		t.Errorf("total = %d, want 7", resp.Total)
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != `{"sessions":[],"total":7}` {
+		t.Errorf("re-emitted = %s, want the {sessions,total} envelope with []", out)
+	}
+}
+
+// TestListAgentSessions_SendsLimit checks a non-zero limit reaches the query
+// string and zero leaves the server's default page size in place.
+func TestListAgentSessions_SendsLimit(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"sessions":[],"total":0}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	if _, err := c.ListAgentSessions(5); err != nil {
+		t.Fatalf("ListAgentSessions(5): %v", err)
+	}
+	if gotQuery != "limit=5" {
+		t.Errorf("query = %q, want limit=5", gotQuery)
+	}
+	if _, err := c.ListAgentSessions(0); err != nil {
+		t.Fatalf("ListAgentSessions(0): %v", err)
+	}
+	if gotQuery != "" {
+		t.Errorf("query = %q, want no limit param", gotQuery)
 	}
 }

--- a/go/internal/apiclient/client_agent_sessions_test.go
+++ b/go/internal/apiclient/client_agent_sessions_test.go
@@ -123,12 +123,15 @@ func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClient(srv.URL, "test-token")
-	sessions, err := c.ListAgentSessions()
+	sessions, total, err := c.ListAgentSessions(0)
 	if err != nil {
 		t.Fatalf("ListAgentSessions: %v", err)
 	}
 	if len(sessions) != 2 {
 		t.Fatalf("len = %d, want 2", len(sessions))
+	}
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
 	}
 	if sessions[0].SandboxID != "sbx_1" || sessions[0].Agent != "claude" {
 		t.Errorf("sessions[0] = %+v", sessions[0])
@@ -162,7 +165,7 @@ func TestGetAgentSession_EscapesIDAndParsesMessages(t *testing.T) {
           "agent":"claude","status":"active","preview":null,"started_at":"t0","ended_at":null,
           "created_at":"t0","updated_at":"t1","messages":[
           {"role":"user","content":"hi","timestamp":"t0"},
-          {"role":"assistant","content":"hello","timestamp":"t1"},
+          {"role":"assistant","content":"hello","timestamp":"t1","is_error":false},
           {"role":"assistant","content":"Not logged in","timestamp":"t2","is_error":true}
         ]}`)
 	}))
@@ -190,10 +193,24 @@ func TestGetAgentSession_EscapesIDAndParsesMessages(t *testing.T) {
 		detail.Messages[0].Timestamp != "t0" {
 		t.Errorf("messages[0] = %+v", detail.Messages[0])
 	}
-	if detail.Messages[1].IsError {
-		t.Errorf("messages[1].IsError = true, want false")
+	// Absent on a user turn, explicitly false on a successful assistant turn,
+	// true on a failed one — three states the pointer must keep distinct so
+	// `--output json` re-emits what the API actually sent.
+	if detail.Messages[0].IsError != nil {
+		t.Errorf("messages[0].IsError = %v, want nil (absent)", *detail.Messages[0].IsError)
 	}
-	if !detail.Messages[2].IsError {
-		t.Errorf("messages[2].IsError = false, want true")
+	if detail.Messages[1].IsError == nil || *detail.Messages[1].IsError {
+		t.Errorf("messages[1].IsError = %v, want an explicit false", detail.Messages[1].IsError)
+	}
+	if detail.Messages[2].IsError == nil || !*detail.Messages[2].IsError {
+		t.Errorf("messages[2].IsError = %v, want true", detail.Messages[2].IsError)
+	}
+	// An explicit false must survive the round trip, not vanish via omitempty.
+	out, err := json.Marshal(detail.Messages[1])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"is_error":false`) {
+		t.Errorf("re-emitted message = %s, want an explicit is_error:false", out)
 	}
 }

--- a/go/internal/apiclient/client_agent_sessions_test.go
+++ b/go/internal/apiclient/client_agent_sessions_test.go
@@ -5,12 +5,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 // TestSendAgentSession_RequestAndResponse checks that SendAgentSession posts to
 // the agent-sessions collection with the request body and parses the full
-// AgentSessionSendResponse (including the optional cost_usd).
+// AgentSessionSendResponse (including the optional nested usage).
 func TestSendAgentSession_RequestAndResponse(t *testing.T) {
 	var gotMethod, gotPath string
 	var gotReq AgentSessionSendRequest
@@ -27,7 +28,11 @@ func TestSendAgentSession_RequestAndResponse(t *testing.T) {
 			"is_error":        false,
 			"is_new_session":  true,
 			"created_sandbox": true,
-			"cost_usd":        0.5,
+			"usage": map[string]any{
+				"cost_usd":      0.5,
+				"input_tokens":  120,
+				"output_tokens": 45,
+			},
 		})
 	}))
 	defer srv.Close()
@@ -53,13 +58,53 @@ func TestSendAgentSession_RequestAndResponse(t *testing.T) {
 	if resp.Response != "hello there" || !resp.IsNewSession || !resp.CreatedSandbox {
 		t.Errorf("resp = %+v", resp)
 	}
-	if resp.CostUSD == nil || *resp.CostUSD != 0.5 {
-		t.Errorf("CostUSD = %v, want 0.5", resp.CostUSD)
+	if resp.Usage == nil {
+		t.Fatalf("Usage = nil, want the nested usage object")
+	}
+	if resp.Usage.CostUSD == nil || *resp.Usage.CostUSD != 0.5 {
+		t.Errorf("Usage.CostUSD = %v, want 0.5", resp.Usage.CostUSD)
+	}
+	if resp.Usage.InputTokens == nil || *resp.Usage.InputTokens != 120 {
+		t.Errorf("Usage.InputTokens = %v, want 120", resp.Usage.InputTokens)
+	}
+	// A field the provider didn't report stays absent rather than becoming 0.
+	if resp.Usage.NumTurns != nil {
+		t.Errorf("Usage.NumTurns = %v, want nil", resp.Usage.NumTurns)
+	}
+}
+
+// TestSendAgentSession_OmitsUsageWhenAbsent checks a response without `usage`
+// (a provider that reports no accounting, e.g. codex) parses to a nil Usage
+// that is dropped again when the response is re-emitted under `--output json`.
+func TestSendAgentSession_OmitsUsageWhenAbsent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"session_id":"chat_1","sandbox_id":"sbx_1","agent":"codex",
+          "response":"ok","is_error":false,"is_new_session":false,"created_sandbox":false}`)
+	}))
+	defer srv.Close()
+
+	resp, err := NewClient(srv.URL, "test-token").SendAgentSession(
+		AgentSessionSendRequest{Message: "hi"},
+	)
+	if err != nil {
+		t.Fatalf("SendAgentSession: %v", err)
+	}
+	if resp.Usage != nil {
+		t.Errorf("Usage = %+v, want nil", resp.Usage)
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "usage") {
+		t.Errorf("re-emitted JSON = %s, want no usage key", out)
 	}
 }
 
 // TestListAgentSessions_ParsesEnvelope checks the list method unwraps the
-// {sessions,total} envelope and parses nullable sandbox_id/agent.
+// {sessions,total} envelope and parses the nullable sandbox_name/preview/
+// ended_at fields.
 func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v0beta1/agent-sessions" {
@@ -67,8 +112,12 @@ func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{"sessions":[
-          {"session_id":"chat_cnv_1","sandbox_id":"sbx_1","agent":"claude","status":"idle","last_error":null,"created_at":"t0","updated_at":"t1"},
-          {"session_id":"chat_cnv_2","sandbox_id":null,"agent":null,"status":"idle","last_error":null,"created_at":"t0","updated_at":"t2"}
+          {"session_id":"as_1","sandbox_id":"sbx_1","sandbox_name":"silver-wuhan","agent":"claude",
+           "status":"active","preview":"hi there","started_at":"t0","ended_at":null,
+           "created_at":"t0","updated_at":"t1"},
+          {"session_id":"as_2","sandbox_id":"sbx_2","sandbox_name":null,"agent":"codex",
+           "status":"ended","preview":null,"started_at":"t0","ended_at":"t2",
+           "created_at":"t0","updated_at":"t2"}
         ],"total":2}`)
 	}))
 	defer srv.Close()
@@ -81,40 +130,70 @@ func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
 	if len(sessions) != 2 {
 		t.Fatalf("len = %d, want 2", len(sessions))
 	}
-	if sessions[0].SandboxID == nil || *sessions[0].SandboxID != "sbx_1" {
-		t.Errorf("sessions[0].SandboxID = %v", sessions[0].SandboxID)
+	if sessions[0].SandboxID != "sbx_1" || sessions[0].Agent != "claude" {
+		t.Errorf("sessions[0] = %+v", sessions[0])
 	}
-	if sessions[1].SandboxID != nil || sessions[1].Agent != nil {
-		t.Errorf("sessions[1] should have null sandbox_id/agent: %+v", sessions[1])
+	if sessions[0].SandboxName == nil || *sessions[0].SandboxName != "silver-wuhan" {
+		t.Errorf("sessions[0].SandboxName = %v", sessions[0].SandboxName)
+	}
+	if sessions[0].Preview == nil || *sessions[0].Preview != "hi there" {
+		t.Errorf("sessions[0].Preview = %v", sessions[0].Preview)
+	}
+	if sessions[0].EndedAt != nil {
+		t.Errorf("sessions[0].EndedAt = %v, want nil", sessions[0].EndedAt)
+	}
+	if sessions[1].SandboxName != nil || sessions[1].Preview != nil {
+		t.Errorf("sessions[1] should have null sandbox_name/preview: %+v", sessions[1])
+	}
+	if sessions[1].EndedAt == nil || *sessions[1].EndedAt != "t2" {
+		t.Errorf("sessions[1].EndedAt = %v, want t2", sessions[1].EndedAt)
 	}
 }
 
 // TestGetAgentSession_EscapesIDAndParsesMessages checks the id is path-escaped
-// and the message history is parsed.
+// and the transcript is parsed in the API's {role,content,timestamp} shape,
+// including the optional per-turn is_error flag.
 func TestGetAgentSession_EscapesIDAndParsesMessages(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.EscapedPath()
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, `{"session_id":"chat_cnv/1","sandbox_id":"sbx_1","agent":"claude","status":"idle","created_at":"t0","updated_at":"t1","messages":[
-          {"id":"m1","direction":"inbound","author":"user","contents":"hi","is_error":false,"occurred_at":"t0"},
-          {"id":"m2","direction":"outbound","author":"claude","contents":"hello","is_error":false,"occurred_at":"t1"}
+		io.WriteString(w, `{"session_id":"as/1","sandbox_id":"sbx_1","sandbox_name":"silver-wuhan",
+          "agent":"claude","status":"active","preview":null,"started_at":"t0","ended_at":null,
+          "created_at":"t0","updated_at":"t1","messages":[
+          {"role":"user","content":"hi","timestamp":"t0"},
+          {"role":"assistant","content":"hello","timestamp":"t1"},
+          {"role":"assistant","content":"Not logged in","timestamp":"t2","is_error":true}
         ]}`)
 	}))
 	defer srv.Close()
 
 	c := NewClient(srv.URL, "test-token")
-	detail, err := c.GetAgentSession("chat_cnv/1")
+	detail, err := c.GetAgentSession("as/1")
 	if err != nil {
 		t.Fatalf("GetAgentSession: %v", err)
 	}
-	if gotPath != "/api/v0beta1/agent-sessions/chat_cnv%2F1" {
+	if gotPath != "/api/v0beta1/agent-sessions/as%2F1" {
 		t.Errorf("path = %s, want the id path-escaped", gotPath)
 	}
-	if len(detail.Messages) != 2 {
-		t.Fatalf("messages = %d, want 2", len(detail.Messages))
+	// The detail embeds the summary, so its fields parse from the same object.
+	if detail.SessionID != "as/1" || detail.Agent != "claude" || detail.Status != "active" {
+		t.Errorf("detail = %+v", detail.AgentSessionSummary)
 	}
-	if detail.Messages[0].Direction != "inbound" || detail.Messages[1].Contents != "hello" {
-		t.Errorf("messages = %+v", detail.Messages)
+	if detail.SandboxName == nil || *detail.SandboxName != "silver-wuhan" {
+		t.Errorf("detail.SandboxName = %v", detail.SandboxName)
+	}
+	if len(detail.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3", len(detail.Messages))
+	}
+	if detail.Messages[0].Role != "user" || detail.Messages[0].Content != "hi" ||
+		detail.Messages[0].Timestamp != "t0" {
+		t.Errorf("messages[0] = %+v", detail.Messages[0])
+	}
+	if detail.Messages[1].IsError {
+		t.Errorf("messages[1].IsError = true, want false")
+	}
+	if !detail.Messages[2].IsError {
+		t.Errorf("messages[2].IsError = false, want true")
 	}
 }

--- a/go/internal/apiclient/client_agent_sessions_test.go
+++ b/go/internal/apiclient/client_agent_sessions_test.go
@@ -1,0 +1,120 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSendAgentSession_RequestAndResponse checks that SendAgentSession posts to
+// the agent-sessions collection with the request body and parses the full
+// AgentSessionSendResponse (including the optional cost_usd).
+func TestSendAgentSession_RequestAndResponse(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotReq AgentSessionSendRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotReq)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"session_id":      "chat_cnv_1",
+			"sandbox_id":      "sbx_1",
+			"agent":           "codex",
+			"response":        "hello there",
+			"is_error":        false,
+			"is_new_session":  true,
+			"created_sandbox": true,
+			"cost_usd":        0.5,
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	resp, err := c.SendAgentSession(AgentSessionSendRequest{
+		Message:   "hi",
+		Agent:     "codex",
+		SessionID: "chat_cnv_1",
+	})
+	if err != nil {
+		t.Fatalf("SendAgentSession: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/api/v0beta1/agent-sessions" {
+		t.Errorf("request = %s %s", gotMethod, gotPath)
+	}
+	if gotReq.Message != "hi" || gotReq.Agent != "codex" || gotReq.SessionID != "chat_cnv_1" {
+		t.Errorf("request body = %+v", gotReq)
+	}
+	if resp.SessionID != "chat_cnv_1" || resp.SandboxID != "sbx_1" || resp.Agent != "codex" {
+		t.Errorf("resp = %+v", resp)
+	}
+	if resp.Response != "hello there" || !resp.IsNewSession || !resp.CreatedSandbox {
+		t.Errorf("resp = %+v", resp)
+	}
+	if resp.CostUSD == nil || *resp.CostUSD != 0.5 {
+		t.Errorf("CostUSD = %v, want 0.5", resp.CostUSD)
+	}
+}
+
+// TestListAgentSessions_ParsesEnvelope checks the list method unwraps the
+// {sessions,total} envelope and parses nullable sandbox_id/agent.
+func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0beta1/agent-sessions" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"sessions":[
+          {"session_id":"chat_cnv_1","sandbox_id":"sbx_1","agent":"claude","status":"idle","last_error":null,"created_at":"t0","updated_at":"t1"},
+          {"session_id":"chat_cnv_2","sandbox_id":null,"agent":null,"status":"idle","last_error":null,"created_at":"t0","updated_at":"t2"}
+        ],"total":2}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	sessions, err := c.ListAgentSessions()
+	if err != nil {
+		t.Fatalf("ListAgentSessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("len = %d, want 2", len(sessions))
+	}
+	if sessions[0].SandboxID == nil || *sessions[0].SandboxID != "sbx_1" {
+		t.Errorf("sessions[0].SandboxID = %v", sessions[0].SandboxID)
+	}
+	if sessions[1].SandboxID != nil || sessions[1].Agent != nil {
+		t.Errorf("sessions[1] should have null sandbox_id/agent: %+v", sessions[1])
+	}
+}
+
+// TestGetAgentSession_EscapesIDAndParsesMessages checks the id is path-escaped
+// and the message history is parsed.
+func TestGetAgentSession_EscapesIDAndParsesMessages(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"session_id":"chat_cnv/1","sandbox_id":"sbx_1","agent":"claude","status":"idle","created_at":"t0","updated_at":"t1","messages":[
+          {"id":"m1","direction":"inbound","author":"user","contents":"hi","is_error":false,"occurred_at":"t0"},
+          {"id":"m2","direction":"outbound","author":"claude","contents":"hello","is_error":false,"occurred_at":"t1"}
+        ]}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	detail, err := c.GetAgentSession("chat_cnv/1")
+	if err != nil {
+		t.Fatalf("GetAgentSession: %v", err)
+	}
+	if gotPath != "/api/v0beta1/agent-sessions/chat_cnv%2F1" {
+		t.Errorf("path = %s, want the id path-escaped", gotPath)
+	}
+	if len(detail.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2", len(detail.Messages))
+	}
+	if detail.Messages[0].Direction != "inbound" || detail.Messages[1].Contents != "hello" {
+		t.Errorf("messages = %+v", detail.Messages)
+	}
+}


### PR DESCRIPTION
## What

Adds the CLI half of the agent-sessions feature: a one-shot `amika send` and a `sessions` browser, driving the new remote `agent-sessions` API.

- **`amika send [message]`** — send a message to a coding agent. With neither `--session-id` nor `--sandbox`, a sandbox is created behind the scenes and a new chat starts; the returned `session_id` continues it next time. Agent from `--agent` (claude|codex), else the org default, else claude. Message from a positional arg or stdin. Synchronous — prints the reply. Flags: `--agent`, `--session-id`, `--sandbox`, `--new-session`, `--repo`. In text mode `session_id`/created-sandbox notes go to stderr so stdout stays the pure response; `--output json` emits the `AgentSessionSendResponse` verbatim.
- **`amika sessions list` / `amika sessions show <id>`** — browse the durable chats those sends create (backed by `GET /agent-sessions`).
- **API client**: `SendAgentSession`, `ListAgentSessions`, `GetAgentSession` + mirror types. `SendAgentSession` uses the same 10-minute timeout as the existing synchronous agent-send.

## Server dependency

Requires the `agent-sessions` endpoint in amika-mono (gofixpoint/amika-mono#866). The client structs are hand-maintained mirrors of that API's OpenAPI schema, matching how the rest of `apiclient` works.

## Testing

- `httptest` coverage of the three client methods: request method/path/body, full response parsing, nullable `sandbox_id`/`agent`, `[]`-not-`null` list, and id path-escaping.
- Command tests: `send`/`sessions` registration + flags, message-required, and `--output` validation.
- `make fmtcheck vet lint` and `go test ./internal/apiclient/... ./cmd/amika/...` pass; the CLI builds (`make build-cli`).

## Streaming (update)

`amika send` now streams the reply in real time via the new
`POST /agent-sessions/stream` SSE endpoint (amika-mono#915), instead of
blocking on the whole message.

- **API client**: `SendAgentSessionStream(req, handlers)` POSTs with
  `Accept: text/event-stream`, forwards `status` (sandbox lifecycle) and
  `delta` (agent text) frames to callbacks as they arrive, and returns the
  terminal `done` frame — the same `AgentSessionSendResponse` the buffered
  `SendAgentSession` returns. A mid-stream `error` frame, or a stream that
  ends without `done`, becomes an error; auth/validation failures arrive as a
  JSON error before the stream opens and are surfaced like the buffered path.
- **`amika send --stream`**: streams by default when stdout is a terminal;
  buffers when stdout is piped (so a captured pipe stays the single final
  response, not the concatenated deltas) and always for `--output json` (which
  must stay one valid object). `--stream` / `--stream=false` forces either
  mode. Sandbox progress + `session_id` go to stderr; only agent text goes to
  stdout, matching the buffered path. Buffered `SendAgentSession` is unchanged.

The `--session-id` returned by either mode continues the chat as before.

### Testing (streaming)

- `httptest` SSE coverage of `SendAgentSessionStream`: in-order `status`/`delta`
  dispatch + `done` parsing (and `Accept`/method/path), an `error` frame → error,
  a stream with no `done` → error, and a pre-stream 4xx → error.
- `send` command test now also asserts the `--stream` flag is registered.


## Schema-drift fix + live verification (update)

Rebased on `main`. The hand-maintained mirror types had drifted from the
server's actual responses, so three fields never parsed:

- `AgentSessionMessage` used `{id, direction, author, contents, occurred_at}`;
  the API returns `{role, content, timestamp, is_error}` — every field missed,
  so `sessions show` printed a blank line per turn instead of the transcript.
- `AgentSessionSendResponse` had a top-level `cost_usd`, but the API nests
  accounting under `usage` (tokens, duration, turns, cost). The object was
  dropped entirely, including from `--output json`, which is documented as
  emitting the response verbatim.
- `AgentSessionSummary` lacked `sandbox_name`/`preview`/`started_at`/`ended_at`
  and carried a `last_error` the API never sends; `sandbox_id`/`agent` are
  non-null in the schema. `AgentSessionDetail` now embeds the summary.

`list`/`show` display the sandbox name, falling back to the id when it can't be
resolved. Also fixed the revive failure (unused handler param) that was red.

### Live verification

Built the CLI and ran it against the live API (`app.amika.dev`), which has the
`agent-sessions` endpoints enabled — no longer hand-verified:

| Case | Result |
|------|--------|
| `send --stream` with no session/sandbox | Provisioned a sandbox (~95s), streamed `status` → `delta` → `done`; stdout the pure reply, stderr the progress + `session_id` |
| `send --session-id` (continuation) | Same sandbox, `is_new_session:false`, agent recalled the prior turn |
| `send --output json` | One valid object, `usage` present (this is what the old mirror silently dropped) |
| `send` from stdin, piped stdout | Buffered by default as documented |
| `send --sandbox <name> --new-session` | Resolved the sandbox by name, new session id, `created_sandbox:false` |
| `sessions list` / `sessions show` | Full transcript renders; all three turns persisted |
| Bad `--session-id`, both transports | Clean `HTTP 404: validation_failed: Agent session not found` before the stream opens |
| No message | `message is required as an argument or via stdin` |

`make fmtcheck vet lint build-cli` and `go test ./internal/apiclient/...
./cmd/amika/...` all pass locally.



## Review fixes (update)

A review pass over the streaming transport found several ways a completed turn
could be reported as a failure, or a reply silently truncated. All fixed:

| Bug | Effect |
|-----|--------|
| Data buffer reset only inside `dispatch()` | An `event:`-less `data:` frame (a legal SSE `message`, and a common keepalive) left its payload buffered and glued onto the next frame, so the following `done` failed to parse — failing a send whose turn had already run and persisted |
| Unparseable `delta` dropped silently | One bad frame printed a truncated reply and still exited 0; now an error (`status` stays lenient — cosmetic, carries no reply text) |
| `resp.Response` printed only when no delta arrived | On a failed turn `response` carries the agent CLI's own message, derived from the result object and never streamed — so streaming showed *less* than buffered for the same turn |
| 4 MiB `bufio.Scanner` frame cap | A large-but-valid turn failed *after* being billed, and only when streaming; `bufio.Reader` removes the bound so both transports accept the same responses |
| Parsing continued past `done` | A later `error` frame could discard a completed turn's result; `done` is now terminal and a result outranks an error frame |
| `data:`/`event:` required the optional space | Spec violation in a hand-rolled parser; one space is now stripped if present |

Also: dropped the `extractAgentAuthError` branches from both agent-sessions
paths (dead code — the helper matches the older agent-send route's `{error,
details}` body, while `ApiError` emits `{type, error_code, message, details}`,
and a provider auth failure here is a 200 with `is_error` set, not an HTTP
error); `sessions list` gained `--limit` and now reports when the server's
50-row page hides chats instead of presenting it as the whole list;
`AgentSessionMessage.IsError` became `*bool` so an explicit `false` survives
`--output json`; and the comment claiming the server caps its run well under
the client's 10 minutes was corrected (its ceiling is 300s — *lower*, and what
actually ends a long stream).

Regression tests cover each parser fix: event-less data frame, malformed delta,
spaceless `data:`, `error` after `done`, an 8 MiB response, and CRLF +
heartbeats. Re-verified against the live API — streamed and buffered sends,
continuation, `--output json`, `--limit`, and `sessions show`.

> Unrelated server-side issue found while testing: sending to a sandbox that has
> auto-stopped returns a 500 (`internal_error`) on both transports, rather than
> resuming it as `resolveSandboxForSend` intends. That's in amika-mono, not this
> PR.
