### PR TITLE
Resolve SSH relay review annotations and document the connect-token round trip

### DIFF
--- a/.agents/skills/amika-annotations/SKILL.md
+++ b/.agents/skills/amika-annotations/SKILL.md
@@ -95,6 +95,7 @@ trample what they protect.
 | `review-change` | XML | The wrapped content was changed by the author and is flagged for review. Evaluate the change against the surrounding context. If it's an improvement, accept it (unwrap). If it should be reverted, note it as a conflict and leave the tags for the user to handle — you cannot recover the original automatically. | unwrap if accepted; leave tagged if rejected |
 | `todo` | EDN or XML | Perform the described task on/around the target. | delete |
 | `note` | EDN | A standing label or informational marker. Incorporate its content into the surrounding prose or action context, then delete. If it marks something that should remain (e.g. a label the user explicitly wants to keep), leave it — use judgment. | delete |
+| `annotate` | EDN or XML | A free-form question or request left for the agent (e.g. "is this still right?" or "can you make X configurable?"). Investigate the question or make the requested change, then record the result at the target. | delete |
 
 > The imperative set above is a **starter**. It's safe to extend this table as new types
 > appear; until then, unknown types are handled by inference (below).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,13 @@ The repo also ships `amikalog`, a separate, separately-installed CLI that captur
 This repository is an OSS monorepo. Go sources live under `go/`. Other
 language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
 
+Comments and docstrings here sometimes point at `amika-mono`, Amika's private
+control-plane monorepo, for protocol details owned by that side (e.g. "the
+ssh-relay repo's specs/019-sandbox-ssh-stream-relay.d/...",
+`devdocs/sandbox-secret-scrubbing.md`). This repo's own `specs/` directory is
+numbered separately and covers only OSS-specific specs. Look for `amika-mono`
+checked out as a sibling worktree rather than searching for those paths in this repo.
+
 ## Runtime Dependencies
 
 - **Docker** is required for `materialize`, `sandbox`, and `volume` commands. Preset images (`coder`, `claude`) are auto-built on first use from Dockerfiles in `go/internal/sandbox/presets/`.

