### PR TITLE
Fix the managed sshd port, add `amika scpv2`, and scope SSH sessions per control plane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ For user-facing docs (`docs/`, README):
 | `AMIKA_STATE_DIRECTORY` | Override default state directory (`~/.local/state/amika`) |
 | `AMIKA_PRESET_IMAGE_PREFIX` | Override Docker image name prefix for presets |
 | `AMIKA_API_URL` | Override remote API base URL (default: `https://app.amika.dev`) |
+| `AMIKA_BINARY_PATH` | Absolute path to the `amika` executable recorded in generated config (the SSH `ProxyCommand`). Defaults to the running binary; set it inside a wrapper script so the wrapper names itself and the environment it exports survives |
 | `AMIKA_WORKOS_CLIENT_ID` | Override default WorkOS client ID for `amika auth login` |
 | `AMIKA_RUN_EXPENSIVE_TESTS` | Set to `1` to enable expensive Docker integration tests |
 | `PORT` | Override listen address for `amika-server` (mutually exclusive with `-addr` flag) |

--- a/go/cmd/amika/sandbox/sandbox_ssh_v2.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_v2.go
@@ -2,7 +2,6 @@ package sandboxcmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/output"
@@ -37,46 +36,13 @@ var sandboxSSHV2Cmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		alias, err := ssh.BuildSessionAlias(sandbox.Name, sandbox.ID)
-		if err != nil {
-			return err
-		}
-		paths := basedir.New("")
-		state, err := ssh.LoadState(paths)
-		if err != nil {
-			return err
-		}
-		var sessionConfig ssh.SessionConfig
-		if state.SessionConfig != nil {
-			sessionConfig = *state.SessionConfig
-		} else {
-			identityFile, err := paths.SSHIdentityFile()
-			if err != nil {
-				return err
-			}
-			knownHostsFile, err := paths.SSHKnownHostsFile()
-			if err != nil {
-				return err
-			}
-			sessionConfig = ssh.SessionConfig{
-				IdentityFile:   identityFile,
-				KnownHostsFile: knownHostsFile,
-				ProxyCommand:   "amika plumbing ssh-stdio-proxy %h",
-			}
-		}
-		identityInfo, err := os.Stat(sessionConfig.IdentityFile)
-		if err != nil || !identityInfo.Mode().IsRegular() || identityInfo.Mode().Perm()&0o077 != 0 {
-			return fmt.Errorf("SSH identity is missing or unsafe; run \"amika secret ssh-keygen\"")
-		}
-		if err := ssh.ConfigureSession(paths, sessionConfig); err != nil {
-			return err
-		}
-		if _, err := ssh.PrepareSessionHost(
+		alias, err := ssh.PrepareSessionTarget(
+			basedir.New(""),
 			client,
-			ssh.FileHostKeyPinStore{Path: sessionConfig.KnownHostsFile},
+			sandbox.Name,
 			sandbox.ID,
-			alias,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 		forcePTY, _ := cmd.Flags().GetBool("t")

--- a/go/cmd/amika/scp/scpv2.go
+++ b/go/cmd/amika/scp/scpv2.go
@@ -1,0 +1,186 @@
+package scpcmd
+
+// scpv2.go implements `amika scpv2`: the same operand grammar as `amika scp`,
+// carried over the beta direct WebSocket transport that backs
+// `amika sandbox sshv2` instead of the v1 provider-native SSH access.
+//
+// The transport difference is entirely in how a sandbox reference becomes an
+// scp operand. v1 resolves a sandbox to a concrete host/port/user and spells
+// out connection options on the command line; v2 resolves it to its
+// `<name>.<id>.amika` alias, whose User, IdentityFile, host-key policy, and
+// ProxyCommand all come from the managed `Host *.amika` block in
+// ~/.ssh/amika.conf. So there are no connection options to prepend here — the
+// operands are rewritten and system scp is handed the rest unchanged.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/gofixpoint/amika/go/internal/output"
+	"github.com/gofixpoint/amika/go/internal/runmode"
+	"github.com/gofixpoint/amika/go/internal/ssh"
+	"github.com/spf13/cobra"
+)
+
+// aliasResolver resolves a sandbox name to its prepared v2 host alias.
+type aliasResolver func(name string) (string, error)
+
+func runSCPV2(cmd *cobra.Command, rawArgs []string) error {
+	// DisableFlagParsing bypasses cobra's built-in help flag, so handle it here.
+	if hasHelpFlag(rawArgs) {
+		return cmd.Help()
+	}
+	if err := output.RejectFlagInArgs(rawArgs); err != nil {
+		return err
+	}
+	if runmode.Resolve(cmd) == runmode.Local {
+		return fmt.Errorf("direct WebSocket SSH requires a remote sandbox")
+	}
+
+	plan, err := parseSCPArgs(rawArgs)
+	if err != nil {
+		return err
+	}
+
+	// Resolved lazily and cached by name: each sandbox is fetched and pinned at
+	// most once, and a copy naming no sandbox performs no API call and needs no
+	// auth (the same contract as `amika scp`).
+	var client *apiclient.Client
+	aliases := map[string]string{}
+	resolve := func(name string) (string, error) {
+		if alias, ok := aliases[name]; ok {
+			return alias, nil
+		}
+		if client == nil {
+			if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+				return "", err
+			}
+			client = runmode.NewRemoteClient()
+		}
+		sandbox, err := client.GetSandbox(name)
+		if err != nil {
+			return "", err
+		}
+		alias, err := ssh.PrepareSessionTarget(
+			basedir.New(""),
+			client,
+			sandbox.Name,
+			sandbox.ID,
+		)
+		if err != nil {
+			return "", err
+		}
+		aliases[name] = alias
+		return alias, nil
+	}
+
+	scpArgs, err := buildSCPV2Invocation(plan, resolve)
+	if err != nil {
+		return err
+	}
+	if plan.printOnly {
+		fmt.Fprintln(cmd.OutOrStdout(), formatCommand(append([]string{"scp"}, scpArgs...)))
+		return nil
+	}
+	return execSCP(scpArgs)
+}
+
+// buildSCPV2Invocation rewrites each sandbox reference in the residual scp argv
+// to its `<alias>:<absolute path>` form, leaving every flag, local path, and
+// scp:// URI untouched and in its original position.
+func buildSCPV2Invocation(plan scpPlan, resolve aliasResolver) ([]string, error) {
+	rewritten := make([]string, 0, len(plan.scpArgv))
+	for i := 0; i < len(plan.scpArgv); i++ {
+		tok := plan.scpArgv[i]
+		// An option and, when it takes one, its separate value pass straight
+		// through — a value like "-o User=x" must never be read as an operand.
+		if strings.HasPrefix(tok, "-") && tok != "-" {
+			rewritten = append(rewritten, tok)
+			if consumesNextArg(tok) && i+1 < len(plan.scpArgv) {
+				i++
+				rewritten = append(rewritten, plan.scpArgv[i])
+			}
+			continue
+		}
+		operand, err := rewriteV2Operand(tok, resolve)
+		if err != nil {
+			return nil, err
+		}
+		rewritten = append(rewritten, operand)
+	}
+	return rewritten, nil
+}
+
+// rewriteV2Operand converts one operand to its scp form. Sandbox references
+// become alias operands; scp:// URIs and local paths are returned unchanged.
+func rewriteV2Operand(tok string, resolve aliasResolver) (string, error) {
+	switch {
+	case strings.HasPrefix(tok, "sbox://"):
+		name, path, err := parseSboxURI(tok)
+		if err != nil {
+			return "", err
+		}
+		alias, err := resolve(name)
+		if err != nil {
+			return "", err
+		}
+		return alias + ":" + resolveSandboxURIPath(path), nil
+	case strings.HasPrefix(tok, "scp://"):
+		return parseSCPURI(tok)
+	case looksLikeRemote(tok):
+		name, path := splitSandboxRef(tok)
+		alias, err := resolve(name)
+		if err != nil {
+			return "", err
+		}
+		return alias + ":" + resolveSandboxScpPath(path), nil
+	default:
+		return tok, nil
+	}
+}
+
+// NewV2 builds the `amika scpv2` command.
+func NewV2() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scpv2 <source> ... <target>",
+		Short: "Copy files to or from sandboxes over the beta direct WebSocket transport",
+		Long: `Copy files between the local machine, sandboxes, and SSH hosts using scp,
+over the same beta direct WebSocket transport as "amika sandbox sshv2".
+
+Operands take the same forms as "amika scp":
+
+  PATH                              a local path
+  NAME[:PATH]                       a path in sandbox NAME (scp-style): a
+                                    relative PATH is under the sandbox home, an
+                                    absolute PATH is used verbatim
+  sbox://NAME[/PATH]                a path in sandbox NAME (URI form): PATH is
+                                    absolute and "~" is the home directory. A
+                                    "/" in NAME must be percent-encoded as %2F
+  scp://[user@]host[:port][/path]   a path on an arbitrary SSH host
+
+Each sandbox resolves to its "<name>.<id>.amika" alias, and the connection
+settings come from the managed block in ~/.ssh/amika.conf, so a fresh session
+is created and the host key re-pinned per dial. Requires an SSH identity from
+"amika secret ssh-keygen".
+
+Examples:
+  # Upload a file into the sandbox home
+  amika scpv2 ./local.txt my-sandbox:local.txt
+
+  # Recursively download an absolute directory from the sandbox
+  amika scpv2 -r my-sandbox:/srv/out ./out
+
+  # Print the resolved scp command instead of running it
+  amika scpv2 --print ./a.txt my-sandbox:a.txt`,
+		Args: cobra.MinimumNArgs(1),
+		// As with `amika scp`, every argument is forwarded to system scp, so
+		// scp's own single-dash options pass through untouched.
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSCPV2(cmd, args)
+		},
+	}
+	return cmd
+}

