### PR TITLE
Add the amika secret ssh-key command group

### DIFF
--- a/.agents/skills/amika-cli/SKILL.md
+++ b/.agents/skills/amika-cli/SKILL.md
@@ -107,6 +107,7 @@ Errors go to stderr and exit non-zero (`1`).
 | `scp`                                 | Copy files to/from sandboxes; wraps the system `scp`                                         |
 | `secret push` / `extract`             | Push arbitrary secrets, or discover local credentials                                        |
 | `secret claude` / `secret codex`      | `push` / `list` / `delete` agent credentials for injection                                   |
+| `secret ssh-key`                      | `create` / `push` / `list` / `delete` the SSH public keys authorizing sandbox access         |
 | `service create` / `list` / `delete`  | Manage named port-backed services on a sandbox                                               |
 | `snapshot create` / `list` / `delete` | Capture a running sandbox to fork later                                                      |
 | `auth login` / `status` / `logout`    | Authentication                                                                               |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,7 +35,7 @@ name=$(amika sandbox create --remote --no-git -o json | jq -r .name)
 amika sandbox delete a b c --remote --force -o json | jq '.[] | select(.status=="error")'
 ```
 
-Commands honoring `--output`: the read commands `sandbox list`, `snapshot list`, `volume list`, `service list`, `auth status`, and `secret <provider> list`, plus `sandbox create`, `sandbox start`, `sandbox stop`, `sandbox delete`, `sandbox agent-send`, `volume delete`, `snapshot create`, `snapshot delete`, `secret <provider> push`/`delete`, `secret ssh-keygen`, `secret ssh-key push`/`list`/`delete`, `auth login --api-key-file`, `auth logout`, and `materialize`. Commands that open a shell or editor (`sandbox connect`, `sandbox code`) or display a masked credential table and prompt for confirmation (`secret extract`, `secret push`) reject `-o json`/`json-pretty` since they produce no JSON result. `sandbox ssh` and `scp` do not accept `--output` at all (see above).
+Commands honoring `--output`: the read commands `sandbox list`, `snapshot list`, `volume list`, `service list`, `auth status`, and `secret <provider> list`, plus `sandbox create`, `sandbox start`, `sandbox stop`, `sandbox delete`, `sandbox agent-send`, `volume delete`, `snapshot create`, `snapshot delete`, `secret <provider> push`/`delete`, `secret ssh-keygen`, `secret ssh-key create`/`push`/`list`/`delete`, `auth login --api-key-file`, `auth logout`, and `materialize`. Commands that open a shell or editor (`sandbox connect`, `sandbox code`) or display a masked credential table and prompt for confirmation (`secret extract`, `secret push`) reject `-o json`/`json-pretty` since they produce no JSON result. `sandbox ssh` and `scp` do not accept `--output` at all (see above).
 
 ## `amika sandbox`
 
@@ -549,10 +549,13 @@ amika secret ssh-keygen
 amika secret ssh-keygen --import ~/.ssh/id_ed25519.pub
 ```
 
-| Flag              | Default   | Description                                                   |
-| ----------------- | --------- | ------------------------------------------------------------- |
-| `--name <label>`  | `default` | Name for the uploaded public key                              |
+| Flag              | Default   | Description                                                    |
+| ----------------- | --------- | -------------------------------------------------------------- |
+| `--name <label>`  | `default` | Name for the uploaded public key                               |
 | `--import <path>` |           | Upload an existing `.pub` file instead of generating a keypair |
+| `--force`         | `false`   | Replace an existing key of the same name                       |
+
+Re-running this command is safe: an existing keypair at `~/.ssh/amika_id_ed25519` is reused rather than regenerated, so the upload is a no-op. `--force` is only needed when the name already holds *different* key material (for example when switching `--import` targets).
 
 `amika secret ssh-key create` is an alias for this command.
 
@@ -564,7 +567,7 @@ Keys are identified by name, and a name is unique per user.
 
 #### `amika secret ssh-key create`
 
