### PR TITLE
Test snapshot scrubbing end to end

### DIFF
--- a/go/test/e2e/README.md
+++ b/go/test/e2e/README.md
@@ -70,7 +70,9 @@ steps:
         name: "@string"
         state: "@oneof: active, running, started"
       stdout_contains: "substring"                          # optional
+      stdout_not_contains: "substring"                      # optional
       stderr_contains: "substring"                          # optional
+      stderr_not_contains: "substring"                      # optional
       schema: "SandboxResponse"                             # optional: components.schemas.<name>
     capture:                                                # optional: extract vars for later steps
       sandbox_name: $.name
@@ -79,16 +81,27 @@ steps:
       name: "{{sandbox_name}}"
       cleanup: [sandbox, delete, "{{sandbox_name}}", --force, -o, json]
       register_on_failure: false                            # optional: set true to register even on an unexpected exit (default false)
+    release_resource:                                      # optional: retire a consumed resource after this step passes
+      type: sandbox
+      name: "{{sandbox_name}}"
 ```
 
 Every field except `name` and `cmd` is optional on a step. `name` is
 required at both the case and step level; every step needs a non-empty
 `cmd`. `LoadCase` validates this before running anything.
 
+`release_resource` removes a matching prior `resource` entry from the cleanup
+ledger only after the command and every assertion succeed. Use it when the
+operation under test consumes a resource, such as `snapshot create --mode
+scrub_and_delete` deleting its source sandbox. If the step fails, the ledger
+entry remains available for best-effort cleanup.
+
 ### Variable substitution
 
 Any `{{var}}` placeholder in `cmd`, `stdin`, `env` values, `resource.name`,
-`resource.cleanup`, `expect.stdout_contains`, `expect.stderr_contains`, and
+`resource.cleanup`, `release_resource.type`, `release_resource.name`,
+`expect.stdout_contains`, `expect.stdout_not_contains`,
+`expect.stderr_contains`, `expect.stderr_not_contains`, and
 (recursively, through nested maps/lists) `expect.stdout_json` is replaced
 with a previously `capture`d value. Referencing a variable that was never
 captured is an error: the step fails immediately rather than sending a

--- a/go/test/e2e/cases/api-snapshot-scrub.yaml
+++ b/go/test/e2e/cases/api-snapshot-scrub.yaml
@@ -1,0 +1,146 @@
+name: scrub a snapshot without breaking the restored environment
+# This real-API case writes only test sentinels into a throwaway sandbox. It
+# covers every declared credential target, service environment metadata, git
+# remote token removal, and restoration of `/etc/environment` from its clean
+# baseline. Assertions look for the old sentinels rather than requiring paths
+# to stay absent, because fresh provisioning may legitimately recreate them.
+steps:
+  - name: create a source sandbox
+    cmd: [sandbox, create, --remote, --no-git, --preset, coder, --size, xs, --yes, -o, json]
+    expect:
+      exit: 0
+      schema: Sandbox
+      stdout_json:
+        name: "@string"
+    capture:
+      source_sandbox: $.name
+    resource:
+      type: sandbox
+      name: "{{source_sandbox}}"
+      cleanup: [sandbox, delete, "{{source_sandbox}}", --remote, --force, -o, json]
+
+  - name: inject scrub sentinels into the source sandbox
+    cmd:
+      - sandbox
+      - ssh
+      - "{{source_sandbox}}"
+      - --
+      - sh
+      - -lc
+      - |
+        set -eu
+        sentinel='snapshot-scrub-e2e-secret'
+        baseline='SNAPSHOT_SCRUB_E2E_BASELINE=preserved'
+
+        mkdir -p \
+          "$HOME/.config/gh" \
+          "$HOME/.cache/amika" \
+          "$HOME/.claude" \
+          "$HOME/.codex" \
+          "$HOME/.local/share/opencode" \
+          "$HOME/workspace/snapshot-scrub-e2e/.git"
+        printf '%s\n' "https://${sentinel}@github.com" > "$HOME/.git-credentials"
+        printf '%s\n' "$sentinel" > "$HOME/.config/gh/hosts.yml"
+        printf '%s\n' "$sentinel" > "$HOME/.cache/amika/github-token"
+        printf '%s\n' "$sentinel" > "$HOME/.claude/snapshot-scrub-e2e-sentinel"
+        printf '%s\n' "$sentinel" > "$HOME/.codex/snapshot-scrub-e2e-sentinel"
+        printf '%s\n' "$sentinel" > "$HOME/.local/share/opencode/snapshot-scrub-e2e-sentinel"
+        printf '%s\n' \
+          '[remote "origin"]' \
+          "  url = https://x-access-token:${sentinel}@github.com/gofixpoint/amika.git" \
+          > "$HOME/workspace/snapshot-scrub-e2e/.git/config"
+
+        printf '%s\n' "$baseline" | sudo tee -a /usr/local/etc/amikad/environment.base >/dev/null
+        printf '%s\n' "$baseline" | sudo tee -a /etc/environment >/dev/null
+        sudo tee -a /etc/environment >/dev/null <<'EOF'
+        # >>> AMIKA INJECTED ENV >>>
+        SNAPSHOT_SCRUB_E2E_TOKEN='snapshot-scrub-e2e-secret'
+        # <<< AMIKA INJECTED ENV <<<
+        EOF
+        printf '{"sentinel":"%s"}\n' "$sentinel" \
+          | sudo tee /usr/local/etc/amikad/service-env-vars.json >/dev/null
+
+        grep -q "$sentinel" "$HOME/.git-credentials"
+        grep -q "$sentinel" "$HOME/.config/gh/hosts.yml"
+        grep -q "$sentinel" "$HOME/.cache/amika/github-token"
+        grep -q "$sentinel" "$HOME/.claude/snapshot-scrub-e2e-sentinel"
+        grep -q "$sentinel" "$HOME/.codex/snapshot-scrub-e2e-sentinel"
+        grep -q "$sentinel" "$HOME/.local/share/opencode/snapshot-scrub-e2e-sentinel"
+        grep -q "$sentinel" "$HOME/workspace/snapshot-scrub-e2e/.git/config"
+        sudo grep -q "$sentinel" /usr/local/etc/amikad/service-env-vars.json
+        grep -q 'SNAPSHOT_SCRUB_E2E_TOKEN' /etc/environment
+        grep -q "$baseline" /etc/environment
+    expect:
+      exit: 0
+
+  - name: capture a scrubbed snapshot
+    cmd: [snapshot, create, --no-interactive, --mode, scrub_and_delete, --name, "e2e-scrub-{{source_sandbox}}", --sandbox, "{{source_sandbox}}", -o, json]
+    expect:
+      exit: 0
+      schema: SandboxSnapshot
+      stdout_json:
+        snapshot: "@string"
+        state: active
+    capture:
+      snapshot_ref: $.snapshot
+    resource:
+      type: snapshot
+      name: "{{snapshot_ref}}"
+      cleanup: [snapshot, delete, "{{snapshot_ref}}", --force, -o, json]
+
+  - name: confirm scrub and delete removed the source sandbox
+    cmd: [sandbox, list, --remote, -o, json]
+    expect:
+      exit: 0
+      stdout_not_contains: "{{source_sandbox}}"
+    release_resource:
+      type: sandbox
+      name: "{{source_sandbox}}"
+
+  - name: fork a sandbox from the scrubbed snapshot
+    cmd: [sandbox, create, --remote, --no-git, --preset, coder, --size, xs, --snapshot, "{{snapshot_ref}}", --yes, -o, json]
+    expect:
+      exit: 0
+      schema: Sandbox
+      stdout_json:
+        name: "@string"
+    capture:
+      restored_sandbox: $.name
+    resource:
+      type: sandbox
+      name: "{{restored_sandbox}}"
+      cleanup: [sandbox, delete, "{{restored_sandbox}}", --remote, --force, -o, json]
+
+  - name: verify the scrubbed snapshot restores a clean usable environment
+    cmd:
+      - sandbox
+      - ssh
+      - "{{restored_sandbox}}"
+      - --
+      - sh
+      - -lc
+      - |
+        set -eu
+        sentinel='snapshot-scrub-e2e-secret'
+        baseline='SNAPSHOT_SCRUB_E2E_BASELINE=preserved'
+
+        if test -e "$HOME/.git-credentials"; then ! grep -q "$sentinel" "$HOME/.git-credentials"; fi
+        if test -e "$HOME/.config/gh/hosts.yml"; then ! grep -q "$sentinel" "$HOME/.config/gh/hosts.yml"; fi
+        if test -e "$HOME/.cache/amika/github-token"; then ! grep -q "$sentinel" "$HOME/.cache/amika/github-token"; fi
+        test ! -e "$HOME/.claude/snapshot-scrub-e2e-sentinel"
+        test ! -e "$HOME/.codex/snapshot-scrub-e2e-sentinel"
+        test ! -e "$HOME/.local/share/opencode/snapshot-scrub-e2e-sentinel"
+
+        test -f "$HOME/workspace/snapshot-scrub-e2e/.git/config"
+        ! grep -q "$sentinel" "$HOME/workspace/snapshot-scrub-e2e/.git/config"
+        test -f /etc/environment
+        test -f /usr/local/etc/amikad/environment.base
+        grep -q "$baseline" /etc/environment
+        sudo grep -q "$baseline" /usr/local/etc/amikad/environment.base
+        ! grep -q 'SNAPSHOT_SCRUB_E2E_TOKEN' /etc/environment
+        if sudo test -e /usr/local/etc/amikad/service-env-vars.json; then
+          ! sudo grep -q "$sentinel" /usr/local/etc/amikad/service-env-vars.json
+        fi
+        zsh -lc true
+    expect:
+      exit: 0

--- a/go/test/e2e/e2e_test.go
+++ b/go/test/e2e/e2e_test.go
@@ -45,6 +45,28 @@ var credentialEnvVars = map[string]bool{
 	"AMIKA_API_URL": true,
 }
 
+// TestE2ECaseFilesLoad validates every case file without executing commands.
+// It stays outside the E2E environment gates so ordinary CI catches malformed
+// YAML and unknown fields even in real-API cases that are normally skipped.
+func TestE2ECaseFilesLoad(t *testing.T) {
+	moduleRoot := testutil.FindModuleRoot(t)
+	caseFiles, err := runner.DiscoverCases(filepath.Join(moduleRoot, "test", "e2e", "cases"))
+	if err != nil {
+		t.Fatalf("discover cases: %v", err)
+	}
+	if len(caseFiles) == 0 {
+		t.Fatal("no E2E case files found")
+	}
+	for _, caseFile := range caseFiles {
+		caseFile := caseFile
+		t.Run(filepath.Base(caseFile), func(t *testing.T) {
+			if _, err := runner.LoadCase(caseFile); err != nil {
+				t.Fatalf("load case: %v", err)
+			}
+		})
+	}
+}
+
 // baseEnvFor returns the base environment for a case's steps. API cases get
 // the process environment unchanged (nil defers to os.Environ() in the
 // runner). Offline cases get os.Environ() with credential vars removed.

--- a/go/test/e2e/runner/ledger.go
+++ b/go/test/e2e/runner/ledger.go
@@ -74,6 +74,31 @@ func (l *Ledger) Append(entry Entry) error {
 	return l.flushLocked()
 }
 
+// Remove deletes the most recently registered resource matching resourceType
+// and name, then flushes the updated ledger. It is used after a case verifies
+// that an operation consumed a previously registered resource. If the flush
+// fails, the in-memory ledger is restored so cleanup protection is retained.
+func (l *Ledger) Remove(resourceType, name string) (bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := len(l.entries) - 1; i >= 0; i-- {
+		if l.entries[i].Type != resourceType || l.entries[i].Name != name {
+			continue
+		}
+		original := l.entries
+		updated := make([]Entry, 0, len(original)-1)
+		updated = append(updated, original[:i]...)
+		updated = append(updated, original[i+1:]...)
+		l.entries = updated
+		if err := l.flushLocked(); err != nil {
+			l.entries = original
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
 // Entries returns a copy of the entries recorded so far, in registration
 // order.
 func (l *Ledger) Entries() []Entry {

--- a/go/test/e2e/runner/runner.go
+++ b/go/test/e2e/runner/runner.go
@@ -54,6 +54,9 @@ type Step struct {
 	// Resource, if set, registers a resource the step created so it is
 	// cleaned up after the run.
 	Resource *Resource `yaml:"resource"`
+	// ReleaseResource, if set, removes a previously registered resource from
+	// the cleanup ledger after this step and all of its assertions succeed.
+	ReleaseResource *ResourceRef `yaml:"release_resource"`
 }
 
 // Expectation describes the assertions to make about a step's result. All
@@ -69,8 +72,12 @@ type Expectation struct {
 	StdoutJSON any `yaml:"stdout_json"`
 	// StdoutContains, if set, must be a substring of stdout.
 	StdoutContains string `yaml:"stdout_contains"`
+	// StdoutNotContains, if set, must not be a substring of stdout.
+	StdoutNotContains string `yaml:"stdout_not_contains"`
 	// StderrContains, if set, must be a substring of stderr.
 	StderrContains string `yaml:"stderr_contains"`
+	// StderrNotContains, if set, must not be a substring of stderr.
+	StderrNotContains string `yaml:"stderr_not_contains"`
 	// Schema, if set, names a components.schemas.<Schema> definition in
 	// the OpenAPI document that stdout, parsed as JSON, must validate
 	// against.
@@ -109,6 +116,13 @@ type Resource struct {
 	// run may not have created could delete one owned by another run. Enable it
 	// only for a command known to create the resource before it can fail.
 	RegisterOnFailure bool `yaml:"register_on_failure"`
+}
+
+// ResourceRef identifies a previously registered resource that a successful
+// step has verified no longer exists.
+type ResourceRef struct {
+	Type string `yaml:"type"`
+	Name string `yaml:"name"`
 }
 
 // LoadCase reads and parses a case file at path.
@@ -193,6 +207,14 @@ func LoadCase(path string) (*Case, error) {
 			}
 			if len(step.Resource.Cleanup) == 0 {
 				return nil, fmt.Errorf("case %s: step %d (%s): resource requires a non-empty \"cleanup\" argv", path, i+1, step.Name)
+			}
+		}
+		if step.ReleaseResource != nil {
+			if step.ReleaseResource.Type == "" {
+				return nil, fmt.Errorf("case %s: step %d (%s): release_resource requires a \"type\"", path, i+1, step.Name)
+			}
+			if step.ReleaseResource.Name == "" {
+				return nil, fmt.Errorf("case %s: step %d (%s): release_resource requires a \"name\"", path, i+1, step.Name)
 			}
 		}
 	}
@@ -428,7 +450,10 @@ func (r *Runner) runStep(index int, rawStep Step) error {
 		return transcriptErr
 	}
 
-	return r.checkContent(step, parsed, stdout, stderr)
+	if err := r.checkContent(step, parsed, stdout, stderr); err != nil {
+		return err
+	}
+	return r.releaseResource(step)
 }
 
 // execStep runs step.Cmd through the binary under test and returns its
@@ -572,8 +597,14 @@ func (r *Runner) checkContent(step Step, parsed any, stdout, stderr []byte) erro
 	if step.Expect.StdoutContains != "" && !strings.Contains(string(stdout), step.Expect.StdoutContains) {
 		return fmt.Errorf("stdout_contains: %q not found in stdout:\n%s", step.Expect.StdoutContains, stdout)
 	}
+	if step.Expect.StdoutNotContains != "" && strings.Contains(string(stdout), step.Expect.StdoutNotContains) {
+		return fmt.Errorf("stdout_not_contains: %q unexpectedly found in stdout:\n%s", step.Expect.StdoutNotContains, stdout)
+	}
 	if step.Expect.StderrContains != "" && !strings.Contains(string(stderr), step.Expect.StderrContains) {
 		return fmt.Errorf("stderr_contains: %q not found in stderr:\n%s", step.Expect.StderrContains, stderr)
+	}
+	if step.Expect.StderrNotContains != "" && strings.Contains(string(stderr), step.Expect.StderrNotContains) {
+		return fmt.Errorf("stderr_not_contains: %q unexpectedly found in stderr:\n%s", step.Expect.StderrNotContains, stderr)
 	}
 	if step.Expect.hasStdoutJSON() {
 		if err := Match(step.Expect.StdoutJSON, parsed); err != nil {
@@ -651,6 +682,20 @@ func (r *Runner) registerResource(step Step) error {
 	}
 	if err := r.ledger.Append(entry); err != nil {
 		return fmt.Errorf("register resource %q: %w", name, err)
+	}
+	return nil
+}
+
+func (r *Runner) releaseResource(step Step) error {
+	if step.ReleaseResource == nil {
+		return nil
+	}
+	removed, err := r.ledger.Remove(step.ReleaseResource.Type, step.ReleaseResource.Name)
+	if err != nil {
+		return fmt.Errorf("release resource %s %q: %w", step.ReleaseResource.Type, step.ReleaseResource.Name, err)
+	}
+	if !removed {
+		return fmt.Errorf("release resource %s %q: no matching resource is registered", step.ReleaseResource.Type, step.ReleaseResource.Name)
 	}
 	return nil
 }
@@ -795,6 +840,18 @@ func (r *Runner) substituteStep(step Step) (Step, error) {
 	// (e.g. the id of the resource just created), which is only known after
 	// the command runs and captureVars populates r.vars. registerResource
 	// templates the resource block afterward, once those vars exist.
+	if step.ReleaseResource != nil {
+		release := *step.ReleaseResource
+		release.Type, err = substituteString(release.Type, r.vars)
+		if err != nil {
+			return Step{}, fmt.Errorf("release_resource.type: %w", err)
+		}
+		release.Name, err = substituteString(release.Name, r.vars)
+		if err != nil {
+			return Step{}, fmt.Errorf("release_resource.name: %w", err)
+		}
+		out.ReleaseResource = &release
+	}
 
 	stdoutContains, err := substituteString(step.Expect.StdoutContains, r.vars)
 	if err != nil {
@@ -802,11 +859,23 @@ func (r *Runner) substituteStep(step Step) (Step, error) {
 	}
 	out.Expect.StdoutContains = stdoutContains
 
+	stdoutNotContains, err := substituteString(step.Expect.StdoutNotContains, r.vars)
+	if err != nil {
+		return Step{}, fmt.Errorf("expect.stdout_not_contains: %w", err)
+	}
+	out.Expect.StdoutNotContains = stdoutNotContains
+
 	stderrContains, err := substituteString(step.Expect.StderrContains, r.vars)
 	if err != nil {
 		return Step{}, fmt.Errorf("expect.stderr_contains: %w", err)
 	}
 	out.Expect.StderrContains = stderrContains
+
+	stderrNotContains, err := substituteString(step.Expect.StderrNotContains, r.vars)
+	if err != nil {
+		return Step{}, fmt.Errorf("expect.stderr_not_contains: %w", err)
+	}
+	out.Expect.StderrNotContains = stderrNotContains
 
 	if step.Expect.StdoutJSON != nil {
 		v, err := substituteAny(step.Expect.StdoutJSON, r.vars)

--- a/go/test/e2e/runner/runner_test.go
+++ b/go/test/e2e/runner/runner_test.go
@@ -511,6 +511,33 @@ func TestSubstituteStepResolvesNestedStdoutJSONVar(t *testing.T) {
 	}
 }
 
+func TestSubstituteStepResolvesNegativeContentVars(t *testing.T) {
+	r, err := New(Options{BinPath: "unused", RunDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	r.vars["name"] = "sb-1"
+
+	step := Step{
+		Name: "negative templates",
+		Cmd:  []string{"version"},
+		Expect: Expectation{
+			StdoutNotContains: "{{name}}",
+			StderrNotContains: "error for {{name}}",
+		},
+	}
+	out, err := r.substituteStep(step)
+	if err != nil {
+		t.Fatalf("substituteStep: %v", err)
+	}
+	if out.Expect.StdoutNotContains != "sb-1" {
+		t.Fatalf("stdout_not_contains = %q, want sb-1", out.Expect.StdoutNotContains)
+	}
+	if out.Expect.StderrNotContains != "error for sb-1" {
+		t.Fatalf("stderr_not_contains = %q, want error for sb-1", out.Expect.StderrNotContains)
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	cases := map[string]string{
 		"create remote sandbox": "create-remote-sandbox",
@@ -557,6 +584,42 @@ func TestLedgerAppendPersistsToDisk(t *testing.T) {
 	}
 	if len(onDisk) != 2 || onDisk[1].Type != "volume" {
 		t.Fatalf("unexpected on-disk entries: %+v", onDisk)
+	}
+}
+
+func TestLedgerRemovePersistsToDisk(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "ledger.json")
+	l, err := NewLedger(ledgerPath)
+	if err != nil {
+		t.Fatalf("NewLedger: %v", err)
+	}
+	for _, entry := range []Entry{
+		{Type: "sandbox", Name: "sb-1"},
+		{Type: "snapshot", Name: "snap-1"},
+	} {
+		if err := l.Append(entry); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+
+	removed, err := l.Remove("sandbox", "sb-1")
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected matching resource to be removed")
+	}
+	if removed, err := l.Remove("sandbox", "missing"); err != nil || removed {
+		t.Fatalf("remove missing resource = %v, %v; want false, nil", removed, err)
+	}
+
+	onDisk, err := LoadLedgerEntries(ledgerPath)
+	if err != nil {
+		t.Fatalf("LoadLedgerEntries: %v", err)
+	}
+	if len(onDisk) != 1 || onDisk[0].Name != "snap-1" {
+		t.Fatalf("unexpected on-disk entries after remove: %+v", onDisk)
 	}
 }
 
@@ -760,6 +823,83 @@ func TestRunnerRunCaseCapturesTemplatesAndRegistersResource(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(runDir, "steps", "02-use-captured-var.stdout")); err != nil {
 		t.Fatalf("expected step 2 transcript: %v", err)
 	}
+}
+
+func TestRunnerReleasesResourceOnlyAfterAssertionsPass(t *testing.T) {
+	bin := stubScript(t)
+
+	t.Run("successful assertion releases resource", func(t *testing.T) {
+		r, err := New(Options{BinPath: bin, RunDir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		c := &Case{
+			Name: "release consumed resource",
+			Steps: []Step{
+				{
+					Name:    "create",
+					Cmd:     []string{"0", `{"name":"sb-1"}`, ""},
+					Capture: map[string]string{"sandbox_name": "$.name"},
+					Resource: &Resource{
+						Type:    "sandbox",
+						Name:    "{{sandbox_name}}",
+						Cleanup: []string{"0", "", ""},
+					},
+				},
+				{
+					Name:   "confirm deletion",
+					Cmd:    []string{"0", "[]", ""},
+					Expect: Expectation{StdoutNotContains: "{{sandbox_name}}"},
+					ReleaseResource: &ResourceRef{
+						Type: "sandbox",
+						Name: "{{sandbox_name}}",
+					},
+				},
+			},
+		}
+		if err := r.RunCase(c); err != nil {
+			t.Fatalf("RunCase: %v", err)
+		}
+		if entries := r.Ledger().Entries(); len(entries) != 0 {
+			t.Fatalf("expected released resource to leave the ledger, got %+v", entries)
+		}
+	})
+
+	t.Run("failed assertion retains resource", func(t *testing.T) {
+		r, err := New(Options{BinPath: bin, RunDir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		c := &Case{
+			Name: "retain resource on failure",
+			Steps: []Step{
+				{
+					Name: "create",
+					Cmd:  []string{"0", "", ""},
+					Resource: &Resource{
+						Type:    "sandbox",
+						Name:    "sb-1",
+						Cleanup: []string{"0", "", ""},
+					},
+				},
+				{
+					Name:   "failed deletion check",
+					Cmd:    []string{"0", "sb-1", ""},
+					Expect: Expectation{StdoutNotContains: "sb-1"},
+					ReleaseResource: &ResourceRef{
+						Type: "sandbox",
+						Name: "sb-1",
+					},
+				},
+			},
+		}
+		if err := r.RunCase(c); err == nil {
+			t.Fatal("expected deletion assertion to fail")
+		}
+		if entries := r.Ledger().Entries(); len(entries) != 1 || entries[0].Name != "sb-1" {
+			t.Fatalf("expected failed assertion to retain cleanup resource, got %+v", entries)
+		}
+	})
 }
 
 // TestRunnerRegistersResourceFromSameStepCapture covers the common real-world
@@ -1549,6 +1689,69 @@ func TestRunnerStdinIsPassedToStep(t *testing.T) {
 	if err := r.RunCase(c); err != nil {
 		t.Fatalf("RunCase: %v", err)
 	}
+}
+
+func TestRunnerNegativeContentAssertions(t *testing.T) {
+	bin := stubScript(t)
+
+	t.Run("pass when forbidden content is absent", func(t *testing.T) {
+		r, err := New(Options{BinPath: bin, RunDir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		c := &Case{
+			Name: "negative content passes",
+			Steps: []Step{{
+				Name: "clean output",
+				Cmd:  []string{"0", "safe stdout", "safe stderr"},
+				Expect: Expectation{
+					StdoutNotContains: "secret",
+					StderrNotContains: "secret",
+				},
+			}},
+		}
+		if err := r.RunCase(c); err != nil {
+			t.Fatalf("RunCase: %v", err)
+		}
+	})
+
+	t.Run("fail when forbidden stdout is present", func(t *testing.T) {
+		r, err := New(Options{BinPath: bin, RunDir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		c := &Case{
+			Name: "negative stdout fails",
+			Steps: []Step{{
+				Name:   "leaked stdout",
+				Cmd:    []string{"0", "contains secret", ""},
+				Expect: Expectation{StdoutNotContains: "secret"},
+			}},
+		}
+		err = r.RunCase(c)
+		if err == nil || !strings.Contains(err.Error(), "stdout_not_contains") {
+			t.Fatalf("expected stdout_not_contains failure, got %v", err)
+		}
+	})
+
+	t.Run("fail when forbidden stderr is present", func(t *testing.T) {
+		r, err := New(Options{BinPath: bin, RunDir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		c := &Case{
+			Name: "negative stderr fails",
+			Steps: []Step{{
+				Name:   "leaked stderr",
+				Cmd:    []string{"0", "", "contains secret"},
+				Expect: Expectation{StderrNotContains: "secret"},
+			}},
+		}
+		err = r.RunCase(c)
+		if err == nil || !strings.Contains(err.Error(), "stderr_not_contains") {
+			t.Fatalf("expected stderr_not_contains failure, got %v", err)
+		}
+	})
 }
 
 func TestRunnerStateDirInjectedIntoEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a real-API E2E case that snapshots a sandbox in `scrub_and_delete` mode and validates the restored sandbox
- cover credential files, tokenized Git remotes, service environment metadata, and `/etc/environment` baseline restoration
- extend the E2E runner with negative output assertions and resource retirement after consuming operations
- validate every E2E YAML case during ordinary test runs, including API-gated cases

## Tests

- `go test ./test/e2e/...`
- `go test ./...` (Go 1.25 Alpine with git, bash, and rsync)