--- a/go/cmd/amika/scp/scpv2_test.go
+++ b/go/cmd/amika/scp/scpv2_test.go
@@ -1,0 +1,144 @@
+package scpcmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stubResolver resolves any sandbox name to a deterministic v2 alias and
+// records the names it was asked for.
+func stubResolver(seen *[]string) aliasResolver {
+	return func(name string) (string, error) {
+		if name == "missing" {
+			return "", errors.New("sandbox not found")
+		}
+		*seen = append(*seen, name)
+		return name + ".sbx-1234.amika", nil
+	}
+}
+
+func TestBuildSCPV2InvocationRewritesSandboxOperands(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		argv []string
+		want []string
+	}{
+		{
+			name: "relative sandbox path resolves under the sandbox home",
+			argv: []string{"./local.txt", "box:notes/a.txt"},
+			want: []string{"./local.txt", "box.sbx-1234.amika:/home/amika/notes/a.txt"},
+		},
+		{
+			name: "absolute sandbox path is used verbatim",
+			argv: []string{"-r", "box:/srv/out", "./out"},
+			want: []string{"-r", "box.sbx-1234.amika:/srv/out", "./out"},
+		},
+		{
+			name: "bare sandbox reference means the home directory",
+			argv: []string{"box:", "./out"},
+			want: []string{"box.sbx-1234.amika:/home/amika", "./out"},
+		},
+		{
+			name: "sbox URI form resolves the same way",
+			argv: []string{"sbox://box/~/a.txt", "./a.txt"},
+			want: []string{"box.sbx-1234.amika:/home/amika/a.txt", "./a.txt"},
+		},
+		{
+			name: "sandbox to sandbox rewrites both operands",
+			argv: []string{"one:/a", "two:/b"},
+			want: []string{"one.sbx-1234.amika:/a", "two.sbx-1234.amika:/b"},
+		},
+		{
+			name: "local paths pass through untouched",
+			argv: []string{"./a.txt", "/tmp/b.txt"},
+			want: []string{"./a.txt", "/tmp/b.txt"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen []string
+			got, err := buildSCPV2Invocation(scpPlan{scpArgv: tc.argv}, stubResolver(&seen))
+			if err != nil {
+				t.Fatalf("buildSCPV2Invocation: %v", err)
+			}
+			if strings.Join(got, " ") != strings.Join(tc.want, " ") {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildSCPV2InvocationDoesNotTreatOptionValuesAsOperands(t *testing.T) {
+	// "-o" takes a separate value; reading "ConnectTimeout=5" as an operand
+	// would try to resolve a sandbox named "ConnectTimeout=5".
+	var seen []string
+	got, err := buildSCPV2Invocation(
+		scpPlan{scpArgv: []string{"-o", "ConnectTimeout=5", "box:/a", "./a"}},
+		stubResolver(&seen),
+	)
+	if err != nil {
+		t.Fatalf("buildSCPV2Invocation: %v", err)
+	}
+	want := "-o ConnectTimeout=5 box.sbx-1234.amika:/a ./a"
+	if strings.Join(got, " ") != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if len(seen) != 1 || seen[0] != "box" {
+		t.Fatalf("resolved names = %v, want [box]", seen)
+	}
+}
+
+func TestBuildSCPV2InvocationResolvesEachSandboxOnce(t *testing.T) {
+	// The cache lives in runSCPV2's closure, so exercise it the way the command
+	// does: one resolver shared across every operand.
+	var seen []string
+	inner := stubResolver(&seen)
+	cache := map[string]string{}
+	cached := func(name string) (string, error) {
+		if alias, ok := cache[name]; ok {
+			return alias, nil
+		}
+		alias, err := inner(name)
+		if err != nil {
+			return "", err
+		}
+		cache[name] = alias
+		return alias, nil
+	}
+
+	if _, err := buildSCPV2Invocation(
+		scpPlan{scpArgv: []string{"box:/a", "box:/b", "./out"}},
+		cached,
+	); err != nil {
+		t.Fatalf("buildSCPV2Invocation: %v", err)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("resolved %d times, want 1 (%v)", len(seen), seen)
+	}
+}
+
+func TestBuildSCPV2InvocationPropagatesResolveFailure(t *testing.T) {
+	var seen []string
+	if _, err := buildSCPV2Invocation(
+		scpPlan{scpArgv: []string{"missing:/a", "./out"}},
+		stubResolver(&seen),
+	); err == nil {
+		t.Fatal("expected an error for an unresolvable sandbox")
+	}
+}
+
+func TestBuildSCPV2InvocationLeavesSCPURIsAlone(t *testing.T) {
+	// An scp:// URI names an arbitrary SSH host, not a sandbox, so it must not
+	// be resolved or rewritten into an alias.
+	var seen []string
+	got, err := buildSCPV2Invocation(
+		scpPlan{scpArgv: []string{"scp://user@host:22/tmp/a.csv", "./a.csv"}},
+		stubResolver(&seen),
+	)
+	if err != nil {
+		t.Fatalf("buildSCPV2Invocation: %v", err)
+	}
+	if !strings.HasPrefix(got[0], "scp://") || len(seen) != 0 {
+		t.Fatalf("got %q with resolved names %v", got, seen)
+	}
+}

--- a/go/cmd/amika/scpv2.go
+++ b/go/cmd/amika/scpv2.go
@@ -1,0 +1,7 @@
+package main
+
+import scpcmd "github.com/gofixpoint/amika/go/cmd/amika/scp"
+
+func init() {
+	rootCmd.AddCommand(scpcmd.NewV2())
+}

--- a/go/cmd/amika/ssh_keygen.go
+++ b/go/cmd/amika/ssh_keygen.go
@@ -51,7 +51,6 @@ func newSSHKeygenCmd() *cobra.Command {
 			if err := ssh.ConfigureSession(paths, ssh.SessionConfig{
 				IdentityFile:   identityPath,
 				KnownHostsFile: knownHostsPath,
-				ProxyCommand:   "amika plumbing ssh-stdio-proxy %h",
 			}); err != nil {
 				return err
 			}

--- a/go/internal/amikad/command.go
+++ b/go/internal/amikad/command.go
@@ -35,6 +35,7 @@ type Operations interface {
 	SetupSSHD(context.Context, SetupSSHDOptions) error
 	ShowHostKey(context.Context, io.Writer) error
 	SetAuthorizedKeys(context.Context, io.Reader) error
+	ClearAuthorizedKeys(context.Context) error
 	SetConnectToken(context.Context, io.Reader) error
 	Serve(context.Context, ServeOptions) error
 }
@@ -55,6 +56,11 @@ func (UnimplementedOperations) ShowHostKey(context.Context, io.Writer) error {
 
 // SetAuthorizedKeys returns ErrNotImplemented without reading or writing keys.
 func (UnimplementedOperations) SetAuthorizedKeys(context.Context, io.Reader) error {
+	return ErrNotImplemented
+}
+
+// ClearAuthorizedKeys returns ErrNotImplemented without writing keys.
+func (UnimplementedOperations) ClearAuthorizedKeys(context.Context) error {
 	return ErrNotImplemented
 }
 
@@ -117,6 +123,14 @@ func NewCommand(operations Operations) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return operations.SetAuthorizedKeys(cmd.Context(), cmd.InOrStdin())
+		},
+	})
+	authorizedKeys.AddCommand(&cobra.Command{
+		Use:   "clear",
+		Short: "Install an empty authorized-key set (authorize no logins)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return operations.ClearAuthorizedKeys(cmd.Context())
 		},
 	})
 

--- a/go/internal/amikad/command_test.go
+++ b/go/internal/amikad/command_test.go
@@ -35,6 +35,7 @@ func TestCommandTopology(t *testing.T) {
 		{"setup", "sshd"},
 		{"host-key", "show"},
 		{"authorized-keys", "set"},
+		{"authorized-keys", "clear"},
 		{"connect-token", "set"},
 		{"serve"},
 	} {

--- a/go/internal/amikad/operations.go
+++ b/go/internal/amikad/operations.go
@@ -37,6 +37,7 @@ type SSHDManager interface {
 	Setup(context.Context, sshd.SetupOptions) error
 	ShowHostKey(context.Context, io.Writer) error
 	SetAuthorizedKeys(context.Context, io.Reader) error
+	ClearAuthorizedKeys(context.Context) error
 	Serve(context.Context) error
 }
 
@@ -98,6 +99,12 @@ func (o *DaemonOperations) ShowHostKey(ctx context.Context, output io.Writer) er
 // SetAuthorizedKeys validates and replaces the complete authorized key set.
 func (o *DaemonOperations) SetAuthorizedKeys(ctx context.Context, input io.Reader) error {
 	return o.sshd.SetAuthorizedKeys(ctx, input)
+}
+
+// ClearAuthorizedKeys installs an empty authorized-key set so sshd can serve
+// while authorizing no logins.
+func (o *DaemonOperations) ClearAuthorizedKeys(ctx context.Context) error {
+	return o.sshd.ClearAuthorizedKeys(ctx)
 }
 
 // SetConnectToken validates canonical base64url input and stores it without a

--- a/go/internal/amikad/operations.go
+++ b/go/internal/amikad/operations.go
@@ -39,6 +39,9 @@ type SSHDManager interface {
 	SetAuthorizedKeys(context.Context, io.Reader) error
 	ClearAuthorizedKeys(context.Context) error
 	Serve(context.Context) error
+	// LoopbackAddress is the managed sshd's listen address, which the bridge
+	// dials. Sourced from the manager so the two can never disagree.
+	LoopbackAddress() string
 }
 
 // DaemonOperations implements the amikad command surface.
@@ -142,7 +145,7 @@ func (o *DaemonOperations) Serve(ctx context.Context, options ServeOptions) erro
 	}
 
 	handler := norelay.NewHandler(
-		norelay.Config{MaxConnections: 64, SSHDAddress: "127.0.0.1:22"},
+		norelay.Config{MaxConnections: 64, SSHDAddress: o.sshd.LoopbackAddress()},
 		norelay.Dependencies{
 			Verifier: o.verifier,
 			Upgrader: norelay.WebSocketUpgrader{},

--- a/go/internal/amikad/operations_test.go
+++ b/go/internal/amikad/operations_test.go
@@ -31,6 +31,7 @@ func (m *fakeSSHDManager) Setup(_ context.Context, options sshd.SetupOptions) er
 }
 func (*fakeSSHDManager) ShowHostKey(context.Context, io.Writer) error       { return nil }
 func (*fakeSSHDManager) SetAuthorizedKeys(context.Context, io.Reader) error { return nil }
+func (*fakeSSHDManager) ClearAuthorizedKeys(context.Context) error          { return nil }
 func (m *fakeSSHDManager) Serve(context.Context) error {
 	m.serveCalls++
 	return nil

--- a/go/internal/amikad/operations_test.go
+++ b/go/internal/amikad/operations_test.go
@@ -36,6 +36,7 @@ func (m *fakeSSHDManager) Serve(context.Context) error {
 	m.serveCalls++
 	return nil
 }
+func (*fakeSSHDManager) LoopbackAddress() string { return "127.0.0.1:60997" }
 
 func testOperations(t *testing.T) (*DaemonOperations, string, *fakeSSHDManager) {
 	t.Helper()

--- a/go/internal/amikad/sshd/manager.go
+++ b/go/internal/amikad/sshd/manager.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"os"
 	"os/exec"
 	"os/user"
@@ -19,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/gofixpoint/amika/go/internal/amikad/state"
+	"github.com/gofixpoint/amika/go/internal/constants"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -30,7 +32,8 @@ var ErrExistingConfiguration = errors.New("existing sshd configuration requires 
 // input.
 var ErrInvalidPublicKey = errors.New("invalid SSH public key")
 
-// Paths contains every filesystem location owned by the managed sshd.
+// Paths contains every filesystem location owned by the managed sshd, plus
+// the loopback port it listens on.
 type Paths struct {
 	Config            string
 	HostPrivateKey    string
@@ -40,6 +43,10 @@ type Paths struct {
 	RuntimeDirectory  string
 	AuthorizedKeysUID int
 	AuthorizedKeysGID int
+	// Port the managed sshd binds on 127.0.0.1. This is the single source of
+	// truth for the loopback address: the rendered config listens on it and
+	// the no-relay bridge dials it, so the two can never drift apart.
+	Port int
 }
 
 // DefaultPaths returns the production paths owned by amikad.
@@ -58,6 +65,7 @@ func DefaultPaths() Paths {
 		RuntimeDirectory:  "/run/sshd",
 		AuthorizedKeysUID: uid,
 		AuthorizedKeysGID: gid,
+		Port:              constants.ManagedSSHDPort,
 	}
 }
 
@@ -283,6 +291,13 @@ func (m *Manager) Serve(ctx context.Context) error {
 	return m.processes.Run(ctx, "sshd", "-D", "-e", "-f", m.paths.Config)
 }
 
+// LoopbackAddress is where the managed sshd accepts connections. The no-relay
+// bridge dials this rather than hardcoding a port, so the listener and the
+// dial target are always the same value.
+func (m *Manager) LoopbackAddress() string {
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(m.paths.Port))
+}
+
 func (m *Manager) generateHostKey(ctx context.Context) error {
 	generated, err := m.keygen.Generate(ctx)
 	if err != nil {
@@ -360,12 +375,15 @@ func validatePaths(paths Paths) error {
 	if paths.AuthorizedKeysUID < 0 || paths.AuthorizedKeysGID < 0 {
 		return fmt.Errorf("invalid authorized-keys owner: %w", state.ErrInvalidPath)
 	}
+	if paths.Port < 1 || paths.Port > 65535 {
+		return fmt.Errorf("invalid sshd port %d", paths.Port)
+	}
 	return nil
 }
 
 // RenderConfig returns the complete loopback-only sshd policy.
 func RenderConfig(paths Paths) string {
-	return fmt.Sprintf(`Port 22
+	return fmt.Sprintf(`Port %d
 ListenAddress 127.0.0.1
 Protocol 2
 HostKey %s
@@ -387,7 +405,7 @@ PermitTunnel no
 PermitUserEnvironment no
 UsePAM no
 Subsystem sftp internal-sftp
-`, paths.HostPrivateKey, paths.PID, paths.AuthorizedKeys)
+`, paths.Port, paths.HostPrivateKey, paths.PID, paths.AuthorizedKeys)
 }
 
 // Ed25519KeyGenerator creates a passwordless OpenSSH keypair in memory.

--- a/go/internal/amikad/sshd/manager.go
+++ b/go/internal/amikad/sshd/manager.go
@@ -223,10 +223,28 @@ func (m *Manager) SetAuthorizedKeys(ctx context.Context, input io.Reader) error 
 	if len(keys) == 0 {
 		return ErrInvalidPublicKey
 	}
+	return m.writeAuthorizedKeys(ctx, strings.Join(keys, "\n")+"\n")
+}
+
+// ClearAuthorizedKeys atomically installs an empty authorized-key set,
+// authorizing no logins while keeping sshd runnable. This is the deliberate
+// zero-key state: unlike SetAuthorizedKeys, which fail-closes on empty input to
+// catch a caller that meant to pass keys, Clear is the explicit way to say
+// "no keys". It overwrites any prior generation's keys through the same
+// scrub-registered store, so a re-provisioned sandbox never inherits stale
+// authorizations.
+func (m *Manager) ClearAuthorizedKeys(ctx context.Context) error {
+	if err := m.prepareAuthorizedKeysDirectory(); err != nil {
+		return err
+	}
+	return m.writeAuthorizedKeys(ctx, "")
+}
+
+func (m *Manager) writeAuthorizedKeys(ctx context.Context, contents string) error {
 	return m.store.WriteAndRegisterOwned(
 		ctx,
 		m.paths.AuthorizedKeys,
-		strings.NewReader(strings.Join(keys, "\n")+"\n"),
+		strings.NewReader(contents),
 		0o600,
 		state.Ownership{
 			UID: m.paths.AuthorizedKeysUID,

--- a/go/internal/amikad/sshd/manager_test.go
+++ b/go/internal/amikad/sshd/manager_test.go
@@ -228,6 +228,24 @@ func TestAuthorizedKeysRejectsOptionsAndWritesCanonicalKeys(t *testing.T) {
 	}
 }
 
+func TestClearAuthorizedKeysOverwritesPriorKeysWithEmptySet(t *testing.T) {
+	manager, paths, _, _ := testManager(t)
+	key := newTestAuthorizedKey(t)
+	if err := manager.SetAuthorizedKeys(context.Background(), strings.NewReader(key+"\n")); err != nil {
+		t.Fatalf("SetAuthorizedKeys: %v", err)
+	}
+	if err := manager.ClearAuthorizedKeys(context.Background()); err != nil {
+		t.Fatalf("ClearAuthorizedKeys: %v", err)
+	}
+	got, err := os.ReadFile(paths.AuthorizedKeys)
+	if err != nil {
+		t.Fatalf("read authorized keys: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("authorized keys = %q, want empty", got)
+	}
+}
+
 func newTestAuthorizedKey(t *testing.T) string {
 	t.Helper()
 	public, _, err := ed25519.GenerateKey(rand.Reader)

--- a/go/internal/amikad/sshd/manager_test.go
+++ b/go/internal/amikad/sshd/manager_test.go
@@ -7,12 +7,14 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gofixpoint/amika/go/internal/amikad/state"
+	"github.com/gofixpoint/amika/go/internal/constants"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -61,6 +63,7 @@ func testManager(t *testing.T) (*Manager, Paths, *fakeKeyGenerator, *fakeProcess
 		RuntimeDirectory:  filepath.Join(directory, "run", "sshd"),
 		AuthorizedKeysUID: os.Getuid(),
 		AuthorizedKeysGID: os.Getgid(),
+		Port:              constants.ManagedSSHDPort,
 	}
 	if err := os.MkdirAll(filepath.Dir(paths.AuthorizedKeys), 0o700); err != nil {
 		t.Fatal(err)
@@ -276,5 +279,29 @@ func TestShowHostKeyAndServeUseOnlyPublicManagedState(t *testing.T) {
 	}
 	if processes.name != "sshd" || strings.Join(processes.args, " ") != "-D -e -f "+manager.paths.Config {
 		t.Fatalf("process = %q %#v", processes.name, processes.args)
+	}
+}
+
+func TestManagedPortIsOffSystemSSHAndMatchesTheDialTarget(t *testing.T) {
+	manager, _, _, _ := testManager(t)
+
+	// Port 22 is the bug: base images can ship a socket-activated system sshd
+	// on the wildcard *:22, which also covers 127.0.0.1:22, so the managed
+	// sshd cannot bind and `serve --beta-no-relay` dies.
+	if manager.paths.Port == 22 {
+		t.Fatal("managed sshd must not bind port 22")
+	}
+	if manager.paths.Port < constants.ReservedPortStart || manager.paths.Port > constants.ReservedPortEnd {
+		t.Fatalf("port %d is outside the Amika reserved range", manager.paths.Port)
+	}
+
+	// The rendered listener and the address the no-relay bridge dials come
+	// from one field, so they cannot drift apart.
+	config := RenderConfig(manager.paths)
+	if !strings.Contains(config, fmt.Sprintf("Port %d\n", manager.paths.Port)) {
+		t.Fatalf("config does not listen on the managed port:\n%s", config)
+	}
+	if got, want := manager.LoopbackAddress(), fmt.Sprintf("127.0.0.1:%d", manager.paths.Port); got != want {
+		t.Fatalf("LoopbackAddress = %q, want %q", got, want)
 	}
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -2,7 +2,11 @@
 package config
 
 import (
+	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/gofixpoint/amika/go/internal/basedir"
 )
@@ -17,6 +21,9 @@ const (
 	// EnvAPIKey is the environment variable that provides a WorkOS organization API key
 	// for bearer-token authentication. When set, it takes precedence over stored credentials.
 	EnvAPIKey = "AMIKA_API_KEY"
+	// EnvBinaryPath is the environment variable that overrides the amika executable
+	// path recorded in generated configuration that re-invokes amika later.
+	EnvBinaryPath = "AMIKA_BINARY_PATH"
 
 	// DefaultAPIURL is the default remote API base URL.
 	DefaultAPIURL = "https://app.amika.dev"
@@ -38,6 +45,86 @@ func WorkOSClientID() string {
 		return id
 	}
 	return DefaultWorkOSClientID
+}
+
+// BinaryPath returns the absolute path of the amika executable to record in
+// generated configuration that re-invokes amika later, such as the SSH
+// ProxyCommand in ~/.ssh/amika.conf.
+//
+// It defaults to the running executable. AMIKA_BINARY_PATH overrides that,
+// because os.Executable resolves to the real binary and can never see that it
+// was invoked through a wrapper script. A wrapper that exports AMIKA_API_URL
+// (and friends) must name itself here, or the generated config would point at
+// the bare binary and lose the wrapper's environment.
+//
+// An override that is not a usable absolute path is an error rather than a
+// silent fallback: the value ends up in a config file that has to work later,
+// and a typo would otherwise surface as an opaque connection failure.
+func BinaryPath() (string, error) {
+	override := os.Getenv(EnvBinaryPath)
+	if override == "" {
+		path, err := os.Executable()
+		if err != nil {
+			return "", fmt.Errorf("resolve amika executable: %w", err)
+		}
+		return path, nil
+	}
+	if !filepath.IsAbs(override) {
+		return "", fmt.Errorf("%s must be an absolute path, got %q", EnvBinaryPath, override)
+	}
+	path := filepath.Clean(override)
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("%s %q: %w", EnvBinaryPath, path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%s %q is not a regular file", EnvBinaryPath, path)
+	}
+	return path, nil
+}
+
+// EnvironmentSlug returns a stable identifier for the control plane named by
+// AMIKA_API_URL, safe to embed as one segment of an SSH host alias.
+//
+// Sandboxes only exist on the control plane that created them, so anything
+// keyed by sandbox — host-key pins, session config blocks — has to be keyed by
+// environment too, or a local and a staging sandbox sharing a name would
+// collide. Deriving the slug from the URL rather than a user-supplied label
+// means it cannot drift from the control plane it actually names.
+func EnvironmentSlug() (string, error) {
+	return environmentSlugFor(APIURL())
+}
+
+// environmentSlugFor reduces an API base URL to its host and port, lowercased
+// with every character outside [a-z0-9-] folded to a single dash. Dots included:
+// the slug is one alias segment, and a dot in it would break the parse.
+func environmentSlugFor(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse %s %q: %w", EnvAPIURL, rawURL, err)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("%s %q has no host", EnvAPIURL, rawURL)
+	}
+	var b strings.Builder
+	for _, r := range strings.ToLower(parsed.Host) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-':
+			b.WriteRune(r)
+		case b.Len() > 0 && b.String()[b.Len()-1] != '-':
+			b.WriteByte('-')
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		return "", fmt.Errorf("%s %q has no usable host characters", EnvAPIURL, rawURL)
+	}
+	// 63 is the DNS label limit. Real control-plane hosts are far shorter, and
+	// truncating instead would let two environments collapse onto one slug.
+	if len(slug) > 63 {
+		return "", fmt.Errorf("%s %q host is too long for an SSH alias segment", EnvAPIURL, rawURL)
+	}
+	return slug, nil
 }
 
 // StateDir returns the resolved amika state directory path.

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gofixpoint/amika/go/internal/basedir"
@@ -217,5 +218,101 @@ func TestVolumesStateFile_EnvOverride(t *testing.T) {
 	want := basedir.VolumesStateFileIn(override)
 	if got != want {
 		t.Errorf("VolumesStateFile() = %q, want %q", got, want)
+	}
+}
+
+func TestEnvironmentSlugFoldsHostAndPortIntoOneAliasSegment(t *testing.T) {
+	for _, tc := range []struct {
+		apiURL string
+		want   string
+	}{
+		{"http://localhost:3011", "localhost-3011"},
+		{"https://app.staging-amika.dev", "app-staging-amika-dev"},
+		{"https://app.amika.dev", "app-amika-dev"},
+		{"https://APP.Amika.Dev", "app-amika-dev"},
+		{"http://127.0.0.1:8080/some/path", "127-0-0-1-8080"},
+	} {
+		got, err := environmentSlugFor(tc.apiURL)
+		if err != nil {
+			t.Errorf("environmentSlugFor(%q): %v", tc.apiURL, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("environmentSlugFor(%q) = %q, want %q", tc.apiURL, got, tc.want)
+		}
+	}
+}
+
+// The slug becomes one dot-separated segment of an SSH host alias, so it must
+// never itself contain a dot or the alias would parse with shifted fields.
+func TestEnvironmentSlugNeverContainsADot(t *testing.T) {
+	slug, err := environmentSlugFor("https://a.b.c.d.example.com:9999")
+	if err != nil {
+		t.Fatalf("environmentSlugFor: %v", err)
+	}
+	if strings.Contains(slug, ".") {
+		t.Fatalf("slug %q contains a dot", slug)
+	}
+}
+
+func TestEnvironmentSlugRejectsURLsWithoutAHost(t *testing.T) {
+	for _, apiURL := range []string{"", "not-a-url", "/just/a/path"} {
+		if _, err := environmentSlugFor(apiURL); err == nil {
+			t.Errorf("environmentSlugFor(%q) was accepted", apiURL)
+		}
+	}
+}
+
+func TestBinaryPathDefaultsToTheRunningExecutable(t *testing.T) {
+	t.Setenv(EnvBinaryPath, "")
+
+	got, err := BinaryPath()
+	if err != nil {
+		t.Fatalf("BinaryPath: %v", err)
+	}
+	want, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	if got != want {
+		t.Errorf("BinaryPath() = %q, want %q", got, want)
+	}
+}
+
+// The override exists so a wrapper script can name itself: os.Executable
+// resolves to the real binary and cannot see the wrapper that exported the
+// environment amika needs.
+func TestBinaryPathHonorsTheOverride(t *testing.T) {
+	wrapper := filepath.Join(t.TempDir(), "amika-local")
+	if err := os.WriteFile(wrapper, []byte("#!/bin/bash\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvBinaryPath, wrapper)
+
+	got, err := BinaryPath()
+	if err != nil {
+		t.Fatalf("BinaryPath: %v", err)
+	}
+	if got != wrapper {
+		t.Errorf("BinaryPath() = %q, want %q", got, wrapper)
+	}
+}
+
+// An unusable override is an error rather than a silent fallback: the value is
+// written into a config file that has to work later, so a typo must surface at
+// the command that set it, not as an opaque connection failure.
+func TestBinaryPathRejectsAnUnusableOverride(t *testing.T) {
+	dir := t.TempDir()
+	for name, override := range map[string]string{
+		"relative": "bin/amika",
+		"missing":  filepath.Join(dir, "does-not-exist"),
+		"director": dir,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(EnvBinaryPath, override)
+			if _, err := BinaryPath(); err == nil {
+				t.Errorf("BinaryPath() accepted %q", override)
+			}
+		})
 	}
 }

--- a/go/internal/constants/constants.go
+++ b/go/internal/constants/constants.go
@@ -19,4 +19,13 @@ const (
 
 	// OpenCodeWebPort is the container port reserved for the OpenCode web UI.
 	OpenCodeWebPort = 60998
+
+	// ManagedSSHDPort is the loopback port amikad's managed sshd binds.
+	//
+	// Deliberately not 22: base images may ship a socket-activated system
+	// `ssh.socket` bound to the wildcard `*:22`, which also covers
+	// `127.0.0.1:22` and makes the managed sshd fail with EADDRINUSE. Living
+	// in the Amika reserved range keeps it clear of both the system sshd and
+	// the random port allocator, which skips the whole range.
+	ManagedSSHDPort = 60997
 )

--- a/go/internal/sandbox/presets/base/Dockerfile
+++ b/go/internal/sandbox/presets/base/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.25.3-bookworm AS amikad-builder
 
 # Build from an immutable reviewed commit until the first standalone amikad
 # release exists. The final image receives only the binary, not the toolchain.
-ARG AMIKAD_SOURCE_REF=3fde13c92ff8c3e43a393138459945f7b641cb09
+ARG AMIKAD_SOURCE_REF=9dccbfd32f90834e962cb4070d920a5df3096d7d
 ENV GOBIN=/out
 RUN go install "github.com/gofixpoint/amika/go/cmd/amikad@${AMIKAD_SOURCE_REF}"
 

--- a/go/internal/sandbox/presets/base/Dockerfile
+++ b/go/internal/sandbox/presets/base/Dockerfile
@@ -30,7 +30,15 @@ RUN apt-get update && apt-get install -y \
     tmux \
     ncurses-term \
     openssh-server \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # openssh-server is installed for amikad to configure and supervise as a
+    # loopback-only sshd — never as a system service. On the systemd-backed VM
+    # snapshots the package would otherwise leave socket-activated `ssh.socket`
+    # listening on the wildcard *:22, an inbound SSH surface Amika never
+    # intended. Masking is a symlink to /dev/null, so it applies at build time
+    # without systemd running, and is inert on the plain container presets.
+    && ln -sf /dev/null /etc/systemd/system/ssh.socket \
+    && ln -sf /dev/null /etc/systemd/system/ssh.service
 
 # Install Ghostty terminfo so SSH sessions from Ghostty render correctly.
 # (Alacritty, kitty, foot, etc. come from the ncurses-term package above;

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/gofixpoint/amika/go/internal/config"
 )
 
 // aliasPrefix is prepended to a sandbox id to form its stable SSH host alias.
@@ -35,8 +36,16 @@ type HostEntry struct {
 
 // HostsState is the source of truth from which ~/.ssh/amika.conf is rendered.
 type HostsState struct {
-	Hosts         []HostEntry    `json:"hosts"`
+	Hosts []HostEntry `json:"hosts"`
+	// SessionConfig holds the key material shared by every environment. State
+	// written before session blocks became per-environment also carried a
+	// ProxyCommand here; that field no longer exists, so decoding drops it and
+	// the next write regenerates the blocks from SessionProxyCommands.
 	SessionConfig *SessionConfig `json:"session_config,omitempty"`
+	// SessionProxyCommands maps an environment slug to the amika invocation
+	// that proxies its aliases, one entry per control plane this machine has
+	// opened a v2 session against.
+	SessionProxyCommands map[string]string `json:"session_proxy_commands,omitempty"`
 }
 
 // Alias returns the stable SSH host alias for a sandbox id. Cursor keys its
@@ -219,14 +228,55 @@ func Render(state HostsState) string {
 		}
 		b.WriteString("  StrictHostKeyChecking accept-new\n")
 	}
-	if state.SessionConfig != nil {
-		block, err := RenderSessionConfig(*state.SessionConfig)
-		if err == nil {
-			b.WriteString("\n# No-relay WebSocket SSH aliases.\n")
+	if blocks := renderSessionBlocks(state); len(blocks) > 0 {
+		b.WriteString("\n# No-relay WebSocket SSH aliases, one block per control plane.\n")
+		for i, block := range blocks {
+			if i > 0 {
+				b.WriteString("\n")
+			}
 			b.WriteString(block)
 		}
 	}
 	return b.String()
+}
+
+// renderSessionBlocks renders one wildcard block per configured environment, in
+// sorted order so the generated file does not churn between runs. Blocks that
+// fail validation are skipped rather than fatal, matching how Render treats the
+// rest of the state: a bad entry must not make the whole config unwritable.
+func renderSessionBlocks(state HostsState) []string {
+	if state.SessionConfig == nil {
+		return nil
+	}
+	environments := make([]string, 0, len(state.SessionProxyCommands))
+	for environment := range state.SessionProxyCommands {
+		environments = append(environments, environment)
+	}
+	sort.Strings(environments)
+
+	blocks := make([]string, 0, len(environments))
+	for _, environment := range environments {
+		block, err := RenderSessionConfig(environment, state.SessionProxyCommands[environment], *state.SessionConfig)
+		if err == nil {
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks
+}
+
+// validateSessionState rejects a state whose session blocks would not render,
+// so a bad value fails at the call that introduced it rather than silently
+// vanishing from the generated config.
+func validateSessionState(state HostsState) error {
+	if state.SessionConfig == nil {
+		return nil
+	}
+	for environment, proxyCommand := range state.SessionProxyCommands {
+		if _, err := RenderSessionConfig(environment, proxyCommand, *state.SessionConfig); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // LoadState reads the SSH hosts state, returning an empty state if the file does
@@ -255,10 +305,8 @@ func LoadState(paths basedir.Paths) (HostsState, error) {
 
 // SaveState writes the SSH hosts state atomically with owner-only permissions.
 func SaveState(paths basedir.Paths, state HostsState) error {
-	if state.SessionConfig != nil {
-		if _, err := RenderSessionConfig(*state.SessionConfig); err != nil {
-			return err
-		}
+	if err := validateSessionState(state); err != nil {
+		return err
 	}
 	path, err := paths.SSHHostsStateFile()
 	if err != nil {
@@ -273,10 +321,8 @@ func SaveState(paths basedir.Paths, state HostsState) error {
 
 // WriteAmikaConfig renders the state to ~/.ssh/amika.conf atomically.
 func WriteAmikaConfig(paths basedir.Paths, state HostsState) error {
-	if state.SessionConfig != nil {
-		if _, err := RenderSessionConfig(*state.SessionConfig); err != nil {
-			return err
-		}
+	if err := validateSessionState(state); err != nil {
+		return err
 	}
 	path, err := paths.SSHAmikaConfigFile()
 	if err != nil {
@@ -285,17 +331,36 @@ func WriteAmikaConfig(paths basedir.Paths, state HostsState) error {
 	return writeFileAtomic(path, []byte(Render(state)), 0o600)
 }
 
-// ConfigureSession persists and renders the strict wildcard session block
-// without disturbing legacy provider-native host entries.
-func ConfigureSession(paths basedir.Paths, config SessionConfig) error {
-	if _, err := RenderSessionConfig(config); err != nil {
+// ConfigureSession persists the shared session identity plus the ProxyCommand
+// for the environment this process points at, then regenerates
+// ~/.ssh/amika.conf without disturbing legacy provider-native host entries.
+//
+// The environment and the executable path are resolved here rather than passed
+// in so every caller records the same thing, and so the ProxyCommand is rebuilt
+// from the live process on each run. A path persisted by an earlier run may name
+// a binary that has since moved or been replaced by one that cannot serve as a
+// proxy.
+func ConfigureSession(paths basedir.Paths, session SessionConfig) error {
+	environment, err := config.EnvironmentSlug()
+	if err != nil {
+		return err
+	}
+	proxyCommand, err := ResolveProxyCommand()
+	if err != nil {
+		return err
+	}
+	if _, err := RenderSessionConfig(environment, proxyCommand, session); err != nil {
 		return err
 	}
 	state, err := LoadState(paths)
 	if err != nil {
 		return err
 	}
-	state.SessionConfig = &config
+	state.SessionConfig = &session
+	if state.SessionProxyCommands == nil {
+		state.SessionProxyCommands = make(map[string]string)
+	}
+	state.SessionProxyCommands[environment] = proxyCommand
 	if err := SaveState(paths, state); err != nil {
 		return err
 	}

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/gofixpoint/amika/go/internal/config"
 )
 
 func TestAlias(t *testing.T) {
@@ -330,5 +331,173 @@ func assertPerm(t *testing.T, path string, want os.FileMode) {
 	}
 	if got := info.Mode().Perm(); got != want {
 		t.Fatalf("perm of %q = %o, want %o", path, got, want)
+	}
+}
+
+// testBinary creates a stand-in amika executable and points AMIKA_BINARY_PATH
+// at it, mirroring how a wrapper script names itself.
+func testBinary(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("#!/bin/bash\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(config.EnvBinaryPath, path)
+	return path
+}
+
+func TestConfigureSessionWritesTheCurrentEnvironmentsBlock(t *testing.T) {
+	paths := testPaths(t)
+	t.Setenv(config.EnvAPIURL, "http://localhost:3011")
+	binary := testBinary(t, "amika-local")
+
+	if err := ConfigureSession(paths, SessionConfig{
+		IdentityFile:   "/home/user/.ssh/amika_id_ed25519",
+		KnownHostsFile: "/home/user/.ssh/amika_known_hosts",
+	}); err != nil {
+		t.Fatalf("ConfigureSession: %v", err)
+	}
+
+	confPath, _ := paths.SSHAmikaConfigFile()
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	for _, want := range []string{
+		"Host *.localhost-3011.amika",
+		"ProxyCommand " + binary + " plumbing ssh-stdio-proxy %h",
+	} {
+		if !strings.Contains(string(conf), want) {
+			t.Errorf("amika.conf missing %q:\n%s", want, conf)
+		}
+	}
+}
+
+// Each control plane owns its own sandboxes, so connecting to a second one adds
+// a block rather than replacing the first: aliases for both must keep working.
+func TestConfigureSessionKeepsOneBlockPerEnvironment(t *testing.T) {
+	paths := testPaths(t)
+	session := SessionConfig{
+		IdentityFile:   "/home/user/.ssh/amika_id_ed25519",
+		KnownHostsFile: "/home/user/.ssh/amika_known_hosts",
+	}
+
+	t.Setenv(config.EnvAPIURL, "http://localhost:3011")
+	localBinary := testBinary(t, "amika-local")
+	if err := ConfigureSession(paths, session); err != nil {
+		t.Fatalf("ConfigureSession local: %v", err)
+	}
+
+	t.Setenv(config.EnvAPIURL, "https://app.staging-amika.dev")
+	stagingBinary := testBinary(t, "amika-staging")
+	if err := ConfigureSession(paths, session); err != nil {
+		t.Fatalf("ConfigureSession staging: %v", err)
+	}
+
+	confPath, _ := paths.SSHAmikaConfigFile()
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	for _, want := range []string{
+		"Host *.localhost-3011.amika",
+		"ProxyCommand " + localBinary + " plumbing ssh-stdio-proxy %h",
+		"Host *.app-staging-amika-dev.amika",
+		"ProxyCommand " + stagingBinary + " plumbing ssh-stdio-proxy %h",
+	} {
+		if !strings.Contains(string(conf), want) {
+			t.Errorf("amika.conf missing %q:\n%s", want, conf)
+		}
+	}
+	// Sorted rendering keeps the file from churning between runs.
+	if strings.Index(string(conf), "*.app-staging-amika-dev.amika") > strings.Index(string(conf), "*.localhost-3011.amika") {
+		t.Errorf("environment blocks are not in sorted order:\n%s", conf)
+	}
+}
+
+// Re-running against the same environment with a different binary replaces that
+// environment's ProxyCommand instead of accumulating a stale one.
+func TestConfigureSessionReplacesAnEnvironmentsStaleProxyCommand(t *testing.T) {
+	paths := testPaths(t)
+	session := SessionConfig{
+		IdentityFile:   "/home/user/.ssh/amika_id_ed25519",
+		KnownHostsFile: "/home/user/.ssh/amika_known_hosts",
+	}
+	t.Setenv(config.EnvAPIURL, "http://localhost:3011")
+
+	oldBinary := testBinary(t, "amika-old")
+	if err := ConfigureSession(paths, session); err != nil {
+		t.Fatalf("ConfigureSession first: %v", err)
+	}
+	newBinary := testBinary(t, "amika-new")
+	if err := ConfigureSession(paths, session); err != nil {
+		t.Fatalf("ConfigureSession second: %v", err)
+	}
+
+	confPath, _ := paths.SSHAmikaConfigFile()
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	if strings.Contains(string(conf), oldBinary) {
+		t.Errorf("amika.conf kept the stale ProxyCommand:\n%s", conf)
+	}
+	if !strings.Contains(string(conf), newBinary) {
+		t.Errorf("amika.conf missing the new ProxyCommand:\n%s", conf)
+	}
+	if got := strings.Count(string(conf), "Host *.localhost-3011.amika"); got != 1 {
+		t.Errorf("expected exactly one block for the environment, got %d:\n%s", got, conf)
+	}
+}
+
+// State written before session blocks became per-environment carries a
+// ProxyCommand inside session_config and no session_proxy_commands. Its
+// environment-agnostic `Host *.amika` block would still match every new alias
+// and win the ProxyCommand for it, so regeneration must drop it.
+func TestLegacySessionStateLosesItsEnvironmentAgnosticWildcard(t *testing.T) {
+	paths := testPaths(t)
+	statePath, err := paths.SSHHostsStateFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{
+  "hosts": [],
+  "session_config": {
+    "IdentityFile": "/home/user/.ssh/amika_id_ed25519",
+    "KnownHostsFile": "/home/user/.ssh/amika_known_hosts",
+    "ProxyCommand": "amika plumbing ssh-stdio-proxy %h"
+  }
+}`
+	if err := writeFileAtomic(statePath, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := LoadState(paths)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	// The imported identity survives; only the environment-less block is lost.
+	if state.SessionConfig == nil || state.SessionConfig.IdentityFile != "/home/user/.ssh/amika_id_ed25519" {
+		t.Fatalf("session identity not preserved: %#v", state.SessionConfig)
+	}
+	if rendered := Render(state); strings.Contains(rendered, "Host *.amika") {
+		t.Errorf("legacy wildcard survived regeneration:\n%s", rendered)
+	}
+
+	t.Setenv(config.EnvAPIURL, "http://localhost:3011")
+	binary := testBinary(t, "amika-local")
+	if err := ConfigureSession(paths, *state.SessionConfig); err != nil {
+		t.Fatalf("ConfigureSession: %v", err)
+	}
+	confPath, _ := paths.SSHAmikaConfigFile()
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	if strings.Contains(string(conf), "Host *.amika\n") {
+		t.Errorf("amika.conf still has the environment-agnostic wildcard:\n%s", conf)
+	}
+	if !strings.Contains(string(conf), "ProxyCommand "+binary+" plumbing ssh-stdio-proxy %h") {
+		t.Errorf("amika.conf missing the resolved ProxyCommand:\n%s", conf)
 	}
 }

--- a/go/internal/ssh/known_hosts_test.go
+++ b/go/internal/ssh/known_hosts_test.go
@@ -13,7 +13,7 @@ func TestFileHostKeyPinStoreRefusesChangedKey(t *testing.T) {
 	store := FileHostKeyPinStore{Path: path}
 	first := testHostKey(t)
 	second := testHostKey(t)
-	alias := "team.sbx_1.amika"
+	alias := "team.sbx_1.localhost-3011.amika"
 	if err := store.Pin(alias, first); err != nil {
 		t.Fatalf("first Pin: %v", err)
 	}

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/wsstream"
 	cryptossh "golang.org/x/crypto/ssh"
 )
@@ -20,6 +22,11 @@ import (
 const proxyCopyBufferBytes = 32 * 1024
 
 var safeAliasPart = regexp.MustCompile(`^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$`)
+
+// DefaultProxyCommand is the only ProxyCommand the managed session config
+// accepts. It is a fixed string so a session config read back from disk can
+// never smuggle an arbitrary command into the user's SSH config.
+const DefaultProxyCommand = "amika plumbing ssh-stdio-proxy %h"
 
 // ErrInvalidSessionAlias marks a host value that is not a safe v2 Amika
 // alias.
@@ -98,7 +105,7 @@ func ParseSessionAlias(alias string) (SandboxAlias, error) {
 // RenderSessionConfig renders the strict wildcard block used only by v2
 // aliases.
 func RenderSessionConfig(config SessionConfig) (string, error) {
-	if !safeConfigPath(config.IdentityFile) || !safeConfigPath(config.KnownHostsFile) || config.ProxyCommand != "amika plumbing ssh-stdio-proxy %h" {
+	if !safeConfigPath(config.IdentityFile) || !safeConfigPath(config.KnownHostsFile) || config.ProxyCommand != DefaultProxyCommand {
 		return "", ErrInvalidSessionAlias
 	}
 	return fmt.Sprintf(`Host *.amika
@@ -246,4 +253,70 @@ func canonicalHostPublicKey(value string) (string, error) {
 		return "", ErrHostKeyMismatch
 	}
 	return strings.TrimSpace(string(cryptossh.MarshalAuthorizedKey(key))), nil
+}
+
+// PrepareSessionTarget readies one sandbox for a v2 dial and returns its host
+// alias: it builds the alias, writes the strict wildcard session config, and
+// pins the sandbox's host key.
+//
+// Shared by every command that hands a `*.amika` alias to system OpenSSH
+// (`sandbox sshv2`, `scpv2`), so they cannot drift in how the identity is
+// checked or the host key is pinned.
+func PrepareSessionTarget(
+	paths basedir.Paths,
+	creator SessionCreator,
+	sandboxName string,
+	sandboxID string,
+) (string, error) {
+	alias, err := BuildSessionAlias(sandboxName, sandboxID)
+	if err != nil {
+		return "", err
+	}
+	sessionConfig, err := resolveSessionConfig(paths)
+	if err != nil {
+		return "", err
+	}
+	// A world- or group-readable private key is refused rather than used:
+	// OpenSSH would reject it anyway, and the clearer error names the fix.
+	identityInfo, statErr := os.Stat(sessionConfig.IdentityFile)
+	if statErr != nil || !identityInfo.Mode().IsRegular() || identityInfo.Mode().Perm()&0o077 != 0 {
+		return "", fmt.Errorf("SSH identity is missing or unsafe; run %q", "amika secret ssh-keygen")
+	}
+	if err := ConfigureSession(paths, sessionConfig); err != nil {
+		return "", err
+	}
+	if _, err := PrepareSessionHost(
+		creator,
+		FileHostKeyPinStore{Path: sessionConfig.KnownHostsFile},
+		sandboxID,
+		alias,
+	); err != nil {
+		return "", err
+	}
+	return alias, nil
+}
+
+// resolveSessionConfig returns the persisted session config, or the default
+// one built from the standard identity and known-hosts paths.
+func resolveSessionConfig(paths basedir.Paths) (SessionConfig, error) {
+	state, err := LoadState(paths)
+	if err != nil {
+		return SessionConfig{}, err
+	}
+	if state.SessionConfig != nil {
+		return *state.SessionConfig, nil
+	}
+	identityFile, err := paths.SSHIdentityFile()
+	if err != nil {
+		return SessionConfig{}, err
+	}
+	knownHostsFile, err := paths.SSHKnownHostsFile()
+	if err != nil {
+		return SessionConfig{}, err
+	}
+	return SessionConfig{
+		IdentityFile:   identityFile,
+		KnownHostsFile: knownHostsFile,
+		ProxyCommand:   DefaultProxyCommand,
+	}, nil
 }

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -15,38 +15,63 @@ import (
 	"github.com/coder/websocket"
 	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/gofixpoint/amika/go/internal/config"
 	"github.com/gofixpoint/amika/go/internal/wsstream"
 	cryptossh "golang.org/x/crypto/ssh"
 )
 
 const proxyCopyBufferBytes = 32 * 1024
 
+// safeAliasPart matches a sandbox name, which may itself contain dots.
 var safeAliasPart = regexp.MustCompile(`^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$`)
 
-// DefaultProxyCommand is the only ProxyCommand the managed session config
-// accepts. It is a fixed string so a session config read back from disk can
-// never smuggle an arbitrary command into the user's SSH config.
-const DefaultProxyCommand = "amika plumbing ssh-stdio-proxy %h"
+// safeAliasSegment matches exactly one dot-free alias segment, used for the
+// parts an alias is split on: the sandbox id and the environment slug.
+var safeAliasSegment = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// proxyCommandSuffix is the fixed argv tail every managed ProxyCommand carries.
+// Only the leading executable path may vary, so a session config read back from
+// disk can never smuggle a different command into the user's SSH config.
+const proxyCommandSuffix = " plumbing ssh-stdio-proxy %h"
+
+// proxyPathUnsafeRunes must never appear in a ProxyCommand executable path.
+// OpenSSH runs the line through a shell, so a metacharacter in the path would
+// be executed rather than treated as part of it, and OpenSSH expands %-tokens
+// in the line before running it.
+const proxyPathUnsafeRunes = "%\"'`$&;|<>()[]{}*?!#~\\\r\n\t "
 
 // ErrInvalidSessionAlias marks a host value that is not a safe v2 Amika
 // alias.
 var ErrInvalidSessionAlias = errors.New("invalid Amika SSH host alias")
 
+// ErrUnsafeBinaryPath marks an amika executable path that cannot be safely
+// embedded in a ProxyCommand line.
+var ErrUnsafeBinaryPath = errors.New("unsafe amika executable path for ProxyCommand")
+
 // ErrHostKeyMismatch marks a descriptor whose immutable identity does not
 // match the requested host.
 var ErrHostKeyMismatch = errors.New("SSH host identity mismatch")
 
-// SandboxAlias identifies the immutable sandbox id parsed from a v2 host alias.
+// SandboxAlias identifies the immutable sandbox id and the control-plane
+// environment parsed from a v2 host alias.
 type SandboxAlias struct {
-	Name string
-	ID   string
+	Name        string
+	ID          string
+	Environment string
 }
 
-// SessionConfig describes the strict wildcard SSH configuration.
+// SessionConfig describes the local key material shared by every environment's
+// session block: the private key OpenSSH authenticates with and the file its
+// host-key pins live in.
+//
+// Neither is per-environment. One private key authenticates to every control
+// plane, each of which holds its own uploaded copy of the public key, so an
+// identity imported while pointed at one environment stays in effect for all of
+// them. Only the ProxyCommand varies per environment, and it is stored
+// separately in HostsState.
 type SessionConfig struct {
 	IdentityFile   string
 	KnownHostsFile string
-	ProxyCommand   string
 }
 
 // SessionCreator creates a fresh transport descriptor for each SSH dial.
@@ -72,43 +97,105 @@ type HostKeyPinStore interface {
 	Pin(string, string) error
 }
 
-// BuildSessionAlias combines a safe human name and immutable sandbox id.
-func BuildSessionAlias(name, id string) (string, error) {
-	if name == "" || id == "" || !safeAliasPart.MatchString(name) || !safeAliasPart.MatchString(id) || strings.Contains(id, ".") {
+// BuildSessionAlias combines a safe human name, immutable sandbox id, and the
+// control-plane environment slug into a v2 host alias.
+//
+// The environment goes second-to-last rather than first because the sandbox
+// name may itself contain dots: parsing has to pop fixed-position segments off
+// the right and let the name absorb whatever remains.
+func BuildSessionAlias(name, id, environment string) (string, error) {
+	if name == "" || id == "" || environment == "" ||
+		!safeAliasPart.MatchString(name) ||
+		!safeAliasSegment.MatchString(id) ||
+		!safeAliasSegment.MatchString(environment) {
 		return "", ErrInvalidSessionAlias
 	}
-	alias := name + "." + id + ".amika"
+	alias := name + "." + id + "." + environment + ".amika"
 	if len(alias) > 253 {
 		return "", ErrInvalidSessionAlias
 	}
 	return alias, nil
 }
 
-// ParseSessionAlias splits from the right so dotted sandbox names remain
-// intact.
+// ParseSessionAlias pops the environment and sandbox id off the right so dotted
+// sandbox names remain intact.
 func ParseSessionAlias(alias string) (SandboxAlias, error) {
 	if len(alias) > 253 || !strings.HasSuffix(alias, ".amika") || strings.ContainsAny(alias, "\r\n\t *?![]\\") {
 		return SandboxAlias{}, ErrInvalidSessionAlias
 	}
-	withoutSuffix := strings.TrimSuffix(alias, ".amika")
-	separator := strings.LastIndexByte(withoutSuffix, '.')
-	if separator <= 0 || separator == len(withoutSuffix)-1 {
+	rest, environment, ok := cutLastSegment(strings.TrimSuffix(alias, ".amika"))
+	if !ok {
 		return SandboxAlias{}, ErrInvalidSessionAlias
 	}
-	parsed := SandboxAlias{Name: withoutSuffix[:separator], ID: withoutSuffix[separator+1:]}
-	if !safeAliasPart.MatchString(parsed.Name) || !safeAliasPart.MatchString(parsed.ID) || strings.Contains(parsed.ID, ".") {
+	name, id, ok := cutLastSegment(rest)
+	if !ok {
+		return SandboxAlias{}, ErrInvalidSessionAlias
+	}
+	parsed := SandboxAlias{Name: name, ID: id, Environment: environment}
+	if !safeAliasPart.MatchString(parsed.Name) ||
+		!safeAliasSegment.MatchString(parsed.ID) ||
+		!safeAliasSegment.MatchString(parsed.Environment) {
 		return SandboxAlias{}, ErrInvalidSessionAlias
 	}
 	return parsed, nil
 }
 
-// RenderSessionConfig renders the strict wildcard block used only by v2
-// aliases.
-func RenderSessionConfig(config SessionConfig) (string, error) {
-	if !safeConfigPath(config.IdentityFile) || !safeConfigPath(config.KnownHostsFile) || config.ProxyCommand != DefaultProxyCommand {
+// cutLastSegment splits value at its final dot into the text before it and the
+// segment after it, reporting false when there is no dot or either side is
+// empty.
+func cutLastSegment(value string) (string, string, bool) {
+	separator := strings.LastIndexByte(value, '.')
+	if separator <= 0 || separator == len(value)-1 {
+		return "", "", false
+	}
+	return value[:separator], value[separator+1:], true
+}
+
+// BuildProxyCommand renders the ProxyCommand line that reaches amika through
+// the given executable path.
+func BuildProxyCommand(binaryPath string) (string, error) {
+	if !safeProxyBinaryPath(binaryPath) {
+		return "", ErrUnsafeBinaryPath
+	}
+	return binaryPath + proxyCommandSuffix, nil
+}
+
+// ParseProxyCommand returns the executable path from a managed ProxyCommand
+// line, rejecting any line whose argv tail is not the fixed proxy invocation or
+// whose path is not shell-safe.
+func ParseProxyCommand(proxyCommand string) (string, error) {
+	binaryPath, ok := strings.CutSuffix(proxyCommand, proxyCommandSuffix)
+	if !ok || !safeProxyBinaryPath(binaryPath) {
+		return "", ErrUnsafeBinaryPath
+	}
+	return binaryPath, nil
+}
+
+// ResolveProxyCommand builds the ProxyCommand for the amika executable the
+// current process should be reached through.
+func ResolveProxyCommand() (string, error) {
+	binaryPath, err := config.BinaryPath()
+	if err != nil {
+		return "", err
+	}
+	return BuildProxyCommand(binaryPath)
+}
+
+// RenderSessionConfig renders one environment's wildcard block. The pattern is
+// scoped to `*.<environment>.amika` rather than `*.amika` so each control plane
+// gets its own ProxyCommand: a bare `*.amika` would also match every other
+// environment's aliases, and OpenSSH takes the first value it finds for an
+// option.
+func RenderSessionConfig(environment, proxyCommand string, session SessionConfig) (string, error) {
+	if !safeAliasSegment.MatchString(environment) ||
+		!safeConfigPath(session.IdentityFile) ||
+		!safeConfigPath(session.KnownHostsFile) {
 		return "", ErrInvalidSessionAlias
 	}
-	return fmt.Sprintf(`Host *.amika
+	if _, err := ParseProxyCommand(proxyCommand); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`Host *.%s.amika
   User amika
   IdentityFile %s
   IdentitiesOnly yes
@@ -117,7 +204,7 @@ func RenderSessionConfig(config SessionConfig) (string, error) {
   ProxyCommand %s
   ServerAliveInterval 15
   ServerAliveCountMax 3
-`, config.IdentityFile, config.KnownHostsFile, config.ProxyCommand), nil
+`, environment, session.IdentityFile, session.KnownHostsFile, proxyCommand), nil
 }
 
 // KnownHostLine returns one canonical alias-keyed Ed25519 pin.
@@ -247,6 +334,13 @@ func safeConfigPath(path string) bool {
 	return filepath.IsAbs(path) && filepath.Clean(path) == path && !strings.ContainsAny(path, "\r\n\t ")
 }
 
+// safeProxyBinaryPath holds a ProxyCommand executable to a stricter standard
+// than safeConfigPath: OpenSSH treats IdentityFile as a filename but hands the
+// ProxyCommand line to a shell, so anything a shell would interpret is refused.
+func safeProxyBinaryPath(path string) bool {
+	return safeConfigPath(path) && !strings.ContainsAny(path, proxyPathUnsafeRunes)
+}
+
 func canonicalHostPublicKey(value string) (string, error) {
 	key, _, options, rest, err := cryptossh.ParseAuthorizedKey([]byte(value))
 	if err != nil || len(options) != 0 || strings.TrimSpace(string(rest)) != "" || key.Type() != cryptossh.KeyAlgoED25519 {
@@ -268,7 +362,11 @@ func PrepareSessionTarget(
 	sandboxName string,
 	sandboxID string,
 ) (string, error) {
-	alias, err := BuildSessionAlias(sandboxName, sandboxID)
+	environment, err := config.EnvironmentSlug()
+	if err != nil {
+		return "", err
+	}
+	alias, err := BuildSessionAlias(sandboxName, sandboxID, environment)
 	if err != nil {
 		return "", err
 	}
@@ -296,8 +394,10 @@ func PrepareSessionTarget(
 	return alias, nil
 }
 
-// resolveSessionConfig returns the persisted session config, or the default
-// one built from the standard identity and known-hosts paths.
+// resolveSessionConfig returns the persisted session identity, or the default
+// one built from the standard identity and known-hosts paths. The persisted
+// value is honored so an identity imported by `amika ssh-keygen --import` keeps
+// being used.
 func resolveSessionConfig(paths basedir.Paths) (SessionConfig, error) {
 	state, err := LoadState(paths)
 	if err != nil {
@@ -317,6 +417,5 @@ func resolveSessionConfig(paths basedir.Paths) (SessionConfig, error) {
 	return SessionConfig{
 		IdentityFile:   identityFile,
 		KnownHostsFile: knownHostsFile,
-		ProxyCommand:   DefaultProxyCommand,
 	}, nil
 }

--- a/go/internal/ssh/session_test.go
+++ b/go/internal/ssh/session_test.go
@@ -16,37 +16,109 @@ import (
 	cryptossh "golang.org/x/crypto/ssh"
 )
 
-func TestParseSessionAliasUsesRightmostSandboxID(t *testing.T) {
-	parsed, err := ParseSessionAlias("my.team.sbx-123.amika")
+func TestParseSessionAliasPopsEnvironmentAndIDFromTheRight(t *testing.T) {
+	parsed, err := ParseSessionAlias("my.team.sbx-123.localhost-3011.amika")
 	if err != nil {
 		t.Fatalf("ParseSessionAlias: %v", err)
 	}
-	if parsed.Name != "my.team" || parsed.ID != "sbx-123" {
+	if parsed.Name != "my.team" || parsed.ID != "sbx-123" || parsed.Environment != "localhost-3011" {
 		t.Fatalf("parsed = %#v", parsed)
 	}
 }
 
-func TestRenderSessionConfigPinsHostKeysAndFetchesEveryDial(t *testing.T) {
-	config, err := RenderSessionConfig(SessionConfig{
-		IdentityFile:   "/home/user/.ssh/amika_id_ed25519",
-		KnownHostsFile: "/home/user/.ssh/amika_known_hosts",
-		ProxyCommand:   "amika plumbing ssh-stdio-proxy %h",
-	})
+func TestBuildSessionAliasRoundTripsThroughParse(t *testing.T) {
+	alias, err := BuildSessionAlias("my.team", "sbx-123", "app-amika-dev")
+	if err != nil {
+		t.Fatalf("BuildSessionAlias: %v", err)
+	}
+	if alias != "my.team.sbx-123.app-amika-dev.amika" {
+		t.Fatalf("alias = %q", alias)
+	}
+	parsed, err := ParseSessionAlias(alias)
+	if err != nil {
+		t.Fatalf("ParseSessionAlias: %v", err)
+	}
+	if parsed.Name != "my.team" || parsed.ID != "sbx-123" || parsed.Environment != "app-amika-dev" {
+		t.Fatalf("parsed = %#v", parsed)
+	}
+}
+
+// A dot in the environment would be popped as its own segment and shift every
+// other field, so it must be refused at build time.
+func TestBuildSessionAliasRejectsDottedEnvironment(t *testing.T) {
+	if _, err := BuildSessionAlias("team", "sbx-123", "app.amika.dev"); err == nil {
+		t.Fatal("expected a dotted environment to be rejected")
+	}
+}
+
+func TestRenderSessionConfigScopesTheWildcardToOneEnvironment(t *testing.T) {
+	config, err := RenderSessionConfig(
+		"localhost-3011",
+		"/Users/dev/bin/amika-local plumbing ssh-stdio-proxy %h",
+		SessionConfig{
+			IdentityFile:   "/home/user/.ssh/amika_id_ed25519",
+			KnownHostsFile: "/home/user/.ssh/amika_known_hosts",
+		},
+	)
 	if err != nil {
 		t.Fatalf("RenderSessionConfig: %v", err)
 	}
 	for _, line := range []string{
-		"Host *.amika",
+		"Host *.localhost-3011.amika",
 		"User amika",
 		"IdentityFile /home/user/.ssh/amika_id_ed25519",
 		"IdentitiesOnly yes",
 		"StrictHostKeyChecking yes",
 		"UserKnownHostsFile /home/user/.ssh/amika_known_hosts",
-		"ProxyCommand amika plumbing ssh-stdio-proxy %h",
+		"ProxyCommand /Users/dev/bin/amika-local plumbing ssh-stdio-proxy %h",
 		"ServerAliveInterval 15",
 	} {
 		if !strings.Contains(config, line) {
 			t.Errorf("config missing %q:\n%s", line, config)
+		}
+	}
+	// A bare `*.amika` would also match every other environment's aliases and
+	// win the ProxyCommand for them, since OpenSSH takes the first value found.
+	if strings.Contains(config, "Host *.amika") {
+		t.Errorf("config still has an environment-agnostic wildcard:\n%s", config)
+	}
+}
+
+// OpenSSH hands the ProxyCommand line to a shell, so only an absolute, clean,
+// metacharacter-free executable path may be embedded in it.
+func TestProxyCommandRejectsUnsafeExecutablePaths(t *testing.T) {
+	for _, binaryPath := range []string{
+		"amika",
+		"bin/amika",
+		"/usr/local/bin/amika; rm -rf /tmp/x",
+		"/usr/local/bin/amika && curl evil.example",
+		"/usr/local/bin/$(id)/amika",
+		"/usr/local/bin/amika `id`",
+		"/usr/local/bin/my amika",
+		"/usr/local/bin/amika%h",
+		"/usr/local/../bin/amika",
+	} {
+		if _, err := BuildProxyCommand(binaryPath); err == nil {
+			t.Errorf("BuildProxyCommand(%q) was accepted", binaryPath)
+		}
+	}
+}
+
+func TestParseProxyCommandRequiresTheFixedInvocation(t *testing.T) {
+	binaryPath, err := ParseProxyCommand("/usr/local/bin/amika plumbing ssh-stdio-proxy %h")
+	if err != nil {
+		t.Fatalf("ParseProxyCommand: %v", err)
+	}
+	if binaryPath != "/usr/local/bin/amika" {
+		t.Fatalf("binary path = %q", binaryPath)
+	}
+	for _, proxyCommand := range []string{
+		"/usr/local/bin/amika sandbox delete everything",
+		"/usr/local/bin/amika plumbing ssh-stdio-proxy",
+		"/usr/local/bin/amika plumbing ssh-stdio-proxy %h; id",
+	} {
+		if _, err := ParseProxyCommand(proxyCommand); err == nil {
+			t.Errorf("ParseProxyCommand(%q) was accepted", proxyCommand)
 		}
 	}
 }
@@ -54,13 +126,13 @@ func TestRenderSessionConfigPinsHostKeysAndFetchesEveryDial(t *testing.T) {
 func TestKnownHostLinePinsTheAliasToTheExactHostKey(t *testing.T) {
 	hostKey := testHostKey(t)
 	line, err := KnownHostLine(
-		"my.team.sbx-123.amika",
+		"my.team.sbx-123.localhost-3011.amika",
 		hostKey+" host-comment",
 	)
 	if err != nil {
 		t.Fatalf("KnownHostLine: %v", err)
 	}
-	if line != "my.team.sbx-123.amika "+hostKey+"\n" {
+	if line != "my.team.sbx-123.localhost-3011.amika "+hostKey+"\n" {
 		t.Fatalf("known-host line = %q", line)
 	}
 }
@@ -90,7 +162,7 @@ func TestPrepareSessionHostPinsAPIHostKeyBeforeOpenSSH(t *testing.T) {
 		creator,
 		pins,
 		"sbx_123",
-		"my.team.sbx_123.amika",
+		"my.team.sbx_123.localhost-3011.amika",
 	)
 	if err != nil {
 		t.Fatalf("PrepareSessionHost: %v", err)
@@ -98,7 +170,7 @@ func TestPrepareSessionHostPinsAPIHostKeyBeforeOpenSSH(t *testing.T) {
 	if session.SandboxID != "sbx_123" || creator.calls != 1 {
 		t.Fatalf("session = %#v, creator calls = %d", session, creator.calls)
 	}
-	if pins.calls != 1 || pins.alias != "my.team.sbx_123.amika" || pins.key != creator.hostKey {
+	if pins.calls != 1 || pins.alias != "my.team.sbx_123.localhost-3011.amika" || pins.key != creator.hostKey {
 		t.Fatalf("pin calls = %d alias = %q key = %q", pins.calls, pins.alias, pins.key)
 	}
 }
@@ -156,7 +228,7 @@ func TestProxySessionCreatesSessionAndCopiesBytes(t *testing.T) {
 		context.Background(),
 		creator,
 		dialer,
-		"my.team.sbx_123.amika",
+		"my.team.sbx_123.localhost-3011.amika",
 		strings.NewReader("from-openssh"),
 		&stdout,
 	)
@@ -189,7 +261,7 @@ func TestProxySessionAcceptsNormalWebSocketClosure(t *testing.T) {
 		context.Background(),
 		creator,
 		dialer,
-		"my.team.sbx_123.amika",
+		"my.team.sbx_123.localhost-3011.amika",
 		strings.NewReader(""),
 		io.Discard,
 	); err != nil {


### PR DESCRIPTION
Makes the no-relay SSH daemon actually serve on a Daytona VM, gives the beta
transport file-copy parity with `amika scp`, and scopes the generated SSH
config to the control plane each sandbox actually belongs to.

Found and fixed by running the path end to end against a real sandbox — see
the run log in `amika-mono`'s
`specs/019-sandbox-ssh-stream-relay.d/no-relay-websocket-ssh.d/prompt-e2e-tests.md`.

## Changes

**`amikad authorized-keys clear`** — the control plane calls this when a
sandbox has no permitted keys, so sshd comes up with an empty key set rather
than the daemon being absent.

**Reserved loopback port for the managed sshd** (KAPRO-716). The daemon
hardcoded `127.0.0.1:22`, but the Daytona VM base snapshot ships
socket-activated `ssh.socket` on the wildcard `*:22`, which also covers
loopback — so `amikad serve --beta-no-relay` died at startup with:

```
Bind to port 22 on 127.0.0.1 failed: Address already in use.
sshd failed: exit status 255
```

`sshd.Paths` gains a `Port`, defaulted to a new reserved-range constant
(60997, clear of 60999 amikad HTTP and 60998 opencode-web). `RenderConfig`
emits it and `Serve` dials `Manager.LoopbackAddress()` instead of a literal,
so the listener and the bridge's dial target are one value and cannot drift.
Also masks `ssh.socket`/`ssh.service` in the base image — spec 019 wants
openssh-server installed but never enabled as a system service, and the
package otherwise leaves an unintended inbound `0.0.0.0:22` listener.

**`amika scpv2`** (KAPRO-721). Keeps the whole `amika scp` operand grammar
(local paths, `NAME:PATH`, `sbox://NAME/PATH`, `scp://` URIs, all flags
forwarded to system scp) and changes only how a sandbox reference becomes an
operand: v1 resolves a host/port/user and spells out connection options, v2
resolves the `<name>.<id>.<environment>.amika` alias whose settings come from
the managed block in `~/.ssh/amika.conf`. The v1 stream-transfer workaround
for Daytona's SSH gateway does not apply to this transport.

Both commands now share `ssh.PrepareSessionTarget`, extracted from `sandbox
sshv2`, so alias construction, the identity permission check, and host-key
pinning cannot drift between them.

**Scope v2 SSH session config per control plane.** The generated `Host
*.amika` block hardcoded a bare `amika` as its ProxyCommand, so OpenSSH
resolved the proxy from `PATH` — a machine with a released binary installed
alongside a dev build got whichever hit first, failing with `unknown command
"plumbing"` when the release predated that subcommand. A bare name was also
the wrong unit: the proxy mints a session against `AMIKA_API_URL`, so one
wildcard block shared by every environment let the last `sshv2` run win, and
alias-keyed host-key pins collided across environments.

- A new `AMIKA_BINARY_PATH` env var overrides the executable path recorded
  in the ProxyCommand, since `os.Executable` can't see a wrapper script that
  exported the environment amika needs; a wrapper names itself here.
- Aliases now carry an environment slug derived from `AMIKA_API_URL`:
  `<name>.<id>.<environment>.amika`. `HostsState` holds one ProxyCommand per
  environment and `Render` emits a `Host *.<environment>.amika` block for
  each, sorted so the file doesn't churn. `SessionConfig` keeps only the
  identity and known-hosts paths, which stay per-machine.
- Old `SessionConfig.ProxyCommand` state is dropped on load and regenerated
  from the new per-environment map, so a leftover `Host *.amika` block (which
  would otherwise still match every new alias) doesn't survive an upgrade.

**Repin `AMIKAD_SOURCE_REF`** to the branch head, so a rebuilt base image
carries the port fix and `authorized-keys clear` rather than the older pinned
commit.

## Verification

`go vet ./...` and `make test-unit` pass (the pre-existing `internal/materialize`
failures are unrelated and reproduce on the base branch).

Against a live Daytona sandbox created from a snapshot built from this branch:

- `amika sandbox sshv2 <sandbox> -- 'hostname; whoami'` opens a shell as `amika`
- exit codes propagate (`exit 42` → 42)
- `SSH_CONNECTION` confirms the session lands on `127.0.0.1:60997`
- `amika scpv2` round-trips a 200 KiB file byte-for-byte in both directions

## Follow-up

KAPRO-722 — the `sshv2` ProxyCommand still re-reads `AMIKA_API_URL` from the
ambient environment on every dial, which is unreliable inside a sandbox. Not
fixed here; it needs a design decision about pinning the transport target to
the session.

## Stack

1. `dylan/amika-cli-skill` #315
2. `dylan/ssh-impl-no-relay` #316
3. `dylan/no-ssh-keygen-yet-fix` `#THIS` ← you are here
4. `dylan/ssh-websocket-code-review` #322