--- a/go/cmd/amika/plumbing.go
+++ b/go/cmd/amika/plumbing.go
@@ -13,10 +13,9 @@ var plumbingCmd = &cobra.Command{
 }
 
 var sshStdioProxyCmd = &cobra.Command{
-	Use:    "ssh-stdio-proxy <host>",
-	Short:  "Proxy standard IO to one SSH transport",
-	Hidden: true,
-	Args:   cobra.ExactArgs(1),
+	Use:   "ssh-stdio-proxy <host>",
+	Short: "Proxy standard IO to one SSH transport",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return ssh.ProxySession(
 			cmd.Context(),

--- a/go/cmd/amika/scp/scpv2.go
+++ b/go/cmd/amika/scp/scpv2.go
@@ -7,10 +7,11 @@ package scpcmd
 // The transport difference is entirely in how a sandbox reference becomes an
 // scp operand. v1 resolves a sandbox to a concrete host/port/user and spells
 // out connection options on the command line; v2 resolves it to its
-// `<name>.<id>.amika` alias, whose User, IdentityFile, host-key policy, and
-// ProxyCommand all come from the managed `Host *.amika` block in
-// ~/.ssh/amika.conf. So there are no connection options to prepend here — the
-// operands are rewritten and system scp is handed the rest unchanged.
+// `<name>.<id>.<environment>.amika` alias (ssh.BuildSessionAlias), whose
+// User, IdentityFile, host-key policy, and ProxyCommand all come from the
+// managed `Host *.amika` block in ~/.ssh/amika.conf. So there are no
+// connection options to prepend here — the operands are rewritten and system
+// scp is handed the rest unchanged.
 
 import (
 	"fmt"
@@ -160,10 +161,10 @@ Operands take the same forms as "amika scp":
                                     "/" in NAME must be percent-encoded as %2F
   scp://[user@]host[:port][/path]   a path on an arbitrary SSH host
 
-Each sandbox resolves to its "<name>.<id>.amika" alias, and the connection
-settings come from the managed block in ~/.ssh/amika.conf, so a fresh session
-is created and the host key re-pinned per dial. Requires an SSH identity from
-"amika secret ssh-keygen".
+Each sandbox resolves to its "<name>.<id>.<environment>.amika" alias, and the
+connection settings come from the managed block in ~/.ssh/amika.conf, so a
+fresh session is created and the host key re-pinned per dial. Requires an SSH
+identity from "amika secret ssh-keygen".
 
 Examples:
   # Upload a file into the sandbox home

--- a/go/cmd/amika/scp/scpv2_test.go
+++ b/go/cmd/amika/scp/scpv2_test.go
@@ -7,7 +7,14 @@ import (
 )
 
 // stubResolver resolves any sandbox name to a deterministic v2 alias and
-// records the names it was asked for.
+// records the names it was asked for. The fixture alias below is a stand-in
+// for exercising buildSCPV2Invocation's operand rewriting in isolation, not a
+// copy of the real format: production aliases are
+// "<name>.<id>.<environment>.amika" (ssh.BuildSessionAlias), where
+// <environment> is the AMIKA_API_URL host reformatted to [a-z0-9-]
+// (config.EnvironmentSlug). That third segment landed after this test was
+// written; it doesn't need to be reflected here since nothing in this file
+// depends on the resolver's output shape, only on where it gets substituted.
 func stubResolver(seen *[]string) aliasResolver {
 	return func(name string) (string, error) {
 		if name == "missing" {

--- a/go/cmd/amika/secrets.go
+++ b/go/cmd/amika/secrets.go
@@ -1,5 +1,8 @@
 package main
 
+// TODO(KAPRO-747): this file is too big; split it up under go/cmd/amika/secrets/...
+// as a standalone commit unrelated to other in-flight work.
+
 import (
 	"bufio"
 	"encoding/json"

--- a/go/internal/amikad/command.go
+++ b/go/internal/amikad/command.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/gofixpoint/amika/go/internal/amikad/norelay"
 	"github.com/gofixpoint/amika/go/internal/buildmeta"
 	"github.com/spf13/cobra"
 )
@@ -22,6 +23,9 @@ type ServeOptions struct {
 	Port        int
 	BetaNoRelay bool
 	Background  bool
+	// MaxConnections bounds concurrent no-relay bridge sessions. Values <= 0
+	// fall back to norelay.DefaultMaxConnections (see norelay.NewHandler).
+	MaxConnections int
 }
 
 // SetupSSHDOptions controls whether managed setup may replace an existing
@@ -168,6 +172,12 @@ func NewCommand(operations Operations) *cobra.Command {
 		"bg",
 		false,
 		"start in the background and wait until healthy",
+	)
+	serve.Flags().IntVar(
+		&serveOptions.MaxConnections,
+		"max-connections",
+		norelay.DefaultMaxConnections,
+		"maximum concurrent no-relay bridge sessions",
 	)
 
 	root.AddCommand(setup, hostKey, authorizedKeys, connectToken, serve)

--- a/go/internal/amikad/norelay/handler.go
+++ b/go/internal/amikad/norelay/handler.go
@@ -71,10 +71,14 @@ type Handler struct {
 	streams   map[Stream]struct{}
 }
 
+// DefaultMaxConnections is the connection cap used when Config.MaxConnections
+// is left unset.
+const DefaultMaxConnections = 64
+
 // NewHandler creates a no-relay handler without opening any listener.
 func NewHandler(config Config, deps Dependencies) *Handler {
 	if config.MaxConnections <= 0 {
-		config.MaxConnections = 64
+		config.MaxConnections = DefaultMaxConnections
 	}
 	if config.SSHDAddress == "" {
 		config.SSHDAddress = "127.0.0.1:22"

--- a/go/internal/amikad/norelay/token.go
+++ b/go/internal/amikad/norelay/token.go
@@ -1,5 +1,28 @@
 package norelay
 
+// This file implements only the sandbox-side verification half of the
+// no-relay connect-token system. The full round trip:
+//
+//  1. The control plane (js/coding-agents in the ssh-relay repo) generates a
+//     random 32-byte token per rotation, base64url-encodes it, and delivers
+//     the plaintext to this sandbox over the provider's exec/stdin channel by
+//     invoking `amikad connect-token set` — never a CLI argument, so it never
+//     appears in `ps` or shell history. See operations.go's SetConnectToken
+//     for the write side.
+//  2. The control plane keeps only a SHA-256 hash of the token (plus a
+//     Vault-encrypted copy) in its own database, and hands the plaintext back
+//     to an authorized CLI caller as a bearer credential scoped to one SSH
+//     session.
+//  3. FileTokenVerifier below re-reads the on-disk token on every WebSocket
+//     upgrade (see handler.go), so a control-plane rotation takes effect
+//     immediately without restarting `amikad serve`. It fails closed on
+//     anything but an owner-only, exact-size, canonically-encoded token file,
+//     and never returns the stored value to callers — only whether a
+//     candidate matches.
+//
+// This file has no knowledge of Vault, orgs, or rotation history; it only
+// answers "does this candidate match what's currently on disk."
+
 import (
 	"crypto/sha256"
 	"crypto/subtle"

--- a/go/internal/amikad/operations.go
+++ b/go/internal/amikad/operations.go
@@ -1,5 +1,26 @@
 package amikad
 
+// SetConnectToken (below) is the sandbox-side write half of the no-relay
+// connect-token system that norelay.FileTokenVerifier (norelay/token.go)
+// verifies. Round trip, briefly:
+//
+//   - The control plane generates a fresh 32-byte token on every
+//     start/resume, keeps a SHA-256 hash of it (plus a Vault-encrypted copy)
+//     in its own database, and delivers the plaintext here over the
+//     provider's exec/stdin channel by running `amikad connect-token set`.
+//   - SetConnectToken validates the token is canonical (see
+//     norelay.IsCanonicalToken) and writes it at 0600 through the
+//     scrub-registered SensitiveStore, so it is both fail-closed on bad input
+//     and covered by the snapshot-scrubbing manifest.
+//   - Serve refuses to start the bridge at all unless a valid token is
+//     already on disk (verifier.Ready()); once serving, every WebSocket
+//     upgrade re-reads the file, so a later rotation takes effect without a
+//     restart.
+//
+// See the ssh-relay repo's specs/019-sandbox-ssh-stream-relay.d/
+// no-relay-websocket-ssh.md ("Connection flow" / "Resolved decisions") for
+// the control-plane side: generation, hashing, and per-start rotation.
+
 import (
 	"context"
 	"encoding/json"

--- a/go/internal/amikad/operations.go
+++ b/go/internal/amikad/operations.go
@@ -146,6 +146,11 @@ func (o *DaemonOperations) SetConnectToken(ctx context.Context, input io.Reader)
 	if !norelay.IsCanonicalToken(token) {
 		return ErrUnsafeConnectToken
 	}
+	// Registration here is the "find" half of scrubbing: the control plane's
+	// snapshot-capture scrub reads the manifest this call appends to, removes
+	// every absolute path it lists, and fails snapshot capture closed if it
+	// can't confirm a path is gone. See package state's doc comment for the
+	// manifest format and the full mechanism.
 	return o.store.WriteAndRegister(ctx, o.tokenPath, strings.NewReader(token), 0o600)
 }
 
@@ -166,7 +171,7 @@ func (o *DaemonOperations) Serve(ctx context.Context, options ServeOptions) erro
 	}
 
 	handler := norelay.NewHandler(
-		norelay.Config{MaxConnections: 64, SSHDAddress: o.sshd.LoopbackAddress()},
+		norelay.Config{MaxConnections: options.MaxConnections, SSHDAddress: o.sshd.LoopbackAddress()},
 		norelay.Dependencies{
 			Verifier: o.verifier,
 			Upgrader: norelay.WebSocketUpgrader{},
@@ -176,6 +181,10 @@ func (o *DaemonOperations) Serve(ctx context.Context, options ServeOptions) erro
 	)
 	mux := http.NewServeMux()
 	mux.Handle(norelay.SSHSessionsPath, handler)
+	// "healthz" follows the Kubernetes/Google convention for a liveness
+	// endpoint (distinct from an app-level "/health" that might carry richer
+	// status); the control plane's own e2e checks already probe this exact
+	// path, so renaming it would be a breaking change for no functional gain.
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Content-Type", "application/json")

--- a/go/internal/amikad/sshd/manager.go
+++ b/go/internal/amikad/sshd/manager.go
@@ -49,10 +49,22 @@ type Paths struct {
 	Port int
 }
 
-// DefaultPaths returns the production paths owned by amikad.
+// EnvManagedUser overrides the account whose UID/GID own the managed sshd's
+// authorized_keys file, and whose home directory it lives under. Empty (the
+// default) uses "amika". This is a single-user override, not multi-user
+// support: everything under DefaultPaths still assumes exactly one managed
+// account.
+const EnvManagedUser = "AMIKA_SSHD_USER"
+
+// DefaultPaths returns the production paths owned by amikad, for the managed
+// user named by EnvManagedUser (default "amika").
 func DefaultPaths() Paths {
+	username := os.Getenv(EnvManagedUser)
+	if username == "" {
+		username = "amika"
+	}
 	uid, gid := -1, -1
-	if account, err := user.Lookup("amika"); err == nil {
+	if account, err := user.Lookup(username); err == nil {
 		uid, _ = strconv.Atoi(account.Uid)
 		gid, _ = strconv.Atoi(account.Gid)
 	}
@@ -60,7 +72,7 @@ func DefaultPaths() Paths {
 		Config:            "/var/lib/amikad/sshd_config",
 		HostPrivateKey:    "/var/lib/amikad/ssh_host_ed25519_key",
 		HostPublicKey:     "/var/lib/amikad/ssh_host_ed25519_key.pub",
-		AuthorizedKeys:    "/home/amika/.ssh/authorized_keys",
+		AuthorizedKeys:    "/home/" + username + "/.ssh/authorized_keys",
 		PID:               "/var/lib/amikad/sshd.pid",
 		RuntimeDirectory:  "/run/sshd",
 		AuthorizedKeysUID: uid,

--- a/go/internal/amikad/state/contracts.go
+++ b/go/internal/amikad/state/contracts.go
@@ -1,4 +1,30 @@
 // Package state owns amikad's sensitive files and scrub manifest.
+//
+// The contract with the amika-mono control plane is register-before-write:
+// WriteAndRegister and WriteAndRegisterOwned durably append a sensitive
+// file's absolute path to the manifest before installing the file itself, so
+// a consumer that reads the manifest and removes every path it lists can
+// never miss a file this package has fully written. Worst case the consumer
+// deletes a path that turned out not to be needed; it can never skip one
+// that is.
+//
+// The manifest is a JSON array of absolute file path strings, e.g.
+// `["/home/amika/.ssh/authorized_keys", "/var/lib/amikad/connect-token"]`,
+// at a fixed path (production: /var/lib/amikad/injected-paths.json — under
+// /var/lib per the Filesystem Hierarchy Standard, since this is variable
+// runtime state rather than config). Entries must be clean, absolute,
+// non-duplicate, and never equal to the manifest path itself; readManifest
+// rejects a manifest violating any of those (ErrInvalidManifest).
+//
+// Before capturing a sandbox into a snapshot, the amika-mono control plane
+// scrubs every path the manifest lists — running as root, since some
+// registered paths (e.g. the SSH host key) are root-owned — then scrubs the
+// manifest file itself last. Scrub verification fails closed: if the control
+// plane cannot confirm a listed path is gone, snapshot capture aborts rather
+// than let a credential ride along into the snapshot. See the ssh-relay
+// repo's specs/019-sandbox-ssh-stream-relay.d/no-relay-websocket-ssh.md
+// ("Injection must register its own cleanup") and amika-mono's
+// devdocs/sandbox-secret-scrubbing.md for the full mechanism.
 package state
 
 import (

--- a/go/internal/amikad/state/contracts_test.go
+++ b/go/internal/amikad/state/contracts_test.go
@@ -1,3 +1,15 @@
+// This file's coverage of Store's fail-closed guarantees: registration
+// ordering (TestStoreRegistersBeforeWritingSensitiveFile,
+// TestStoreDoesNotWriteSecretWhenManifestWriteFails,
+// TestStoreLeavesRegistrationWhenSensitiveWriteFails), unsafe target paths
+// (TestStoreRejectsUnsafePaths), and concurrent manifest updates
+// (TestStoreSerializesConcurrentManifestUpdates,
+// TestOSStoresSerializeManifestAcrossInstances). Everything below adds
+// adversarial cases against a corrupt or hostile on-disk manifest, a
+// symlinked ancestor directory, and the write-parameter bounds
+// (TestStoreRejectsCorruptManifest, TestStoreRejectsUnsafeWriteParameters,
+// TestStoreFailsClosedOnCancelledContext, plus a symlinked-parent subtest in
+// TestStoreRejectsUnsafePaths).
 package state
 
 import (
@@ -257,6 +269,131 @@ func TestStoreRejectsUnsafePaths(t *testing.T) {
 			t.Fatalf("symlink path caused writes: %#v", files.writes)
 		}
 	})
+
+	t.Run("symlinked ancestor directory", func(t *testing.T) {
+		// rejectSymlinkComponents walks every ancestor, not just the leaf, so
+		// a symlinked parent (e.g. an attacker-controlled directory swapped
+		// in ahead of the write) must be rejected too, not just a symlinked
+		// leaf file.
+		files := newMemoryFiles()
+		linkedParent := filepath.Join(dir, "linked-dir")
+		files.symlinks[linkedParent] = true
+		tokenPath := filepath.Join(linkedParent, "token")
+		store := NewStore(manifestPath, files)
+		err := store.WriteAndRegister(context.Background(), tokenPath, strings.NewReader("token"), 0o600)
+		if !errors.Is(err, ErrSymlinkPath) {
+			t.Fatalf("error = %v, want ErrSymlinkPath", err)
+		}
+		if len(files.writes) != 0 {
+			t.Fatalf("symlinked ancestor caused writes: %#v", files.writes)
+		}
+	})
+}
+
+func TestStoreRejectsCorruptManifest(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "injected-paths.json")
+	tokenPath := filepath.Join(dir, "connect-token")
+
+	// Each case seeds an on-disk manifest a hostile or corrupted write could
+	// have produced, then confirms WriteAndRegister fails closed (no writes
+	// at all) instead of trusting or silently repairing it.
+	cases := map[string][]byte{
+		"invalid json":          []byte("not json"),
+		"json null":             []byte("null"),
+		"duplicate entries":     mustMarshal(t, []string{tokenPath, tokenPath}),
+		"relative entry":        mustMarshal(t, []string{"relative/secret"}),
+		"entry equals manifest": mustMarshal(t, []string{manifestPath}),
+	}
+	for name, seed := range cases {
+		t.Run(name, func(t *testing.T) {
+			files := newMemoryFiles()
+			files.contents[manifestPath] = seed
+			store := NewStore(manifestPath, files)
+			err := store.WriteAndRegister(context.Background(), tokenPath, strings.NewReader("token"), 0o600)
+			if !errors.Is(err, ErrInvalidManifest) {
+				t.Fatalf("error = %v, want ErrInvalidManifest", err)
+			}
+			if len(files.writes) != 0 {
+				t.Fatalf("corrupt manifest caused writes: %#v", files.writes)
+			}
+		})
+	}
+}
+
+func TestStoreRejectsUnsafeWriteParameters(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "injected-paths.json")
+	tokenPath := filepath.Join(dir, "connect-token")
+
+	t.Run("mode carries non-permission bits", func(t *testing.T) {
+		files := newMemoryFiles()
+		store := NewStore(manifestPath, files)
+		err := store.WriteAndRegister(
+			context.Background(), tokenPath, strings.NewReader("token"), 0o600|fs.ModeSetuid,
+		)
+		if !errors.Is(err, ErrInvalidPath) {
+			t.Fatalf("error = %v, want ErrInvalidPath", err)
+		}
+		if len(files.writes) != 0 {
+			t.Fatalf("unsafe mode caused writes: %#v", files.writes)
+		}
+	})
+
+	t.Run("ownership below sentinel", func(t *testing.T) {
+		files := newMemoryFiles()
+		store := NewStore(manifestPath, files)
+		err := store.WriteAndRegisterOwned(
+			context.Background(), tokenPath, strings.NewReader("token"), 0o600, Ownership{UID: -2, GID: 0},
+		)
+		if !errors.Is(err, ErrInvalidPath) {
+			t.Fatalf("error = %v, want ErrInvalidPath", err)
+		}
+		if len(files.writes) != 0 {
+			t.Fatalf("unsafe ownership caused writes: %#v", files.writes)
+		}
+	})
+
+	t.Run("content exceeds size limit", func(t *testing.T) {
+		files := newMemoryFiles()
+		store := NewStore(manifestPath, files)
+		oversized := strings.NewReader(strings.Repeat("a", maxSensitiveFileBytes+1))
+		err := store.WriteAndRegister(context.Background(), tokenPath, oversized, 0o600)
+		if !errors.Is(err, ErrSensitiveFileTooLarge) {
+			t.Fatalf("error = %v, want ErrSensitiveFileTooLarge", err)
+		}
+		if len(files.writes) != 0 {
+			t.Fatalf("oversized content caused writes: %#v", files.writes)
+		}
+	})
+}
+
+func TestStoreFailsClosedOnCancelledContext(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "injected-paths.json")
+	tokenPath := filepath.Join(dir, "connect-token")
+	files := newMemoryFiles()
+	store := NewStore(manifestPath, files)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := store.WriteAndRegister(ctx, tokenPath, strings.NewReader("token"), 0o600)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(files.writes) != 0 {
+		t.Fatalf("cancelled context caused writes: %#v", files.writes)
+	}
+}
+
+func mustMarshal(t *testing.T, paths []string) []byte {
+	t.Helper()
+	data, err := json.Marshal(paths)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return data
 }
 
 func TestStoreSerializesConcurrentManifestUpdates(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes out the `#amika/annotate` review annotations left on the SSH
relay diff (no-relay connect-token bridge, scpv2, managed sshd, and
`state` package), documents the connect-token round trip for future
readers, and folds this session's annotation-handling learnings back
into the agent docs.

## Changes

**Connect-token documentation**
- Add top-of-file comments to `norelay/token.go` and `operations.go`
  explaining how the sandbox-side verifier and writer fit into the
  full connect-token lifecycle (generation, hashing, delivery,
  rotation), cross-referencing each other and the control-plane spec.

**Review annotation resolutions**
- `amikad serve`: replace the hardcoded `MaxConnections: 64` with a
  configurable `ServeOptions.MaxConnections` and `--max-connections`
  flag, defaulting to the newly exported
  `norelay.DefaultMaxConnections`.
- `state` package: document the amika-mono side of the scrub-manifest
  contract (manifest format, register-before-write guarantee, the
  control plane's fail-closed sudo scrub at snapshot time), and point
  `SetConnectToken`'s call site at it.
- `/healthz`: document why it isn't named `/health` (Kubernetes/Google
  liveness convention; the control plane's e2e checks already probe
  this path) and leave it as-is.
- `scpv2`: update `scpv2.go`'s doc comments to the current
  `<name>.<id>.<environment>.amika` alias shape
  (`ssh.BuildSessionAlias`), and note in `scpv2_test.go` why the test's
  stub alias fixture doesn't need to track that format.
- managed sshd: add `AMIKA_SSHD_USER` (default `amika`) to make the
  managed account configurable for both the UID/GID lookup and the
  `authorized_keys` home path; multi-user support stays out of scope.
- `state` package tests: add coverage for a symlinked ancestor
  directory, a corrupt or hostile on-disk manifest (invalid JSON,
  JSON `null`, duplicate/relative/self-referential entries), the
  sensitive file size cap, non-permission mode bits, out-of-range
  ownership, and a pre-cancelled context.
- `plumbing`: drop the redundant `Hidden: true` on `ssh-stdio-proxy`
  since the parent `plumbing` command is already hidden.
- `secrets.go`: replace the "split this file up" annotation with
  `TODO(KAPRO-747)` to track it as a standalone follow-up.

**Agent docs**
- `amika-annotations` skill: add `annotate` to the built-in
  imperative-types table for free-form review questions/requests.
- `AGENTS.md`: note that comments here sometimes point at `amika-mono`
  (the private control-plane monorepo) for protocol details owned by
  that side, and that it should be looked up as a sibling worktree
  rather than searched for in this repo.


## Stack

1. `dylan/amika-cli-skill` #315
2. `dylan/ssh-impl-no-relay` #316
3. `dylan/no-ssh-keygen-yet-fix` #321
4. `dylan/ssh-websocket-code-review` `#THIS` ← you are here