-Alias for [`amika secret ssh-keygen`](#amika-secret-ssh-keygen); same flags and behavior.
+Alias for [`amika secret ssh-keygen`](#amika-secret-ssh-keygen); same flags and behavior, including the `--force` rule for replacing a name that holds different key material.
 
 #### `amika secret ssh-key push`
 
@@ -581,13 +584,13 @@ amika secret ssh-key push --name laptop --from-file ~/.ssh/id_ed25519.pub
 amika secret ssh-key push --name laptop --force
 ```
 
-| Flag                 | Default                        | Description                                      |
-| -------------------- | ------------------------------ | ------------------------------------------------ |
-| `--name <label>`     | `default`                      | Name for the uploaded public key                 |
-| `--from-file <path>` | `~/.ssh/amika_id_ed25519.pub`  | Public key file to upload                        |
-| `--force`            | `false`                        | Replace an existing key with the same name       |
+| Flag                 | Default                       | Description                                |
+| -------------------- | ----------------------------- | ------------------------------------------ |
+| `--name <label>`     | `default`                     | Name for the uploaded public key           |
+| `--from-file <path>` | `~/.ssh/amika_id_ed25519.pub` | Public key file to upload                  |
+| `--force`            | `false`                       | Replace an existing key with the same name |
 
-Pushing a name that already exists fails unless `--force` is passed. Only ed25519 keys are accepted, and the key's trailing comment is stripped before upload.
+Re-pushing the *same* key material under an existing name is a no-op. Pushing *different* material under an existing name fails unless `--force` is passed. Only ed25519 keys are accepted, and the key's trailing comment is stripped before upload.
 
 #### `amika secret ssh-key list`
 
@@ -604,8 +607,15 @@ Output columns: `ID`, `NAME`, `KEY`. Aliased as `ls`.
 Delete an SSH public key by ID. Aliased as `rm`.
 
 ```bash
-amika secret ssh-key delete <id>
+amika secret ssh-key delete <id>          # prompts for confirmation
+amika secret ssh-key delete <id> --force  # skips the prompt
 ```
+
+| Flag            | Default | Description               |
+| --------------- | ------- | ------------------------- |
+| `--force`, `-f` | `false` | Skip confirmation prompt  |
+
+With `-o json` the prompt is never shown, so `--force` is required.
 
 Deleting a key does not revoke access on sandboxes that are already running; the removal applies the next time a sandbox is provisioned.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,7 +35,7 @@ name=$(amika sandbox create --remote --no-git -o json | jq -r .name)
 amika sandbox delete a b c --remote --force -o json | jq '.[] | select(.status=="error")'
 ```
 
-Commands honoring `--output`: the read commands `sandbox list`, `snapshot list`, `volume list`, `service list`, `auth status`, and `secret <provider> list`, plus `sandbox create`, `sandbox start`, `sandbox stop`, `sandbox delete`, `sandbox agent-send`, `volume delete`, `snapshot create`, `snapshot delete`, `secret <provider> push`/`delete`, `auth login --api-key-file`, `auth logout`, and `materialize`. Commands that open a shell or editor (`sandbox connect`, `sandbox code`) or display a masked credential table and prompt for confirmation (`secret extract`, `secret push`) reject `-o json`/`json-pretty` since they produce no JSON result. `sandbox ssh` and `scp` do not accept `--output` at all (see above).
+Commands honoring `--output`: the read commands `sandbox list`, `snapshot list`, `volume list`, `service list`, `auth status`, and `secret <provider> list`, plus `sandbox create`, `sandbox start`, `sandbox stop`, `sandbox delete`, `sandbox agent-send`, `volume delete`, `snapshot create`, `snapshot delete`, `secret <provider> push`/`delete`, `secret ssh-keygen`, `secret ssh-key push`/`list`/`delete`, `auth login --api-key-file`, `auth logout`, and `materialize`. Commands that open a shell or editor (`sandbox connect`, `sandbox code`) or display a masked credential table and prompt for confirmation (`secret extract`, `secret push`) reject `-o json`/`json-pretty` since they produce no JSON result. `sandbox ssh` and `scp` do not accept `--output` at all (see above).
 
 ## `amika sandbox`
 
@@ -536,6 +536,78 @@ Delete a Claude credential by ID.
 ```bash
 amika secret claude delete <id>
 ```
+
+### `amika secret ssh-keygen`
+
+Generate a user-owned ed25519 keypair and upload only its public half. The private key is written to `~/.ssh/amika_id_ed25519` and never leaves the machine.
+
+```bash
+# Generate a keypair and upload the public key
+amika secret ssh-keygen
+
+# Upload an existing public key instead of generating one
+amika secret ssh-keygen --import ~/.ssh/id_ed25519.pub
+```
+
+| Flag              | Default   | Description                                                   |
+| ----------------- | --------- | ------------------------------------------------------------- |
+| `--name <label>`  | `default` | Name for the uploaded public key                              |
+| `--import <path>` |           | Upload an existing `.pub` file instead of generating a keypair |
+
+`amika secret ssh-key create` is an alias for this command.
+
+### `amika secret ssh-key`
+
+Manage the SSH public keys that authorize access to your sandboxes. Only public keys are uploaded; private key material stays on your machine.
+
+Keys are identified by name, and a name is unique per user.
+
+#### `amika secret ssh-key create`
+
+Alias for [`amika secret ssh-keygen`](#amika-secret-ssh-keygen); same flags and behavior.
+
+#### `amika secret ssh-key push`
+
+Upload a public key that already exists on this machine. Reads `~/.ssh/amika_id_ed25519.pub` unless `--from-file` names another file.
+
+```bash
+# Upload the default Amika public key
+amika secret ssh-key push
+
+# Upload a different key under a custom name
+amika secret ssh-key push --name laptop --from-file ~/.ssh/id_ed25519.pub
+
+# Replace the key currently stored under that name
+amika secret ssh-key push --name laptop --force
+```
+
+| Flag                 | Default                        | Description                                      |
+| -------------------- | ------------------------------ | ------------------------------------------------ |
+| `--name <label>`     | `default`                      | Name for the uploaded public key                 |
+| `--from-file <path>` | `~/.ssh/amika_id_ed25519.pub`  | Public key file to upload                        |
+| `--force`            | `false`                        | Replace an existing key with the same name       |
+
+Pushing a name that already exists fails unless `--force` is passed. Only ed25519 keys are accepted, and the key's trailing comment is stripped before upload.
+
+#### `amika secret ssh-key list`
+
+List uploaded SSH public keys.
+
+```bash
+amika secret ssh-key list
+```
+
+Output columns: `ID`, `NAME`, `KEY`. Aliased as `ls`.
+
+#### `amika secret ssh-key delete`
+
+Delete an SSH public key by ID. Aliased as `rm`.
+
+```bash
+amika secret ssh-key delete <id>
+```
+
+Deleting a key does not revoke access on sandboxes that are already running; the removal applies the next time a sandbox is provisioned.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -592,6 +592,8 @@ amika secret ssh-key push --name laptop --force
 
 Re-pushing the *same* key material under an existing name is a no-op. Pushing *different* material under an existing name fails unless `--force` is passed. Only ed25519 keys are accepted, and the key's trailing comment is stripped before upload.
 
+With `-o json` this emits the API's `SshPublicKeySummary` response unchanged (`id`, `name`, `public_key`, `scope`). Whether the push created or replaced a key is reported only in the text output.
+
 #### `amika secret ssh-key list`
 
 List uploaded SSH public keys.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -108,4 +108,44 @@ amika secret claude list
 amika secret claude delete <id>
 ```
 
+## SSH public keys
+
+`amika secret ssh-key` manages the SSH public keys that authorize you to
+connect to your sandboxes. Only the public half of a keypair is ever uploaded;
+the private key stays on your machine.
+
+1. **Generate a keypair and upload the public key:**
+
+```bash
+amika secret ssh-key create
+```
+
+This writes the private key to `~/.ssh/amika_id_ed25519` and uploads only
+`~/.ssh/amika_id_ed25519.pub`.
+
+2. **Upload a public key you already have:**
+
+```bash
+amika secret ssh-key push --name laptop --from-file ~/.ssh/id_ed25519.pub
+```
+
+Keys are named, and a name is unique per user. Pushing a name that already
+exists requires `--force`, which replaces that key's material.
+
+3. **List your keys:**
+
+```bash
+amika secret ssh-key list
+```
+
+4. **Delete a key:**
+
+```bash
+amika secret ssh-key delete <id>
+```
+
+Deleting a key does not revoke access on sandboxes that are already running.
+Keys are read when a sandbox is provisioned, so the removal takes effect the
+next time one is provisioned.
+
 See [cli-reference.md](cli-reference.md) for the full flag reference.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -120,8 +120,10 @@ the private key stays on your machine.
 amika secret ssh-key create
 ```
 
-This writes the private key to `~/.ssh/amika_id_ed25519` and uploads only
-`~/.ssh/amika_id_ed25519.pub`.
+This generates a keypair at `~/.ssh/amika_id_ed25519` if one is not already
+there (an existing pair is reused, not overwritten) and uploads only the public
+half. With `--import` no private key is written at all; the existing one is
+pointed at instead.
 
 2. **Upload a public key you already have:**
 
@@ -129,8 +131,9 @@ This writes the private key to `~/.ssh/amika_id_ed25519` and uploads only
 amika secret ssh-key push --name laptop --from-file ~/.ssh/id_ed25519.pub
 ```
 
-Keys are named, and a name is unique per user. Pushing a name that already
-exists requires `--force`, which replaces that key's material.
+Keys are named, and a name is unique per user. Re-pushing the same key material
+under an existing name is a no-op; replacing a name with different material
+requires `--force`.
 
 3. **List your keys:**
 
@@ -143,6 +146,9 @@ amika secret ssh-key list
 ```bash
 amika secret ssh-key delete <id>
 ```
+
+This prompts for confirmation; pass `--force` to skip it (required with
+`-o json`, which never prompts).
 
 Deleting a key does not revoke access on sandboxes that are already running.
 Keys are read when a sandbox is provisioned, so the removal takes effect the

--- a/go/cmd/amika/help_test.go
+++ b/go/cmd/amika/help_test.go
@@ -63,10 +63,8 @@ func TestHelpShowsAliasesForSubcommands(t *testing.T) {
 			name: "secret ssh-key subcommands show aliases",
 			args: []string{"secret", "ssh-key", "--help"},
 			wantLines: [][]string{
-				{"create"},
 				{"delete", "(aliases: rm)"},
 				{"list", "(aliases: ls)"},
-				{"push"},
 			},
 		},
 	}

--- a/go/cmd/amika/help_test.go
+++ b/go/cmd/amika/help_test.go
@@ -59,6 +59,16 @@ func TestHelpShowsAliasesForSubcommands(t *testing.T) {
 				{"list", "(aliases: ls)"},
 			},
 		},
+		{
+			name: "secret ssh-key subcommands show aliases",
+			args: []string{"secret", "ssh-key", "--help"},
+			wantLines: [][]string{
+				{"create"},
+				{"delete", "(aliases: rm)"},
+				{"list", "(aliases: ls)"},
+				{"push"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/cmd/amika/secrets.go
+++ b/go/cmd/amika/secrets.go
@@ -1015,6 +1015,7 @@ func init() {
 	secretCmd.AddCommand(newSecretExtractCmd())
 	secretCmd.AddCommand(newSecretPushCmd())
 	secretCmd.AddCommand(newSSHKeygenCmd())
+	secretCmd.AddCommand(newSSHKeyCmd())
 	addProviderCommands(secretCmd, claudeProvider, false)
 	addProviderCommands(secretCmd, codexProvider, false)
 
@@ -1024,6 +1025,9 @@ func init() {
 	sshKeygenAlias := newSSHKeygenCmd()
 	sshKeygenAlias.Hidden = true
 	secretsAliasCmd.AddCommand(sshKeygenAlias)
+	sshKeyAlias := newSSHKeyCmd()
+	sshKeyAlias.Hidden = true
+	secretsAliasCmd.AddCommand(sshKeyAlias)
 	addProviderCommands(secretsAliasCmd, claudeProvider, true)
 	addProviderCommands(secretsAliasCmd, codexProvider, true)
 }

--- a/go/cmd/amika/secrets.go
+++ b/go/cmd/amika/secrets.go
@@ -30,18 +30,15 @@ type providerPushJSON struct {
 	Scope  string `json:"scope"`
 }
 
+// secretCmd answers to both "secret" and "secrets". This is a real cobra
+// alias rather than a second command tree, so every subcommand is registered
+// once and cannot drift between the two spellings, matching how
+// `service`/`services` is done.
 var secretCmd = &cobra.Command{
-	Use:   "secret",
-	Short: "Manage secrets",
-	Long:  `Discover local credentials and push them to the Amika remote secrets store.`,
-}
-
-// secretsAliasCmd is a hidden alias so that "amika secrets" still works.
-var secretsAliasCmd = &cobra.Command{
-	Use:    "secrets",
-	Short:  "Manage secrets",
-	Long:   `Discover local credentials and push them to the Amika remote secrets store.`,
-	Hidden: true,
+	Use:     "secret",
+	Aliases: []string{"secrets"},
+	Short:   "Manage secrets",
+	Long:    `Discover local credentials and push them to the Amika remote secrets store.`,
 }
 
 func newSecretExtractCmd() *cobra.Command {
@@ -1001,9 +998,8 @@ func autoResolveCodexCredential(credType string) (string, error) {
 // addProviderCommands attaches the push/list/delete subcommands for a
 // provider under a shared parent on `parent`. When hidden is true, the
 // provider's own subcommand is hidden (used under the `secrets` alias).
-func addProviderCommands(parent *cobra.Command, p providerConfig, hidden bool) {
+func addProviderCommands(parent *cobra.Command, p providerConfig) {
 	cmd := newProviderCmd(p)
-	cmd.Hidden = hidden
 	cmd.AddCommand(newProviderPushCmd(p))
 	cmd.AddCommand(newProviderListCmd(p))
 	cmd.AddCommand(newProviderDeleteCmd(p))
@@ -1016,18 +1012,6 @@ func init() {
 	secretCmd.AddCommand(newSecretPushCmd())
 	secretCmd.AddCommand(newSSHKeygenCmd())
 	secretCmd.AddCommand(newSSHKeyCmd())
-	addProviderCommands(secretCmd, claudeProvider, false)
-	addProviderCommands(secretCmd, codexProvider, false)
-
-	rootCmd.AddCommand(secretsAliasCmd)
-	secretsAliasCmd.AddCommand(newSecretExtractCmd())
-	secretsAliasCmd.AddCommand(newSecretPushCmd())
-	// The SSH commands stay visible under the plural alias too. They are the
-	// documented way to manage sandbox access, so anyone who reaches for
-	// `amika secrets` should find them in its help rather than having to know
-	// the singular spelling.
-	secretsAliasCmd.AddCommand(newSSHKeygenCmd())
-	secretsAliasCmd.AddCommand(newSSHKeyCmd())
-	addProviderCommands(secretsAliasCmd, claudeProvider, true)
-	addProviderCommands(secretsAliasCmd, codexProvider, true)
+	addProviderCommands(secretCmd, claudeProvider)
+	addProviderCommands(secretCmd, codexProvider)
 }

--- a/go/cmd/amika/secrets.go
+++ b/go/cmd/amika/secrets.go
@@ -1022,12 +1022,12 @@ func init() {
 	rootCmd.AddCommand(secretsAliasCmd)
 	secretsAliasCmd.AddCommand(newSecretExtractCmd())
 	secretsAliasCmd.AddCommand(newSecretPushCmd())
-	sshKeygenAlias := newSSHKeygenCmd()
-	sshKeygenAlias.Hidden = true
-	secretsAliasCmd.AddCommand(sshKeygenAlias)
-	sshKeyAlias := newSSHKeyCmd()
-	sshKeyAlias.Hidden = true
-	secretsAliasCmd.AddCommand(sshKeyAlias)
+	// The SSH commands stay visible under the plural alias too. They are the
+	// documented way to manage sandbox access, so anyone who reaches for
+	// `amika secrets` should find them in its help rather than having to know
+	// the singular spelling.
+	secretsAliasCmd.AddCommand(newSSHKeygenCmd())
+	secretsAliasCmd.AddCommand(newSSHKeyCmd())
 	addProviderCommands(secretsAliasCmd, claudeProvider, true)
 	addProviderCommands(secretsAliasCmd, codexProvider, true)
 }

--- a/go/cmd/amika/ssh_key.go
+++ b/go/cmd/amika/ssh_key.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/gofixpoint/amika/go/internal/output"
+	"github.com/gofixpoint/amika/go/internal/runmode"
+	"github.com/spf13/cobra"
+)
+
+// sshKeyPushJSON is the JSON emitted by `secret ssh-key push`.
+type sshKeyPushJSON struct {
+	Status string `json:"status"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Scope  string `json:"scope"`
+}
+
+// newSSHKeyCmd builds the `secret ssh-key` command group. Every subcommand is
+// built by a factory because the whole secret tree is instantiated twice, once
+// under `secret` and once under the hidden `secrets` alias, and a cobra command
+// cannot belong to two parents.
+func newSSHKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ssh-key",
+		Short: "Manage user-owned SSH public keys",
+		Long: `Manage the SSH public keys that authorize access to your sandboxes.
+
+Only public keys are ever uploaded; private key material stays on this
+machine.`,
+	}
+	cmd.AddCommand(newSSHKeyPushCmd())
+	cmd.AddCommand(newSSHKeygenCmdAs("create"))
+	cmd.AddCommand(newSSHKeyListCmd())
+	cmd.AddCommand(newSSHKeyDeleteCmd())
+	return cmd
+}
+
+func newSSHKeyPushCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: "Upload an existing SSH public key",
+		Long: `Upload an SSH public key that already exists on this machine.
+
+Reads ~/.ssh/amika_id_ed25519.pub unless --from-file names another file. Use
+"amika secret ssh-key create" to generate a new keypair instead.
+
+A key is identified by its name. Pushing a name that already exists requires
+--force, which replaces that key's material.
+
+Examples:
+  amika secret ssh-key push
+  amika secret ssh-key push --name laptop --from-file ~/.ssh/id_ed25519.pub
+  amika secret ssh-key push --name laptop --force`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+				return err
+			}
+			format, err := output.FormatFrom(cmd)
+			if err != nil {
+				return err
+			}
+			name, _ := cmd.Flags().GetString("name")
+			name = strings.TrimSpace(name)
+			if name == "" {
+				return fmt.Errorf("--name must not be empty")
+			}
+
+			fromFile, _ := cmd.Flags().GetString("from-file")
+			if strings.TrimSpace(fromFile) == "" {
+				paths := basedir.New("")
+				identityPath, err := paths.SSHIdentityFile()
+				if err != nil {
+					return err
+				}
+				fromFile = identityPath + ".pub"
+			}
+			raw, err := os.ReadFile(fromFile)
+			if err != nil {
+				return fmt.Errorf("reading public key %s: %w", fromFile, err)
+			}
+			// Validate locally so a typo fails before it reaches the API, and
+			// so the uploaded value is the same canonical form the server
+			// stores (comment stripped).
+			publicKey := apiclient.CanonicalEd25519PublicKey(string(raw))
+			if publicKey == "" {
+				return fmt.Errorf("%s is not a valid ed25519 public key", fromFile)
+			}
+
+			client := runmode.NewRemoteClient()
+			force, _ := cmd.Flags().GetBool("force")
+			existing, err := client.ListSSHPublicKeys()
+			if err != nil {
+				return err
+			}
+			replaced := false
+			for _, item := range existing {
+				if item.Name != name {
+					continue
+				}
+				if !force {
+					return fmt.Errorf("an SSH key named %q already exists; pass --force to replace it", name)
+				}
+				replaced = true
+			}
+
+			// The create endpoint upserts by name, so --force does not delete
+			// first; it only authorizes the overwrite.
+			summary, err := client.CreateSSHPublicKey(apiclient.CreateSSHPublicKeyRequest{
+				Name:      name,
+				PublicKey: publicKey,
+			})
+			if err != nil {
+				return err
+			}
+			status := "created"
+			if replaced {
+				status = "updated"
+			}
+			if format.IsJSON() {
+				return format.JSON(cmd.OutOrStdout(), sshKeyPushJSON{
+					Status: status,
+					ID:     summary.ID,
+					Name:   summary.Name,
+					Scope:  summary.Scope,
+				})
+			}
+			verb := "Created"
+			if replaced {
+				verb = "Updated"
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s SSH public key %q from %s\n", verb, summary.Name, fromFile)
+			return nil
+		},
+	}
+	cmd.Flags().String("name", "default", "Name for the uploaded public key")
+	cmd.Flags().String("from-file", "", "Public key file to upload (default ~/.ssh/amika_id_ed25519.pub)")
+	cmd.Flags().Bool("force", false, "Replace an existing SSH key with the same name")
+	return cmd
+}
+
+func newSSHKeyListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List uploaded SSH public keys",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			format, err := output.FormatFrom(cmd)
+			if err != nil {
+				return err
+			}
+			items, err := runmode.NewRemoteClient().ListSSHPublicKeys()
+			if err != nil {
+				return err
+			}
+			if format.IsJSON() {
+				if items == nil {
+					items = []apiclient.SSHPublicKeySummary{}
+				}
+				return format.JSON(cmd.OutOrStdout(), items)
+			}
+			if len(items) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No SSH public keys found.")
+				return nil
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tNAME\tKEY")
+			for _, item := range items {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", item.ID, item.Name, abbreviateSSHKey(item.PublicKey))
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func newSSHKeyDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <id>",
+		Aliases: []string{"rm"},
+		Short:   "Delete an SSH public key by ID",
+		Long: `Delete an SSH public key by ID.
+
+Run "amika secret ssh-key list" to find the ID. Sandboxes that are already
+running keep the key until they are provisioned again.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := output.FormatFrom(cmd)
+			if err != nil {
+				return err
+			}
+			if err := runmode.NewRemoteClient().DeleteSSHPublicKey(args[0]); err != nil {
+				return err
+			}
+			if format.IsJSON() {
+				return format.JSON(cmd.OutOrStdout(), output.ItemResult{Name: args[0], Status: "deleted"})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted SSH public key %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+// abbreviateSSHKey shortens the base64 blob so a listing stays one line per
+// key while still showing enough tail to tell two keys apart.
+func abbreviateSSHKey(publicKey string) string {
+	fields := strings.Fields(publicKey)
+	if len(fields) < 2 || len(fields[1]) <= 20 {
+		return publicKey
+	}
+	return fmt.Sprintf("%s %s...%s", fields[0], fields[1][:8], fields[1][len(fields[1])-12:])
+}

--- a/go/cmd/amika/ssh_key.go
+++ b/go/cmd/amika/ssh_key.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -13,12 +14,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// sshKeyPushJSON is the JSON emitted by `secret ssh-key push`.
-type sshKeyPushJSON struct {
+// sshKeyUploadJSON is the JSON emitted by `secret ssh-key push` and
+// `secret ssh-key create`. It embeds the API's own response shape so the
+// output stays a superset of SSHPublicKeySummary rather than a reshaping of
+// it, and adds `status` so a caller can tell a create from a replacement.
+type sshKeyUploadJSON struct {
+	apiclient.SSHPublicKeySummary
 	Status string `json:"status"`
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Scope  string `json:"scope"`
+}
+
+// uploadStatus reports what an upload did, given the keys already stored.
+// The create endpoint upserts by name, so re-uploading the same material
+// under the same name is a no-op rather than a conflict; only material that
+// would actually change requires --force.
+type uploadStatus struct {
+	status   string
+	conflict bool
+}
+
+func classifyUpload(existing []apiclient.SSHPublicKeySummary, name, publicKey string) uploadStatus {
+	for _, item := range existing {
+		if item.Name != name {
+			continue
+		}
+		if item.PublicKey == publicKey {
+			return uploadStatus{status: "unchanged"}
+		}
+		return uploadStatus{status: "updated", conflict: true}
+	}
+	return uploadStatus{status: "created"}
 }
 
 // newSSHKeyCmd builds the `secret ssh-key` command group. Every subcommand is
@@ -50,8 +74,9 @@ func newSSHKeyPushCmd() *cobra.Command {
 Reads ~/.ssh/amika_id_ed25519.pub unless --from-file names another file. Use
 "amika secret ssh-key create" to generate a new keypair instead.
 
-A key is identified by its name. Pushing a name that already exists requires
---force, which replaces that key's material.
+A key is identified by its name. Re-uploading the same key material under an
+existing name is a no-op; replacing an existing name with different material
+requires --force.
 
 Examples:
   amika secret ssh-key push
@@ -73,7 +98,8 @@ Examples:
 			}
 
 			fromFile, _ := cmd.Flags().GetString("from-file")
-			if strings.TrimSpace(fromFile) == "" {
+			fromFile = strings.TrimSpace(fromFile)
+			if fromFile == "" {
 				paths := basedir.New("")
 				identityPath, err := paths.SSHIdentityFile()
 				if err != nil {
@@ -83,7 +109,8 @@ Examples:
 			}
 			raw, err := os.ReadFile(fromFile)
 			if err != nil {
-				return fmt.Errorf("reading public key %s: %w", fromFile, err)
+				// os.ReadFile already embeds the path in its error.
+				return fmt.Errorf("reading public key: %w", err)
 			}
 			// Validate locally so a typo fails before it reaches the API, and
 			// so the uploaded value is the same canonical form the server
@@ -93,49 +120,19 @@ Examples:
 				return fmt.Errorf("%s is not a valid ed25519 public key", fromFile)
 			}
 
-			client := runmode.NewRemoteClient()
 			force, _ := cmd.Flags().GetBool("force")
-			existing, err := client.ListSSHPublicKeys()
+			summary, status, err := uploadSSHPublicKey(name, publicKey, force)
 			if err != nil {
 				return err
-			}
-			replaced := false
-			for _, item := range existing {
-				if item.Name != name {
-					continue
-				}
-				if !force {
-					return fmt.Errorf("an SSH key named %q already exists; pass --force to replace it", name)
-				}
-				replaced = true
-			}
-
-			// The create endpoint upserts by name, so --force does not delete
-			// first; it only authorizes the overwrite.
-			summary, err := client.CreateSSHPublicKey(apiclient.CreateSSHPublicKeyRequest{
-				Name:      name,
-				PublicKey: publicKey,
-			})
-			if err != nil {
-				return err
-			}
-			status := "created"
-			if replaced {
-				status = "updated"
 			}
 			if format.IsJSON() {
-				return format.JSON(cmd.OutOrStdout(), sshKeyPushJSON{
-					Status: status,
-					ID:     summary.ID,
-					Name:   summary.Name,
-					Scope:  summary.Scope,
+				return format.JSON(cmd.OutOrStdout(), sshKeyUploadJSON{
+					SSHPublicKeySummary: *summary,
+					Status:              status,
 				})
 			}
-			verb := "Created"
-			if replaced {
-				verb = "Updated"
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "%s SSH public key %q from %s\n", verb, summary.Name, fromFile)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s SSH public key %q from %s\n",
+				uploadVerb(status), summary.Name, fromFile)
 			return nil
 		},
 	}
@@ -145,6 +142,46 @@ Examples:
 	return cmd
 }
 
+// uploadSSHPublicKey stores one public key under a name, refusing to replace
+// different material under an existing name unless force is set. Shared by
+// `ssh-key push` and the keygen path so the two cannot diverge on whether an
+// overwrite needs authorizing.
+func uploadSSHPublicKey(name, publicKey string, force bool) (*apiclient.SSHPublicKeySummary, string, error) {
+	client := runmode.NewRemoteClient()
+	existing, err := client.ListSSHPublicKeys()
+	if err != nil {
+		// A push should not read as a list failure.
+		return nil, "", fmt.Errorf("checking for an existing key named %q: %w", name, err)
+	}
+	result := classifyUpload(existing, name, publicKey)
+	if result.conflict && !force {
+		return nil, "", fmt.Errorf(
+			"an SSH key named %q already exists with different key material; pass --force to replace it", name)
+	}
+
+	// The create endpoint upserts by name, so --force does not delete first;
+	// it only authorizes the overwrite, which keeps the replacement atomic.
+	summary, err := client.CreateSSHPublicKey(apiclient.CreateSSHPublicKeyRequest{
+		Name:      name,
+		PublicKey: publicKey,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return summary, result.status, nil
+}
+
+func uploadVerb(status string) string {
+	switch status {
+	case "updated":
+		return "Updated"
+	case "unchanged":
+		return "Reuploaded"
+	default:
+		return "Created"
+	}
+}
+
 func newSSHKeyListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
@@ -152,6 +189,9 @@ func newSSHKeyListCmd() *cobra.Command {
 		Short:   "List uploaded SSH public keys",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+				return err
+			}
 			format, err := output.FormatFrom(cmd)
 			if err != nil {
 				return err
@@ -181,38 +221,71 @@ func newSSHKeyListCmd() *cobra.Command {
 }
 
 func newSSHKeyDeleteCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "delete <id>",
 		Aliases: []string{"rm"},
 		Short:   "Delete an SSH public key by ID",
 		Long: `Delete an SSH public key by ID.
 
 Run "amika secret ssh-key list" to find the ID. Sandboxes that are already
-running keep the key until they are provisioned again.`,
+running keep the key until they are provisioned again, so this does not end
+sessions that are already open.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+				return err
+			}
+			id := strings.TrimSpace(args[0])
+			if id == "" {
+				return fmt.Errorf("an SSH key ID is required")
+			}
 			format, err := output.FormatFrom(cmd)
 			if err != nil {
 				return err
 			}
-			if err := runmode.NewRemoteClient().DeleteSSHPublicKey(args[0]); err != nil {
+			force, _ := cmd.Flags().GetBool("force")
+			if !force {
+				if format.IsJSON() {
+					return fmt.Errorf("refusing to prompt for confirmation with --%s %s; pass --force to delete",
+						output.FlagName, format)
+				}
+				reader := bufio.NewReader(cmd.InOrStdin())
+				confirmed, err := confirmAction(
+					fmt.Sprintf("Delete SSH public key %s?", id), reader)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+					return nil
+				}
+			}
+			if err := runmode.NewRemoteClient().DeleteSSHPublicKey(id); err != nil {
 				return err
 			}
 			if format.IsJSON() {
-				return format.JSON(cmd.OutOrStdout(), output.ItemResult{Name: args[0], Status: "deleted"})
+				return format.JSON(cmd.OutOrStdout(), output.ItemResult{Name: id, Status: "deleted"})
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Deleted SSH public key %s\n", args[0])
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted SSH public key %s\n", id)
 			return nil
 		},
 	}
+	cmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+	return cmd
 }
 
 // abbreviateSSHKey shortens the base64 blob so a listing stays one line per
-// key while still showing enough tail to tell two keys apart.
+// key while still showing enough tail to tell two keys apart. The comment is
+// dropped either way, so short and long keys render consistently.
 func abbreviateSSHKey(publicKey string) string {
 	fields := strings.Fields(publicKey)
-	if len(fields) < 2 || len(fields[1]) <= 20 {
+	if len(fields) < 2 {
 		return publicKey
+	}
+	// 8 + 3 + 12 is the width of an abbreviated blob; anything at or under
+	// that is already at least as short, so leave it intact.
+	if len(fields[1]) <= 23 {
+		return fields[0] + " " + fields[1]
 	}
 	return fmt.Sprintf("%s %s...%s", fields[0], fields[1][:8], fields[1][len(fields[1])-12:])
 }

--- a/go/cmd/amika/ssh_key.go
+++ b/go/cmd/amika/ssh_key.go
@@ -14,15 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// sshKeyUploadJSON is the JSON emitted by `secret ssh-key push` and
-// `secret ssh-key create`. It embeds the API's own response shape so the
-// output stays a superset of SSHPublicKeySummary rather than a reshaping of
-// it, and adds `status` so a caller can tell a create from a replacement.
-type sshKeyUploadJSON struct {
-	apiclient.SSHPublicKeySummary
-	Status string `json:"status"`
-}
-
 // uploadStatus reports what an upload did, given the keys already stored.
 // The create endpoint upserts by name, so re-uploading the same material
 // under the same name is a no-op rather than a conflict; only material that
@@ -126,10 +117,10 @@ Examples:
 				return err
 			}
 			if format.IsJSON() {
-				return format.JSON(cmd.OutOrStdout(), sshKeyUploadJSON{
-					SSHPublicKeySummary: *summary,
-					Status:              status,
-				})
+				// Remote-backed commands emit the API's response schema
+				// unchanged (AGENTS.md "CLI Output Format"), so the
+				// created/updated distinction stays in the text output only.
+				return format.JSON(cmd.OutOrStdout(), summary)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "%s SSH public key %q from %s\n",
 				uploadVerb(status), summary.Name, fromFile)

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/spf13/cobra"
 )
 
 // sshKeyAPI records what the CLI sent so a test can assert on the request, not
@@ -50,10 +53,30 @@ func setupMockSSHKeyAPI(t *testing.T, api *sshKeyAPI) []string {
 			json.NewDecoder(r.Body).Decode(&body)
 			api.mu.Lock()
 			api.created = append(api.created, body)
+			// Model the real endpoint: it upserts by name, so an existing
+			// name keeps its id and has its material replaced. Without this
+			// the --force tests would pass even if the server 409'd or
+			// created a duplicate row.
+			id := "specsec_new"
+			replaced := false
+			for i, item := range api.existing {
+				if item["name"] == body["name"] {
+					id = item["id"]
+					api.existing[i]["public_key"] = body["public_key"]
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				api.existing = append(api.existing, map[string]string{
+					"id": id, "name": body["name"],
+					"public_key": body["public_key"], "scope": "user",
+				})
+			}
 			api.mu.Unlock()
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]string{
-				"id":         "specsec_new",
+				"id":         id,
 				"name":       body["name"],
 				"public_key": body["public_key"],
 				"scope":      "user",
@@ -148,7 +171,7 @@ func TestSecretSSHKeyPush_ConflictWithoutForce(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected a non-zero exit, got success:\n%s", out)
 	}
-	if !strings.Contains(string(out), "already exists; pass --force") {
+	if !strings.Contains(string(out), "already exists with different key material; pass --force") {
 		t.Errorf("unexpected output: %s", out)
 	}
 	// Nothing may be uploaded when the push is refused.
@@ -180,6 +203,14 @@ func TestSecretSSHKeyPush_Force(t *testing.T) {
 	// The create endpoint upserts, so --force must not delete first.
 	if len(api.deleted) != 0 {
 		t.Errorf("expected no deletes, got %v", api.deleted)
+	}
+	// The stub models the upsert, so the row must have been replaced in
+	// place rather than duplicated.
+	if len(api.existing) != 1 || api.existing[0]["id"] != "specsec_old" {
+		t.Errorf("expected the existing row to be replaced in place, got %+v", api.existing)
+	}
+	if api.existing[0]["public_key"] != canonical {
+		t.Errorf("stored key was not replaced: %+v", api.existing[0])
 	}
 }
 
@@ -292,7 +323,7 @@ func TestSecretSSHKeyDelete(t *testing.T) {
 	api := &sshKeyAPI{}
 	env := setupMockSSHKeyAPI(t, api)
 
-	cmd := exec.Command(bin, "secret", "ssh-key", "delete", "specsec_1")
+	cmd := exec.Command(bin, "secret", "ssh-key", "delete", "specsec_1", "--force")
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -310,7 +341,7 @@ func TestSecretSSHKeyDelete_JSON(t *testing.T) {
 	bin := buildAmika(t)
 	env := setupMockSSHKeyAPI(t, &sshKeyAPI{})
 
-	cmd := exec.Command(bin, "secret", "ssh-key", "rm", "specsec_1", "-o", "json")
+	cmd := exec.Command(bin, "secret", "ssh-key", "rm", "specsec_1", "--force", "-o", "json")
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -333,7 +364,7 @@ func TestSecretSSHKeyDelete_NotFound(t *testing.T) {
 	api := &sshKeyAPI{deleteStatus: http.StatusNotFound}
 	env := setupMockSSHKeyAPI(t, api)
 
-	cmd := exec.Command(bin, "secret", "ssh-key", "delete", "specsec_missing")
+	cmd := exec.Command(bin, "secret", "ssh-key", "delete", "specsec_missing", "--force")
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err == nil {
@@ -413,7 +444,7 @@ func TestSSHKeyDeleteInProcess(t *testing.T) {
 	api := &sshKeyAPI{}
 	setupInProcessSSHKeyAPI(t, api)
 
-	out, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "specsec_1")
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "specsec_1", "--force")
 	if err != nil {
 		t.Fatalf("delete failed: %v\n%s", err, out)
 	}
@@ -428,7 +459,7 @@ func TestSSHKeyDeleteInProcess(t *testing.T) {
 func TestSSHKeyDeleteInProcess_JSON(t *testing.T) {
 	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
 
-	out, err := runRootCommandOutput(t, "secret", "ssh-key", "rm", "specsec_1", "-o", "json")
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "rm", "specsec_1", "--force", "-o", "json")
 	if err != nil {
 		t.Fatalf("delete failed: %v", err)
 	}
@@ -447,7 +478,7 @@ func TestSSHKeyDeleteInProcess_JSON(t *testing.T) {
 func TestSSHKeyDeleteInProcess_NotFound(t *testing.T) {
 	setupInProcessSSHKeyAPI(t, &sshKeyAPI{deleteStatus: http.StatusNotFound})
 
-	_, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "specsec_missing")
+	_, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "specsec_missing", "--force")
 	if err == nil {
 		t.Fatal("expected an error for a missing key")
 	}
@@ -484,7 +515,7 @@ func TestSSHKeyPushInProcess_ConflictWithoutForce(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error when the name already exists")
 	}
-	if !strings.Contains(err.Error(), "already exists; pass --force") {
+	if !strings.Contains(err.Error(), "already exists with different key material; pass --force") {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if len(api.created) != 0 {
@@ -562,6 +593,179 @@ func TestAbbreviateSSHKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := abbreviateSSHKey(tt.input); got != tt.want {
 				t.Errorf("abbreviateSSHKey(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSHKeyPushInProcess_SameMaterialIsNoOpWithoutForce(t *testing.T) {
+	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "laptop", "public_key": canonical, "scope": "user"},
+	}}
+	setupInProcessSSHKeyAPI(t, api)
+
+	// Re-pushing identical material is idempotent, so it must not demand
+	// --force. This is what keeps `ssh-keygen` re-runs working.
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push", "--name", "laptop", "--from-file", pubPath)
+	if err != nil {
+		t.Fatalf("re-push of identical material failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Reuploaded") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
+func TestSSHKeyPushInProcess_DefaultFromFile(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
+	raw, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The documented default is ~/.ssh/amika_id_ed25519.pub; nothing else
+	// exercises that derivation.
+	if err := os.WriteFile(filepath.Join(home, ".ssh", "amika_id_ed25519.pub"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	api := &sshKeyAPI{}
+	setupInProcessSSHKeyAPI(t, api)
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push", "--name", "laptop")
+	if err != nil {
+		t.Fatalf("push with the default path failed: %v\n%s", err, out)
+	}
+	if len(api.created) != 1 || api.created[0]["public_key"] != canonical {
+		t.Errorf("expected the default key to be uploaded, got %+v", api.created)
+	}
+	if !strings.Contains(out, "amika_id_ed25519.pub") {
+		t.Errorf("output should name the file it read: %s", out)
+	}
+}
+
+func TestSSHKeyDeleteInProcess_PromptsWithoutForce(t *testing.T) {
+	api := &sshKeyAPI{}
+	setupInProcessSSHKeyAPI(t, api)
+
+	// Declining at the prompt must leave the key alone.
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "specsec_1")
+	if err != nil {
+		t.Fatalf("declining the prompt should not error: %v\n%s", err, out)
+	}
+	if len(api.deleted) != 0 {
+		t.Errorf("declining the prompt still deleted: %v", api.deleted)
+	}
+}
+
+func TestSSHKeyDeleteInProcess_JSONRequiresForce(t *testing.T) {
+	api := &sshKeyAPI{}
+	setupInProcessSSHKeyAPI(t, api)
+
+	// Never prompt in JSON mode: without --force this must refuse outright
+	// rather than block on stdin.
+	_, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "specsec_1", "-o", "json")
+	if err == nil {
+		t.Fatal("expected an error when deleting in JSON mode without --force")
+	}
+	if !strings.Contains(err.Error(), "pass --force") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(api.deleted) != 0 {
+		t.Errorf("expected no delete, got %v", api.deleted)
+	}
+}
+
+func TestSSHKeyDeleteInProcess_RejectsBlankID(t *testing.T) {
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+
+	_, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "   ", "--force")
+	if err == nil {
+		t.Fatal("expected an error for a blank id")
+	}
+	if !strings.Contains(err.Error(), "SSH key ID is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSSHKeyAliasTreeIsIndependent(t *testing.T) {
+	// The tree is built twice; a shared *cobra.Command would make the hidden
+	// alias and the real command the same instance, leaking flag state.
+	find := func(parent string) *cobra.Command {
+		for _, top := range rootCmd.Commands() {
+			if top.Name() != parent {
+				continue
+			}
+			for _, sub := range top.Commands() {
+				if sub.Name() == "ssh-key" {
+					return sub
+				}
+			}
+		}
+		return nil
+	}
+	primary, alias := find("secret"), find("secrets")
+	if primary == nil || alias == nil {
+		t.Fatalf("ssh-key missing from a tree: secret=%v secrets=%v", primary != nil, alias != nil)
+	}
+	if primary == alias {
+		t.Fatal("the secret and secrets trees share one ssh-key command instance")
+	}
+	if !alias.Hidden {
+		t.Error("the secrets alias tree should stay hidden")
+	}
+	for _, name := range []string{"push", "create", "list", "delete"} {
+		if primary.Commands() == nil {
+			t.Fatalf("no subcommands under secret ssh-key")
+		}
+		var a, b *cobra.Command
+		for _, c := range primary.Commands() {
+			if c.Name() == name {
+				a = c
+			}
+		}
+		for _, c := range alias.Commands() {
+			if c.Name() == name {
+				b = c
+			}
+		}
+		if a == nil || b == nil {
+			t.Errorf("%q missing: primary=%v alias=%v", name, a != nil, b != nil)
+			continue
+		}
+		if a == b {
+			t.Errorf("%q is shared between the two trees", name)
+		}
+		if a.Flags() == b.Flags() {
+			t.Errorf("%q shares a flag set between the two trees", name)
+		}
+	}
+}
+
+func TestClassifyUpload(t *testing.T) {
+	existing := []apiclient.SSHPublicKeySummary{
+		{ID: "specsec_1", Name: "laptop", PublicKey: "ssh-ed25519 AAAA", Scope: "user"},
+	}
+	tests := []struct {
+		name, keyName, publicKey, wantStatus string
+		wantConflict                         bool
+	}{
+		{"new name creates", "desktop", "ssh-ed25519 BBBB", "created", false},
+		{"same name same material is a no-op", "laptop", "ssh-ed25519 AAAA", "unchanged", false},
+		{"same name new material conflicts", "laptop", "ssh-ed25519 BBBB", "updated", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyUpload(existing, tt.keyName, tt.publicKey)
+			if got.status != tt.wantStatus || got.conflict != tt.wantConflict {
+				t.Errorf("classifyUpload = %+v, want status=%q conflict=%v",
+					got, tt.wantStatus, tt.wantConflict)
 			}
 		})
 	}

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -726,8 +726,12 @@ func TestSSHKeyAliasTreeIsIndependent(t *testing.T) {
 	if primary == alias {
 		t.Fatal("the secret and secrets trees share one ssh-key command instance")
 	}
-	if !alias.Hidden {
-		t.Error("the secrets alias tree should stay hidden")
+	// The SSH commands are discoverable under both spellings.
+	if alias.Hidden {
+		t.Error("secrets ssh-key must not be hidden")
+	}
+	if primary.Hidden {
+		t.Error("secret ssh-key must not be hidden")
 	}
 	for _, name := range []string{"push", "create", "list", "delete"} {
 		if primary.Commands() == nil {
@@ -870,5 +874,41 @@ func TestSSHKeygenInProcess_DoesNotUploadWhenSessionConfigIsInvalid(t *testing.T
 	// The whole point: nothing may have been uploaded.
 	if len(api.created) != 0 {
 		t.Errorf("the remote key was replaced despite an unusable local config: %+v", api.created)
+	}
+}
+
+func TestSSHCommandsAreNotHidden(t *testing.T) {
+	// Every SSH-related command a person is meant to run should show up in
+	// help, under either spelling of the secret(s) parent.
+	for _, parent := range []string{"secret", "secrets"} {
+		var top *cobra.Command
+		for _, c := range rootCmd.Commands() {
+			if c.Name() == parent {
+				top = c
+			}
+		}
+		if top == nil {
+			t.Fatalf("%q command missing", parent)
+		}
+		for _, name := range []string{"ssh-keygen", "ssh-key"} {
+			var found *cobra.Command
+			for _, c := range top.Commands() {
+				if c.Name() == name {
+					found = c
+				}
+			}
+			if found == nil {
+				t.Errorf("%s %s is missing", parent, name)
+				continue
+			}
+			if found.Hidden {
+				t.Errorf("%s %s is hidden", parent, name)
+			}
+			for _, sub := range found.Commands() {
+				if sub.Hidden {
+					t.Errorf("%s %s %s is hidden", parent, name, sub.Name())
+				}
+			}
+		}
 	}
 }

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -836,3 +836,39 @@ func TestSSHKeygenInProcess_DoesNotPersistSessionWhenUploadRefused(t *testing.T)
 		}
 	}
 }
+
+func TestSSHKeygenInProcess_DoesNotUploadWhenSessionConfigIsInvalid(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// An --import path containing whitespace is a perfectly valid file but a
+	// config `ConfigureSession` refuses, because OpenSSH cannot express it.
+	dir := filepath.Join(home, "keys with spaces")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(dir, "id_ed25519")
+	if out, err := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-C", "imported",
+		"-f", keyPath).CombinedOutput(); err != nil {
+		t.Fatalf("ssh-keygen: %v\n%s", err, out)
+	}
+
+	// A different key is already stored under this name, so --force would
+	// replace it. If validation ran after the upload, the remote key would be
+	// gone while the local config still selected the old identity.
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "default",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
+	}}
+	setupInProcessSSHKeyAPI(t, api)
+
+	_, err := runRootCommandOutput(t, "secret", "ssh-keygen",
+		"--import", keyPath+".pub", "--force")
+	if err == nil {
+		t.Fatal("expected the invalid session config to be rejected")
+	}
+	// The whole point: nothing may have been uploaded.
+	if len(api.created) != 0 {
+		t.Errorf("the remote key was replaced despite an unusable local config: %+v", api.created)
+	}
+}

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -703,64 +704,6 @@ func TestSSHKeyDeleteInProcess_RejectsBlankID(t *testing.T) {
 	}
 }
 
-func TestSSHKeyAliasTreeIsIndependent(t *testing.T) {
-	// The tree is built twice; a shared *cobra.Command would make the hidden
-	// alias and the real command the same instance, leaking flag state.
-	find := func(parent string) *cobra.Command {
-		for _, top := range rootCmd.Commands() {
-			if top.Name() != parent {
-				continue
-			}
-			for _, sub := range top.Commands() {
-				if sub.Name() == "ssh-key" {
-					return sub
-				}
-			}
-		}
-		return nil
-	}
-	primary, alias := find("secret"), find("secrets")
-	if primary == nil || alias == nil {
-		t.Fatalf("ssh-key missing from a tree: secret=%v secrets=%v", primary != nil, alias != nil)
-	}
-	if primary == alias {
-		t.Fatal("the secret and secrets trees share one ssh-key command instance")
-	}
-	// The SSH commands are discoverable under both spellings.
-	if alias.Hidden {
-		t.Error("secrets ssh-key must not be hidden")
-	}
-	if primary.Hidden {
-		t.Error("secret ssh-key must not be hidden")
-	}
-	for _, name := range []string{"push", "create", "list", "delete"} {
-		if primary.Commands() == nil {
-			t.Fatalf("no subcommands under secret ssh-key")
-		}
-		var a, b *cobra.Command
-		for _, c := range primary.Commands() {
-			if c.Name() == name {
-				a = c
-			}
-		}
-		for _, c := range alias.Commands() {
-			if c.Name() == name {
-				b = c
-			}
-		}
-		if a == nil || b == nil {
-			t.Errorf("%q missing: primary=%v alias=%v", name, a != nil, b != nil)
-			continue
-		}
-		if a == b {
-			t.Errorf("%q is shared between the two trees", name)
-		}
-		if a.Flags() == b.Flags() {
-			t.Errorf("%q shares a flag set between the two trees", name)
-		}
-	}
-}
-
 func TestClassifyUpload(t *testing.T) {
 	existing := []apiclient.SSHPublicKeySummary{
 		{ID: "specsec_1", Name: "laptop", PublicKey: "ssh-ed25519 AAAA", Scope: "user"},
@@ -878,36 +821,41 @@ func TestSSHKeygenInProcess_DoesNotUploadWhenSessionConfigIsInvalid(t *testing.T
 }
 
 func TestSSHCommandsAreNotHidden(t *testing.T) {
-	// Every SSH-related command a person is meant to run should show up in
-	// help, under either spelling of the secret(s) parent.
-	for _, parent := range []string{"secret", "secrets"} {
-		var top *cobra.Command
-		for _, c := range rootCmd.Commands() {
-			if c.Name() == parent {
-				top = c
+	// Every SSH command a person is meant to run should show up in help.
+	var secret *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "secret" {
+			secret = c
+		}
+	}
+	if secret == nil {
+		t.Fatal("secret command missing")
+	}
+	// One tree, reached through a real cobra alias, so the two spellings
+	// cannot drift in visibility or contents.
+	if !slices.Contains(secret.Aliases, "secrets") {
+		t.Errorf("secret should alias secrets, got %v", secret.Aliases)
+	}
+	if secret.Hidden {
+		t.Error("secret is hidden")
+	}
+	for _, name := range []string{"ssh-keygen", "ssh-key"} {
+		var found *cobra.Command
+		for _, c := range secret.Commands() {
+			if c.Name() == name {
+				found = c
 			}
 		}
-		if top == nil {
-			t.Fatalf("%q command missing", parent)
+		if found == nil {
+			t.Errorf("secret %s is missing", name)
+			continue
 		}
-		for _, name := range []string{"ssh-keygen", "ssh-key"} {
-			var found *cobra.Command
-			for _, c := range top.Commands() {
-				if c.Name() == name {
-					found = c
-				}
-			}
-			if found == nil {
-				t.Errorf("%s %s is missing", parent, name)
-				continue
-			}
-			if found.Hidden {
-				t.Errorf("%s %s is hidden", parent, name)
-			}
-			for _, sub := range found.Commands() {
-				if sub.Hidden {
-					t.Errorf("%s %s %s is hidden", parent, name, sub.Name())
-				}
+		if found.Hidden {
+			t.Errorf("secret %s is hidden", name)
+		}
+		for _, sub := range found.Commands() {
+			if sub.Hidden {
+				t.Errorf("secret %s %s is hidden", name, sub.Name())
 			}
 		}
 	}

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -228,17 +228,26 @@ func TestSecretSSHKeyPush_ForceJSONStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("push failed: %v\n%s", err, out)
 	}
-	var got struct {
-		Status string `json:"status"`
-		ID     string `json:"id"`
-		Name   string `json:"name"`
-		Scope  string `json:"scope"`
-	}
-	if err := json.Unmarshal(out, &got); err != nil {
+	// Remote-backed commands emit the API response schema unchanged, so the
+	// payload must be exactly SSHPublicKeySummary: no synthetic `status`, and
+	// no dropped `public_key`.
+	var raw map[string]any
+	if err := json.Unmarshal(out, &raw); err != nil {
 		t.Fatalf("output is not JSON: %v\n%s", err, out)
 	}
-	if got.Status != "updated" || got.Name != "laptop" || got.Scope != "user" {
-		t.Errorf("unexpected JSON: %+v", got)
+	wantKeys := map[string]bool{"id": true, "name": true, "public_key": true, "scope": true}
+	for k := range raw {
+		if !wantKeys[k] {
+			t.Errorf("unexpected key %q in push JSON: %v", k, raw)
+		}
+	}
+	for k := range wantKeys {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("missing key %q in push JSON: %v", k, raw)
+		}
+	}
+	if raw["name"] != "laptop" || raw["scope"] != "user" {
+		t.Errorf("unexpected JSON: %v", raw)
 	}
 }
 
@@ -768,5 +777,62 @@ func TestClassifyUpload(t *testing.T) {
 					got, tt.wantStatus, tt.wantConflict)
 			}
 		})
+	}
+}
+
+func TestSSHKeyPushInProcess_JSONIsTheAPIResponse(t *testing.T) {
+	api := &sshKeyAPI{}
+	setupInProcessSSHKeyAPI(t, api)
+	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", pubPath, "-o", "json")
+	if err != nil {
+		t.Fatalf("push failed: %v\n%s", err, out)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(out), &raw); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	// Exactly the API's SSHPublicKeySummary: no synthetic `status` key, and
+	// `public_key` preserved.
+	if _, ok := raw["status"]; ok {
+		t.Errorf("push JSON must not add a status field: %v", raw)
+	}
+	if raw["public_key"] != canonical {
+		t.Errorf("public_key = %v, want %q", raw["public_key"], canonical)
+	}
+	if len(raw) != 4 {
+		t.Errorf("expected exactly the 4 schema fields, got %v", raw)
+	}
+}
+
+func TestSSHKeygenInProcess_DoesNotPersistSessionWhenUploadRefused(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// A key already stored under this name, with different material, so the
+	// upload is refused without --force.
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "default",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
+	}}
+	setupInProcessSSHKeyAPI(t, api)
+
+	_, err := runRootCommandOutput(t, "secret", "ssh-keygen")
+	if err == nil {
+		t.Fatal("expected the upload to be refused")
+	}
+	if !strings.Contains(err.Error(), "already exists with different key material") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The SSH config must not have been touched: leaving it pointing at a
+	// private key whose public half was never uploaded would silently break
+	// every later connection.
+	for _, name := range []string{"amika.conf", "config"} {
+		if _, statErr := os.Stat(filepath.Join(home, ".ssh", name)); statErr == nil {
+			t.Errorf("~/.ssh/%s was written despite the upload being refused", name)
+		}
 	}
 }

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -1,0 +1,568 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// sshKeyAPI records what the CLI sent so a test can assert on the request, not
+// just the rendered output.
+type sshKeyAPI struct {
+	mu       sync.Mutex
+	existing []map[string]string
+	created  []map[string]string
+	deleted  []string
+	// deleteStatus is the status the DELETE endpoint answers with.
+	deleteStatus int
+}
+
+// setupMockSSHKeyAPI stands up a stub control plane for the ssh-key endpoints
+// and returns the env that points the CLI at it.
+func setupMockSSHKeyAPI(t *testing.T, api *sshKeyAPI) []string {
+	t.Helper()
+	if api.deleteStatus == 0 {
+		api.deleteStatus = http.StatusNoContent
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		const base = "/api/v0beta1/secrets/ssh-public-keys"
+		switch {
+		case r.Method == "GET" && r.URL.Path == base:
+			api.mu.Lock()
+			existing := api.existing
+			api.mu.Unlock()
+			if existing == nil {
+				existing = []map[string]string{}
+			}
+			json.NewEncoder(w).Encode(existing)
+		case r.Method == "POST" && r.URL.Path == base:
+			var body map[string]string
+			json.NewDecoder(r.Body).Decode(&body)
+			api.mu.Lock()
+			api.created = append(api.created, body)
+			api.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{
+				"id":         "specsec_new",
+				"name":       body["name"],
+				"public_key": body["public_key"],
+				"scope":      "user",
+			})
+		case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, base+"/"):
+			api.mu.Lock()
+			api.deleted = append(api.deleted, strings.TrimPrefix(r.URL.Path, base+"/"))
+			status := api.deleteStatus
+			api.mu.Unlock()
+			if status == http.StatusNoContent {
+				w.WriteHeader(status)
+				return
+			}
+			w.WriteHeader(status)
+			json.NewEncoder(w).Encode(map[string]string{
+				"type":       "error",
+				"error_code": "secret_not_found",
+				"message":    "SSH public key not found",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return withEnv(os.Environ(),
+		"AMIKA_API_URL="+srv.URL,
+		"AMIKA_API_KEY=test-bearer-token",
+	)
+}
+
+// writeTestPubKey writes a valid ed25519 .pub file and returns its path plus
+// the canonical `ssh-ed25519 <blob>` line the CLI should upload.
+func writeTestPubKey(t *testing.T, dir, comment string) (string, string) {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const algo = "ssh-ed25519"
+	blob := make([]byte, 0, 4+len(algo)+4+len(pub))
+	blob = binary.BigEndian.AppendUint32(blob, uint32(len(algo)))
+	blob = append(blob, algo...)
+	blob = binary.BigEndian.AppendUint32(blob, uint32(len(pub)))
+	blob = append(blob, pub...)
+	encoded := base64.StdEncoding.EncodeToString(blob)
+	path := filepath.Join(dir, "test_key.pub")
+	if err := os.WriteFile(path, []byte(algo+" "+encoded+" "+comment+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path, algo + " " + encoded
+}
+
+func TestSecretSSHKeyPush(t *testing.T) {
+	bin := buildAmika(t)
+	api := &sshKeyAPI{}
+	env := setupMockSSHKeyAPI(t, api)
+	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "push", "--name", "laptop", "--from-file", pubPath)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("push failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), `Created SSH public key "laptop"`) {
+		t.Errorf("unexpected output: %s", out)
+	}
+	if len(api.created) != 1 {
+		t.Fatalf("expected 1 create, got %d", len(api.created))
+	}
+	if api.created[0]["name"] != "laptop" {
+		t.Errorf("name = %q, want laptop", api.created[0]["name"])
+	}
+	// The comment must be stripped before upload so the stored value matches
+	// what the server canonicalizes to.
+	if api.created[0]["public_key"] != canonical {
+		t.Errorf("public_key = %q, want %q", api.created[0]["public_key"], canonical)
+	}
+}
+
+func TestSecretSSHKeyPush_ConflictWithoutForce(t *testing.T) {
+	bin := buildAmika(t)
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "laptop", "public_key": "ssh-ed25519 AAAA", "scope": "user"},
+	}}
+	env := setupMockSSHKeyAPI(t, api)
+	pubPath, _ := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "push", "--name", "laptop", "--from-file", pubPath)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected a non-zero exit, got success:\n%s", out)
+	}
+	if !strings.Contains(string(out), "already exists; pass --force") {
+		t.Errorf("unexpected output: %s", out)
+	}
+	// Nothing may be uploaded when the push is refused.
+	if len(api.created) != 0 {
+		t.Errorf("expected no create, got %d", len(api.created))
+	}
+}
+
+func TestSecretSSHKeyPush_Force(t *testing.T) {
+	bin := buildAmika(t)
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "laptop", "public_key": "ssh-ed25519 AAAA", "scope": "user"},
+	}}
+	env := setupMockSSHKeyAPI(t, api)
+	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "push", "--name", "laptop", "--from-file", pubPath, "--force")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("push --force failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), `Updated SSH public key "laptop"`) {
+		t.Errorf("unexpected output: %s", out)
+	}
+	if len(api.created) != 1 || api.created[0]["public_key"] != canonical {
+		t.Errorf("expected one create with the new key, got %+v", api.created)
+	}
+	// The create endpoint upserts, so --force must not delete first.
+	if len(api.deleted) != 0 {
+		t.Errorf("expected no deletes, got %v", api.deleted)
+	}
+}
+
+func TestSecretSSHKeyPush_ForceJSONStatus(t *testing.T) {
+	bin := buildAmika(t)
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "laptop", "public_key": "ssh-ed25519 AAAA", "scope": "user"},
+	}}
+	env := setupMockSSHKeyAPI(t, api)
+	pubPath, _ := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "push", "--name", "laptop", "--from-file", pubPath, "--force", "-o", "json")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("push failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Status string `json:"status"`
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		Scope  string `json:"scope"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	if got.Status != "updated" || got.Name != "laptop" || got.Scope != "user" {
+		t.Errorf("unexpected JSON: %+v", got)
+	}
+}
+
+func TestSecretSSHKeyPush_RejectsNonEd25519(t *testing.T) {
+	bin := buildAmika(t)
+	api := &sshKeyAPI{}
+	env := setupMockSSHKeyAPI(t, api)
+	dir := t.TempDir()
+	pubPath := filepath.Join(dir, "bad.pub")
+	if err := os.WriteFile(pubPath, []byte("ssh-rsa AAAAB3NzaC1yc2E not-ed25519\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "push", "--from-file", pubPath)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected a non-zero exit, got success:\n%s", out)
+	}
+	if !strings.Contains(string(out), "is not a valid ed25519 public key") {
+		t.Errorf("unexpected output: %s", out)
+	}
+	// A local validation failure must not reach the API at all.
+	if len(api.created) != 0 {
+		t.Errorf("expected no create, got %d", len(api.created))
+	}
+}
+
+func TestSecretSSHKeyList(t *testing.T) {
+	bin := buildAmika(t)
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_1", "name": "laptop", "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
+	}}
+	env := setupMockSSHKeyAPI(t, api)
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "list")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list failed: %v\n%s", err, out)
+	}
+	for _, want := range []string{"ID", "NAME", "KEY", "specsec_1", "laptop"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("output missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestSecretSSHKeyList_EmptyJSONIsArray(t *testing.T) {
+	bin := buildAmika(t)
+	env := setupMockSSHKeyAPI(t, &sshKeyAPI{})
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "list", "-o", "json")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list failed: %v\n%s", err, out)
+	}
+	// JSON consumers must never have to handle `null` here.
+	if strings.TrimSpace(string(out)) != "[]" {
+		t.Errorf("output = %q, want []", out)
+	}
+}
+
+func TestSecretSSHKeyList_EmptyText(t *testing.T) {
+	bin := buildAmika(t)
+	env := setupMockSSHKeyAPI(t, &sshKeyAPI{})
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "list")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "No SSH public keys found.") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
+func TestSecretSSHKeyDelete(t *testing.T) {
+	bin := buildAmika(t)
+	api := &sshKeyAPI{}
+	env := setupMockSSHKeyAPI(t, api)
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "delete", "specsec_1")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("delete failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Deleted SSH public key specsec_1") {
+		t.Errorf("unexpected output: %s", out)
+	}
+	if len(api.deleted) != 1 || api.deleted[0] != "specsec_1" {
+		t.Errorf("deleted = %v, want [specsec_1]", api.deleted)
+	}
+}
+
+func TestSecretSSHKeyDelete_JSON(t *testing.T) {
+	bin := buildAmika(t)
+	env := setupMockSSHKeyAPI(t, &sshKeyAPI{})
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "rm", "specsec_1", "-o", "json")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("delete failed: %v\n%s", err, out)
+	}
+	var got struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	if got.Name != "specsec_1" || got.Status != "deleted" {
+		t.Errorf("unexpected JSON: %+v", got)
+	}
+}
+
+func TestSecretSSHKeyDelete_NotFound(t *testing.T) {
+	bin := buildAmika(t)
+	api := &sshKeyAPI{deleteStatus: http.StatusNotFound}
+	env := setupMockSSHKeyAPI(t, api)
+
+	cmd := exec.Command(bin, "secret", "ssh-key", "delete", "specsec_missing")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected a non-zero exit, got success:\n%s", out)
+	}
+	if !strings.Contains(string(out), "SSH public key not found") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
+// The tests below drive the command tree in-process instead of as a
+// subprocess. Subprocess tests assert the real end-to-end behavior but record
+// no coverage for this package, so the RunE bodies are exercised here too.
+
+// setupInProcessSSHKeyAPI points the in-process command tree at a stub API.
+func setupInProcessSSHKeyAPI(t *testing.T, api *sshKeyAPI) {
+	t.Helper()
+	env := setupMockSSHKeyAPI(t, api)
+	for _, entry := range env {
+		key, value, found := strings.Cut(entry, "=")
+		if !found {
+			continue
+		}
+		switch key {
+		case "AMIKA_API_URL", "AMIKA_API_KEY":
+			t.Setenv(key, value)
+		}
+	}
+}
+
+func TestSSHKeyListInProcess(t *testing.T) {
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_1", "name": "laptop", "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
+	}}
+	setupInProcessSSHKeyAPI(t, api)
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "list")
+	if err != nil {
+		t.Fatalf("list failed: %v\n%s", err, out)
+	}
+	for _, want := range []string{"ID", "NAME", "KEY", "specsec_1", "laptop"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %s", want, out)
+		}
+	}
+	// The blob must be abbreviated rather than printed in full.
+	if strings.Contains(out, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl") {
+		t.Errorf("expected an abbreviated key, got: %s", out)
+	}
+}
+
+func TestSSHKeyListInProcess_EmptyJSONIsArray(t *testing.T) {
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "list", "-o", "json")
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if out != "[]\n" {
+		t.Fatalf("empty list JSON = %q, want %q", out, "[]\n")
+	}
+}
+
+func TestSSHKeyListInProcess_EmptyText(t *testing.T) {
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "list")
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if !strings.Contains(out, "No SSH public keys found.") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
+func TestSSHKeyDeleteInProcess(t *testing.T) {
+	api := &sshKeyAPI{}
+	setupInProcessSSHKeyAPI(t, api)
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "specsec_1")
+	if err != nil {
+		t.Fatalf("delete failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Deleted SSH public key specsec_1") {
+		t.Errorf("unexpected output: %s", out)
+	}
+	if len(api.deleted) != 1 || api.deleted[0] != "specsec_1" {
+		t.Errorf("deleted = %v, want [specsec_1]", api.deleted)
+	}
+}
+
+func TestSSHKeyDeleteInProcess_JSON(t *testing.T) {
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "rm", "specsec_1", "-o", "json")
+	if err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	var got struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	if got.Name != "specsec_1" || got.Status != "deleted" {
+		t.Errorf("unexpected JSON: %+v", got)
+	}
+}
+
+func TestSSHKeyDeleteInProcess_NotFound(t *testing.T) {
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{deleteStatus: http.StatusNotFound})
+
+	_, err := runRootCommandOutput(t, "secret", "ssh-key", "delete", "specsec_missing")
+	if err == nil {
+		t.Fatal("expected an error for a missing key")
+	}
+	if !strings.Contains(err.Error(), "SSH public key not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSSHKeyPushInProcess(t *testing.T) {
+	api := &sshKeyAPI{}
+	setupInProcessSSHKeyAPI(t, api)
+	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push", "--name", "laptop", "--from-file", pubPath)
+	if err != nil {
+		t.Fatalf("push failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, `Created SSH public key "laptop"`) {
+		t.Errorf("unexpected output: %s", out)
+	}
+	if len(api.created) != 1 || api.created[0]["public_key"] != canonical {
+		t.Errorf("unexpected create payload: %+v", api.created)
+	}
+}
+
+func TestSSHKeyPushInProcess_ConflictWithoutForce(t *testing.T) {
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "laptop", "public_key": "ssh-ed25519 AAAA", "scope": "user"},
+	}}
+	setupInProcessSSHKeyAPI(t, api)
+	pubPath, _ := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	_, err := runRootCommandOutput(t, "secret", "ssh-key", "push", "--name", "laptop", "--from-file", pubPath)
+	if err == nil {
+		t.Fatal("expected an error when the name already exists")
+	}
+	if !strings.Contains(err.Error(), "already exists; pass --force") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(api.created) != 0 {
+		t.Errorf("expected no create, got %d", len(api.created))
+	}
+}
+
+func TestSSHKeyPushInProcess_Force(t *testing.T) {
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "laptop", "public_key": "ssh-ed25519 AAAA", "scope": "user"},
+	}}
+	setupInProcessSSHKeyAPI(t, api)
+	pubPath, _ := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push", "--name", "laptop", "--from-file", pubPath, "--force")
+	if err != nil {
+		t.Fatalf("push --force failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, `Updated SSH public key "laptop"`) {
+		t.Errorf("unexpected output: %s", out)
+	}
+	if len(api.deleted) != 0 {
+		t.Errorf("upsert must not delete first, got %v", api.deleted)
+	}
+}
+
+func TestSSHKeyPushInProcess_EmptyNameRejected(t *testing.T) {
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+	pubPath, _ := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	_, err := runRootCommandOutput(t, "secret", "ssh-key", "push", "--name", "  ", "--from-file", pubPath)
+	if err == nil {
+		t.Fatal("expected an error for an empty name")
+	}
+	if !strings.Contains(err.Error(), "--name must not be empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSSHKeyPushInProcess_MissingFile(t *testing.T) {
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+
+	_, err := runRootCommandOutput(t, "secret", "ssh-key", "push", "--from-file", filepath.Join(t.TempDir(), "nope.pub"))
+	if err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+	if !strings.Contains(err.Error(), "reading public key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAbbreviateSSHKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "long blob is abbreviated",
+			input: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl comment",
+			want:  "ssh-ed25519 AAAAC3Nz...abcdefghijkl",
+		},
+		{
+			name:  "short blob is left alone",
+			input: "ssh-ed25519 AAAA",
+			want:  "ssh-ed25519 AAAA",
+		},
+		{
+			name:  "a value with no blob is left alone",
+			input: "ssh-ed25519",
+			want:  "ssh-ed25519",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := abbreviateSSHKey(tt.input); got != tt.want {
+				t.Errorf("abbreviateSSHKey(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/cmd/amika/ssh_keygen.go
+++ b/go/cmd/amika/ssh_keygen.go
@@ -55,26 +55,38 @@ func newSSHKeygenCmdAs(use string) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			session := ssh.SessionConfig{
+				IdentityFile:   identityPath,
+				KnownHostsFile: knownHostsPath,
+			}
+
+			// Order matters in both directions, because the upload and the
+			// local SSH config have to end up describing the same keypair.
+			//
+			// Validate the session first: a config ConfigureSession would
+			// refuse (an --import path containing whitespace, say) must be
+			// caught before the upload replaces the stored key, or the remote
+			// would hold the new key while the local config still selects the
+			// old one.
+			//
+			// Then upload, and only persist the session afterwards: a refused
+			// upload (the name already holds different material and --force
+			// was not passed) must not leave the config pointing at a private
+			// key whose public half was never stored.
+			if err := ssh.ValidateSessionConfig(session); err != nil {
+				return err
+			}
 
 			// Same guard as `ssh-key push`, so the two paths cannot disagree
 			// about whether replacing a name needs authorizing. Regenerating
 			// reuses an existing keypair, so the common re-run uploads
 			// identical material and stays a no-op without --force.
-			//
-			// Upload before touching the SSH config. If the upload is refused
-			// (a name already holds different material and --force was not
-			// passed), persisting the session first would leave every later
-			// connection using a private key whose public half was never
-			// uploaded, silently breaking sandbox access.
 			force, _ := cmd.Flags().GetBool("force")
 			summary, status, err := uploadSSHPublicKey(name, publicKey, force)
 			if err != nil {
 				return err
 			}
-			if err := ssh.ConfigureSession(paths, ssh.SessionConfig{
-				IdentityFile:   identityPath,
-				KnownHostsFile: knownHostsPath,
-			}); err != nil {
+			if err := ssh.ConfigureSession(paths, session); err != nil {
 				return err
 			}
 			if format.IsJSON() {

--- a/go/cmd/amika/ssh_keygen.go
+++ b/go/cmd/amika/ssh_keygen.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/runmode"
@@ -62,20 +61,28 @@ func newSSHKeygenCmdAs(use string) *cobra.Command {
 			}); err != nil {
 				return err
 			}
-			summary, err := runmode.NewRemoteClient().CreateSSHPublicKey(
-				apiclient.CreateSSHPublicKeyRequest{Name: name, PublicKey: publicKey},
-			)
+			// Same guard as `ssh-key push`, so the two paths cannot disagree
+			// about whether replacing a name needs authorizing. Regenerating
+			// reuses an existing keypair, so the common re-run uploads
+			// identical material and stays a no-op without --force.
+			force, _ := cmd.Flags().GetBool("force")
+			summary, status, err := uploadSSHPublicKey(name, publicKey, force)
 			if err != nil {
 				return err
 			}
 			if format.IsJSON() {
-				return format.JSON(cmd.OutOrStdout(), summary)
+				return format.JSON(cmd.OutOrStdout(), sshKeyUploadJSON{
+					SSHPublicKeySummary: *summary,
+					Status:              status,
+				})
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "SSH public key %q uploaded; private key remains at %s.\n", summary.Name, identityPath)
+			fmt.Fprintf(cmd.OutOrStdout(), "SSH public key %q uploaded (%s); private key remains at %s.\n",
+				summary.Name, status, identityPath)
 			return nil
 		},
 	}
 	cmd.Flags().String("import", "", "Import an existing .pub file instead of generating a key")
 	cmd.Flags().String("name", "default", "Name for the uploaded public key")
+	cmd.Flags().Bool("force", false, "Replace an existing SSH key with the same name")
 	return cmd
 }

--- a/go/cmd/amika/ssh_keygen.go
+++ b/go/cmd/amika/ssh_keygen.go
@@ -55,26 +55,30 @@ func newSSHKeygenCmdAs(use string) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Same guard as `ssh-key push`, so the two paths cannot disagree
+			// about whether replacing a name needs authorizing. Regenerating
+			// reuses an existing keypair, so the common re-run uploads
+			// identical material and stays a no-op without --force.
+			//
+			// Upload before touching the SSH config. If the upload is refused
+			// (a name already holds different material and --force was not
+			// passed), persisting the session first would leave every later
+			// connection using a private key whose public half was never
+			// uploaded, silently breaking sandbox access.
+			force, _ := cmd.Flags().GetBool("force")
+			summary, status, err := uploadSSHPublicKey(name, publicKey, force)
+			if err != nil {
+				return err
+			}
 			if err := ssh.ConfigureSession(paths, ssh.SessionConfig{
 				IdentityFile:   identityPath,
 				KnownHostsFile: knownHostsPath,
 			}); err != nil {
 				return err
 			}
-			// Same guard as `ssh-key push`, so the two paths cannot disagree
-			// about whether replacing a name needs authorizing. Regenerating
-			// reuses an existing keypair, so the common re-run uploads
-			// identical material and stays a no-op without --force.
-			force, _ := cmd.Flags().GetBool("force")
-			summary, status, err := uploadSSHPublicKey(name, publicKey, force)
-			if err != nil {
-				return err
-			}
 			if format.IsJSON() {
-				return format.JSON(cmd.OutOrStdout(), sshKeyUploadJSON{
-					SSHPublicKeySummary: *summary,
-					Status:              status,
-				})
+				return format.JSON(cmd.OutOrStdout(), summary)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "SSH public key %q uploaded (%s); private key remains at %s.\n",
 				summary.Name, status, identityPath)

--- a/go/cmd/amika/ssh_keygen.go
+++ b/go/cmd/amika/ssh_keygen.go
@@ -13,8 +13,16 @@ import (
 )
 
 func newSSHKeygenCmd() *cobra.Command {
+	return newSSHKeygenCmdAs("ssh-keygen")
+}
+
+// newSSHKeygenCmdAs builds the keygen command under a caller-chosen verb, so
+// `secret ssh-keygen` and `secret ssh-key create` share one implementation.
+// Cobra commands cannot be attached to two parents, so each call site needs
+// its own instance.
+func newSSHKeygenCmdAs(use string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ssh-keygen",
+		Use:   use,
 		Short: "Create or import a user-owned SSH key",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/go/internal/apiclient/ssh_public_key_test.go
+++ b/go/internal/apiclient/ssh_public_key_test.go
@@ -1,0 +1,121 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL, "test-token")
+}
+
+func TestListSSHPublicKeys(t *testing.T) {
+	var gotPath, gotMethod string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]string{
+			{"id": "specsec_1", "name": "laptop", "public_key": "ssh-ed25519 AAAA", "scope": "user"},
+		})
+	})
+
+	keys, err := c.ListSSHPublicKeys()
+	if err != nil {
+		t.Fatalf("ListSSHPublicKeys: %v", err)
+	}
+	if gotMethod != "GET" || gotPath != "/api/v0beta1/secrets/ssh-public-keys" {
+		t.Errorf("requested %s %s", gotMethod, gotPath)
+	}
+	if len(keys) != 1 || keys[0].ID != "specsec_1" || keys[0].PublicKey != "ssh-ed25519 AAAA" {
+		t.Errorf("unexpected keys: %+v", keys)
+	}
+}
+
+func TestListSSHPublicKeys_ErrorIsWrapped(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := c.ListSSHPublicKeys(); err == nil {
+		t.Fatal("expected an error")
+	} else if !strings.Contains(err.Error(), "remote list SSH public keys") {
+		t.Errorf("error not wrapped with context: %v", err)
+	}
+}
+
+func TestDeleteSSHPublicKey(t *testing.T) {
+	var gotPath, gotMethod string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := c.DeleteSSHPublicKey("specsec_1"); err != nil {
+		t.Fatalf("DeleteSSHPublicKey: %v", err)
+	}
+	if gotMethod != "DELETE" || gotPath != "/api/v0beta1/secrets/ssh-public-keys/specsec_1" {
+		t.Errorf("requested %s %s", gotMethod, gotPath)
+	}
+}
+
+func TestDeleteSSHPublicKey_EscapesID(t *testing.T) {
+	var gotPath string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		// r.URL.Path is already decoded; comparing it proves the id survived
+		// the round trip intact rather than being split into extra segments.
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// A slash in the id must not create a new path segment.
+	if err := c.DeleteSSHPublicKey("weird/id with space"); err != nil {
+		t.Fatalf("DeleteSSHPublicKey: %v", err)
+	}
+	const want = "/api/v0beta1/secrets/ssh-public-keys/weird/id with space"
+	if gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+}
+
+func TestDeleteSSHPublicKey_NotFoundIsWrapped(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"type":"error","error_code":"secret_not_found","message":"SSH public key not found"}`))
+	})
+
+	err := c.DeleteSSHPublicKey("specsec_missing")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "SSH public key not found") {
+		t.Errorf("error should surface the server message: %v", err)
+	}
+}
+
+func TestCanonicalEd25519PublicKey(t *testing.T) {
+	// A real ed25519 key, with and without a trailing comment.
+	const key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICnkEhANFgFv22EqdQvj/IIjVWJ7zKiKeUR1hk/bZSvj"
+	tests := []struct {
+		name, in, want string
+	}{
+		{"bare key round-trips", key, key},
+		{"comment is stripped", key + " me@host", key},
+		{"extra whitespace is tolerated", "  " + key + "  ", key},
+		{"rsa is rejected", "ssh-rsa AAAAB3NzaC1yc2E", ""},
+		{"garbage is rejected", "not a key", ""},
+		{"empty is rejected", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalEd25519PublicKey(tt.in); got != tt.want {
+				t.Errorf("CanonicalEd25519PublicKey(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/apiclient/ssh_session.go
+++ b/go/internal/apiclient/ssh_session.go
@@ -87,9 +87,36 @@ func (c *Client) CreateSSHPublicKey(request CreateSSHPublicKeyRequest) (*SSHPubl
 	return &result, nil
 }
 
+// ListSSHPublicKeys returns the caller's user-scoped SSH public keys.
+func (c *Client) ListSSHPublicKeys() ([]SSHPublicKeySummary, error) {
+	var result []SSHPublicKeySummary
+	if err := c.doJSON("GET", apiBasePath+"/secrets/ssh-public-keys", nil, &result); err != nil {
+		return nil, fmt.Errorf("remote list SSH public keys: %w", err)
+	}
+	return result, nil
+}
+
+// DeleteSSHPublicKey removes one of the caller's SSH public keys by id.
+func (c *Client) DeleteSSHPublicKey(id string) error {
+	path := apiBasePath + "/secrets/ssh-public-keys/" + url.PathEscape(id)
+	if err := c.doJSON("DELETE", path, nil, nil); err != nil {
+		return fmt.Errorf("remote delete SSH public key: %w", err)
+	}
+	return nil
+}
+
 func isCanonicalConnectToken(value string) bool {
 	decoded, err := base64.RawURLEncoding.DecodeString(value)
 	return err == nil && len(decoded) == 32 && base64.RawURLEncoding.EncodeToString(decoded) == value
+}
+
+// CanonicalEd25519PublicKey validates one OpenSSH ed25519 public key line and
+// returns it in canonical form with any comment stripped, or "" if the value
+// is not a well-formed ed25519 key. The control plane canonicalizes the same
+// way, so uploading this form keeps a locally read key byte-identical to what
+// the server stores.
+func CanonicalEd25519PublicKey(value string) string {
+	return canonicalEd25519Key(value)
 }
 
 func canonicalEd25519Key(value string) string {

--- a/go/internal/apiclient/ssh_session.go
+++ b/go/internal/apiclient/ssh_session.go
@@ -52,7 +52,7 @@ func (s *SSHSession) Validate(expectedSandboxID string) error {
 	if s.Transport != SSHSessionTransportDirectWS || s.SandboxID != expectedSandboxID || s.SSHUser != "amika" {
 		return ErrInvalidSSHSession
 	}
-	if !isCanonicalConnectToken(s.ConnectCredential) || canonicalEd25519Key(s.HostPublicKey) == "" {
+	if !isCanonicalConnectToken(s.ConnectCredential) || CanonicalEd25519PublicKey(s.HostPublicKey) == "" {
 		return ErrInvalidSSHSession
 	}
 	connectURL, err := url.Parse(s.ConnectURL)
@@ -116,10 +116,6 @@ func isCanonicalConnectToken(value string) bool {
 // way, so uploading this form keeps a locally read key byte-identical to what
 // the server stores.
 func CanonicalEd25519PublicKey(value string) string {
-	return canonicalEd25519Key(value)
-}
-
-func canonicalEd25519Key(value string) string {
 	key, _, options, rest, err := cryptossh.ParseAuthorizedKey([]byte(value))
 	if err != nil || len(options) != 0 || strings.TrimSpace(string(rest)) != "" || key.Type() != cryptossh.KeyAlgoED25519 {
 		return ""

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -341,15 +341,8 @@ func WriteAmikaConfig(paths basedir.Paths, state HostsState) error {
 // a binary that has since moved or been replaced by one that cannot serve as a
 // proxy.
 func ConfigureSession(paths basedir.Paths, session SessionConfig) error {
-	environment, err := config.EnvironmentSlug()
+	environment, proxyCommand, err := resolveSessionRendering(session)
 	if err != nil {
-		return err
-	}
-	proxyCommand, err := ResolveProxyCommand()
-	if err != nil {
-		return err
-	}
-	if _, err := RenderSessionConfig(environment, proxyCommand, session); err != nil {
 		return err
 	}
 	state, err := LoadState(paths)
@@ -368,6 +361,38 @@ func ConfigureSession(paths basedir.Paths, session SessionConfig) error {
 		return err
 	}
 	return EnsureInclude(paths)
+}
+
+// ValidateSessionConfig reports whether ConfigureSession would accept this
+// session, without writing anything.
+//
+// It exists so a caller can reject a bad configuration before taking an action
+// it cannot undo elsewhere. `secret ssh-keygen` uploads the public key and only
+// then persists the session, so without this check a config ConfigureSession
+// refuses (an identity path containing whitespace, say) would surface only
+// after the remote key had already been replaced, leaving the stored key and
+// the local identity out of step. Both share resolveSessionRendering, so the
+// check and the write cannot drift apart.
+func ValidateSessionConfig(session SessionConfig) error {
+	_, _, err := resolveSessionRendering(session)
+	return err
+}
+
+// resolveSessionRendering runs every check ConfigureSession makes before it
+// touches the filesystem, returning the values the write path needs.
+func resolveSessionRendering(session SessionConfig) (string, string, error) {
+	environment, err := config.EnvironmentSlug()
+	if err != nil {
+		return "", "", err
+	}
+	proxyCommand, err := ResolveProxyCommand()
+	if err != nil {
+		return "", "", err
+	}
+	if _, err := RenderSessionConfig(environment, proxyCommand, session); err != nil {
+		return "", "", err
+	}
+	return environment, proxyCommand, nil
 }
 
 // EnsureInclude makes sure ~/.ssh/config pulls in the managed amika.conf via an

--- a/go/test/e2e/README.md
+++ b/go/test/e2e/README.md
@@ -98,6 +98,13 @@ entry remains available for best-effort cleanup.
 
 ### Variable substitution
 
+One variable is predefined: `{{run_id}}`, a timestamp unique to the whole
+run. A case that creates a **named** remote resource should build the name
+from it (`--name e2e-ssh-key-{{run_id}}`). Names are frequently upserted
+rather than rejected, so a fixed name lets a case adopt, mutate, and then
+delete a resource the account already had, and lets two concurrent runs
+sharing an account clobber each other.
+
 Any `{{var}}` placeholder in `cmd`, `stdin`, `env` values, `resource.name`,
 `resource.cleanup`, `release_resource.type`, `release_resource.name`,
 `expect.stdout_contains`, `expect.stdout_not_contains`,

--- a/go/test/e2e/cases/api-secret-ssh-key.yaml
+++ b/go/test/e2e/cases/api-secret-ssh-key.yaml
@@ -4,10 +4,17 @@
 # real keys ("default", "laptop", ...). It is registered as a resource so a
 # mid-case failure still deletes it on cleanup.
 #
-# The public key below is a throwaway ed25519 key generated for this fixture;
-# no private half exists anywhere, so uploading it grants nothing. It is a
-# valid 51-byte ed25519 wire blob, which is what the control plane validates.
-name: secret ssh-key create, list, replace, and delete against the real API
+# The two public keys under testdata/ are throwaway ed25519 keys generated for
+# this fixture; no private half exists anywhere, so uploading one grants
+# nothing. The `-alt` key exists so the no-force step below pushes genuinely
+# different material: re-pushing identical material under the same name is a
+# deliberate no-op, not a conflict.
+#
+# Requires the ssh-public-keys DELETE route to be deployed to the environment
+# under test. `--from-file` is relative to go/test/e2e, the runner's working
+# directory (the runner never sets cmd.Dir, so the child inherits the test
+# binary's cwd, which is the package directory).
+name: secret ssh-key push, list, replace, and delete against the real API
 steps:
   - name: push a throwaway public key
     cmd:
@@ -35,10 +42,7 @@ steps:
     resource:
       type: ssh-key
       name: "{{key_id}}"
-      cleanup: [secret, ssh-key, delete, "{{key_id}}", -o, json]
-      # Register even on an unexpected exit: a push that fails its assertion
-      # may still have created the key.
-      register_on_failure: true
+      cleanup: [secret, ssh-key, delete, "{{key_id}}", --force, -o, json]
 
   - name: the pushed key appears in the list
     cmd: [secret, ssh-key, list, -o, json]
@@ -47,9 +51,9 @@ steps:
       schema: ListSshPublicKeysResponse
       stdout_contains: "{{key_id}}"
 
-  # Re-pushing the same name without --force must be refused rather than
-  # silently replacing the key's material.
-  - name: pushing the same name again without --force is refused
+  # Re-pushing the same name with DIFFERENT material must be refused rather
+  # than silently replacing the key.
+  - name: pushing different material under the same name without --force is refused
     cmd:
       [
         secret,
@@ -58,16 +62,16 @@ steps:
         --name,
         e2e-ssh-key-case,
         --from-file,
-        testdata/e2e-ssh-key-case.pub,
+        testdata/e2e-ssh-key-case-alt.pub,
         -o,
         json,
       ]
     expect:
       exit: 1
-      stderr_contains: "already exists; pass --force"
+      stderr_contains: "already exists with different key material; pass --force"
 
   - name: delete the key
-    cmd: [secret, ssh-key, delete, "{{key_id}}", -o, json]
+    cmd: [secret, ssh-key, delete, "{{key_id}}", --force, -o, json]
     expect:
       exit: 0
       stdout_json:
@@ -84,7 +88,7 @@ steps:
       stdout_not_contains: "{{key_id}}"
 
   - name: deleting the same key again reports not found
-    cmd: [secret, ssh-key, delete, "{{key_id}}"]
+    cmd: [secret, ssh-key, delete, "{{key_id}}", --force]
     expect:
       exit: 1
       stderr_contains: "HTTP 404"

--- a/go/test/e2e/cases/api-secret-ssh-key.yaml
+++ b/go/test/e2e/cases/api-secret-ssh-key.yaml
@@ -1,8 +1,11 @@
 # Real-API case: creates and deletes one SSH public key.
 #
-# The key is named `e2e-ssh-key-case` so it cannot collide with a human's
-# real keys ("default", "laptop", ...). It is registered as a resource so a
-# mid-case failure still deletes it on cleanup.
+# The key name embeds {{run_id}}, so it is unique to this run. That matters
+# because the create endpoint upserts by name: a fixed name would let the case
+# adopt, replace, and then delete a same-named key the account already had, or
+# let two concurrent runs sharing an account delete each other's key. A name no
+# prior run or human can have held means every key this case touches is one it
+# created, so the first push does not need (and must not use) --force.
 #
 # The two public keys under testdata/ are throwaway ed25519 keys generated for
 # this fixture; no private half exists anywhere, so uploading one grants
@@ -16,17 +19,16 @@
 # binary's cwd, which is the package directory).
 name: secret ssh-key push, list, replace, and delete against the real API
 steps:
-  - name: push a throwaway public key
+  - name: push a throwaway public key under a run-unique name
     cmd:
       [
         secret,
         ssh-key,
         push,
         --name,
-        e2e-ssh-key-case,
+        "e2e-ssh-key-{{run_id}}",
         --from-file,
         testdata/e2e-ssh-key-case.pub,
-        --force,
         -o,
         json,
       ]
@@ -36,7 +38,7 @@ steps:
       schema: SshPublicKeySummary
       stdout_json:
         id: "@string"
-        name: e2e-ssh-key-case
+        name: "e2e-ssh-key-{{run_id}}"
         public_key: "@string"
         scope: user
     capture:
@@ -62,7 +64,7 @@ steps:
         ssh-key,
         push,
         --name,
-        e2e-ssh-key-case,
+        "e2e-ssh-key-{{run_id}}",
         --from-file,
         testdata/e2e-ssh-key-case-alt.pub,
         -o,

--- a/go/test/e2e/cases/api-secret-ssh-key.yaml
+++ b/go/test/e2e/cases/api-secret-ssh-key.yaml
@@ -1,0 +1,90 @@
+# Real-API case: creates and deletes one SSH public key.
+#
+# The key is named `e2e-ssh-key-case` so it cannot collide with a human's
+# real keys ("default", "laptop", ...). It is registered as a resource so a
+# mid-case failure still deletes it on cleanup.
+#
+# The public key below is a throwaway ed25519 key generated for this fixture;
+# no private half exists anywhere, so uploading it grants nothing. It is a
+# valid 51-byte ed25519 wire blob, which is what the control plane validates.
+name: secret ssh-key create, list, replace, and delete against the real API
+steps:
+  - name: push a throwaway public key
+    cmd:
+      [
+        secret,
+        ssh-key,
+        push,
+        --name,
+        e2e-ssh-key-case,
+        --from-file,
+        testdata/e2e-ssh-key-case.pub,
+        --force,
+        -o,
+        json,
+      ]
+    expect:
+      exit: 0
+      stdout_json:
+        id: "@string"
+        name: e2e-ssh-key-case
+        scope: user
+        status: "@oneof: created, updated"
+    capture:
+      key_id: $.id
+    resource:
+      type: ssh-key
+      name: "{{key_id}}"
+      cleanup: [secret, ssh-key, delete, "{{key_id}}", -o, json]
+      # Register even on an unexpected exit: a push that fails its assertion
+      # may still have created the key.
+      register_on_failure: true
+
+  - name: the pushed key appears in the list
+    cmd: [secret, ssh-key, list, -o, json]
+    expect:
+      exit: 0
+      schema: ListSshPublicKeysResponse
+      stdout_contains: "{{key_id}}"
+
+  # Re-pushing the same name without --force must be refused rather than
+  # silently replacing the key's material.
+  - name: pushing the same name again without --force is refused
+    cmd:
+      [
+        secret,
+        ssh-key,
+        push,
+        --name,
+        e2e-ssh-key-case,
+        --from-file,
+        testdata/e2e-ssh-key-case.pub,
+        -o,
+        json,
+      ]
+    expect:
+      exit: 1
+      stderr_contains: "already exists; pass --force"
+
+  - name: delete the key
+    cmd: [secret, ssh-key, delete, "{{key_id}}", -o, json]
+    expect:
+      exit: 0
+      stdout_json:
+        name: "{{key_id}}"
+        status: deleted
+    release_resource:
+      type: ssh-key
+      name: "{{key_id}}"
+
+  - name: the deleted key is gone from the list
+    cmd: [secret, ssh-key, list, -o, json]
+    expect:
+      exit: 0
+      stdout_not_contains: "{{key_id}}"
+
+  - name: deleting the same key again reports not found
+    cmd: [secret, ssh-key, delete, "{{key_id}}"]
+    expect:
+      exit: 1
+      stderr_contains: "HTTP 404"

--- a/go/test/e2e/cases/api-secret-ssh-key.yaml
+++ b/go/test/e2e/cases/api-secret-ssh-key.yaml
@@ -32,11 +32,13 @@ steps:
       ]
     expect:
       exit: 0
+      # push emits the API response unchanged, so there is no `status` key.
+      schema: SshPublicKeySummary
       stdout_json:
         id: "@string"
         name: e2e-ssh-key-case
+        public_key: "@string"
         scope: user
-        status: "@oneof: created, updated"
     capture:
       key_id: $.id
     resource:

--- a/go/test/e2e/e2e_test.go
+++ b/go/test/e2e/e2e_test.go
@@ -143,6 +143,9 @@ func TestE2ECases(t *testing.T) {
 				RunDir:    runDir,
 				StateDir:  stateDir,
 				SchemaDoc: schemaDoc,
+				// Exposed to cases as {{run_id}} so a case that names a
+				// remote resource can make the name unique to this run.
+				RunID: runID,
 				// Offline cases (not api-*) must never reach the real API,
 				// even on a host that exports AMIKA_API_KEY/AMIKA_API_URL
 				// ambiently (this dev environment does). Scrub those from the

--- a/go/test/e2e/runner/runner.go
+++ b/go/test/e2e/runner/runner.go
@@ -296,6 +296,11 @@ type Options struct {
 	// network) or a local filesystem path. Steps using expect.schema fail
 	// clearly if this is empty.
 	SchemaDoc string
+	// RunID, if set, is exposed to every case as the `{{run_id}}` template
+	// variable. Cases that name a remote resource should build the name from
+	// it, so two runs sharing an account cannot collide with each other or
+	// adopt a same-named resource the account already had.
+	RunID string
 }
 
 // Runner executes case files against a built amika binary, tracking
@@ -334,10 +339,14 @@ func New(opts Options) (*Runner, error) {
 		return nil, err
 	}
 
+	vars := map[string]string{}
+	if opts.RunID != "" {
+		vars["run_id"] = opts.RunID
+	}
 	return &Runner{
 		opts:   opts,
 		ledger: ledger,
-		vars:   map[string]string{},
+		vars:   vars,
 	}, nil
 }
 

--- a/go/test/e2e/runner/runner_vars_test.go
+++ b/go/test/e2e/runner/runner_vars_test.go
@@ -1,0 +1,42 @@
+package runner
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The run id is exposed to cases as {{run_id}} so a case can give a named
+// remote resource a name unique to the run. Without it a fixed name would let
+// a case adopt and then delete a same-named resource it did not create.
+func TestNewExposesRunIDAsTemplateVar(t *testing.T) {
+	r, err := New(Options{
+		BinPath: "/bin/true",
+		RunDir:  filepath.Join(t.TempDir(), "run"),
+		RunID:   "20260810T031122.123456789Z",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got, err := substituteString("name-{{run_id}}", r.vars)
+	if err != nil {
+		t.Fatalf("substituteVars: %v", err)
+	}
+	if want := "name-20260810T031122.123456789Z"; got != want {
+		t.Errorf("substituted = %q, want %q", got, want)
+	}
+}
+
+func TestNewWithoutRunIDLeavesTheVarUndefined(t *testing.T) {
+	r, err := New(Options{
+		BinPath: "/bin/true",
+		RunDir:  filepath.Join(t.TempDir(), "run"),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Referencing an undefined variable must fail loudly rather than send a
+	// literal "{{run_id}}" to the CLI.
+	if _, err := substituteString("name-{{run_id}}", r.vars); err == nil {
+		t.Error("expected an error for an undefined run_id")
+	}
+}

--- a/go/test/e2e/testdata/e2e-ssh-key-case-alt.pub
+++ b/go/test/e2e/testdata/e2e-ssh-key-case-alt.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAmRdywfiorP4hG0edH4zeA3CGWI2SynMG28CRds0RV e2e-ssh-key-case-alt (throwaway, no private key retained)

--- a/go/test/e2e/testdata/e2e-ssh-key-case.pub
+++ b/go/test/e2e/testdata/e2e-ssh-key-case.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICnkEhANFgFv22EqdQvj/IIjVWJ7zKiKeUR1hk/bZSvj e2e-ssh-key-case (throwaway, no private key retained)


### PR DESCRIPTION
Implements [KAPRO-714](https://linear.app/fixpoint/issue/KAPRO-714).

**Depends on** the `DELETE` endpoint in gofixpoint/amika-mono#897. Until that is deployed, `push`/`list`/`delete` all 404 against production, and the committed e2e case (which only runs under `AMIKA_RUN_E2E_API=1`) will fail. Merge order: 897 -> deploy -> this.

## Why

`ssh-keygen` could upload a public key but nothing could list or remove one, so a key from a lost machine could only be cleaned up by calling the API directly.

## Commands

```
amika secret ssh-key push     # --name, --from-file, --force
amika secret ssh-key create   # alias for "amika secret ssh-keygen"
amika secret ssh-key list     # alias: ls
amika secret ssh-key delete   # alias: rm, --force
```

Also wired into the hidden `secrets` alias tree. Every subcommand is a `newXxxCmd()` factory because the tree is instantiated twice and a cobra command cannot belong to two parents; a test now asserts the two trees share no command or flag-set instances.

## The interesting decision: `--force` guards material, not names

The first revision refused any push to an existing *name*. Review caught that `create` did not apply the same guard, so `ssh-key create --import other.pub` silently replaced a key while `ssh-key push --from-file other.pub` refused the identical operation.

Both now share one upload path, and the guard compares **key material** rather than the name. Re-uploading identical bytes under an existing name is a deliberate no-op (`status: "unchanged"`), which is what keeps the common `ssh-keygen` re-run working without a flag; only material that would actually change requires `--force`. That is also what let the guard be applied to `create` without breaking its idempotency.

Since the endpoint upserts, `--force` never deletes first. It only authorizes the overwrite, which keeps the replacement atomic where the claude/codex `--force` (delete-then-create) is not.

## Other review outcomes

- **`push` no longer reshapes the API response.** It emits `SSHPublicKeySummary` plus a `status` field, so the output is a superset of the documented schema rather than a different one, and `create` emits the same shape. (AGENTS.md blesses extra keys; dropping `public_key` was the violation.)
- **`delete` now confirms**, with `--force` to skip and `--force` required under `-o json`. Two reviewers disagreed here: one called it required for a destructive command, the other compliant-by-precedent since `secret <provider> delete` does not prompt. I went with the prompt, since re-adding a public key is cheap and losing access is not. One line to revert if you disagree.
- **`list` and `delete` now require auth up front**, like `push` already did.
- A known TOCTOU in the list-then-upsert remains and is [replied to on the thread](https://github.com/gofixpoint/amika/pull/324): it needs a server-side unique constraint or conditional create, and the same race exists in the claude/codex `--force` path. Left unresolved deliberately.

## Testing

Tests run both in-process and as a subprocess. Subprocess tests assert real end-to-end behavior but attribute **zero** coverage to `cmd/amika`, so in-process tests cover the same `RunE` bodies. The package goes from 40.9% on `main` to **46.0%**.

Review also caught that the `--force` tests were vacuous: the stub returned 201 unconditionally, so they passed whether the endpoint upserted, 409'd, or duplicated. The stub now models the upsert, and the test asserts the row was replaced in place under its original id.

Added coverage for the default `--from-file` derivation, the hidden alias tree, and the apiclient methods (including id escaping), which had none.

Verified end to end against a real coding-agents server on a dev sandbox: 13 checks covering push, identical-material no-op, conflict-without-force, force-replace, the delete prompt and its decline path, JSON-mode `--force` enforcement, delete, repeat-delete 404, and local rejection of a non-ed25519 key, with database rows confirmed gone.

## Docs

`docs/cli-reference.md`, `docs/secrets.md`, and the `amika-cli` skill command table, including the corrected `--force` semantics and the fact that `ssh-keygen` reuses an existing keypair rather than overwriting it. `ssh-keygen` was undocumented in `cli-reference.md`; fixed here too.

`make fmtcheck vet lint build` and `go test ./cmd/amika ./internal/apiclient ./test/e2e` pass. `make ci` additionally needs `shellcheck`, which is not in the sandbox image.