### PR TITLE
Import @amika/sandbox from amika-mono as a JS workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,58 @@ jobs:
 
       - name: Test
         run: make test
+
+  # This repo owns `@amika/sandbox`, so this job answers "is this package
+  # correct". amika-mono consumes it as a git submodule pinned to an exact
+  # commit and does not duplicate these tests; its CI answers the separate
+  # question of whether the pinned version still satisfies its consumers.
+  check-sandbox:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: js/sandbox
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Format check
+        run: pnpm run formatcheck
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test
+
+  check-eslint-rules:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: eslint-rules
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Test
+        run: pnpm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /amika
 dist/
 scratch/
+node_modules/
+*.tsbuildinfo
 .DS_Store
 .gocache/
 .gotmp/

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,90 @@
+const LOCKFILE_NAMES = new Set([
+  "pnpm-lock.yaml",
+  "package-lock.json",
+  "yarn.lock",
+  "bun.lockb",
+]);
+
+const FORMATTABLE_EXTENSIONS = new Set([
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".mjs",
+  ".cjs",
+  ".json",
+  ".md",
+  ".css",
+  ".scss",
+  ".html",
+  ".yaml",
+  ".yml",
+]);
+
+const PACKAGE_BY_PREFIX = [["js/sandbox/", "@amika/sandbox"]];
+
+function normalizePath(path) {
+  return path.replaceAll("\\", "/");
+}
+
+function shouldFormat(path) {
+  const normalizedPath = normalizePath(path);
+  const fileName = normalizedPath.split("/").at(-1) ?? "";
+  if (LOCKFILE_NAMES.has(fileName)) {
+    return false;
+  }
+
+  const extension = fileName.includes(".")
+    ? `.${fileName.split(".").at(-1)}`
+    : "";
+  return FORMATTABLE_EXTENSIONS.has(extension);
+}
+
+function shellQuote(path) {
+  return JSON.stringify(path);
+}
+
+function getTouchedPackages(paths) {
+  const packages = new Set();
+  for (const path of paths.map(normalizePath)) {
+    for (const [prefix, packageName] of PACKAGE_BY_PREFIX) {
+      if (path.startsWith(prefix)) {
+        packages.add(packageName);
+      }
+    }
+  }
+  return [...packages];
+}
+
+export default {
+  "js/**/*": (stagedPaths) => {
+    const pathsToFormat = stagedPaths.filter(shouldFormat);
+    if (pathsToFormat.length === 0) {
+      return [];
+    }
+
+    const quotedPaths = pathsToFormat.map(shellQuote).join(" ");
+    // Pin to the workspace prettier version (the single `prettier` resolved in
+    // pnpm-lock.yaml). This MUST match every package's `prettier` devDependency
+    // so hook-written formatting is identical to what CI's `formatcheck` (which
+    // runs the workspace prettier) expects. Bump both together.
+    //
+    // This constraint now has to hold independently in amika-mono, whose
+    // .lintstagedrc.mjs carries the same pin: this package is consumed there as
+    // a git submodule, and a formatting disagreement between the two repos
+    // would surface as a `formatcheck` failure in whichever one did not write
+    // the file. Bump both repos together.
+    return [`pnpm dlx prettier@3.8.3 --write ${quotedPaths}`];
+  },
+  "js/**": (stagedPaths) => {
+    const touchedPackages = getTouchedPackages(stagedPaths);
+    if (touchedPackages.length === 0) {
+      return [];
+    }
+
+    return touchedPackages.flatMap((packageName) => [
+      `pnpm --filter ${packageName} run lint`,
+      `pnpm --filter ${packageName} run typecheck`,
+    ]);
+  },
+};

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,24 @@ Amika is a Go module that lets people control sandboxed AI agents, focused on us
 The repo also ships `amikalog`, a separate, separately-installed CLI that captures Claude Code and Codex hook activity (with the git state of each hook's working directory) as raw append-only events under the amika state directory. Run `amikalog start` once to install the hooks. It is versioned and released independently of `amika` (tags `amikalog@v*`).
 
 This repository is an OSS monorepo. Go sources live under `go/`. Other
-language SDKs live under `sdk/` (e.g. `sdk/typescript/`).
+language SDKs live under `sdk/` (e.g. `sdk/typescript/`). TypeScript packages
+that are consumed as source rather than published live under `js/` — currently
+`js/sandbox` (`@amika/sandbox`), the sandbox provider abstraction. See
+[`js/AGENTS.md`](./js/AGENTS.md) for the conventions every `js/` package
+follows.
+
+There are two independent pnpm workspaces here, on purpose. The repo root
+governs `js/*` and `eslint-rules` (root `pnpm-workspace.yaml` and
+`pnpm-lock.yaml`); `sdk/typescript` governs itself, with its own workspace file,
+lockfile, and `packageManager` pin, because it is a published npm package with
+its own release pipeline. Run `pnpm install` at the root for the former and
+from `sdk/typescript/` for the latter.
+
+`js/sandbox` is consumed by `amika-mono` as a git submodule pinned to an exact
+commit, so this repo is the single source of truth for that package: changes
+land here and reach amika-mono through a pointer bump. That also means this
+repo's CI and pre-commit hook own the package's source quality — amika-mono
+sees only a gitlink for the submodule and so cannot lint or format it.
 
 Comments and docstrings here sometimes point at `amika-mono`, Amika's private
 control-plane monorepo, for protocol details owned by that side (e.g. "the

--- a/eslint-rules/index.cjs
+++ b/eslint-rules/index.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    "no-cross-package-internal": require("./no-cross-package-internal.cjs"),
+  },
+};

--- a/eslint-rules/no-cross-package-internal.cjs
+++ b/eslint-rules/no-cross-package-internal.cjs
@@ -1,0 +1,111 @@
+const path = require("node:path");
+
+/**
+ * Enforce Go-style `internal/` visibility boundaries.
+ *
+ * For a module at `foo/internal/bar`, the boundary root is the PARENT of the
+ * (innermost) `internal/` directory — `foo/`. The module is importable only
+ * from files anywhere within the `foo/` subtree:
+ *
+ *   foo/internal/**   ✅ nested inside internal/
+ *   foo/bazinga.ts    ✅ sibling of internal/
+ *   foo/other/baz.ts  ✅ deeper descendant of foo/
+ *   sibling/x.ts      ❌ outside foo/
+ *   foo2/x.ts         ❌ outside foo/
+ *
+ * This mirrors Go, where `.../a/internal/...` is importable only by code rooted
+ * at `.../a`. For nested internals, the innermost `internal` segment's parent
+ * is the root.
+ *
+ * The boundary applies to both `import ... from "X"` and re-exports
+ * (`export ... from "X"`), and to both relative specifiers (`./internal/...`)
+ * and the `@/` path alias, which every package's tsconfig maps to its own
+ * `src/`. Tests get no exemption: a file's legality depends only on its own
+ * location.
+ */
+
+const ALIAS_PREFIX = "@/";
+
+/**
+ * Resolve an import specifier to an absolute path, or null when it is out of
+ * scope (a bare package specifier, or an alias we cannot anchor).
+ */
+function resolveSpecifier(source, importer) {
+  if (source.startsWith(".")) {
+    return path.resolve(path.dirname(importer), source);
+  }
+  if (source.startsWith(ALIAS_PREFIX)) {
+    // `@/*` maps to `<package>/src/*` in every package's tsconfig. Recover the
+    // importing file's own `src/` root and re-root the specifier there.
+    const marker = `${path.sep}src${path.sep}`;
+    const at = importer.indexOf(marker);
+    if (at === -1) return null;
+    const srcRoot = importer.slice(0, at + marker.length - 1);
+    return path.join(srcRoot, source.slice(ALIAS_PREFIX.length));
+  }
+  // Bare specifiers (npm packages, other workspace packages) are out of scope;
+  // package boundaries are enforced by the package system itself.
+  return null;
+}
+
+/**
+ * The boundary root for a resolved path that points into an `internal/`
+ * directory: the parent of the innermost (last) `internal` path segment.
+ * Returns null when there is no such segment.
+ */
+function internalBoundaryRoot(resolvedPath) {
+  const segments = resolvedPath.split(path.sep);
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (segments[i] === "internal") {
+      if (i === 0) return null;
+      return segments.slice(0, i).join(path.sep);
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow importing an internal/ module from outside its parent subtree (Go-style boundary)",
+    },
+    schema: [],
+  },
+  create(context) {
+    function check(node) {
+      // ExportNamedDeclaration without a `from` clause has no source.
+      const source = node.source && node.source.value;
+      if (typeof source !== "string") return;
+      if (!source.includes("/internal/") && !source.endsWith("/internal")) {
+        return;
+      }
+
+      const importer = context.getFilename();
+      const resolved = resolveSpecifier(source, importer);
+      if (resolved === null) return;
+
+      const boundaryRoot = internalBoundaryRoot(resolved);
+      if (boundaryRoot === null) return;
+
+      // Legal iff the importing file lives within the boundary root subtree.
+      if (importer.startsWith(boundaryRoot + path.sep)) return;
+
+      const name = path.basename(boundaryRoot);
+      context.report({
+        node,
+        message:
+          `'${source}' reaches into '${name}/internal', which is only ` +
+          `importable from within '${name}/'. Import it from a public module ` +
+          `in '${name}', or move this file into that subtree.`,
+      });
+    }
+
+    return {
+      ImportDeclaration: check,
+      ExportNamedDeclaration: check,
+      ExportAllDeclaration: check,
+    };
+  },
+};

--- a/eslint-rules/no-cross-package-internal.test.cjs
+++ b/eslint-rules/no-cross-package-internal.test.cjs
@@ -1,0 +1,110 @@
+const { describe, it } = require("node:test");
+const { RuleTester } = require("eslint");
+const rule = require("./no-cross-package-internal.cjs");
+
+// Wire ESLint's RuleTester into node:test so each case is a subtest.
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+// A package's `src/` root; `@/` resolves here for files under it.
+const SRC = "/repo/js/pkg/src";
+
+ruleTester.run("no-cross-package-internal", rule, {
+  valid: [
+    // Sibling of internal/, relative specifier.
+    {
+      filename: `${SRC}/foo/bar.ts`,
+      code: `import { x } from "./internal/baz";`,
+    },
+    // Sibling of internal/, alias specifier.
+    {
+      filename: `${SRC}/foo/bar.ts`,
+      code: `import { x } from "@/foo/internal/baz";`,
+    },
+    // Nested inside internal/, importing a sibling internal module (alias).
+    {
+      filename: `${SRC}/foo/internal/deep/a.ts`,
+      code: `import { x } from "@/foo/internal/baz";`,
+    },
+    // Deeper descendant of the boundary root (alias) — the design decision:
+    // the whole foo/ subtree is in scope, not just direct siblings.
+    {
+      filename: `${SRC}/foo/other/baz.ts`,
+      code: `import { x } from "@/foo/internal/bar";`,
+    },
+    // Deeper descendant of the boundary root (relative).
+    {
+      filename: `${SRC}/foo/other/baz.ts`,
+      code: `import { x } from "../internal/bar";`,
+    },
+    // Barrel re-export from within the subtree.
+    {
+      filename: `${SRC}/foo/index.ts`,
+      code: `export { x } from "./internal/bar";`,
+    },
+    // Nested internals: innermost internal's parent is the boundary root.
+    {
+      filename: `${SRC}/foo/internal/a/internal/b.ts`,
+      code: `import { x } from "@/foo/internal/a/internal/c";`,
+    },
+    // Non-internal import is never flagged.
+    {
+      filename: `${SRC}/foo/bar.ts`,
+      code: `import { x } from "@/other/baz";`,
+    },
+    // Bare specifiers (npm / workspace packages) are out of scope even when
+    // their path contains an internal/ segment.
+    {
+      filename: `${SRC}/foo/bar.ts`,
+      code: `import x from "some-pkg/internal/thing";`,
+    },
+    // Export with no source clause has nothing to resolve.
+    {
+      filename: `${SRC}/foo/bar.ts`,
+      code: `export const y = 1;`,
+    },
+  ],
+  invalid: [
+    // Sibling directory reaching into foo/internal (alias).
+    {
+      filename: `${SRC}/sibling/x.ts`,
+      code: `import { x } from "@/foo/internal/bar";`,
+      errors: 1,
+    },
+    // Adjacent directory whose name prefixes the boundary root (foo2 vs foo).
+    {
+      filename: `${SRC}/foo2/x.ts`,
+      code: `import { x } from "@/foo/internal/bar";`,
+      errors: 1,
+    },
+    // Outside the subtree via a relative specifier.
+    {
+      filename: `${SRC}/sibling/x.ts`,
+      code: `import { x } from "../foo/internal/bar";`,
+      errors: 1,
+    },
+    // A parent barrel cannot reach into a child's internal (alias).
+    {
+      filename: `${SRC}/lib/index.ts`,
+      code: `import { x } from "@/lib/sub/internal/thing";`,
+      errors: 1,
+    },
+    // Re-export leaking a nested internal from the package barrel above it.
+    {
+      filename: `${SRC}/index.ts`,
+      code: `export * from "./foo/internal/scripts";`,
+      errors: 1,
+    },
+    // Tests get no exemption — mirrors the KAPRO-709 escape a red-team test
+    // used to slip through.
+    {
+      filename: `/repo/js/coding-agents/src/lib/api-keys/api-keys.redteam.test.ts`,
+      code: `import { InMemoryApiKeyDirectory } from "@/lib/workos/internal/api-key-directory";`,
+      errors: 1,
+    },
+  ],
+});

--- a/eslint-rules/package.json
+++ b/eslint-rules/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "eslint-rules",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Local ESLint rules shared across the js/ workspace packages",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "eslint": "^9"
+  }
+}

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -6,3 +6,20 @@ echo "Running pre-commit checks..."
 make fmtcheck
 make vet
 make lint
+
+# JS workspace checks. Gated on staged JS-workspace paths so a Go-only commit
+# does not pay for a pnpm resolution, and so this hook keeps working in a clone
+# where `pnpm install` has not been run.
+#
+# lint-staged (config in .lintstagedrc.mjs) formats staged files with the
+# pinned prettier and runs `lint` + `typecheck` for each touched package. This
+# repo owns that responsibility outright: amika-mono consumes js/sandbox as a
+# git submodule, and a superproject only ever stages a single gitlink entry for
+# a submodule, so it cannot see — let alone lint or format — this source.
+staged_js=$(git diff --cached --name-only --diff-filter=ACMR \
+    -- 'js/' 'eslint-rules/' 'package.json' 'pnpm-workspace.yaml' '.lintstagedrc.mjs')
+
+if [ -n "$staged_js" ]; then
+    echo "Running JS checks..."
+    pnpm dlx lint-staged --relative
+fi

--- a/js/AGENTS.md
+++ b/js/AGENTS.md
@@ -1,0 +1,219 @@
+# JS Workspace Conventions
+
+Conventions that apply to every package under `js/`. Package-specific
+guidance lives in each package's own `AGENTS.md`.
+
+These conventions are shared with `amika-mono`, Amika's private control-plane
+monorepo, which consumes `js/sandbox` from this repo as a git submodule. Keep
+the two copies of this file in agreement: a convention that drifts here will
+surface as a review disagreement when a change flows back into amika-mono.
+Where a rule below cites an example that lives only in amika-mono, it is
+labelled as such — look for `amika-mono` checked out as a sibling worktree
+rather than searching for that path in this repo.
+
+## Exhaustive branching over union types
+
+When branching on a closed union (a Zod enum's inferred type, a
+discriminated union's tag, a string-literal union), use branching that lets
+TypeScript catch unhandled union members. This can be a `switch` with a case
+per member and a `default` that calls an `assertNever`-style helper taking
+`never`:
+
+```ts
+function assertNever(value: never): never {
+  throw new Error(`Unhandled case: ${String(value)}`);
+}
+
+switch (mode) {
+  case "pat":
+    // ...
+    break;
+  case "app_token":
+    // ...
+    break;
+  default:
+    assertNever(mode);
+}
+```
+
+An exhaustive `if` / `else if` / `else` chain is also fine as long as the
+final `else` assigns the checked value to `never` or passes it to an
+`assertNever`-style helper:
+
+```ts
+if (mode === "pat") {
+  // ...
+} else if (mode === "app_token") {
+  // ...
+} else {
+  assertNever(mode);
+}
+```
+
+Adding a member to the union then breaks compilation at every branch that
+lacks a case, instead of silently falling through a non-exhaustive fallback.
+
+## `*Parsed` types
+
+When an outer layer accepts input in one shape and an inner layer parses it
+into a stronger, further-validated shape, suffix the inner type with `Parsed`
+(e.g. `FooParsed`). Reserve this for parsing that goes beyond what the
+boundary's own schema/validator already guarantees; don't apply it to every
+validated type.
+
+A Zod schema that fully validates its input is not a parse step, so don't
+suffix schemas or their inferred types with `Parsed`. Use `*Parsed` only when
+an inner layer narrows further than the schema can express, using context the
+schema can't see.
+
+## Prefer Zod over hand-rolled object parsing
+
+When validating or narrowing data whose shape the type system does not already
+guarantee (third-party API responses, request bodies, `unknown` values,
+env-derived JSON), define a Zod schema and use `safeParse` / `parse` rather than
+hand-rolled `typeof` / `in` / property checks. One schema declares the accepted
+shape, fails closed on anything unexpected, and yields a typed result, so the
+narrowing does not drift from the type. Reserve manual narrowing for the rare
+case a schema cannot express (see `*Parsed` types above).
+
+## Static imports only
+
+Import every module statically at the top of the file. Do not use an
+`import(...)` expression to defer or conditionally pull in a module, and do not
+use one in a type position: write `import type { T } from "./module"` at the
+top rather than `type T = import("./module").T`. Dynamic and inline imports
+hide dependencies from the module graph and are usually a workaround for a
+dependency that shouldn't be reached from that module in the first place. If a
+heavy or environment-specific dependency is a problem, inject it (pass it in)
+or split the module so consumers don't pull it in, rather than deferring the
+import.
+
+Some cases genuinely require an `import(...)` expression. These are allowed,
+and the list is illustrative rather than a complete inventory of what is in the
+tree today:
+
+- Code splitting through `next/dynamic` or `React.lazy`, which take a loader
+  function by construction.
+- `typeof import("...")` inside a Vitest `importOriginal<T>()` generic, which
+  has no top-level `import type` equivalent that keeps the call typed.
+- `await import("./module")` after a `vi.mock(...)` call, where the mock must
+  be hoisted above the import to take effect.
+
+This rule is documentation, not lint-enforced; prefer a static import whenever
+one of the three cases above does not apply.
+
+## Module organization
+
+Helpers used only within a package go under an `internal/` subdirectory. The
+`no-cross-package-internal` lint rule (shipped from the repo-root
+`eslint-rules/`) forbids a relative import that reaches into **another**
+package's `internal/` directory, and tells you to import from that package's
+public entry point instead. Imports of your own package's `internal/` files are
+allowed; only cross-package reaches are flagged.
+
+Every `js/*` package wires the rule the same way, in its `eslint.config.mjs`:
+
+```js
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const localRules = require("../../eslint-rules/index.cjs");
+
+// ...inside the config array:
+{
+  plugins: { local: localRules },
+  rules: {
+    "local/no-cross-package-internal": "error",
+  },
+}
+```
+
+When adding a package, copy an existing `eslint.config.mjs` so this block comes
+along — do not hand-write a config that omits it.
+
+## Package scripts & CI
+
+Every package under `js/` must expose a uniform script surface and a matching
+`check-<package>` job in `.github/workflows/ci.yml` that runs them in order:
+Format check → Typecheck → Lint → Test → Build (Build only where the package
+emits an artifact).
+
+| Script        | Command              | Notes                                                 |
+| ------------- | -------------------- | ----------------------------------------------------- |
+| `lint`        | `eslint .`           | Real ESLint, not a `tsc` stand-in.                    |
+| `typecheck`   | `tsc --noEmit`       |                                                       |
+| `test`        | `vitest run`         | Use `vitest run --passWithNoTests` until tests exist. |
+| `format`      | `prettier --write .` | Writes fixes.                                         |
+| `formatcheck` | `prettier --check .` | The check CI runs.                                    |
+| `build`       | `tsc` / etc.         | **Only if the package emits an artifact.**            |
+
+A `tsc` invocation with `noEmit` is a typecheck, not a build; do not dress it
+up as a `build` script or a CI Build step. `js/sandbox` is consumed as
+TypeScript source by its downstream consumers, so it has no `build` script.
+
+Prettier runs with defaults — there is no repository prettier config file.
+Every package invokes the **workspace** prettier (`prettier --check .` /
+`prettier --write .`), never `pnpm dlx prettier` (which floats to the latest
+published version and drifts from what CI checks). Prettier is pinned to a
+single version across the workspace (one entry in `pnpm-lock.yaml`), and the
+pre-commit hook (`.lintstagedrc.mjs`) runs that same version — otherwise
+hook-written formatting would fail CI's `formatcheck`. When bumping prettier,
+bump every package's devDependency and the hook's pinned version **in both this
+repo and amika-mono**, whose hook carries the same pin.
+
+`.lintstagedrc.mjs` matches packages by the `PACKAGE_BY_PREFIX` map
+(`js/<dir>/` → package name). **When you add a package under `js/`, register it
+there** in addition to adding its CI job — otherwise a commit touching only
+that package skips the hook's lint and typecheck.
+
+## Dependency versions
+
+The lint/format/test toolchain is pinned to the same versions across packages
+(no pnpm catalog). When adding tooling to a package, match what `js/sandbox`
+already uses:
+
+```
+@eslint/js         ^9.39.2
+eslint             ^9
+typescript-eslint  ^8.55.0
+globals            ^16.4.0
+prettier           3.8.3     (exact — see below)
+vitest             4.1.0
+```
+
+`prettier` is pinned to an **exact** version rather than a caret range. This
+repo and amika-mono resolve their own lockfiles independently, so a range lets
+the two pick different patch versions of prettier — and prettier's output does
+change across minor versions. When that happened during the submodule
+migration, `js/sandbox` formatted clean under 3.8.3 and dirty under 3.9.6 on
+byte-identical source. An exact pin is what keeps `formatcheck` agreeing across
+both repos and both pre-commit hooks. Bump it in all four places at once:
+this manifest, this table, and each repo's `.lintstagedrc.mjs`.
+
+## Testing
+
+We use [vitest](https://vitest.dev/) in every package that has tests. Each
+package keeps its own config so it can pick the right environment (`node` for
+server-only logic, `jsdom` for client/React code) and wire up its own aliases
+and setup files.
+
+| Suffix                  | What it is                | Picked up by               |
+| ----------------------- | ------------------------- | -------------------------- |
+| `*.test.ts`             | Runtime unit test         | `pnpm test`                |
+| `*.integration.test.ts` | Runtime integration test  | `pnpm test:integration`    |
+| `*.test-d.ts`           | Type-level assertion file | `pnpm run typecheck` (tsc) |
+
+Unit configs exclude `*.integration.test.ts` so slow or externally-dependent
+tests don't run by accident. The default vitest include glob
+(`**/*.{test,spec}.?(c|m)[jt]s?(x)`) intentionally does not match `.test-d.ts`
+— the dash before `d` puts it outside the pattern.
+
+Prefer dependency injection over module mocks: pass collaborators in as
+arguments so a test can supply a fake, rather than reaching for `vi.mock`.
+
+## Workspace layout
+
+`sdk/typescript` (`@amika/sdk`) is deliberately **not** a member of this
+workspace. It is a self-contained pnpm workspace with its own
+`pnpm-workspace.yaml`, `pnpm-lock.yaml`, and `packageManager` pin, and its CI
+and npm publish workflows install from that lockfile. Run its commands from
+`sdk/typescript/`, not from the repo root.

--- a/js/sandbox/.gitignore
+++ b/js/sandbox/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tsbuildinfo

--- a/js/sandbox/eslint.config.mjs
+++ b/js/sandbox/eslint.config.mjs
@@ -1,0 +1,43 @@
+import { createRequire } from "node:module";
+import js from "@eslint/js";
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+const require = createRequire(import.meta.url);
+const localRules = require("../../eslint-rules/index.cjs");
+
+const eslintConfig = defineConfig([
+  {
+    ignores: ["node_modules/**", "dist/**"],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  {
+    plugins: { local: localRules },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
+      "local/no-cross-package-internal": "error",
+    },
+  },
+]);
+
+export default eslintConfig;

--- a/js/sandbox/package.json
+++ b/js/sandbox/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@amika/sandbox",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./client": "./src/client.ts",
+    "./config-env": "./src/config-from-env.ts"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "formatcheck": "prettier --check .",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@daytona/api-client": "^0.193.0",
+    "@daytonaio/sdk": "^0.193.0",
+    "@vercel/sandbox": "^2.2.1",
+    "freestyle": "^0.1.63",
+    "p-retry": "^7.1.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.2",
+    "@types/node": "^22",
+    "eslint": "^9",
+    "globals": "^16.4.0",
+    "pino": "^10.3.1",
+    "prettier": "3.8.3",
+    "typescript": "^5",
+    "typescript-eslint": "^8.55.0",
+    "vite": "7.3.5",
+    "vitest": "4.1.0"
+  }
+}

--- a/js/sandbox/src/client.ts
+++ b/js/sandbox/src/client.ts
@@ -1,0 +1,34 @@
+/**
+ * Client-safe entry (`@amika/sandbox/client`).
+ *
+ * The only surface a browser bundle may import: pure metadata + sizing helpers
+ * and value lists, with NO provider SDK, `node:` built-in, or `server-only`
+ * dependency in its module graph. React components and any other
+ * client-reachable module must import from here, never from the `.` barrel
+ * (which pulls in the provider SDKs).
+ */
+export * from "./providers/capabilities";
+export {
+  freestyleSizingForSize,
+  type FreestyleSizing,
+} from "./providers/freestyle/sizing";
+export {
+  vercelSizingForSize,
+  vercelVcpusForSize,
+  type VercelSizing,
+} from "./providers/vercel/sizing";
+// Pure Freestyle naming helpers (no SDK): reachable from client- and
+// edge-runtime code, so they must come through this SDK-free entry rather than
+// the root barrel.
+export {
+  buildFreestyleSnapshotName,
+  buildFreestyleVmName,
+  freestyleVmNameOrgId,
+  freestyleVmBelongsToOrg,
+} from "./providers/freestyle/naming";
+export * from "./enums";
+// On-box runtime constants (reserved ports, lifecycle script paths, ownership
+// labels, size specs) are plain values with no SDK/`node:` dependency, so
+// client- and edge-reachable code can re-export them from here as the single
+// source of truth for these on-box contracts.
+export * from "./constants";

--- a/js/sandbox/src/config-from-env.test.ts
+++ b/js/sandbox/src/config-from-env.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { sandboxProviderConfigsFromEnv } from "./config-from-env";
+
+const BASE = { DAYTONA_API_KEY: "dk" };
+
+describe("sandboxProviderConfigsFromEnv", () => {
+  it("builds the Daytona slice with defaults and leaves the others null", () => {
+    const { daytona, freestyle, vercel } = sandboxProviderConfigsFromEnv(BASE);
+    expect(daytona).toEqual({
+      apiKey: "dk",
+      apiUrl: "https://app.daytona.io/api",
+      target: undefined,
+      organizationId: undefined,
+      useVm: false,
+    });
+    expect(freestyle).toBeNull();
+    expect(vercel).toBeNull();
+  });
+
+  it("throws when the required Daytona key is missing", () => {
+    expect(() => sandboxProviderConfigsFromEnv({})).toThrow(/DAYTONA_API_KEY/);
+  });
+
+  it("reads Daytona overrides and lenient ENABLE_DAYTONA_VM", () => {
+    const { daytona } = sandboxProviderConfigsFromEnv({
+      ...BASE,
+      DAYTONA_API_URL: "https://custom",
+      DAYTONA_TARGET: "eu",
+      DAYTONA_ORGANIZATION_ID: "org_1",
+      ENABLE_DAYTONA_VM: "on", // lenient token
+    });
+    expect(daytona).toMatchObject({
+      apiUrl: "https://custom",
+      target: "eu",
+      organizationId: "org_1",
+      useVm: true,
+    });
+  });
+
+  it("gates Freestyle on FREESTYLE_ENABLED=true and toggles snapshotPersistence", () => {
+    expect(
+      sandboxProviderConfigsFromEnv({ ...BASE, FREESTYLE_ENABLED: "1" })
+        .freestyle,
+    ).toBeNull(); // strict: only exactly "true" enables
+
+    const on = sandboxProviderConfigsFromEnv({
+      ...BASE,
+      FREESTYLE_ENABLED: "true",
+      FREESTYLE_API_KEY: "fk",
+      FREESTYLE_STAGING_SNAPSHOTS: "true",
+    }).freestyle;
+    expect(on).toEqual({
+      apiKey: "fk",
+      apiUrl: undefined,
+      snapshotPersistence: "sticky",
+    });
+
+    const persistent = sandboxProviderConfigsFromEnv({
+      ...BASE,
+      FREESTYLE_ENABLED: "true",
+      FREESTYLE_API_KEY: "fk",
+    }).freestyle;
+    expect(persistent?.snapshotPersistence).toBe("persistent");
+  });
+
+  it("gates Vercel on VERCEL_ENABLED=true and requires its credentials", () => {
+    // Enabled but missing credentials → throws for the first missing var.
+    expect(() =>
+      sandboxProviderConfigsFromEnv({ ...BASE, VERCEL_ENABLED: "true" }),
+    ).toThrow(/VERCEL_TOKEN/);
+
+    const vercel = sandboxProviderConfigsFromEnv({
+      ...BASE,
+      VERCEL_ENABLED: "true",
+      VERCEL_TOKEN: "vt",
+      VERCEL_TEAM_ID: "team",
+      VERCEL_PROJECT_ID: "proj",
+    }).vercel;
+    expect(vercel).toEqual({ apiKey: "vt", teamId: "team", projectId: "proj" });
+  });
+});

--- a/js/sandbox/src/config-from-env.ts
+++ b/js/sandbox/src/config-from-env.ts
@@ -1,0 +1,101 @@
+/**
+ * Build the per-provider config slices from environment variables.
+ *
+ * The single source of the sandbox provider ENV-VAR CONTRACT
+ * (`DAYTONA_API_KEY`, `FREESTYLE_ENABLED`, `VERCEL_TOKEN`, …). The server
+ * callers each used to hand-parse the identical set of vars into
+ * `{ daytona, freestyle, vercel }`;
+ * they now share this so the credential/enable contract lives in one place and
+ * the two can't drift.
+ *
+ * DELIBERATE EXCEPTION: unlike the rest of `@amika/sandbox` — which takes
+ * explicit config and carries no dependency on the caller's environment — this
+ * module reads specific env-var *names*. That's the trade for a single,
+ * non-duplicated contract. It reads secrets (server-only) so it is NOT in the
+ * browser-safe `./client` entry; but it is itself SDK-free (only type-only
+ * config imports), so it is also exposed as its own `@amika/sandbox/config-env`
+ * entry for server code that must stay SDK-free (e.g. modules reachable from the
+ * Next middleware). Provider construction still takes explicit config via the
+ * registry; this is an opt-in convenience for building it.
+ */
+import type { DaytonaConfig } from "./providers/daytona/config";
+import type { FreestyleConfig } from "./providers/freestyle/config";
+import type { VercelConfig } from "./providers/vercel/config";
+
+/** The three provider config slices a caller supplies to the registry. */
+export interface SandboxProviderConfigs {
+  daytona: DaytonaConfig;
+  freestyle: FreestyleConfig | null;
+  vercel: VercelConfig | null;
+}
+
+type Env = Record<string, string | undefined>;
+
+const DEFAULT_DAYTONA_API_URL = "https://app.daytona.io/api";
+const TRUE_TOKENS = new Set(["1", "true", "on"]);
+const FALSE_TOKENS = new Set(["0", "false", "off"]);
+
+/** Lenient env boolean: `1`/`true`/`on` → true, `0`/`false`/`off` → false. */
+function parseBooleanLike(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return false;
+  if (TRUE_TOKENS.has(normalized)) return true;
+  if (FALSE_TOKENS.has(normalized)) return false;
+  return false;
+}
+
+/** Strict enable flag: exactly `true` (case/space-insensitive) enables. */
+function isEnabled(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
+function required(env: Env, name: string): string {
+  const value = env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+/**
+ * Read the provider config slices from `env` (defaults to `process.env`).
+ *
+ * Daytona is always configured (the baseline provider). Freestyle/Vercel are
+ * gated on `FREESTYLE_ENABLED` / `VERCEL_ENABLED` being exactly `true` and are
+ * `null` otherwise. `ENABLE_DAYTONA_VM` (lenient `1`/`true`/`on`) sets
+ * `daytona.useVm`; `FREESTYLE_STAGING_SNAPSHOTS` toggles Freestyle's
+ * `snapshotPersistence` between `sticky` and `persistent`. Throws if a required
+ * credential for an enabled provider is missing.
+ */
+export function sandboxProviderConfigsFromEnv(
+  env: Env = process.env,
+): SandboxProviderConfigs {
+  const daytona: DaytonaConfig = {
+    apiKey: required(env, "DAYTONA_API_KEY"),
+    apiUrl: env.DAYTONA_API_URL ?? DEFAULT_DAYTONA_API_URL,
+    target: env.DAYTONA_TARGET,
+    organizationId: env.DAYTONA_ORGANIZATION_ID,
+    // Opt-in: run Daytona resources as VMs (`linux-vm`) rather than containers.
+    useVm: parseBooleanLike(env.ENABLE_DAYTONA_VM),
+  };
+
+  const freestyle: FreestyleConfig | null = isEnabled(env.FREESTYLE_ENABLED)
+    ? {
+        apiKey: required(env, "FREESTYLE_API_KEY"),
+        apiUrl: env.FREESTYLE_API_URL,
+        snapshotPersistence: isEnabled(env.FREESTYLE_STAGING_SNAPSHOTS)
+          ? "sticky"
+          : "persistent",
+      }
+    : null;
+
+  const vercel: VercelConfig | null = isEnabled(env.VERCEL_ENABLED)
+    ? {
+        apiKey: required(env, "VERCEL_TOKEN"),
+        teamId: required(env, "VERCEL_TEAM_ID"),
+        projectId: required(env, "VERCEL_PROJECT_ID"),
+      }
+    : null;
+
+  return { daytona, freestyle, vercel };
+}

--- a/js/sandbox/src/config.ts
+++ b/js/sandbox/src/config.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared base shape for provider configuration slices.
+ *
+ * Owned by the provider package so it carries no dependency on the caller's
+ * environment. Each provider defines its own config in its provider folder,
+ * extending this base; the caller constructs the values and the provider
+ * factory (`registry`) receives a single slice per provider.
+ */
+
+/**
+ * The shape every provider config shares. `apiKey` is the provider's auth
+ * secret (a Daytona/Freestyle API key, a Vercel access token); `apiUrl`
+ * overrides the SDK's default API host (omitted uses the SDK default).
+ * Providers that require one of these re-declare it as non-optional in their
+ * own config interface.
+ */
+export interface SandboxConfigBase {
+  apiKey?: string;
+  apiUrl?: string;
+}

--- a/js/sandbox/src/constants.ts
+++ b/js/sandbox/src/constants.ts
@@ -1,0 +1,80 @@
+/**
+ * Sandbox-runtime constants the provider layer stamps into VMs and reads back:
+ * reserved ports, lifecycle script paths, the amikad etc dir, provider ownership
+ * labels, and size specs. Owned here so the provider package is self-contained
+ * and callers can re-export them from the SDK-free `@amika/sandbox/client` entry
+ * as one source of truth for these on-box contracts.
+ */
+
+/** Default port the OpenCode web server listens on inside a sandbox. */
+export const DEFAULT_OPENCODE_PORT = 60998;
+
+/**
+ * Auto-delete interval when a sandbox is stopped.
+ *  -1 = never auto-delete (preserve stopped sandboxes)
+ *   0 = delete immediately on stop
+ *  >0 = delete after N minutes of being stopped
+ */
+export const SANDBOX_DELETE_INTERVAL_KEEP_ON_STOP = -1;
+
+export const SANDBOX_SETUP_SCRIPT = "/usr/local/etc/amikad/setup/setup.sh";
+export const SANDBOX_START_SCRIPT = "/usr/local/etc/amikad/setup/start.sh";
+export const PRE_SETUP_SCRIPT = "/usr/lib/amikad/pre-setup.sh";
+export const POST_SETUP_SCRIPT = "/usr/lib/amikad/post-setup.sh";
+export const RUN_HOOK_SCRIPT = "/usr/lib/amikad/run-hook.sh";
+export const AMIKAD_ETC_DIR = "/usr/local/etc/amikad";
+
+// Daytona exposes `/etc` for system-managed files, but we do not have a
+// supported way to add our own durable files there, so custom state lives
+// under `/usr/local/etc/amikad`.
+export const SERVICE_ENV_VARS_PATH = `${AMIKAD_ETC_DIR}/service-env-vars.json`;
+
+/**
+ * Spool directory for backgrounded agent-send jobs (stdout + exit-code files).
+ * Written by whichever unprivileged user runs the launch (`amika`), so it is
+ * provisioned world-writable + sticky to tolerate a sandbox whose dir was
+ * created by an earlier root-run launch.
+ */
+export const AGENT_JOBS_DIR = "/tmp/amika-jobs";
+
+/** No-op user lifecycle scripts, installed as defaults / when resetting hooks. */
+export const DEFAULT_SETUP_SCRIPT = "#!/bin/bash\nexit 0\n";
+export const DEFAULT_START_SCRIPT = "#!/bin/bash\nexit 0\n";
+
+/**
+ * Label stamped on sandboxes created with secrets kept OUT of the container env
+ * (delivered via `/etc/environment` + credential files instead). Sandboxes
+ * missing this label may have secrets baked into their container spec, which a
+ * snapshot cannot scrub — so "snapshot and delete" is refused for them.
+ */
+export const SANDBOX_ENV_SECRETS_EXCLUDED_LABEL = "amika-env-secrets-excluded";
+export const SANDBOX_ENV_SECRETS_EXCLUDED_VALUE = "1";
+
+/**
+ * Provider-resource labels stamping a sandbox with the org and user that own
+ * it. Daytona attaches these as native sandbox labels; providers without a
+ * label facet (e.g. Freestyle) fold the org id into the resource name instead.
+ * The stored `org_id` remains the security boundary — these are the
+ * provider-side ownership stamp.
+ */
+export const SANDBOX_ORG_ID_LABEL = "amika-org-id";
+export const SANDBOX_USER_ID_LABEL = "amika-user-id";
+
+export const DEFAULT_HOME_DIR = "/home/amika";
+
+export interface SandboxSizeSpec {
+  label: string;
+  vcpus: number;
+  memoryGb: number;
+  diskGb: number;
+}
+
+export const SANDBOX_SIZE_SPECS: Record<
+  "xs" | "m" | "l" | "xl",
+  SandboxSizeSpec
+> = {
+  xs: { label: "XS (Extra Small)", vcpus: 1, memoryGb: 1, diskGb: 3 },
+  m: { label: "M (Medium)", vcpus: 2, memoryGb: 8, diskGb: 10 },
+  l: { label: "L (Large)", vcpus: 2, memoryGb: 12, diskGb: 24 },
+  xl: { label: "XL (Extra Large)", vcpus: 4, memoryGb: 16, diskGb: 32 },
+};

--- a/js/sandbox/src/enums.ts
+++ b/js/sandbox/src/enums.ts
@@ -1,0 +1,14 @@
+/**
+ * Small provider-facing enums. The package owns the canonical value lists so
+ * consumers can build their validation schemas from these and the literal sets
+ * can't drift between the validation layer and the provider API.
+ */
+
+export const SANDBOX_PRESET_VALUES = ["coder", "coder-dind"] as const;
+export type SandboxPreset = (typeof SANDBOX_PRESET_VALUES)[number];
+
+export const SANDBOX_SIZE_VALUES = ["xs", "m", "l", "xl"] as const;
+export type SandboxSize = (typeof SANDBOX_SIZE_VALUES)[number];
+
+export const GITHUB_AUTH_MODE_VALUES = ["pat", "app_token"] as const;
+export type GithubAuthMode = (typeof GITHUB_AUTH_MODE_VALUES)[number];

--- a/js/sandbox/src/index.ts
+++ b/js/sandbox/src/index.ts
@@ -1,0 +1,91 @@
+/**
+ * `@amika/sandbox` — the sandbox provisioner.
+ *
+ * Server entry (the `.` export). The single contract is {@link SandboxProvider}
+ * (create / start / stop / delete / exec / ssh, plus the optional log-streaming,
+ * snapshot, and docker-registry capabilities gated by `capabilities`). Resolve a
+ * provider with {@link createSandboxProvider}.
+ *
+ * Client components must import capability/label helpers from
+ * `@amika/sandbox/capabilities` (SDK-free) rather than this barrel.
+ */
+
+// Core contract: interfaces, error classes, input/result types, the
+// SnapshotIdResolver port, and the re-exported SandboxProviderName /
+// SandboxService.
+export * from "./providers/provider";
+// Provider factory + deps + name guard.
+export * from "./providers/registry";
+// Capability flags + display helpers (also the client-safe `./capabilities` entry).
+export * from "./providers/capabilities";
+
+// Two-track lifecycle status.
+export {
+  SANDBOX_STATUS_VALUES,
+  SANDBOX_SETUP_STATUS_VALUES,
+  parseSandboxSetupStatus,
+  isSetupInProgress,
+  deriveSandboxStatus,
+  type SandboxStatus,
+  type SandboxSetupStatus,
+} from "./sandbox-status";
+
+// Config: the shared base plus each provider's own config slice (defined in its
+// provider folder), enums, shared provider types (names + service shapes),
+// on-box constants, logging contract.
+export * from "./config";
+export type { DaytonaConfig } from "./providers/daytona/config";
+export type { FreestyleConfig } from "./providers/freestyle/config";
+export type { VercelConfig } from "./providers/vercel/config";
+// Server-only env → config-slice factory (the single provider env-var contract).
+export {
+  sandboxProviderConfigsFromEnv,
+  type SandboxProviderConfigs,
+} from "./config-from-env";
+export * from "./enums";
+export * from "./types";
+export * from "./constants";
+export * from "./logger";
+
+// Deep helpers consumed by the control plane (provider sizing, Freestyle
+// naming, the adapter port + fake, github-auth script builders).
+export {
+  freestyleSizingForSize,
+  type FreestyleSizing,
+} from "./providers/freestyle/sizing";
+export {
+  vercelSizingForSize,
+  vercelVcpusForSize,
+  type VercelSizing,
+} from "./providers/vercel/sizing";
+export {
+  buildFreestyleSnapshotName,
+  buildFreestyleVmName,
+  freestyleVmNameOrgId,
+  freestyleVmBelongsToOrg,
+} from "./providers/freestyle/naming";
+export {
+  execChecked,
+  execFailureText,
+  type SandboxAdapter,
+  type ExecOptions,
+  type ExecResult,
+} from "./providers/shared/adapter";
+
+// Provisioning seam: the generic mechanics the lifecycle flows drive the
+// sandbox through. Exported here so callers can import them from the barrel
+// without a reverse (circular) dependency on core internals.
+export {
+  getWorkspaceDir,
+  getRepoDir,
+} from "./providers/shared/adapter-helpers";
+export { buildLifecycleCommands } from "./providers/shared/lifecycle-commands";
+export { EXEC_INPUT_STAGING_ROOT } from "./providers/shared/exec-input";
+export { shellQuote } from "./util/shell";
+export {
+  buildGitCheckoutNewBranchCmd,
+  buildGitSetPlainRemoteCmd,
+  buildRefreshClonedRepoScript,
+  checkBranchExistsOnRemote,
+} from "./util/git-clone";
+export { getRepoNameFromGithubUrl } from "./util/github";

--- a/js/sandbox/src/logger.ts
+++ b/js/sandbox/src/logger.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal logging + context contract the provider layer codes against.
+ *
+ * The package does not depend on any caller-side context class or on `pino`
+ * directly; it defines the small structural surface the providers actually use
+ * (`ctx.logger` + `ctx.childCtx`). Any context object with a `pino`-style
+ * logger satisfies {@link SandboxCtx} structurally, so callers pass their
+ * existing context unchanged.
+ */
+
+/** The subset of a structured logger (e.g. `pino.Logger`) the providers use. */
+export interface Logger {
+  info(obj: object, msg?: string): void;
+  info(msg: string): void;
+  warn(obj: object, msg?: string): void;
+  warn(msg: string): void;
+  error(obj: object, msg?: string): void;
+  error(msg: string): void;
+  debug(obj: object, msg?: string): void;
+  debug(msg: string): void;
+  child(bindings: Record<string, unknown>): Logger;
+}
+
+/** Provider-facing request context: a logger plus child-context derivation. */
+export interface SandboxCtx {
+  readonly logger: Logger;
+  childCtx(bindings: Record<string, unknown>): SandboxCtx;
+}
+
+/**
+ * A minimal console-backed {@link Logger}, for the few module-scoped call sites
+ * that log outside a request context (e.g. best-effort SSH bridge warnings).
+ * Real structured logging flows in through `SandboxCtx.logger`; this is a
+ * dependency-free fallback so the package needs no logging library.
+ */
+export function moduleLogger(bindings: Record<string, unknown> = {}): Logger {
+  const emit =
+    (level: "info" | "warn" | "error" | "debug") =>
+    (objOrMsg: object | string, msg?: string) => {
+      const [obj, message] =
+        typeof objOrMsg === "string" ? [{}, objOrMsg] : [objOrMsg, msg];
+      console[level]({ ...bindings, ...obj }, message ?? "");
+    };
+  return {
+    info: emit("info"),
+    warn: emit("warn"),
+    error: emit("error"),
+    debug: emit("debug"),
+    child: (childBindings) => moduleLogger({ ...bindings, ...childBindings }),
+  };
+}

--- a/js/sandbox/src/providers/README.md
+++ b/js/sandbox/src/providers/README.md
@@ -1,0 +1,172 @@
+# Sandbox providers
+
+A **provider** plugs a sandbox vendor's SDK into the package's provider
+contract (`provider.ts`). Everything provider-agnostic — the resource-object
+synthesis, the adapter port, the shared scrub orchestration — lives in
+`shared/`; a provider folder contains only vendor-specific code. (Repo cloning
+is provisioning orchestration, not a provider concern, so it lives in
+`@amika/sandbox-provisioning`.)
+
+## Layout
+
+| Path              | Role                                                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------------- |
+| `provider.ts`     | The contract: capability interfaces, input/result types, error classes                                  |
+| `registry.ts`     | Name → provider table (`PROVIDERS`); `createSandboxProvider` / `getSandboxAdapter`                      |
+| `capabilities.ts` | Client-safe aggregation of every provider's capability flags + display info                             |
+| `shared/`         | Provider-agnostic framework: `define-provider`, `resources`, the `SandboxAdapter` port, `scrub-exec`, … |
+| `daytona/` etc.   | One folder per provider                                                                                 |
+
+### Provider folder layout
+
+A provider folder root holds its **public entries**; everything that touches
+the vendor SDK lives in `internal/`, which the `local/no-cross-package-internal`
+lint rule makes unreachable from outside the folder. There are three public
+entries:
+
+- `provider.ts` — the SDK-bearing definition. The registry imports the provider
+  factory from here, plus (when the provider has one) the re-exported
+  `openAcmeAdapter`.
+- `config.ts` — the **top-level config slice** the caller constructs. Kept at
+  the root (not in `internal/`, not routed through `provider.ts`) so the
+  registry and the package barrels import the config type straight from it,
+  independent of the SDK-bearing `provider.ts`. It is **SDK-free** — a plain
+  interface extending `SandboxConfigBase` — so importing it pulls in no vendor
+  SDK.
+- `capabilities.ts` — SDK-free capability flags, plus `sizing.ts` / `naming.ts`
+  when a provider has them. These are re-exported from the package's `./client`
+  entry (`src/client.ts`) and imported by browser code, so they must never reach
+  a vendor SDK: routing them through `provider.ts` would pull the SDK into the
+  browser bundle, and moving them into `internal/` would put them out of the
+  client entry's reach.
+
+The fully grown Daytona provider shows the split; other providers additionally
+keep `sizing.ts` (Vercel, Freestyle) and `naming.ts` (Freestyle) at the root:
+
+```
+daytona/
+  provider.ts        # public entry: definition + adapter re-exports
+  config.ts          # SDK-free config slice (read by registry + barrels)
+  capabilities.ts    # SDK-free capability flags (read by ./client)
+  internal/          # unreachable from outside daytona/ (lint-enforced)
+    operations.ts  adapter.ts  client.ts  commands.ts
+    configure.ts  docker-registry.ts  snapshot-operations.ts
+    types.ts  vm.ts
+    *.test.ts        # tests colocate with the module they cover
+```
+
+## Adding a provider ("acme")
+
+1. **Create `acme/`** with:
+   - `config.ts` — the config slice the caller constructs, at the folder root
+     (a top-level public entry: the registry and the package barrels import the
+     config type straight from it, so it must not live in `internal/`). It stays
+     SDK-free — a plain interface — so importing it pulls in no acme SDK:
+
+     ```ts
+     import type { SandboxConfigBase } from "../../config";
+
+     export interface AcmeConfig extends SandboxConfigBase {
+       apiKey: string;
+     }
+     ```
+
+   - `capabilities.ts` — SDK-free capability flags, at the folder root (kept
+     separate so client bundles can read them without importing the acme SDK):
+
+     ```ts
+     import type { SandboxProviderCapabilities } from "../provider";
+
+     export const acmeCapabilities: SandboxProviderCapabilities = {
+       lifecycle: true,
+       ssh: false,
+       services: false,
+       exec: true,
+       listSandboxes: false,
+       streaming: false,
+       snapshots: false,
+       fullSnapshotCapture: false,
+       scrubCapture: false,
+       dockerRegistries: false,
+       skipStartScript: false,
+       snapshotIdsAreOpaque: false,
+       supportsAutoDelete: false,
+     };
+     ```
+
+   - `provider.ts` — the definition, at the folder root. Import the SDK, plug
+     its calls into the capability namespaces, and omit what acme doesn't
+     support. The config type is imported from the sibling `config.ts`; the
+     registry imports it from there too, so `provider.ts` re-exports only
+     `openAcmeAdapter` (if the provider has one):
+
+     ```ts
+     import { Acme } from "acme-sdk";
+     import type { AcmeConfig } from "./config";
+     import { defineProvider } from "../shared/define-provider";
+     import { acmeCapabilities } from "./capabilities";
+
+     export default defineProvider(acmeCapabilities, (config: AcmeConfig) => {
+       const acme = new Acme({ apiKey: config.apiKey });
+       return {
+         name: "acme",
+         signedUrlTtlSeconds: 3600,
+         userHomeDir: "/home/amika", // per-provider constant, surfaced as provider.userHomeDir
+         sandbox: {
+           create: async (ctx, input) => ({
+             provider: "acme",
+             providerSandboxId: (await acme.create(input.name)).id,
+             providerUrl: null,
+             services: input.services,
+           }),
+           delete: (id) => acme.delete(id),
+           // Run-state control (start/stop/getState/mapState): omit the whole
+           // group → create/delete-only, capabilities.lifecycle false.
+           start: (id) => acme.start(id),
+           stop: (id) => acme.stop(id),
+           getState: async (id) => (await acme.get(id)).state,
+           mapState: (raw) => (raw === "running" ? "running" : "unknown"),
+         },
+         exec: { run: (id, command, opts) => acme.exec(id, command, opts) },
+         // omit ssh / services / listing / snapshots / dockerRegistries →
+         // they resolve as unsupported and the flags above must say false.
+       };
+     });
+     ```
+
+     `defineProvider` fills the rest: omitted namespaces become `null`,
+     `exec.streaming` derives from whether `stream` is present, snapshot
+     defaults cover `createImageSnapshot`/`findSnapshot`/`removeInjectedSecrets`,
+     and the flags are checked against the definition at construction — a flag
+     that disagrees with the implementation throws immediately.
+
+     Keep trivial calls inline like above; grow an `internal/operations.ts` when
+     real logic accumulates (see `daytona/` for the fully grown shape).
+
+   - If the provisioning lifecycle should run on acme sandboxes (`lifecycle:
+true`), implement the `SandboxAdapter` port (`shared/adapter.ts`: exec,
+     file read/write, home dir) in `internal/adapter.ts`, expose it as
+     `openAcmeAdapter`, and re-export that from `provider.ts` too, so the
+     registry's `openAdapter` can reach it. You do **not** implement cloning:
+     the provisioning layer clones over the adapter's exec port. Only add a
+     `cloneRepo` override (surfaced as the optional `Sandbox.git`) if acme's SDK
+     has a first-class clone primitive worth preferring over shell `git`.
+
+2. **Register it** (each is one small edit; the type system walks you through):
+   - `src/types.ts` — add `"acme"` to the `SandboxProviderName` union
+   - `registry.ts` — add `acme: AcmeConfig | null` to the
+     `SandboxProviderDeps` interface (import `AcmeConfig` from `./acme/config`),
+     and the `acme` entry to `PROVIDERS` with `create` + `openAdapter` (import
+     `openAcmeAdapter` from `./acme/provider`)
+   - `capabilities.ts` — add `acmeCapabilities` to `SANDBOX_PROVIDER_CAPABILITIES`
+     and a label to `SANDBOX_PROVIDER_DISPLAY`
+   - `src/index.ts` — re-export the config type
+     (`export type { AcmeConfig } from "./providers/acme/config";`) so consumers
+     get it from the package barrel
+
+3. **Wire the config through the caller** — the control plane constructs
+   `SandboxProviderDeps`, so its env builder needs to supply `deps.acme`.
+
+That's it: the registry table is exhaustive over the name union, so forgetting
+a registration fails to compile, and `defineProvider`'s capability
+reconciliation fails construction if the flags oversell the implementation.

--- a/js/sandbox/src/providers/capabilities.test.ts
+++ b/js/sandbox/src/providers/capabilities.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSandboxProviderLabel,
+  SANDBOX_PROVIDER_CAPABILITIES,
+} from "./capabilities";
+
+describe("getSandboxProviderLabel", () => {
+  it("labels a Daytona VM", () => {
+    expect(getSandboxProviderLabel("daytona", true)).toBe("Daytona VM");
+  });
+
+  it("labels a Daytona container when isVm is false", () => {
+    expect(getSandboxProviderLabel("daytona", false)).toBe("Daytona Container");
+  });
+
+  it("treats an unknown Daytona isVm (null/undefined) as a container", () => {
+    // Sandboxes created before VM tracking have a null `isVm`; they are
+    // containers, so they must not read as "VM".
+    expect(getSandboxProviderLabel("daytona", null)).toBe("Daytona Container");
+    expect(getSandboxProviderLabel("daytona", undefined)).toBe(
+      "Daytona Container",
+    );
+  });
+
+  it("leaves non-Daytona providers unqualified", () => {
+    expect(getSandboxProviderLabel("freestyle", true)).toBe("Freestyle");
+    expect(getSandboxProviderLabel("vercel", false)).toBe("Vercel");
+  });
+
+  it("falls back to the raw name for unknown providers", () => {
+    expect(getSandboxProviderLabel("mystery", null)).toBe("mystery");
+  });
+});
+
+describe("skipStartScript capability", () => {
+  // This flag is the UI gate for the Start button's "start without running
+  // start script" dropdown. It must be true only for providers whose
+  // `rerunLifecycle` actually forwards `skipStartScript` to the shared
+  // lifecycle runner, otherwise the dropdown would render a silent no-op.
+  it("is advertised by the providers that wire it through (Daytona, Vercel)", () => {
+    expect(SANDBOX_PROVIDER_CAPABILITIES.daytona.skipStartScript).toBe(true);
+    expect(SANDBOX_PROVIDER_CAPABILITIES.vercel.skipStartScript).toBe(true);
+  });
+
+  it("stays off for providers that always run the start script", () => {
+    expect(SANDBOX_PROVIDER_CAPABILITIES.freestyle.skipStartScript).toBe(false);
+  });
+});

--- a/js/sandbox/src/providers/capabilities.ts
+++ b/js/sandbox/src/providers/capabilities.ts
@@ -1,0 +1,98 @@
+/**
+ * Client-safe provider metadata: capability flags and display info.
+ *
+ * Pure data with no server or SDK imports, so client components can gate UI on
+ * provider capabilities and render provider labels without hardcoding provider
+ * names. This is the single source of truth for the capability flags — the
+ * server-side provider implementations read from it too, so a provider's
+ * capabilities are declared in exactly one place.
+ */
+import type {
+  SandboxProviderCapabilities,
+  SandboxProviderName,
+} from "./provider";
+import { daytonaCapabilities } from "./daytona/capabilities";
+import { freestyleCapabilities } from "./freestyle/capabilities";
+import { vercelCapabilities } from "./vercel/capabilities";
+
+// Colocated pure constants (see each provider's `capabilities.ts`), aggregated
+// here so the client-safe table stays the single source of truth without any
+// provider SDK crossing into client bundles.
+export const SANDBOX_PROVIDER_CAPABILITIES: Record<
+  SandboxProviderName,
+  SandboxProviderCapabilities
+> = {
+  daytona: daytonaCapabilities,
+  freestyle: freestyleCapabilities,
+  vercel: vercelCapabilities,
+};
+
+export interface SandboxProviderDisplay {
+  /** Human label for the provider. */
+  label: string;
+  /** Tailwind classes for the provider badge. */
+  badgeClassName: string;
+}
+
+export const SANDBOX_PROVIDER_DISPLAY: Record<
+  SandboxProviderName,
+  SandboxProviderDisplay
+> = {
+  daytona: { label: "Daytona", badgeClassName: "bg-gray-900 text-white" },
+  freestyle: {
+    label: "Freestyle",
+    badgeClassName: "bg-purple-600 text-white",
+  },
+  vercel: {
+    label: "Vercel",
+    badgeClassName: "bg-black text-white",
+  },
+};
+
+const UNKNOWN_BADGE_CLASS = "bg-gray-200 text-gray-700";
+
+function isKnownProvider(
+  name: string | null | undefined,
+): name is SandboxProviderName {
+  return name === "daytona" || name === "freestyle" || name === "vercel";
+}
+
+/** Capability flags for `name`, or null when the provider is unknown. */
+export function getProviderCapabilities(
+  name: string | null | undefined,
+): SandboxProviderCapabilities | null {
+  return isKnownProvider(name) ? SANDBOX_PROVIDER_CAPABILITIES[name] : null;
+}
+
+/** Display label for `name`, falling back to the raw name. */
+export function getProviderLabel(name: string | null | undefined): string {
+  return isKnownProvider(name)
+    ? SANDBOX_PROVIDER_DISPLAY[name].label
+    : (name ?? "Unknown");
+}
+
+/** Badge CSS classes for `name`. */
+export function getProviderBadgeClassName(
+  name: string | null | undefined,
+): string {
+  return isKnownProvider(name)
+    ? SANDBOX_PROVIDER_DISPLAY[name].badgeClassName
+    : UNKNOWN_BADGE_CLASS;
+}
+
+/**
+ * Provider label for a sandbox, distinguishing a Daytona VM from a Daytona
+ * container. `isVm` reflects whether the sandbox is VM-backed; for Daytona, a
+ * non-true value (a container, or a sandbox created before VMs were tracked)
+ * reads as "Container". Other providers fall back to the plain provider label.
+ */
+export function getSandboxProviderLabel(
+  name: string | null | undefined,
+  isVm: boolean | null | undefined,
+): string {
+  const label = getProviderLabel(name);
+  if (name === "daytona") {
+    return isVm ? `${label} VM` : `${label} Container`;
+  }
+  return label;
+}

--- a/js/sandbox/src/providers/daytona/capabilities.ts
+++ b/js/sandbox/src/providers/daytona/capabilities.ts
@@ -1,0 +1,30 @@
+/**
+ * Daytona capability flags. Colocated with the provider but kept SDK-free so the
+ * client-safe capabilities table (`../capabilities`) can aggregate it without
+ * pulling in the Daytona SDK.
+ *
+ * The full-featured, control-plane provider: per-sandbox lifecycle + exec + log
+ * streaming + SSH + snapshots, plus the image-derived snapshots and docker
+ * registries no other provider backs. Streaming is real (session command logs
+ * over a WebSocket). Daytona honors `skipStartScript` in its start-phase
+ * lifecycle rerun.
+ */
+import type { SandboxProviderCapabilities } from "../provider";
+
+export const daytonaCapabilities: SandboxProviderCapabilities = {
+  lifecycle: true,
+  ssh: true,
+  services: true,
+  exec: true,
+  listSandboxes: true,
+  streaming: true,
+  snapshots: true,
+  scrubCapture: true,
+  fullSnapshotCapture: true,
+  dockerRegistries: true,
+  skipStartScript: true,
+  // Snapshots are booted by their org-scoped name (no separate id handle).
+  snapshotIdsAreOpaque: false,
+  // Daytona deletes idle sandboxes on the auto-delete interval.
+  supportsAutoDelete: true,
+};

--- a/js/sandbox/src/providers/daytona/config.ts
+++ b/js/sandbox/src/providers/daytona/config.ts
@@ -1,0 +1,18 @@
+import type { SandboxConfigBase } from "../../config";
+
+export interface DaytonaConfig extends SandboxConfigBase {
+  apiKey: string;
+  apiUrl: string;
+  target?: string;
+  organizationId?: string;
+  /**
+   * Provision Daytona resources as VMs (`SandboxClass.LINUX_VM`) instead of the
+   * default container class (`ENABLE_DAYTONA_VM`): new sandboxes are created
+   * with `class: "linux-vm"`, and snapshots are captured cold from the stopped
+   * VM. Off/undefined means container sandboxes. Daytona only accepts the VM
+   * class on the create/snapshot calls the high-level SDK wrapper doesn't
+   * expose, so the VM paths reach the generated api-client directly (see
+   * `./internal/vm`).
+   */
+  useVm?: boolean;
+}

--- a/js/sandbox/src/providers/daytona/internal/adapter.ts
+++ b/js/sandbox/src/providers/daytona/internal/adapter.ts
@@ -1,0 +1,55 @@
+/**
+ * Daytona adapter for the provider-agnostic {@link SandboxAdapter} port.
+ *
+ * A thin passthrough: it wraps an already-fetched Daytona `Sandbox` and maps
+ * the adapter primitives onto the SDK calls the Daytona provider has always
+ * made (`process.executeCommand`, `fs.uploadFile`, `fs.downloadFile`). The
+ * shared provisioning orchestration runs against this with no behavior change
+ * versus the previous direct calls.
+ */
+import type { Daytona } from "@daytonaio/sdk";
+import { executeCommand } from "./commands";
+import type {
+  ExecOptions,
+  ExecResult,
+  SandboxAdapter,
+} from "../../shared/adapter";
+
+type DaytonaSandbox = Awaited<ReturnType<Daytona["get"]>>;
+
+export class DaytonaAdapter implements SandboxAdapter {
+  /**
+   * @param sandbox the already-fetched Daytona sandbox handle.
+   * @param client the SDK client the sandbox was fetched with, retained so
+   *   callers can reuse the one already-constructed client for further SDK work
+   *   instead of building a fresh one. Optional — provider-specific and off the
+   *   SDK-free {@link SandboxAdapter} port (Vercel's static SDK has no client).
+   */
+  constructor(
+    private readonly sandbox: DaytonaSandbox,
+    readonly client?: Daytona,
+  ) {}
+
+  async exec(command: string, opts?: ExecOptions): Promise<ExecResult> {
+    // Delegates to the provider's public exec path so both share one command
+    // builder (sudo → root shell + `--preserve-env`) and one stream-separating
+    // session runner. The SDK's `process.executeCommand` is deliberately not
+    // used: it returns a single combined string, with stderr folded in.
+    return executeCommand(this.sandbox, command, opts);
+  }
+
+  async uploadFile(content: Buffer | string, path: string): Promise<void> {
+    const buffer =
+      typeof content === "string" ? Buffer.from(content, "utf8") : content;
+    await this.sandbox.fs.uploadFile(buffer, path);
+  }
+
+  async downloadFile(path: string): Promise<string | null> {
+    try {
+      const content = await this.sandbox.fs.downloadFile(path);
+      return content.toString("utf8");
+    } catch {
+      return null;
+    }
+  }
+}

--- a/js/sandbox/src/providers/daytona/internal/client.ts
+++ b/js/sandbox/src/providers/daytona/internal/client.ts
@@ -1,0 +1,51 @@
+/**
+ * Daytona SDK client construction.
+ */
+import { Daytona } from "@daytonaio/sdk";
+import type { DaytonaConfig } from "../config";
+
+/**
+ * Target used for the experimental sandbox-snapshot APIs
+ * (`sandbox._experimental_createSnapshot`, plus creating new sandboxes
+ * off those snapshots). Daytona currently gates these capabilities
+ * behind this target regardless of which target the existing image-
+ * derived snapshots use.
+ */
+export const EXPERIMENTAL_DAYTONA_TARGET = "experimental";
+
+export interface DaytonaClientOptions {
+  /**
+   * Override the configured target for this client. Passed-through value
+   * is honored verbatim — used to switch to the experimental target for
+   * the sandbox-snapshot APIs without rebuilding the entire SDK config.
+   */
+  target?: string;
+}
+
+export function createDaytonaClient(
+  config: DaytonaConfig,
+  options: DaytonaClientOptions = {},
+): Daytona {
+  return new Daytona({
+    apiKey: config.apiKey,
+    apiUrl: config.apiUrl,
+    target: options.target ?? config.target,
+    // Scope every operation to the configured Daytona organization when one is
+    // set (`DAYTONA_ORGANIZATION_ID`). Without it the SDK targets the account's
+    // default org, so a `daytona.get`/`list` for a sandbox created under a
+    // non-default org would come up empty. Spread conditionally so an unset
+    // value stays absent rather than forcing the default-org path.
+    ...(config.organizationId ? { organizationId: config.organizationId } : {}),
+  });
+}
+
+/**
+ * Build a Daytona client pinned to the experimental target. Required
+ * by the `_experimental_createSnapshot` sandbox method and by creating
+ * a sandbox from one of those snapshots.
+ */
+export function createExperimentalDaytonaClient(
+  config: DaytonaConfig,
+): Daytona {
+  return createDaytonaClient(config, { target: EXPERIMENTAL_DAYTONA_TARGET });
+}

--- a/js/sandbox/src/providers/daytona/internal/commands.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildDaytonaCommand,
+  buildDaytonaSessionCommand,
+  executeCommand,
+} from "./commands";
+import { fakeDaytonaSandbox } from "./test-support";
+
+type DaytonaSandbox = Parameters<typeof executeCommand>[0];
+
+describe("buildDaytonaCommand", () => {
+  it("runs a non-sudo command verbatim", () => {
+    expect(buildDaytonaCommand("echo hi")).toBe("echo hi");
+    expect(buildDaytonaCommand("echo hi", { sudo: false })).toBe("echo hi");
+  });
+
+  it("wraps a sudo command in a root bash -c so a compound command runs fully elevated", () => {
+    // A bare `sudo touch a && touch b` would elevate only the first `touch`;
+    // the whole command must be the `bash -c` argument.
+    const cmd = buildDaytonaCommand("touch /root/a && touch /root/b", {
+      sudo: true,
+    });
+    expect(cmd.startsWith("sudo -n")).toBe(true);
+    expect(cmd).toContain("bash -c 'touch /root/a && touch /root/b'");
+  });
+
+  it("preserves the caller's env keys across the sudo boundary (plus the Amika hook vars)", () => {
+    const cmd = buildDaytonaCommand("printenv FOO", {
+      sudo: true,
+      env: { FOO: "bar" },
+    });
+    expect(cmd).toContain(
+      "--preserve-env=AMIKA_AGENT_CWD,AMIKA_OPENCODE_WEB,OPENCODE_SERVER_PASSWORD,FOO",
+    );
+  });
+});
+
+describe("buildDaytonaSessionCommand", () => {
+  it("applies cwd and env in the outer shell, before sudo", () => {
+    // Sessions take no cwd/env parameters, so both must be emitted into the
+    // command string, and env must be exported *before* sudo, or
+    // `--preserve-env` has nothing to preserve.
+    const cmd = buildDaytonaSessionCommand("printenv FOO", {
+      cwd: "/home/amika",
+      env: { FOO: "bar" },
+      sudo: true,
+    });
+    expect(
+      cmd.startsWith("cd '/home/amika' && export FOO='bar' && sudo -n"),
+    ).toBe(true);
+  });
+
+  it("rejects an environment variable name that is not shell-legal", () => {
+    // The name is interpolated into an `export`, so it can't be trusted.
+    expect(() =>
+      buildDaytonaSessionCommand("true", { env: { "A; rm -rf /": "x" } }),
+    ).toThrow(/Invalid environment variable name/u);
+  });
+});
+
+describe("executeCommand", () => {
+  it("keeps stderr out of stdout on a successful command", async () => {
+    // The regression this guards: `sudo` writes "unable to resolve host …" to
+    // stderr on images whose hostname doesn't resolve. Merging that into the
+    // value stream broke every stdout parser, `amikad host-key show` first.
+    const { sandbox } = fakeDaytonaSandbox(() => ({
+      exitCode: 0,
+      stdout: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5\n",
+      stderr: "sudo: unable to resolve host sandbox\n",
+    }));
+
+    const result = await executeCommand(
+      sandbox as DaytonaSandbox,
+      "amikad host-key show",
+      { sudo: true },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5\n");
+    expect(result.stdout).not.toContain("unable to resolve host");
+    expect(result.stderr).toBe("sudo: unable to resolve host sandbox\n");
+  });
+
+  it("pipes input to the command and closes stdin at the exact byte count", async () => {
+    const { sandbox, commands } = fakeDaytonaSandbox();
+
+    await executeCommand(
+      sandbox as DaytonaSandbox,
+      "amikad authorized-keys set",
+      {
+        input: "ssh-ed25519 AAAA\n",
+      },
+    );
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]!.command).toContain("head -c 17 | (");
+    expect(commands[0]!.input).toBe("ssh-ed25519 AAAA\n");
+  });
+
+  it("treats empty input as no stdin wiring", async () => {
+    const { sandbox, commands } = fakeDaytonaSandbox();
+
+    await executeCommand(sandbox as DaytonaSandbox, "true", { input: "" });
+
+    expect(commands[0]!.command).not.toContain("head -c");
+    expect(commands[0]!.input).toBeUndefined();
+  });
+
+  it("deletes the session even when the command fails", async () => {
+    const { sandbox, openSessions } = fakeDaytonaSandbox(() => ({
+      exitCode: 1,
+      stderr: "boom",
+    }));
+
+    const result = await executeCommand(sandbox as DaytonaSandbox, "false");
+
+    expect(result.exitCode).toBe(1);
+    expect(openSessions.size).toBe(0);
+  });
+});

--- a/js/sandbox/src/providers/daytona/internal/commands.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.ts
@@ -1,0 +1,200 @@
+/**
+ * Command execution and workspace path helpers for Daytona sandboxes.
+ */
+import { Daytona } from "@daytonaio/sdk";
+import { randomUUID } from "node:crypto";
+import { shellQuote } from "../../../util/shell";
+import { execFailureText } from "../../shared/adapter";
+
+/**
+ * Amika hook vars that must survive the `sudo` environment reset even when the
+ * caller passes no explicit `env` (the lifecycle scripts read these).
+ */
+const SUDO_PRESERVE_ENV_BASE = [
+  "AMIKA_AGENT_CWD",
+  "AMIKA_OPENCODE_WEB",
+  "OPENCODE_SERVER_PASSWORD",
+] as const;
+
+/**
+ * Build the on-box command string for Daytona's `process.executeCommand`.
+ * Non-sudo commands run verbatim (Daytona execs them through a shell, so
+ * compound commands already work). For `sudo: true` we:
+ *
+ *   - run the *entire* command in a root shell (`bash -c '<command>'`) so a
+ *     compound command / pipeline / redirection runs fully elevated, not just
+ *     its first simple command; and
+ *   - extend `--preserve-env` with the caller's explicit `env` keys (on top of
+ *     the Amika hook vars) so `sudo`'s environment reset doesn't strip the
+ *     variables the public `ExecCommandOptions.env` promises to expose.
+ *
+ * `sudo -n` is non-interactive so it fails fast instead of hanging on a
+ * password prompt. Exported for unit testing.
+ */
+export function buildDaytonaCommand(
+  command: string,
+  opts?: { env?: Record<string, string>; sudo?: boolean },
+): string {
+  if (!opts?.sudo) return command;
+  const preserve = [...SUDO_PRESERVE_ENV_BASE, ...Object.keys(opts.env ?? {})];
+  return `sudo -n --preserve-env=${preserve.join(",")} bash -c ${shellQuote(command)}`;
+}
+
+/** Shell-legal environment variable name; anything else is rejected. */
+const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+/**
+ * Wrap {@link buildDaytonaCommand} with the `cwd` and `env` that Daytona's
+ * one-shot `process.executeCommand` used to apply for us.
+ *
+ * Sessions carry no cwd/env parameters (`SessionExecuteRequest` is just a
+ * command string), so both are applied in the outer shell, before `sudo`,
+ * so that `--preserve-env` actually has something to preserve. Exported for
+ * unit testing.
+ */
+export function buildDaytonaSessionCommand(
+  command: string,
+  opts?: { cwd?: string; env?: Record<string, string>; sudo?: boolean },
+): string {
+  const prefix: string[] = [];
+  if (opts?.cwd) prefix.push(`cd ${shellQuote(opts.cwd)}`);
+  for (const [name, value] of Object.entries(opts?.env ?? {})) {
+    if (!ENV_NAME_RE.test(name)) {
+      throw new Error(`Invalid environment variable name: ${name}`);
+    }
+    prefix.push(`export ${name}=${shellQuote(value)}`);
+  }
+  return [...prefix, buildDaytonaCommand(command, opts)].join(" && ");
+}
+
+export async function executeCommand(
+  sandbox: Awaited<ReturnType<Daytona["get"]>>,
+  command: string,
+  opts?: {
+    cwd?: string;
+    env?: Record<string, string>;
+    sudo?: boolean;
+    input?: string;
+  },
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  // An empty string means "no bytes on stdin", which is what a command with no
+  // stdin wiring already sees, so it takes the same path as the no-input case.
+  return opts?.input
+    ? executeSessionCommandWithInput(sandbox, command, opts.input, opts)
+    : executeSessionCommand(sandbox, command, opts);
+}
+
+const MAX_COMMAND_INPUT_BYTES = 1024 * 1024;
+
+type DaytonaSandbox = Awaited<ReturnType<Daytona["get"]>>;
+
+/** Run `body` against a throwaway session, always tearing the session down. */
+async function withSession<T>(
+  sandbox: DaytonaSandbox,
+  body: (sessionId: string) => Promise<T>,
+): Promise<T> {
+  const sessionId = `exec-${randomUUID()}`;
+  await sandbox.process.createSession(sessionId);
+  try {
+    return await body(sessionId);
+  } finally {
+    await sandbox.process.deleteSession(sessionId).catch(() => {});
+  }
+}
+
+/**
+ * Run one command in a session and read back its two streams.
+ *
+ * Sessions rather than `process.executeCommand`, which returns only a single
+ * combined `result` string: stderr folded into the value stream corrupts
+ * every caller that parses stdout (host keys, JSON, PIDs). A synchronous
+ * session command reports `stdout`, `stderr`, and the exit code directly, so
+ * this costs one extra round-trip over the one-shot API, not several.
+ */
+async function executeSessionCommand(
+  sandbox: DaytonaSandbox,
+  command: string,
+  opts?: { cwd?: string; env?: Record<string, string>; sudo?: boolean },
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return withSession(sandbox, async (sessionId) => {
+    const response = await sandbox.process.executeSessionCommand(sessionId, {
+      command: buildDaytonaSessionCommand(command, opts),
+    });
+    return {
+      exitCode: response.exitCode ?? 1,
+      stdout: response.stdout ?? "",
+      stderr: response.stderr ?? "",
+    };
+  });
+}
+
+/**
+ * As {@link executeSessionCommand}, but with `input` on the command's stdin.
+ *
+ * Sending stdin needs the command's id, which only an async run hands back
+ * before the command finishes, so this variant runs detached and collects the
+ * streams from the log callbacks instead.
+ */
+async function executeSessionCommandWithInput(
+  sandbox: DaytonaSandbox,
+  command: string,
+  input: string,
+  opts?: { cwd?: string; env?: Record<string, string>; sudo?: boolean },
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const byteLength = Buffer.byteLength(input, "utf8");
+  if (byteLength > MAX_COMMAND_INPUT_BYTES) {
+    throw new Error("Command input exceeds the 1 MiB limit");
+  }
+  return withSession(sandbox, async (sessionId) => {
+    // Daytona does not expose a close-stdin operation. Bound the reader to the
+    // exact byte count so the command sees EOF without putting input in argv.
+    const onBox = buildDaytonaSessionCommand(command, opts);
+    const response = await sandbox.process.executeSessionCommand(sessionId, {
+      command: `head -c ${byteLength} | (${onBox})`,
+      runAsync: true,
+      suppressInputEcho: true,
+    });
+    if (!response.cmdId) throw new Error("Daytona command returned no id");
+    await sandbox.process.sendSessionCommandInput(
+      sessionId,
+      response.cmdId,
+      input,
+    );
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    await sandbox.process.getSessionCommandLogs(
+      sessionId,
+      response.cmdId,
+      (chunk) => stdout.push(chunk),
+      (chunk) => stderr.push(chunk),
+    );
+    const completed = await sandbox.process.getSessionCommand(
+      sessionId,
+      response.cmdId,
+    );
+    return {
+      exitCode: completed.exitCode ?? 1,
+      stdout: stdout.join(""),
+      stderr: stderr.join(""),
+    };
+  });
+}
+
+export async function executeCheckedCommand(
+  sandbox: Awaited<ReturnType<Daytona["get"]>>,
+  command: string,
+  opts?: {
+    cwd?: string;
+    env?: Record<string, string>;
+    sudo?: boolean;
+  },
+): Promise<void> {
+  const result = await executeCommand(sandbox, command, opts);
+  if (result.exitCode !== 0) {
+    throw new Error(execFailureText(result) || `Command failed: ${command}`);
+  }
+}
+
+// Workspace path helpers are provider-agnostic; re-exported from the shared
+// module so there is a single definition shared with the Freestyle provider.
+export { getWorkspaceDir, getRepoDir } from "../../shared/adapter-helpers";

--- a/js/sandbox/src/providers/daytona/internal/configure.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/configure.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { stopDockerForSnapshot, startDockerForSnapshot } from "./configure";
+import { fakeDaytonaSandbox } from "./test-support";
+
+describe("stopDockerForSnapshot", () => {
+  it("runs a single root bash teardown that no-ops without dockerd", async () => {
+    const { sandbox, commands } = fakeDaytonaSandbox();
+
+    await stopDockerForSnapshot(
+      sandbox as Parameters<typeof stopDockerForSnapshot>[0],
+    );
+
+    expect(commands).toHaveLength(1);
+    const command = commands[0]!.command;
+    // Runs as root (the daemon/containerd stop needs it)...
+    expect(command).toContain("sudo -n");
+    // ...wrapped in `bash -c` so the multi-line script runs as one unit.
+    expect(command).toContain("bash -c ");
+    // No-ops when dockerd isn't installed (non-dind preset).
+    expect(command).toContain("command -v dockerd >/dev/null 2>&1 || exit 0");
+    // Docker CLI calls are bounded by `timeout` so a wedged daemon can't
+    // hang the teardown before it reaches the pkill fallback.
+    expect(command).toContain("timeout 30 docker ps");
+    expect(command).toContain("timeout 60 docker stop");
+    // Stops the daemon, waits for it to exit, then stops containerd.
+    expect(command).toContain("pkill -TERM dockerd");
+    expect(command).toContain("pgrep -x dockerd");
+    expect(command).toContain("pkill -TERM containerd");
+  });
+});
+
+describe("startDockerForSnapshot", () => {
+  it("runs a single root bash restart that no-ops without dockerd", async () => {
+    const { sandbox, commands } = fakeDaytonaSandbox();
+
+    await startDockerForSnapshot(
+      sandbox as Parameters<typeof startDockerForSnapshot>[0],
+    );
+
+    expect(commands).toHaveLength(1);
+    const command = commands[0]!.command;
+    // Runs as root, wrapped in `bash -c`.
+    expect(command).toContain("sudo -n");
+    expect(command).toContain("bash -c ");
+    // No-ops when dockerd isn't installed.
+    expect(command).toContain("command -v dockerd >/dev/null 2>&1 || exit 0");
+    // Only starts the daemon if it isn't already running.
+    expect(command).toContain("if ! pgrep -x dockerd");
+    // Falls back to relaunching dockerd directly (no systemd on Daytona).
+    expect(command).toContain("nohup dockerd");
+    // Restarts the containers the stop step recorded.
+    expect(command).toContain("amika-snapshot-running-containers");
+    expect(command).toContain("docker start");
+  });
+
+  it("never throws when the restart exec fails", async () => {
+    // Invoked in a `finally` after a successful capture, so a restart
+    // failure must not surface and mask the capture's success.
+    const sandbox = {
+      process: {
+        createSession: () => Promise.reject(new Error("exec down")),
+      },
+    } as unknown as Parameters<typeof startDockerForSnapshot>[0];
+
+    await expect(startDockerForSnapshot(sandbox)).resolves.toBeUndefined();
+  });
+});

--- a/js/sandbox/src/providers/daytona/internal/configure.ts
+++ b/js/sandbox/src/providers/daytona/internal/configure.ts
@@ -1,0 +1,248 @@
+/**
+ * Daytona-specific adapter configuration.
+ *
+ * The bulk of the adapter provisioning (credentials, lifecycle scripts, MCP
+ * wiring, `/etc/environment`) lives in the provider-agnostic
+ * `../shared/configure-adapter` and runs against the {@link SandboxAdapter}
+ * port. What is here is genuinely Daytona-specific — repo cloning via the
+ * SDK's first-class `git.clone`, and the Docker quiesce/restart around a Daytona
+ * snapshot.
+ */
+import { Sandbox } from "@daytonaio/sdk";
+import {
+  buildGitCheckoutNewBranchCmd,
+  checkBranchExistsOnRemote,
+  isBranchNotFoundError,
+} from "../../../util/git-clone";
+import { shellQuote } from "../../../util/shell";
+import {
+  executeCheckedCommand,
+  executeCommand,
+  getWorkspaceDir,
+  getRepoDir,
+} from "./commands";
+
+function getGitCredentials(githubToken?: string | null): {
+  username?: string;
+  password?: string;
+} {
+  if (!githubToken) {
+    return {};
+  }
+
+  return {
+    username: "x-access-token",
+    password: githubToken,
+  };
+}
+
+/**
+ * Best-effort shell to stop the Docker daemon and quiesce its on-disk
+ * state before a snapshot is captured. Runs as root via `bash -c`.
+ *
+ *  - Exits immediately on a non-dind sandbox (no `dockerd` binary).
+ *  - Records the running containers (so {@link startDockerForSnapshot} can
+ *    restart exactly those if the source sandbox is kept), then stops them
+ *    first so their overlay mounts are released (a bare daemon stop leaves
+ *    them mounted when `live-restore` is on).
+ *  - Wraps every Docker CLI call in `timeout`: a wedged-but-still-listening
+ *    daemon would otherwise hang `docker ps`/`docker stop` indefinitely
+ *    (`docker stop -t` is the container grace period, not a client/daemon
+ *    call timeout), stalling a request that already holds the
+ *    `snapshotting` claim. On timeout we fall through to killing the daemon.
+ *  - Stops the daemon via whatever supervises it, falling back to
+ *    signalling the process directly — Daytona sandboxes typically run no
+ *    systemd, so `pkill` is the path that actually fires.
+ *  - Waits (bounded) for `dockerd` to exit so its overlay unmounts and
+ *    network teardown finish before the filesystem is frozen.
+ *  - Always exits 0: a teardown hiccup must never block the snapshot.
+ */
+const STOP_DOCKER_SCRIPT = `
+command -v dockerd >/dev/null 2>&1 || exit 0
+
+if command -v docker >/dev/null 2>&1; then
+  timeout 30 docker ps -q 2>/dev/null \\
+    > /var/run/amika-snapshot-running-containers
+  xargs -r timeout 60 docker stop -t 10 \\
+    < /var/run/amika-snapshot-running-containers 2>/dev/null
+fi
+
+systemctl stop docker.socket docker 2>/dev/null \\
+  || service docker stop 2>/dev/null \\
+  || pkill -TERM dockerd 2>/dev/null
+
+for _ in $(seq 1 30); do
+  pgrep -x dockerd >/dev/null 2>&1 || break
+  sleep 0.5
+done
+
+systemctl stop containerd 2>/dev/null \\
+  || service containerd stop 2>/dev/null \\
+  || pkill -TERM containerd 2>/dev/null
+
+rm -f /var/run/docker.pid /run/docker.pid 2>/dev/null
+
+exit 0
+`;
+
+/**
+ * Stop the Docker daemon and leave `/var/lib/docker` at rest before a
+ * snapshot is captured.
+ *
+ * Dind sandboxes (`coder-dind` preset) start `dockerd` from the image's
+ * `pre-setup.sh` hook on every boot. A snapshot taken while the daemon is
+ * live bakes in the source sandbox's mid-flight Docker state — active
+ * overlay mounts and network namespaces that no longer exist on a fresh
+ * boot. A sandbox restored from that snapshot then stalls in `dockerd`
+ * recovery and blows the hook's 30s readiness wait, surfacing as
+ * "dockerd did not become ready within 30s" during sandbox init.
+ *
+ * Stopping the daemon cleanly first releases those mounts and tears down
+ * networking, so the captured `/var/lib/docker` restores fast (images and
+ * build cache are preserved — only running state is dropped). Best-effort
+ * and a no-op on non-dind sandboxes; never throws on a stop failure.
+ */
+export async function stopDockerForSnapshot(sandbox: Sandbox): Promise<void> {
+  await executeCommand(sandbox, `bash -c ${shellQuote(STOP_DOCKER_SCRIPT)}`, {
+    sudo: true,
+  });
+}
+
+/**
+ * Best-effort shell to bring the Docker daemon back up after a capture,
+ * undoing {@link stopDockerForSnapshot}. Runs as root via `bash -c`.
+ *
+ *  - Exits immediately on a non-dind sandbox (no `dockerd`).
+ *  - Starts the daemon if it isn't running: prefers a service manager,
+ *    falling back to launching `dockerd` directly in the background —
+ *    Daytona dind sandboxes run no systemd, so the bare relaunch is the
+ *    path that actually fires.
+ *  - Once the daemon is back, restarts the containers
+ *    {@link stopDockerForSnapshot} stopped — those without an
+ *    auto-restart policy won't come back on daemon start otherwise, so
+ *    dev services would stay down. This runs in a bounded background
+ *    subshell so it never blocks the snapshot flow.
+ *  - Always exits 0.
+ */
+const START_DOCKER_SCRIPT = `
+command -v dockerd >/dev/null 2>&1 || exit 0
+
+if ! pgrep -x dockerd >/dev/null 2>&1; then
+  systemctl start docker.socket docker 2>/dev/null \\
+    || service docker start 2>/dev/null \\
+    || { nohup dockerd >/var/log/dockerd-restart.log 2>&1 & }
+fi
+
+# Restart the containers we stopped for the capture, once the daemon is
+# ready. Backgrounded + bounded so a slow/failed daemon can't stall us.
+running_file=/var/run/amika-snapshot-running-containers
+(
+  for _ in $(seq 1 60); do
+    docker info >/dev/null 2>&1 && break
+    sleep 1
+  done
+  if [ -s "$running_file" ]; then
+    xargs -r docker start < "$running_file" >/dev/null 2>&1
+  fi
+  rm -f "$running_file"
+) >/dev/null 2>&1 &
+
+exit 0
+`;
+
+/**
+ * Restart the Docker daemon on a sandbox that survives a capture.
+ *
+ * {@link stopDockerForSnapshot} quiesces Docker so the captured filesystem
+ * is clean, on the assumption that "snapshot and delete" then deletes the
+ * source. When that delete does NOT happen — the capture failed, or the
+ * durability wait timed out and the source is restored to `active` — the
+ * kept sandbox would otherwise be left with its containers and daemon
+ * down. Bring Docker back so the user's workloads recover.
+ *
+ * The capture has already frozen the filesystem by the time this runs, so
+ * restarting the live daemon does not affect the snapshot. Best-effort,
+ * fire-and-forget, and a no-op on non-dind sandboxes. (On the success path
+ * the source is deleted immediately after, so this is a harmless no-op
+ * there.)
+ *
+ * Swallows its own errors so it never throws: callers invoke it in a
+ * `finally` after a *successful* capture, where a thrown restart error
+ * would mask the capture and make the flow treat a captured snapshot as
+ * failed (orphaning the provider snapshot).
+ */
+export async function startDockerForSnapshot(sandbox: Sandbox): Promise<void> {
+  try {
+    await executeCommand(
+      sandbox,
+      `bash -c ${shellQuote(START_DOCKER_SCRIPT)}`,
+      {
+        sudo: true,
+      },
+    );
+  } catch {
+    // Best-effort recovery — never let a restart failure change the
+    // capture's outcome.
+  }
+}
+
+export async function cloneRepository(
+  sandbox: Sandbox,
+  homeDir: string,
+  githubUrl: string,
+  repoName?: string | null,
+  githubToken?: string | null,
+  branch?: string,
+): Promise<void> {
+  const workspaceDir = getWorkspaceDir(homeDir);
+  const repoDir = getRepoDir(homeDir, repoName);
+
+  await executeCheckedCommand(sandbox, `mkdir -p ${workspaceDir}`, {
+    cwd: homeDir,
+  });
+  await executeCheckedCommand(
+    sandbox,
+    repoName ? `rm -rf ${repoDir}` : `rm -rf ${workspaceDir}`,
+    { cwd: homeDir },
+  );
+
+  const credentials = getGitCredentials(githubToken);
+  try {
+    await sandbox.git.clone(
+      githubUrl,
+      repoDir,
+      branch,
+      undefined,
+      credentials.username,
+      credentials.password,
+    );
+  } catch (err) {
+    if (!branch) {
+      throw err;
+    }
+    if (!isBranchNotFoundError(err)) {
+      // Daytona SDK may not produce standard git error messages — verify
+      // the branch actually exists on the remote before giving up.
+      const exists = await checkBranchExistsOnRemote(
+        githubUrl,
+        githubToken,
+        branch,
+      );
+      if (exists) {
+        throw err; // Branch exists; failure is something else
+      }
+    }
+    // Branch doesn't exist on remote: clone the default branch, then create it.
+    await sandbox.git.clone(
+      githubUrl,
+      repoDir,
+      undefined,
+      undefined,
+      credentials.username,
+      credentials.password,
+    );
+    await executeCheckedCommand(sandbox, buildGitCheckoutNewBranchCmd(branch), {
+      cwd: repoDir,
+    });
+  }
+}

--- a/js/sandbox/src/providers/daytona/internal/docker-registry.ts
+++ b/js/sandbox/src/providers/daytona/internal/docker-registry.ts
@@ -1,0 +1,91 @@
+/**
+ * Direct HTTP client for the Daytona Docker Registry API.
+ *
+ * The Daytona SDK does not expose registry management, so these functions
+ * call the REST API directly using fetch().
+ */
+import type { DaytonaConfig } from "../config";
+import type {
+  CreateDockerRegistryInput,
+  ProviderDockerRegistry,
+} from "../../provider";
+
+// The registry shapes are provider-agnostic (defined in `../provider`),
+// re-exported under a Daytona name for the package index.
+export type { CreateDockerRegistryInput } from "../../provider";
+export type DaytonaDockerRegistry = ProviderDockerRegistry;
+
+function registryUrl(config: DaytonaConfig, path: string): string {
+  const base = config.apiUrl.replace(/\/+$/, "");
+  return `${base}/docker-registry${path}`;
+}
+
+function headers(config: DaytonaConfig): Record<string, string> {
+  const requestHeaders: Record<string, string> = {
+    Authorization: `Bearer ${config.apiKey}`,
+    "Content-Type": "application/json",
+  };
+  if (config.organizationId) {
+    requestHeaders["X-Daytona-Organization-ID"] = config.organizationId;
+  }
+  return requestHeaders;
+}
+
+async function handleResponse<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Daytona Docker Registry API error: ${res.status} ${res.statusText}${body ? ` — ${body}` : ""}`,
+    );
+  }
+  return res.json() as Promise<T>;
+}
+
+export async function createDaytonaDockerRegistry(
+  config: DaytonaConfig,
+  input: CreateDockerRegistryInput,
+): Promise<DaytonaDockerRegistry> {
+  const res = await fetch(registryUrl(config, ""), {
+    method: "POST",
+    headers: headers(config),
+    body: JSON.stringify(input),
+  });
+  return handleResponse<DaytonaDockerRegistry>(res);
+}
+
+export async function listDaytonaDockerRegistries(
+  config: DaytonaConfig,
+): Promise<DaytonaDockerRegistry[]> {
+  const res = await fetch(registryUrl(config, ""), {
+    method: "GET",
+    headers: headers(config),
+  });
+  return handleResponse<DaytonaDockerRegistry[]>(res);
+}
+
+export async function getDaytonaDockerRegistry(
+  config: DaytonaConfig,
+  registryId: string,
+): Promise<DaytonaDockerRegistry> {
+  const res = await fetch(registryUrl(config, `/${registryId}`), {
+    method: "GET",
+    headers: headers(config),
+  });
+  return handleResponse<DaytonaDockerRegistry>(res);
+}
+
+export async function deleteDaytonaDockerRegistry(
+  config: DaytonaConfig,
+  registryId: string,
+): Promise<void> {
+  const res = await fetch(registryUrl(config, `/${registryId}`), {
+    method: "DELETE",
+    headers: headers(config),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Daytona Docker Registry API error: ${res.status} ${res.statusText}${body ? ` — ${body}` : ""}`,
+    );
+  }
+}

--- a/js/sandbox/src/providers/daytona/internal/operations.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/operations.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { SANDBOX_ORG_ID_LABEL } from "../../../constants";
+import type { DaytonaConfig } from "../config";
+import {
+  _parseSshDestination,
+  listDaytonaSandboxes,
+  mapDaytonaSandboxState,
+} from "./operations";
+
+const daytonaList = vi.fn();
+vi.mock("./client", () => ({
+  createDaytonaClient: () => ({
+    list: (...args: unknown[]) => daytonaList(...args),
+  }),
+}));
+
+async function* asyncOf<T>(items: T[]): AsyncGenerator<T> {
+  for (const item of items) yield item;
+}
+
+describe("_parseSshDestination", () => {
+  it("strips the leading ssh prefix from a Daytona command", () => {
+    expect(_parseSshDestination("ssh user-token@ssh.app.daytona.io")).toBe(
+      "user-token@ssh.app.daytona.io",
+    );
+  });
+
+  it("collapses extra whitespace after the ssh keyword", () => {
+    expect(_parseSshDestination("ssh   user@host")).toBe("user@host");
+  });
+
+  it("leaves an already-bare destination unchanged", () => {
+    expect(_parseSshDestination("user@host")).toBe("user@host");
+  });
+
+  it("trims trailing whitespace after the destination", () => {
+    expect(_parseSshDestination("ssh user@host  ")).toBe("user@host");
+  });
+});
+
+describe("mapDaytonaSandboxState", () => {
+  it("maps every raw Daytona state onto the canonical vocabulary", () => {
+    const cases: Record<string, string> = {
+      creating: "creating",
+      pending_build: "creating",
+      building_snapshot: "creating",
+      pulling_snapshot: "creating",
+      restoring: "starting",
+      starting: "starting",
+      resuming: "starting",
+      resizing: "starting",
+      started: "running",
+      forking: "running",
+      snapshotting: "snapshotting",
+      stopping: "stopping",
+      pausing: "stopping",
+      stopped: "suspended",
+      paused: "suspended",
+      archiving: "suspended",
+      archived: "suspended",
+      error: "failed",
+      build_failed: "failed",
+      destroying: "failed",
+      destroyed: "failed",
+    };
+    for (const [raw, expected] of Object.entries(cases)) {
+      expect(mapDaytonaSandboxState(raw), raw).toBe(expected);
+    }
+  });
+
+  it("maps unrecognized values to unknown", () => {
+    expect(mapDaytonaSandboxState("unknown")).toBe("unknown");
+    expect(mapDaytonaSandboxState("11184809")).toBe("unknown");
+    expect(mapDaytonaSandboxState("")).toBe("unknown");
+  });
+});
+
+describe("listDaytonaSandboxes", () => {
+  const config: DaytonaConfig = {
+    apiKey: "key",
+    apiUrl: "https://app.daytona.io/api",
+    organizationId: "org_default",
+  };
+
+  beforeEach(() => daytonaList.mockReset());
+
+  it("maps each sandbox to its org (from labels), state, and native GiB sizing", async () => {
+    daytonaList.mockReturnValue(
+      asyncOf([
+        {
+          id: "sb_1",
+          labels: { [SANDBOX_ORG_ID_LABEL]: "org_abc" },
+          cpu: 4,
+          memory: 8,
+          disk: 20,
+          state: "started",
+        },
+      ]),
+    );
+
+    const listings = await listDaytonaSandboxes(config);
+
+    // Daytona reports cpu/memory/disk already in billing units (vCPUs/GiB/GiB).
+    expect(listings).toEqual([
+      {
+        providerSandboxId: "sb_1",
+        orgId: "org_abc",
+        state: "started",
+        sizing: { vcpus: 4, memoryGib: 8, diskGib: 20 },
+      },
+    ]);
+  });
+
+  it("reports a null org and 'unknown' state when the stamp/state are absent", async () => {
+    daytonaList.mockReturnValue(
+      asyncOf([{ id: "sb_1", labels: {}, cpu: 1, memory: 2, disk: 10 }]),
+    );
+
+    const [listing] = await listDaytonaSandboxes(config);
+    expect(listing?.orgId).toBeNull();
+    expect(listing?.state).toBe("unknown");
+  });
+
+  it("walks every page the cursor iterator yields", async () => {
+    daytonaList.mockReturnValue(
+      asyncOf([
+        {
+          id: "sb_1",
+          labels: {},
+          cpu: 1,
+          memory: 2,
+          disk: 10,
+          state: "started",
+        },
+        {
+          id: "sb_2",
+          labels: {},
+          cpu: 2,
+          memory: 4,
+          disk: 10,
+          state: "stopped",
+        },
+      ]),
+    );
+
+    const ids = (await listDaytonaSandboxes(config)).map(
+      (l) => l.providerSandboxId,
+    );
+    expect(ids).toEqual(["sb_1", "sb_2"]);
+  });
+});

--- a/js/sandbox/src/providers/daytona/internal/operations.ts
+++ b/js/sandbox/src/providers/daytona/internal/operations.ts
@@ -1,0 +1,495 @@
+/**
+ * Sandbox-level operations against the Daytona API: create, start/stop/delete,
+ * SSH access, URL refresh, and file reads. The provisioning lifecycle lives in
+ * `@amika/sandbox-provisioning`; this module keeps only the generic provider
+ * mechanics, including {@link openDaytonaAdapter}, the provisioning seam the
+ * package drives.
+ */
+import { Daytona, DaytonaError } from "@daytonaio/sdk";
+import pRetry from "p-retry";
+import {
+  SANDBOX_DELETE_INTERVAL_KEEP_ON_STOP,
+  SANDBOX_ENV_SECRETS_EXCLUDED_LABEL,
+  SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
+  SANDBOX_ORG_ID_LABEL,
+} from "../../../constants";
+import { DEFAULT_HOME_DIR } from "../../../constants";
+import type { DaytonaConfig } from "../config";
+import type { SandboxCtx } from "../../../logger";
+import { createDaytonaClient } from "./client";
+import { createVmSandbox } from "./vm";
+import { ensureDaytonaSnapshotActive } from "./snapshot-operations";
+import { DaytonaAdapter } from "./adapter";
+import {
+  SIGNED_URL_EXPIRY_S,
+  type DaytonaCreateRequest,
+  type SandboxService,
+} from "./types";
+import {
+  type CloneRepoInput,
+  type ExecCommandOptions,
+  type ProviderSandboxListing,
+  type SandboxExecResult,
+  type StreamCommandHandlers,
+} from "../../provider";
+import { executeCommand } from "./commands";
+import { cloneRepository } from "./configure";
+import type { SandboxStatus } from "../../../sandbox-status";
+import type { SandboxAdapter } from "../../shared/adapter";
+import { getRepoDir } from "../../shared/adapter-helpers";
+
+export async function refreshDaytonaUrls(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  services: SandboxService[],
+): Promise<{ providerUrl: string | null; services: SandboxService[] }> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  return refreshServiceUrls(sandbox, services);
+}
+
+/**
+ * Refresh signed preview URLs for all services using an already-fetched
+ * sandbox object.
+ */
+async function refreshServiceUrls(
+  sandbox: Awaited<ReturnType<Daytona["get"]>>,
+  services: SandboxService[],
+): Promise<{ providerUrl: string | null; services: SandboxService[] }> {
+  const refreshed: SandboxService[] = [];
+  let providerUrl: string | null = null;
+
+  for (const service of services) {
+    const preview = await sandbox.getSignedPreviewUrl(
+      service.containerPort,
+      SIGNED_URL_EXPIRY_S,
+    );
+    refreshed.push({ ...service, url: preview.url });
+    if (service.name === "Coding Agent") {
+      providerUrl = preview.url;
+    }
+  }
+
+  return { providerUrl, services: refreshed };
+}
+
+export async function getDaytonaSandboxState(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+): Promise<string> {
+  const daytona = createDaytonaClient(config);
+  try {
+    const sandbox = await daytona.get(providerSandboxId);
+    return sandbox.state ?? "unknown";
+  } catch {
+    // A missing/deleted sandbox makes `daytona.get` reject; report it as
+    // absent rather than throwing, mirroring Vercel/Freestyle's `unknown`
+    // so a deleted VM never reads back as a healthy running sandbox.
+    return "unknown";
+  }
+}
+
+/**
+ * Map a raw Daytona `SandboxState` into the canonical lifecycle vocabulary.
+ * Raw values are the `@daytonaio/sdk` `SandboxState` enum. Judgment calls:
+ * `forking` keeps the source running, so it reads as `running`; `archiving`/
+ * `archived` happen to an already-stopped sandbox, so both read as
+ * `suspended`; `resizing` is a transition back toward up, so `starting`.
+ */
+export function mapDaytonaSandboxState(rawState: string): SandboxStatus {
+  switch (rawState) {
+    case "creating":
+    case "pending_build":
+    case "building_snapshot":
+    case "pulling_snapshot":
+      return "creating";
+    case "restoring":
+    case "starting":
+    case "resuming":
+    case "resizing":
+      return "starting";
+    case "started":
+    case "forking":
+      return "running";
+    case "snapshotting":
+      return "snapshotting";
+    case "stopping":
+    case "pausing":
+      return "stopping";
+    case "stopped":
+    case "paused":
+    case "archiving":
+    case "archived":
+      return "suspended";
+    case "error":
+    case "build_failed":
+    case "destroying":
+    case "destroyed":
+      return "failed";
+    default:
+      return "unknown";
+  }
+}
+
+/** Per-page fetch size for the `daytona.list()` cursor iterator (not a cap on
+ * the total returned). */
+const DAYTONA_LIST_PAGE_SIZE = 100;
+
+/**
+ * Enumerate every sandbox in the Daytona account with its org stamp, raw state,
+ * and provisioned sizing. `daytona.list()` is a cursor-paginated async iterator
+ * (Daytona retired the offset `page`/`limit` flow), so iterating it transparently
+ * walks every page; `limit` is only the per-page fetch size, not a cap on the
+ * total. Errored/deleted sandboxes are excluded by the API default. Daytona
+ * reports sizing already in billing units (`cpu`/`memory`/`disk` =
+ * vCPUs/GiB/GiB), so no MiB→GiB conversion is needed. `createDaytonaClient`
+ * scopes to the configured organization, so the listing is account-wide within
+ * it.
+ */
+export async function listDaytonaSandboxes(
+  config: DaytonaConfig,
+): Promise<ProviderSandboxListing[]> {
+  const daytona = createDaytonaClient(config);
+  const listings: ProviderSandboxListing[] = [];
+  for await (const sandbox of daytona.list({ limit: DAYTONA_LIST_PAGE_SIZE })) {
+    listings.push({
+      providerSandboxId: sandbox.id,
+      orgId: sandbox.labels?.[SANDBOX_ORG_ID_LABEL] ?? null,
+      state: sandbox.state ?? "unknown",
+      sizing: {
+        vcpus: sandbox.cpu,
+        memoryGib: sandbox.memory,
+        diskGib: sandbox.disk,
+      },
+    });
+  }
+  return listings;
+}
+
+export async function startDaytonaSandbox(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  await sandbox.start();
+}
+
+export async function stopDaytonaSandbox(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  await sandbox.stop();
+}
+
+export async function deleteDaytonaSandbox(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+
+  await pRetry(() => sandbox.delete(), {
+    retries: 3,
+    minTimeout: 3_000,
+    factor: 1,
+    shouldRetry: ({ error }) =>
+      error instanceof DaytonaError &&
+      error.statusCode === 400 &&
+      error.message.toLowerCase().includes("state change in progress"),
+  });
+}
+
+/**
+ * Mints short-lived SSH access to a Daytona sandbox.
+ *
+ * `sandbox.createSshAccess()` returns a shape like:
+ *
+ * ```jsonc
+ * {
+ *   "id": "13f7d7e1-...",
+ *   "sandboxId": "8c416541-...",
+ *   "token": "<token>",
+ *   "expiresAt": "2026-06-05T05:38:11.846Z",
+ *   "createdAt": "2026-06-04T21:38:11.845Z",
+ *   "updatedAt": "2026-06-04T21:38:11.845Z",
+ *   "sshCommand": "ssh <token>@ssh.app.daytona.io"
+ * }
+ * ```
+ *
+ * The rotating `token` is the SSH **user** (`ssh <token>@ssh.app.daytona.io`);
+ * the host is the fixed `ssh.app.daytona.io` gateway with no explicit port. We
+ * expose `sshDestination` (the command with the leading `ssh ` stripped, i.e.
+ * `<token>@ssh.app.daytona.io`) so callers consume the parsed destination rather
+ * than re-parsing the command. Because the credential lives in the username, a
+ * new connection mints a brand-new destination each time.
+ */
+export async function createDaytonaSshAccess(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  expiresInMinutes: number = 60,
+): Promise<{
+  token: string;
+  sshCommand: string;
+  sshDestination: string;
+  expiresAt: Date;
+}> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  const sshAccess = await sandbox.createSshAccess(expiresInMinutes);
+  return {
+    token: sshAccess.token,
+    sshCommand: sshAccess.sshCommand,
+    expiresAt: sshAccess.expiresAt,
+    sshDestination: _parseSshDestination(sshAccess.sshCommand),
+  };
+}
+
+/**
+ * Derives the SSH destination (`[user@]host`) from a Daytona `sshCommand` by
+ * stripping the leading `ssh ` prefix. Exported for testing. This is the single
+ * place that knows Daytona's `ssh <destination>` command shape; callers consume
+ * the parsed `sshDestination` rather than re-parsing the command.
+ */
+export function _parseSshDestination(sshCommand: string): string {
+  return sshCommand.replace(/^ssh\s+/, "").trim();
+}
+
+export async function revokeDaytonaSshAccess(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  token: string,
+): Promise<void> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  await sandbox.revokeSshAccess(token);
+}
+
+/**
+ * Timeout for sandbox creation, in seconds. The SDK default is 60s, which
+ * a sandbox created from a captured snapshot cannot meet when the target
+ * runner has to cold-pull the multi-GB snapshot image — observed pulls
+ * run minutes. Preset creates are unaffected: creation resolves as soon
+ * as the sandbox reaches `started`. Applies to both paths: the container
+ * path passes it to `daytona.create` (which waits for `started`), and the
+ * VM path uses it as the budget for `createVmSandbox`'s started-wait.
+ */
+const SANDBOX_CREATE_TIMEOUT_S = 5 * 60;
+
+export async function createDaytonaSandbox(
+  ctx: SandboxCtx,
+  config: DaytonaConfig,
+  input: DaytonaCreateRequest,
+): Promise<{
+  provider: string;
+  providerSandboxId: string;
+  providerUrl: string | null;
+  services: SandboxService[];
+  envVars: Record<string, string>;
+}> {
+  const daytona = createDaytonaClient(config);
+  const cwd = getRepoDir(DEFAULT_HOME_DIR, input.repoName);
+
+  // Only NON-SECRET operational vars go into the container env. Anything
+  // passed to `daytona.create({ envVars })` becomes part of the container's
+  // spec, which `_experimental_createSnapshot` bakes into the snapshot image
+  // — and no Daytona API can scrub a sandbox's env afterward. So secrets
+  // (OPENCODE_SERVER_PASSWORD + injected user env) are deliberately NOT set
+  // here; they are delivered via /etc/environment (configureSshEnvironment)
+  // and passed explicitly to the lifecycle scripts (runLifecycleScripts),
+  // both of which the snapshot scrubber can clean.
+  //
+  // AMIKA_AGENT_CWD and AMIKA_SANDBOX_NAME are also seeded into the base block
+  // of /etc/environment during initialize, but that file is only sourced by
+  // login shells — the launched agent runs via a non-login `process.exec`
+  // (see DaytonaAdapter.exec), which inherits the container env, not the
+  // managed file. Baking them here is what actually makes them visible to the
+  // agent. They are per-sandbox, so a from-snapshot boot re-sets them via this
+  // create call (create-time env overrides the value baked into the snapshot
+  // image); both are non-secret, so baking them carries no scrub concern.
+  const envVars: Record<string, string> = {
+    AMIKA_AGENT_CWD: cwd,
+    AMIKA_SANDBOX_NAME: input.name,
+  };
+  if (input.amikaOpenCodeWeb != null) {
+    envVars.AMIKA_OPENCODE_WEB = input.amikaOpenCodeWeb;
+  }
+
+  // Mark the sandbox as having secrets kept out of its container env, so
+  // "snapshot and delete" can tell it apart from sandboxes whose baked-in
+  // env secrets a snapshot can't scrub. Only stamp it when the base
+  // snapshot is itself clean (`scrubSafe`): a sandbox booted from a dirty
+  // snapshot inherits that snapshot's baked container ENV, so it is NOT
+  // scrub-safe even though this create call injects no new secrets.
+  const labels = input.scrubSafe
+    ? {
+        ...input.labels,
+        [SANDBOX_ENV_SECRETS_EXCLUDED_LABEL]:
+          SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
+      }
+    : input.labels;
+  const autoStopInterval = input.autoStopInterval ?? 30;
+  const autoDeleteInterval =
+    input.autoDeleteInterval ?? SANDBOX_DELETE_INTERVAL_KEEP_ON_STOP;
+
+  // A base snapshot Daytona has flipped to `inactive` (it does so after ~2
+  // weeks without use) makes the create below fail with "Snapshot <name> is
+  // inactive" instead of reactivating it. Reactivate first so the boot
+  // succeeds; no-op for the common already-active case.
+  if (await ensureDaytonaSnapshotActive(config, input.snapshot)) {
+    ctx.logger.info(
+      { snapshot: input.snapshot },
+      "Reactivated inactive Daytona snapshot before create",
+    );
+  }
+
+  ctx.logger.info(
+    {
+      name: input.name,
+      snapshot: input.snapshot,
+      envVarKeys: Object.keys(envVars),
+      useVm: config.useVm ?? false,
+    },
+    "Creating Daytona sandbox",
+  );
+
+  // VM mode boots the sandbox as a `linux-vm` instead of a container. The SDK's
+  // `create()` can't set the sandbox class, so go through the api-client; the
+  // resulting sandbox (and any snapshot later captured from it) is a VM. The
+  // container path keeps using the SDK unchanged.
+  const providerSandboxId = config.useVm
+    ? await createVmSandbox(config, {
+        name: input.name,
+        snapshot: input.snapshot,
+        env: envVars,
+        labels,
+        autoStopInterval,
+        autoDeleteInterval,
+        timeoutSeconds: SANDBOX_CREATE_TIMEOUT_S,
+      })
+    : (
+        await daytona.create(
+          {
+            name: input.name,
+            snapshot: input.snapshot,
+            envVars,
+            labels,
+            public: false,
+            autoStopInterval,
+            autoDeleteInterval,
+          },
+          { timeout: SANDBOX_CREATE_TIMEOUT_S },
+        )
+      ).id;
+
+  return {
+    provider: "daytona",
+    providerSandboxId,
+    providerUrl: null,
+    services: input.services,
+    envVars,
+  };
+}
+
+export async function readSandboxFile(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  filePath: string,
+): Promise<string | null> {
+  try {
+    const daytona = createDaytonaClient(config);
+    const sandbox = await daytona.get(providerSandboxId);
+    const content = await sandbox.fs.downloadFile(filePath);
+    return content.toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSandboxFile(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  filePath: string,
+  content: Buffer | string,
+): Promise<void> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  await new DaytonaAdapter(sandbox, daytona).uploadFile(content, filePath);
+}
+
+/**
+ * Open a Daytona adapter handle (the provisioning seam). Fetches the sandbox
+ * once and wraps it, so a caller can reuse the handle across its many adapter
+ * ops rather than re-fetching per op.
+ */
+export async function openDaytonaAdapter(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+): Promise<SandboxAdapter> {
+  const daytona = createDaytonaClient(config);
+  return new DaytonaAdapter(await daytona.get(providerSandboxId), daytona);
+}
+
+/** Run a one-shot command in the sandbox (fetch the handle, then exec). */
+export async function executeDaytonaCommand(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  command: string,
+  opts?: ExecCommandOptions,
+): Promise<SandboxExecResult> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  return executeCommand(sandbox, command, opts);
+}
+
+/**
+ * Stream a command's output over a Daytona process session. The
+ * WebSocket-based callback overload resolves when the command finishes and the
+ * socket closes; the session is best-effort deleted afterwards.
+ */
+export async function streamDaytonaCommandLogs(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  command: string,
+  handlers: StreamCommandHandlers,
+): Promise<void> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  const sessionId = `agent-stream-${Date.now()}`;
+  await sandbox.process.createSession(sessionId);
+  try {
+    const execResult = await sandbox.process.executeSessionCommand(sessionId, {
+      command,
+      runAsync: true,
+    });
+    const commandId = execResult.cmdId!;
+    await sandbox.process.getSessionCommandLogs(
+      sessionId,
+      commandId,
+      (chunk: string) => handlers.onStdout(chunk),
+      (chunk: string) => handlers.onStderr?.(chunk),
+    );
+  } finally {
+    sandbox.process.deleteSession(sessionId).catch(() => {});
+  }
+}
+
+/** Clone one repo into a Daytona sandbox via the SDK's native `git.clone`. */
+export async function cloneDaytonaRepo(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  input: CloneRepoInput,
+): Promise<void> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  await cloneRepository(
+    sandbox,
+    input.homeDir,
+    input.githubUrl,
+    input.repoName,
+    input.githubToken,
+    input.branch,
+  );
+}

--- a/js/sandbox/src/providers/daytona/internal/sandbox-ops.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/sandbox-ops.test.ts
@@ -1,0 +1,294 @@
+import { DaytonaError } from "@daytonaio/sdk";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SANDBOX_ENV_SECRETS_EXCLUDED_LABEL,
+  SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
+} from "../../../constants";
+import { createDaytonaSandbox, deleteDaytonaSandbox } from "./operations";
+
+vi.mock("@daytonaio/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@daytonaio/sdk")>();
+  return {
+    ...actual,
+    Daytona: vi.fn(),
+  };
+});
+
+// VM mode (`useVm`) bypasses the SDK and creates sandboxes through the generated
+// api-client so it can set the `linux-vm` class. Mock only the client classes;
+// keep the real `SandboxClass`/`SandboxState` enums.
+vi.mock("@daytona/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@daytona/api-client")>();
+  return {
+    ...actual,
+    Configuration: vi.fn(),
+    SandboxApi: vi.fn(),
+  };
+});
+
+const { Daytona } = await import("@daytonaio/sdk");
+const { SandboxApi } = await import("@daytona/api-client");
+
+function setupMockDaytona(deleteFn: () => Promise<void>) {
+  vi.mocked(Daytona).mockImplementation(function () {
+    return {
+      get: vi.fn().mockResolvedValue({ delete: deleteFn }),
+    } as unknown as InstanceType<typeof Daytona>;
+  });
+}
+
+const testConfig = {
+  apiKey: "test-key",
+  apiUrl: "https://test.daytona.io",
+  target: "test-target",
+  organizationId: undefined,
+  useVm: false,
+};
+
+describe("deleteDaytonaSandbox", () => {
+  it("succeeds on first attempt", async () => {
+    const deleteFn = vi.fn().mockResolvedValue(undefined);
+    setupMockDaytona(deleteFn);
+
+    await deleteDaytonaSandbox(testConfig, "sandbox-1");
+
+    expect(deleteFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on state-change error then succeeds", async () => {
+    const stateChangeError = new DaytonaError(
+      "Sandbox state change in progress",
+      400,
+    );
+    const deleteFn = vi
+      .fn()
+      .mockRejectedValueOnce(stateChangeError)
+      .mockResolvedValueOnce(undefined);
+    setupMockDaytona(deleteFn);
+
+    await deleteDaytonaSandbox(testConfig, "sandbox-1");
+
+    expect(deleteFn).toHaveBeenCalledTimes(2);
+  }, 15_000);
+
+  it("throws after all retries exhausted", async () => {
+    const stateChangeError = new DaytonaError(
+      "Sandbox state change in progress",
+      400,
+    );
+    const deleteFn = vi.fn().mockRejectedValue(stateChangeError);
+    setupMockDaytona(deleteFn);
+
+    await expect(deleteDaytonaSandbox(testConfig, "sandbox-1")).rejects.toThrow(
+      "state change in progress",
+    );
+
+    // 1 initial + 3 retries = 4
+    expect(deleteFn).toHaveBeenCalledTimes(4);
+  }, 15_000);
+
+  it("does not retry on non-state-change errors", async () => {
+    const otherError = new DaytonaError("Sandbox not found", 404);
+    const deleteFn = vi.fn().mockRejectedValue(otherError);
+    setupMockDaytona(deleteFn);
+
+    await expect(deleteDaytonaSandbox(testConfig, "sandbox-1")).rejects.toThrow(
+      "Sandbox not found",
+    );
+
+    expect(deleteFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createDaytonaSandbox", () => {
+  it("bakes only non-secret operational vars into the container env", async () => {
+    // The container env is baked into snapshots and can't be scrubbed
+    // afterward. Secrets do not exist on the create input; this pins that the
+    // create path bakes only the allowed operational vars.
+    const createFn = vi.fn().mockResolvedValue({ id: "sandbox-xyz" });
+    vi.mocked(Daytona).mockImplementation(function () {
+      return {
+        create: createFn,
+        snapshot: { get: vi.fn().mockResolvedValue({ state: "active" }) },
+      } as unknown as InstanceType<typeof Daytona>;
+    });
+    const ctx = { logger: { info: vi.fn() } } as unknown as Parameters<
+      typeof createDaytonaSandbox
+    >[0];
+
+    await createDaytonaSandbox(ctx, testConfig, {
+      name: "sb",
+      snapshot: "snap",
+      services: [],
+      amikaOpenCodeWeb: "1",
+      repoName: "example-repo",
+      scrubSafe: true,
+    });
+
+    expect(createFn).toHaveBeenCalledTimes(1);
+    const { envVars, labels } = createFn.mock.calls[0][0] as {
+      envVars: Record<string, string>;
+      labels: Record<string, string>;
+    };
+
+    // Only the non-secret operational vars are baked; nothing else may leak
+    // into the snapshot-captured container env.
+    expect(Object.keys(envVars).sort()).toEqual([
+      "AMIKA_AGENT_CWD",
+      "AMIKA_OPENCODE_WEB",
+      "AMIKA_SANDBOX_NAME",
+    ]);
+    expect(envVars.AMIKA_OPENCODE_WEB).toBe("1");
+    expect(envVars).toHaveProperty("AMIKA_AGENT_CWD");
+    // The sandbox name is baked into the container env so the launched agent
+    // (a non-login exec that doesn't source /etc/environment) can see it.
+    expect(envVars.AMIKA_SANDBOX_NAME).toBe("sb");
+    // A scrub-safe base earns the clean-env marker, which lets
+    // snapshot-and-delete distinguish this sandbox from ones with baked-in
+    // container env secrets.
+    expect(labels[SANDBOX_ENV_SECRETS_EXCLUDED_LABEL]).toBe(
+      SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
+    );
+  });
+
+  it("does NOT mark scrub-safe when the base snapshot is untrusted", async () => {
+    // A sandbox booted from a dirty/pre-fix snapshot inherits that
+    // snapshot's baked-in container ENV, so it must not get the label even
+    // though this create call injects no new secrets.
+    const createFn = vi.fn().mockResolvedValue({ id: "sandbox-xyz" });
+    vi.mocked(Daytona).mockImplementation(function () {
+      return {
+        create: createFn,
+        snapshot: { get: vi.fn().mockResolvedValue({ state: "active" }) },
+      } as unknown as InstanceType<typeof Daytona>;
+    });
+    const ctx = { logger: { info: vi.fn() } } as unknown as Parameters<
+      typeof createDaytonaSandbox
+    >[0];
+
+    await createDaytonaSandbox(ctx, testConfig, {
+      name: "sb",
+      snapshot: "user-snapshot",
+      services: [],
+      repoName: "example-repo",
+      labels: { "amika-org-id": "org_1" },
+      scrubSafe: false,
+    });
+
+    const { labels } = createFn.mock.calls[0][0] as {
+      labels: Record<string, string>;
+    };
+    // Pre-existing labels are preserved, but the scrub-safe marker is absent.
+    expect(labels).toHaveProperty("amika-org-id", "org_1");
+    expect(labels).not.toHaveProperty(SANDBOX_ENV_SECRETS_EXCLUDED_LABEL);
+  });
+
+  it("reactivates an inactive base snapshot before creating from it", async () => {
+    // A base snapshot Daytona has let lapse to `inactive` must be reactivated
+    // before the create — otherwise `daytona.create` rejects with "Snapshot is
+    // inactive". The reactivation must happen *before* the create is issued.
+    const createFn = vi.fn().mockResolvedValue({ id: "sandbox-xyz" });
+    const snapshotGet = vi
+      .fn()
+      .mockResolvedValueOnce({ state: "inactive", name: "snap" }) // ensure's state read
+      .mockResolvedValueOnce({ state: "inactive", name: "snap" }) // activate's own get
+      .mockResolvedValue({ state: "active", name: "snap" }); // waitForActive poll
+    const snapshotActivate = vi.fn().mockResolvedValue({ state: "pending" });
+    const snapshotList = vi
+      .fn()
+      .mockResolvedValue({ items: [], total: 0, page: 1, totalPages: 1 });
+    vi.mocked(Daytona).mockImplementation(function () {
+      return {
+        create: createFn,
+        snapshot: {
+          get: snapshotGet,
+          activate: snapshotActivate,
+          list: snapshotList,
+        },
+      } as unknown as InstanceType<typeof Daytona>;
+    });
+    const ctx = { logger: { info: vi.fn() } } as unknown as Parameters<
+      typeof createDaytonaSandbox
+    >[0];
+
+    await createDaytonaSandbox(ctx, testConfig, {
+      name: "sb",
+      snapshot: "snap",
+      services: [],
+      repoName: "example-repo",
+      scrubSafe: true,
+    });
+
+    expect(snapshotActivate).toHaveBeenCalledTimes(1);
+    expect(createFn).toHaveBeenCalledTimes(1);
+    // Ordering: the snapshot was reactivated before the sandbox create fired.
+    expect(snapshotActivate.mock.invocationCallOrder[0]).toBeLessThan(
+      createFn.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("creates a linux-vm via the api-client when useVm is set", async () => {
+    // VM mode must NOT use the SDK's create() (which can't set the class) and
+    // must POST `class: "linux-vm"` through the api-client instead.
+    const sdkCreateFn = vi.fn();
+    vi.mocked(Daytona).mockImplementation(function () {
+      return {
+        create: sdkCreateFn,
+        snapshot: { get: vi.fn().mockResolvedValue({ state: "active" }) },
+      } as unknown as InstanceType<typeof Daytona>;
+    });
+    const createSandboxFn = vi
+      .fn()
+      .mockResolvedValue({ data: { id: "vm-sandbox-1" } });
+    // createVmSandbox polls getSandbox until the VM reaches `started` before
+    // returning, so the started-wait sees a running VM immediately.
+    const getSandboxFn = vi
+      .fn()
+      .mockResolvedValue({ data: { state: "started" } });
+    vi.mocked(SandboxApi).mockImplementation(function () {
+      return {
+        createSandbox: createSandboxFn,
+        getSandbox: getSandboxFn,
+      } as unknown as InstanceType<typeof SandboxApi>;
+    });
+    const ctx = { logger: { info: vi.fn() } } as unknown as Parameters<
+      typeof createDaytonaSandbox
+    >[0];
+
+    const result = await createDaytonaSandbox(
+      ctx,
+      { ...testConfig, useVm: true },
+      {
+        name: "sb",
+        snapshot: "snap",
+        services: [],
+        repoName: "example-repo",
+        labels: { "amika-org-id": "org_1" },
+        scrubSafe: true,
+      },
+    );
+
+    expect(sdkCreateFn).not.toHaveBeenCalled();
+    expect(createSandboxFn).toHaveBeenCalledTimes(1);
+    expect(result.providerSandboxId).toBe("vm-sandbox-1");
+
+    const body = createSandboxFn.mock.calls[0][0] as {
+      class: string;
+      snapshot: string;
+      target: string | undefined;
+      env: Record<string, string>;
+      labels: Record<string, string>;
+    };
+    expect(body.class).toBe("linux-vm");
+    expect(body.snapshot).toBe("snap");
+    expect(body.target).toBe("test-target");
+    // Same env/label discipline as the container path: no secrets in the
+    // container env, scrub-safe marker preserved.
+    expect(body.env).not.toHaveProperty("OPENCODE_SERVER_PASSWORD");
+    expect(body.env).not.toHaveProperty("SNAPSHOT_TEST_VAR");
+    expect(body.labels["amika-org-id"]).toBe("org_1");
+    expect(body.labels[SANDBOX_ENV_SECRETS_EXCLUDED_LABEL]).toBe(
+      SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
+    );
+  });
+});

--- a/js/sandbox/src/providers/daytona/internal/snapshot-operations.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/snapshot-operations.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DaytonaError } from "@daytonaio/sdk";
+import type { DaytonaConfig } from "../config";
+import {
+  captureDaytonaSandboxSnapshot,
+  ensureDaytonaSnapshotActive,
+  waitForDaytonaSnapshotActive,
+} from "./snapshot-operations";
+
+const getSnapshot = vi.fn();
+const listSnapshots = vi.fn();
+const activateSnapshot = vi.fn();
+const getSandbox = vi.fn();
+const getExperimentalSandbox = vi.fn();
+const stopDockerMock = vi.fn();
+const startDockerMock = vi.fn();
+const captureVmSnapshotMock = vi.fn();
+const isVmSandboxMock = vi.fn();
+
+// The experimental client exposes only sandbox `get` — anything touching
+// `snapshot.*` on it (e.g. waitForDaytonaSnapshotActive, which must use
+// the default target) blows up instead of silently working.
+vi.mock("./client", () => ({
+  createDaytonaClient: () => ({
+    get: (id: string) => getSandbox(id),
+    snapshot: {
+      get: (name: string) => getSnapshot(name),
+      list: (page: number, limit: number) => listSnapshots(page, limit),
+      activate: (snapshot: unknown) => activateSnapshot(snapshot),
+    },
+  }),
+  createExperimentalDaytonaClient: () => ({
+    get: (id: string) => getExperimentalSandbox(id),
+  }),
+}));
+
+vi.mock("./configure", () => ({
+  stopDockerForSnapshot: (...args: unknown[]) => stopDockerMock(...args),
+  startDockerForSnapshot: (...args: unknown[]) => startDockerMock(...args),
+}));
+
+vi.mock("./vm", () => ({
+  captureVmSandboxSnapshot: (...args: unknown[]) =>
+    captureVmSnapshotMock(...args),
+  isVmSandbox: (...args: unknown[]) => isVmSandboxMock(...args),
+}));
+
+const config: DaytonaConfig = {
+  apiKey: "key",
+  apiUrl: "https://daytona.example",
+  target: undefined,
+  organizationId: undefined,
+  useVm: false,
+};
+
+const notFound = () => new DaytonaError("not found", 404);
+const emptyList = { items: [], total: 0, page: 1, totalPages: 1 };
+
+describe("waitForDaytonaSnapshotActive", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getSnapshot.mockReset();
+    listSnapshots.mockReset();
+    listSnapshots.mockResolvedValue(emptyList);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("polls through 404s and non-active states until the snapshot is active", async () => {
+    getSnapshot
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValueOnce({ state: "pending" })
+      .mockResolvedValueOnce({ state: "active", name: "org/sandbox/snap" });
+
+    const promise = waitForDaytonaSnapshotActive(config, "org/sandbox/snap");
+    await vi.advanceTimersByTimeAsync(2_000); // sleep after the 404
+    await vi.advanceTimersByTimeAsync(2_000); // sleep after "pending"
+
+    await expect(promise).resolves.toMatchObject({ state: "active" });
+    expect(getSnapshot).toHaveBeenCalledTimes(3);
+    expect(getSnapshot).toHaveBeenCalledWith("org/sandbox/snap");
+  });
+
+  it("finds a building snapshot via the list when get-by-name 404s", async () => {
+    getSnapshot.mockRejectedValue(notFound());
+    listSnapshots
+      .mockResolvedValueOnce({
+        items: [{ name: "org/sandbox/snap", state: "building" }],
+        total: 1,
+        page: 1,
+        totalPages: 1,
+      })
+      .mockResolvedValueOnce({
+        items: [{ name: "org/sandbox/snap", state: "active" }],
+        total: 1,
+        page: 1,
+        totalPages: 1,
+      });
+
+    const promise = waitForDaytonaSnapshotActive(config, "org/sandbox/snap");
+    await vi.advanceTimersByTimeAsync(2_000); // sleep after "building"
+
+    await expect(promise).resolves.toMatchObject({ state: "active" });
+    expect(listSnapshots).toHaveBeenCalledTimes(2);
+  });
+
+  it("scans multiple list pages for the snapshot", async () => {
+    getSnapshot.mockRejectedValue(notFound());
+    listSnapshots
+      .mockResolvedValueOnce({
+        items: [{ name: "org/sandbox/other", state: "active" }],
+        total: 2,
+        page: 1,
+        totalPages: 2,
+      })
+      .mockResolvedValueOnce({
+        items: [{ name: "org/sandbox/snap", state: "active" }],
+        total: 2,
+        page: 2,
+        totalPages: 2,
+      });
+
+    await expect(
+      waitForDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).resolves.toMatchObject({ state: "active" });
+    expect(listSnapshots).toHaveBeenNthCalledWith(1, 1, 100);
+    expect(listSnapshots).toHaveBeenNthCalledWith(2, 2, 100);
+  });
+
+  it("throws when the snapshot enters a terminal failure state", async () => {
+    getSnapshot.mockResolvedValueOnce({
+      state: "build_failed",
+      errorReason: "image push failed",
+    });
+
+    await expect(
+      waitForDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).rejects.toThrow(
+      'entered terminal state "build_failed": image push failed',
+    );
+  });
+
+  it("throws when the snapshot never becomes active within the timeout", async () => {
+    getSnapshot.mockResolvedValue({ state: "pending" });
+
+    const promise = waitForDaytonaSnapshotActive(config, "org/sandbox/snap", 5);
+    const assertion = expect(promise).rejects.toThrow(
+      'did not become active within 5s (last state: "pending")',
+    );
+    await vi.advanceTimersByTimeAsync(6_000);
+    await assertion;
+  });
+
+  it("reports a snapshot that never appeared when timing out on 404s", async () => {
+    getSnapshot.mockRejectedValue(notFound());
+
+    const promise = waitForDaytonaSnapshotActive(config, "org/sandbox/snap", 5);
+    const assertion = expect(promise).rejects.toThrow(
+      "never appeared in the snapshot list",
+    );
+    await vi.advanceTimersByTimeAsync(6_000);
+    await assertion;
+  });
+
+  it("rethrows non-404 errors immediately", async () => {
+    getSnapshot.mockRejectedValueOnce(new DaytonaError("boom", 500));
+
+    await expect(
+      waitForDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).rejects.toThrow("boom");
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
+    expect(listSnapshots).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureDaytonaSandboxSnapshot", () => {
+  beforeEach(() => {
+    getSandbox.mockReset();
+    getExperimentalSandbox.mockReset();
+    stopDockerMock.mockReset();
+    startDockerMock.mockReset();
+    captureVmSnapshotMock.mockReset();
+    isVmSandboxMock.mockReset();
+    // Default: the sandbox is a container, so the VM path is skipped even when
+    // `useVm` is set. Tests exercising the VM path opt in explicitly.
+    isVmSandboxMock.mockResolvedValue(false);
+  });
+
+  it("captures a VM cold via the api-client, forwarding the keep-source intent", async () => {
+    // VM mode snapshots the VM *cold*: `captureVmSandboxSnapshot` stops the
+    // whole VM (which also quiesces the inner Docker daemon) and takes a
+    // memory-excluded snapshot, so the container Docker stop/start dance is
+    // neither needed nor used, and the capture goes through the VM helper
+    // rather than the SDK's experimental snapshot.
+    getSandbox.mockResolvedValue({ id: "normal-handle" });
+    isVmSandboxMock.mockResolvedValue(true);
+    captureVmSnapshotMock.mockResolvedValue(undefined);
+
+    await captureDaytonaSandboxSnapshot(
+      { ...config, useVm: true },
+      "sbx-1",
+      "org/sandbox/snap",
+      { keepSourceRunning: false },
+    );
+    // Delete-intent skips the power-restart (a stopped VM stays recoverable
+    // via Start): the trailing `restartAfterCapture` arg is false.
+    expect(captureVmSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({ useVm: true }),
+      "sbx-1",
+      "org/sandbox/snap",
+      expect.any(Number),
+      false,
+    );
+    expect(stopDockerMock).not.toHaveBeenCalled();
+    expect(startDockerMock).not.toHaveBeenCalled();
+    expect(getExperimentalSandbox).not.toHaveBeenCalled();
+
+    await captureDaytonaSandboxSnapshot(
+      { ...config, useVm: true },
+      "sbx-1",
+      "org/sandbox/snap",
+      { keepSourceRunning: true },
+    );
+    // Keep-source restarts the VM after the cold capture.
+    expect(captureVmSnapshotMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ useVm: true }),
+      "sbx-1",
+      "org/sandbox/snap",
+      expect.any(Number),
+      true,
+    );
+  });
+
+  it("uses the container path when useVm is set but the sandbox is a container", async () => {
+    // A container created before the flag was enabled must not hit the VM
+    // snapshot call (Daytona rejects it); the real class governs the branch.
+    const sandbox = { id: "normal-handle" };
+    const experimentalSandbox = {
+      _experimental_createSnapshot: vi.fn().mockResolvedValue(undefined),
+    };
+    getSandbox.mockResolvedValue(sandbox);
+    getExperimentalSandbox.mockResolvedValue(experimentalSandbox);
+    isVmSandboxMock.mockResolvedValue(false);
+    stopDockerMock.mockResolvedValue(undefined);
+    startDockerMock.mockResolvedValue(undefined);
+
+    await captureDaytonaSandboxSnapshot(
+      { ...config, useVm: true },
+      "sbx-1",
+      "org/sandbox/snap",
+      { keepSourceRunning: false },
+    );
+
+    expect(captureVmSnapshotMock).not.toHaveBeenCalled();
+    expect(
+      experimentalSandbox._experimental_createSnapshot,
+    ).toHaveBeenCalledWith("org/sandbox/snap", expect.any(Number));
+    expect(startDockerMock).toHaveBeenCalledWith(sandbox);
+  });
+
+  it("keep-source container capture snapshots hot — no docker quiesce", async () => {
+    // Today's full-capture behavior: a kept-alive container is snapshotted
+    // without stopping dockerd (the quiesce exists to protect a snapshot that
+    // will be booted as the org base, and the destructive path covers that).
+    const experimentalSandbox = {
+      _experimental_createSnapshot: vi.fn().mockResolvedValue(undefined),
+    };
+    getExperimentalSandbox.mockResolvedValue(experimentalSandbox);
+
+    await captureDaytonaSandboxSnapshot(config, "sbx-1", "org/sandbox/snap", {
+      keepSourceRunning: true,
+    });
+
+    expect(stopDockerMock).not.toHaveBeenCalled();
+    expect(startDockerMock).not.toHaveBeenCalled();
+    expect(getSandbox).not.toHaveBeenCalled();
+    expect(
+      experimentalSandbox._experimental_createSnapshot,
+    ).toHaveBeenCalledWith("org/sandbox/snap", expect.any(Number));
+  });
+
+  it("delete-intent container capture stops docker before and restarts after", async () => {
+    // Docker stops right before capture so /var/lib/docker is frozen at rest,
+    // then restarts right after so a kept (delete-failed) source isn't left
+    // down. The quiesce/restore run against the normal (non-experimental)
+    // handle — fs/exec through the experimental client can silently no-op.
+    const calls: string[] = [];
+    const sandbox = { id: "normal-handle" };
+    const experimentalSandbox = {
+      _experimental_createSnapshot: vi.fn(async () => {
+        calls.push("capture");
+      }),
+    };
+    getSandbox.mockResolvedValue(sandbox);
+    getExperimentalSandbox.mockResolvedValue(experimentalSandbox);
+    stopDockerMock.mockImplementation(async () => {
+      calls.push("stop-docker");
+    });
+    startDockerMock.mockImplementation(async () => {
+      calls.push("start-docker");
+    });
+
+    await captureDaytonaSandboxSnapshot(config, "sbx-1", "org/sandbox/snap", {
+      keepSourceRunning: false,
+    });
+
+    expect(calls).toEqual(["stop-docker", "capture", "start-docker"]);
+    expect(stopDockerMock).toHaveBeenCalledWith(sandbox);
+    expect(startDockerMock).toHaveBeenCalledWith(sandbox);
+  });
+
+  it("restarts docker even when the capture fails", async () => {
+    // A failed capture leaves the source sandbox alive (restored to `active`
+    // by the caller), so Docker must come back up rather than stay stopped
+    // from the pre-capture quiesce.
+    const sandbox = { id: "normal-handle" };
+    const experimentalSandbox = {
+      _experimental_createSnapshot: vi
+        .fn()
+        .mockRejectedValue(new Error("boom")),
+    };
+    getSandbox.mockResolvedValue(sandbox);
+    getExperimentalSandbox.mockResolvedValue(experimentalSandbox);
+    stopDockerMock.mockResolvedValue(undefined);
+    startDockerMock.mockResolvedValue(undefined);
+
+    await expect(
+      captureDaytonaSandboxSnapshot(config, "sbx-1", "org/sandbox/snap", {
+        keepSourceRunning: false,
+      }),
+    ).rejects.toThrow("boom");
+    expect(startDockerMock).toHaveBeenCalledWith(sandbox);
+  });
+
+  it("restarts docker even when resolving the experimental handle fails", async () => {
+    // The experimental `get` runs after docker is stopped; a failure there
+    // must still hit the restart, or a kept source sandbox is left down.
+    const sandbox = { id: "normal-handle" };
+    getSandbox.mockResolvedValue(sandbox);
+    getExperimentalSandbox.mockRejectedValue(new Error("target down"));
+    stopDockerMock.mockResolvedValue(undefined);
+    startDockerMock.mockResolvedValue(undefined);
+
+    await expect(
+      captureDaytonaSandboxSnapshot(config, "sbx-1", "org/sandbox/snap", {
+        keepSourceRunning: false,
+      }),
+    ).rejects.toThrow("target down");
+    expect(stopDockerMock).toHaveBeenCalledWith(sandbox);
+    expect(startDockerMock).toHaveBeenCalledWith(sandbox);
+  });
+});
+
+describe("ensureDaytonaSnapshotActive", () => {
+  beforeEach(() => {
+    getSnapshot.mockReset();
+    listSnapshots.mockReset();
+    activateSnapshot.mockReset();
+    listSnapshots.mockResolvedValue(emptyList);
+  });
+
+  it("is a no-op for an already-active snapshot", async () => {
+    getSnapshot.mockResolvedValueOnce({
+      state: "active",
+      name: "org/sandbox/snap",
+    });
+
+    await expect(
+      ensureDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).resolves.toBe(false);
+    expect(activateSnapshot).not.toHaveBeenCalled();
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("reactivates an inactive snapshot and waits for it to go active", async () => {
+    getSnapshot
+      .mockResolvedValueOnce({ state: "inactive", name: "org/sandbox/snap" }) // ensure's state read
+      .mockResolvedValueOnce({ state: "inactive", name: "org/sandbox/snap" }) // activate's own get
+      .mockResolvedValueOnce({ state: "active", name: "org/sandbox/snap" }); // waitForActive poll
+    activateSnapshot.mockResolvedValue({
+      state: "pending",
+      name: "org/sandbox/snap",
+    });
+
+    await expect(
+      ensureDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).resolves.toBe(true);
+    expect(activateSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block creation when the snapshot is missing (404)", async () => {
+    getSnapshot.mockRejectedValueOnce(notFound());
+
+    await expect(
+      ensureDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).resolves.toBe(false);
+    expect(activateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("swallows transient (non-404) Daytona API read errors rather than failing the create", async () => {
+    getSnapshot.mockRejectedValueOnce(new DaytonaError("boom", 500));
+
+    await expect(
+      ensureDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).resolves.toBe(false);
+    expect(activateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("propagates non-API errors instead of masking them", async () => {
+    // A non-DaytonaError (e.g. an unexpected client shape / programming bug)
+    // must surface rather than be swallowed as a best-effort read failure.
+    getSnapshot.mockRejectedValueOnce(
+      new TypeError("daytona.snapshot is undefined"),
+    );
+
+    await expect(
+      ensureDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).rejects.toThrow("daytona.snapshot is undefined");
+    expect(activateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("leaves a non-inactive (e.g. terminal) snapshot untouched", async () => {
+    getSnapshot.mockResolvedValueOnce({
+      state: "build_failed",
+      name: "org/sandbox/snap",
+    });
+
+    await expect(
+      ensureDaytonaSnapshotActive(config, "org/sandbox/snap"),
+    ).resolves.toBe(false);
+    expect(activateSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/js/sandbox/src/providers/daytona/internal/snapshot-operations.ts
+++ b/js/sandbox/src/providers/daytona/internal/snapshot-operations.ts
@@ -1,0 +1,412 @@
+/**
+ * Snapshot management operations wrapping the Daytona SDK's snapshot service.
+ *
+ * Each function creates a fresh Daytona client, consistent with the
+ * per-operation pattern used in operations.ts.
+ */
+import { DaytonaError, type Daytona } from "@daytonaio/sdk";
+import {
+  SANDBOX_ENV_SECRETS_EXCLUDED_LABEL,
+  SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
+} from "../../../constants";
+import type { DaytonaConfig } from "../config";
+import { createDaytonaClient, createExperimentalDaytonaClient } from "./client";
+import { captureVmSandboxSnapshot, isVmSandbox } from "./vm";
+import { startDockerForSnapshot, stopDockerForSnapshot } from "./configure";
+
+type SnapshotService = Daytona["snapshot"];
+type DaytonaSnapshot = Awaited<ReturnType<SnapshotService["get"]>>;
+type PaginatedDaytonaSnapshots = Awaited<ReturnType<SnapshotService["list"]>>;
+
+export interface CreateSnapshotInput {
+  name: string;
+  image: string;
+  entrypoint?: string[];
+  regionId?: string;
+}
+
+export async function createDaytonaSnapshot(
+  config: DaytonaConfig,
+  input: CreateSnapshotInput,
+): Promise<DaytonaSnapshot> {
+  const daytona = createDaytonaClient(config);
+  return daytona.snapshot.create({
+    name: input.name,
+    image: input.image,
+    entrypoint: input.entrypoint,
+    regionId: input.regionId,
+  });
+}
+
+export async function listDaytonaSnapshots(
+  config: DaytonaConfig,
+  page?: number,
+  limit?: number,
+): Promise<PaginatedDaytonaSnapshots> {
+  const daytona = createDaytonaClient(config);
+  return daytona.snapshot.list(page, limit);
+}
+
+export async function getDaytonaSnapshot(
+  config: DaytonaConfig,
+  snapshotName: string,
+): Promise<DaytonaSnapshot> {
+  const daytona = createDaytonaClient(config);
+  return daytona.snapshot.get(snapshotName);
+}
+
+/**
+ * Look up a snapshot by name, tolerating one that is still registering: uses
+ * the list-scan fallback so a snapshot present in the list but not yet
+ * addressable by a bare `get` is still found. Returns null when genuinely
+ * absent. Use this (over `getDaytonaSnapshot`) when "does any snapshot occupy
+ * this name?" must account for in-flight captures.
+ */
+export async function findDaytonaSnapshot(
+  config: DaytonaConfig,
+  snapshotName: string,
+): Promise<DaytonaSnapshot | null> {
+  const daytona = createDaytonaClient(config);
+  return (await findDaytonaSnapshotByName(daytona, snapshotName)) ?? null;
+}
+
+export async function deleteDaytonaSnapshot(
+  config: DaytonaConfig,
+  snapshotName: string,
+): Promise<void> {
+  const daytona = createDaytonaClient(config);
+  // Locate via the list-scan fallback rather than a bare get: a snapshot that
+  // is still registering (e.g. a large capture that activated after our wait
+  // timed out, leaving the row `failed`) can be absent from the by-name
+  // lookup yet present in the list. A bare get would 404 here and the caller
+  // would drop its record, leaving the snapshot to finish into an orphan the
+  // listing can't reconcile. The scan finds and deletes it instead. A truly
+  // absent snapshot is a no-op (already gone — callers then clean up refs).
+  const snapshot = await findDaytonaSnapshotByName(daytona, snapshotName);
+  if (!snapshot) return;
+  await daytona.snapshot.delete(snapshot);
+}
+
+export async function activateDaytonaSnapshot(
+  config: DaytonaConfig,
+  snapshotName: string,
+): Promise<DaytonaSnapshot> {
+  const daytona = createDaytonaClient(config);
+  const snapshot = await daytona.snapshot.get(snapshotName);
+  return daytona.snapshot.activate(snapshot);
+}
+
+/**
+ * Per-call timeout for `_experimental_createSnapshot`, in seconds.
+ * The SDK default is 60s, which is far too tight for real sandboxes —
+ * snapshotting a coder-sized image with node_modules / build caches
+ * regularly takes several minutes, and captures exceeding 5 minutes
+ * have been observed in practice. 15 minutes covers those while still
+ * surfacing a genuinely stuck job.
+ */
+const SANDBOX_SNAPSHOT_TIMEOUT_S = 15 * 60;
+
+/**
+ * Capture a snapshot of a running Daytona sandbox (the spec-018 raw capture
+ * primitive — scrubbing, if any, has already happened above in core).
+ *
+ * A `linux-vm` source is snapshotted *cold* via the api-client: the VM is
+ * stopped, snapshotted with memory excluded, then restarted when the caller
+ * keeps the source. A hot memory snapshot would resume a frozen network stack
+ * on restore and break egress — see `captureVmSandboxSnapshot`. The snapshot
+ * inherits the source's `linux-vm` class, so a sandbox later booted from it is
+ * itself a VM. Branch on the sandbox's real class, not `useVm`: a container
+ * created before the flag was enabled is still a container and takes the
+ * experimental-snapshot path below.
+ *
+ * Container captures go through the experimental client's
+ * `_experimental_createSnapshot` — the method and the resulting snapshot exist
+ * only on that target (the underscore is the SDK's own unstable marker).
+ *
+ * `keepSourceRunning: false` is delete-INTENT, not a guarantee: activation can
+ * time out or the delete can fail, after which the source is retained and
+ * released out of band. It therefore only relaxes keep-alive where a
+ * retained source stays recoverable — the VM branch skips the power-restart (a
+ * stopped VM is user-restartable via Start), while the container branch
+ * ALWAYS restores dind in `finally`: a retained source must never come back
+ * with Docker quiesced. The quiesce itself (stop dockerd before the capture
+ * freezes the filesystem) only runs on the destructive path — a kept-alive
+ * container capture snapshots hot, exactly as before.
+ */
+export async function captureDaytonaSandboxSnapshot(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  snapshotName: string,
+  opts: { keepSourceRunning: boolean },
+): Promise<void> {
+  if (config.useVm && (await isVmSandbox(config, providerSandboxId))) {
+    await captureVmSandboxSnapshot(
+      config,
+      providerSandboxId,
+      snapshotName,
+      SANDBOX_SNAPSHOT_TIMEOUT_S,
+      opts.keepSourceRunning,
+    );
+    return;
+  }
+
+  const capture = async (): Promise<void> => {
+    const daytona = createExperimentalDaytonaClient(config);
+    const sandbox = await daytona.get(providerSandboxId);
+    await sandbox._experimental_createSnapshot(
+      snapshotName,
+      SANDBOX_SNAPSHOT_TIMEOUT_S,
+    );
+  };
+
+  if (opts.keepSourceRunning) {
+    await capture();
+    return;
+  }
+
+  // Destructive container path: stop the Docker daemon and quiesce
+  // /var/lib/docker just before capture. A dind snapshot taken with dockerd
+  // live bakes in mid-flight overlay mounts / network state that stall dockerd
+  // recovery on restore, tripping the image hook's 30s readiness wait when a
+  // sandbox boots from this snapshot. No-op on non-dind sandboxes. The
+  // quiesce/restore run through the NORMAL client — exec/filesystem operations
+  // through the experimental client can silently no-op.
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  await stopDockerForSnapshot(sandbox);
+  try {
+    await capture();
+  } finally {
+    // The capture has frozen the filesystem, so restarting the live daemon no
+    // longer affects the snapshot. Bring Docker back unconditionally: if the
+    // capture threw — or it succeeded but the caller's durability wait later
+    // times out — the source sandbox is kept and restored to `active`, and
+    // must not be left with its containers down. On the normal success path
+    // the caller deletes the sandbox right after, so this is a harmless
+    // fire-and-forget no-op.
+    await startDockerForSnapshot(sandbox);
+  }
+}
+
+/**
+ * How long to wait for a freshly captured sandbox snapshot to become
+ * `active`, in seconds. `_experimental_createSnapshot` resolves when the
+ * *sandbox* finishes its capture phase; the snapshot itself registers and
+ * activates asynchronously in the default region afterward (image push +
+ * validation), which for large filesystems takes minutes more — and the
+ * snapshot may not even be addressable by name until that completes, so
+ * the window has to cover the full push, not just a state transition.
+ */
+const SANDBOX_SNAPSHOT_ACTIVE_TIMEOUT_S = 10 * 60;
+
+/**
+ * How long to wait for a *reactivated* snapshot to return to `active`, in
+ * seconds. Shorter than {@link SANDBOX_SNAPSHOT_ACTIVE_TIMEOUT_S}: reactivation
+ * restores an already-built snapshot rather than pushing a freshly captured
+ * image, and the wait runs inline inside `createDaytonaSandbox` (ahead of the
+ * sandbox create), so it must stay well within the create budget.
+ */
+const SNAPSHOT_REACTIVATE_TIMEOUT_S = 5 * 60;
+
+/** Poll cadence for `waitForDaytonaSnapshotActive`. */
+const SNAPSHOT_ACTIVE_POLL_INTERVAL_MS = 2_000;
+
+/** Page size for the list-scan fallback in `findDaytonaSnapshotByName`. */
+const SNAPSHOT_LIST_PAGE_SIZE = 100;
+
+/**
+ * Look up `snapshotName` by direct name lookup, falling back to scanning
+ * the paginated snapshot list. A freshly captured sandbox snapshot can be
+ * invisible to the by-name lookup while it is still registering/building,
+ * yet already present in the list — the fallback both finds it earlier
+ * and lets the caller report its in-flight state instead of a bare 404.
+ */
+async function findDaytonaSnapshotByName(
+  daytona: Daytona,
+  snapshotName: string,
+): Promise<DaytonaSnapshot | undefined> {
+  try {
+    return await daytona.snapshot.get(snapshotName);
+  } catch (err) {
+    if (!(err instanceof DaytonaError && err.statusCode === 404)) {
+      throw err;
+    }
+  }
+  for (let page = 1; ; page++) {
+    const result = await daytona.snapshot.list(page, SNAPSHOT_LIST_PAGE_SIZE);
+    const hit = result.items.find((s) => s.name === snapshotName);
+    if (hit) {
+      return hit;
+    }
+    if (page >= (result.totalPages ?? 1)) {
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Block until `snapshotName` reaches the `active` state in the default
+ * region. Tolerates the snapshot being missing while polling — a snapshot
+ * captured from a sandbox surfaces only some time after
+ * `_experimental_createSnapshot` returns. Throws as soon as Daytona
+ * reports a terminal failure (`error` / `build_failed`), or when the
+ * timeout elapses without activation.
+ *
+ * Callers use this to gate destructive follow-ups (deleting the source
+ * sandbox) on the snapshot actually being durable: deleting the sandbox
+ * while its snapshot is still registering can kill the snapshot.
+ */
+export async function waitForDaytonaSnapshotActive(
+  config: DaytonaConfig,
+  snapshotName: string,
+  timeoutS: number = SANDBOX_SNAPSHOT_ACTIVE_TIMEOUT_S,
+): Promise<DaytonaSnapshot> {
+  const daytona = createDaytonaClient(config);
+  const deadline = Date.now() + timeoutS * 1000;
+  for (;;) {
+    const snapshot = await findDaytonaSnapshotByName(daytona, snapshotName);
+    if (snapshot?.state === "active") {
+      return snapshot;
+    }
+    if (snapshot?.state === "error" || snapshot?.state === "build_failed") {
+      throw new Error(
+        `Snapshot "${snapshotName}" entered terminal state "${snapshot.state}"` +
+          (snapshot.errorReason ? `: ${snapshot.errorReason}` : ""),
+      );
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Snapshot "${snapshotName}" did not become active within ${timeoutS}s ` +
+          (snapshot
+            ? `(last state: "${snapshot.state}")`
+            : "(never appeared in the snapshot list)"),
+      );
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, SNAPSHOT_ACTIVE_POLL_INTERVAL_MS),
+    );
+  }
+}
+
+/**
+ * Ensure a snapshot is usable before a sandbox is booted from it, reactivating
+ * it if Daytona has let it lapse.
+ *
+ * Daytona flips a snapshot to `inactive` after ~2 weeks without use
+ * (https://www.daytona.io/docs/en/snapshots/), and `daytona.create({ snapshot })`
+ * then rejects with "Snapshot <name> is inactive" rather than reactivating it —
+ * reactivation is a separate, explicit step. So do it here: on an `inactive`
+ * snapshot, activate it and wait for it to return to `active`, then let the
+ * caller create from it.
+ *
+ * Best-effort and additive: a snapshot that is already `active` (the common
+ * path) is a no-op, and an *API* failure to read the snapshot's state — a
+ * missing snapshot (404) or a transient error — is swallowed so this never
+ * turns a create that would have worked into a failure. `daytona.create`
+ * remains the authority on a genuinely bad snapshot. A non-API error (e.g. an
+ * unexpected client shape) still propagates rather than being masked, matching
+ * the `instanceof DaytonaError` handling elsewhere in this module. Only a
+ * positively-observed `inactive` state triggers work; an activation that then
+ * fails does propagate (the create would have failed anyway).
+ *
+ * @returns whether the snapshot had to be reactivated (for logging/observability).
+ */
+export async function ensureDaytonaSnapshotActive(
+  config: DaytonaConfig,
+  snapshotName: string,
+): Promise<boolean> {
+  const daytona = createDaytonaClient(config);
+  let snapshot: DaytonaSnapshot;
+  try {
+    snapshot = await daytona.snapshot.get(snapshotName);
+  } catch (err) {
+    // Swallow only the SDK's own API errors (missing/transient) so creation is
+    // never blocked by a failed state read; anything else is a real bug and
+    // should surface.
+    if (err instanceof DaytonaError) return false;
+    throw err;
+  }
+  if (snapshot.state !== "inactive") {
+    return false;
+  }
+  await activateDaytonaSnapshot(config, snapshotName);
+  // Reactivation only restores an already-built snapshot from cold storage, so
+  // it gets a tighter bound than a fresh capture's image push
+  // (`SANDBOX_SNAPSHOT_ACTIVE_TIMEOUT_S`): this wait runs inline in
+  // `createDaytonaSandbox` ahead of the create itself, so an over-long wait
+  // would stack on top of the create timeout.
+  await waitForDaytonaSnapshotActive(
+    config,
+    snapshotName,
+    SNAPSHOT_REACTIVATE_TIMEOUT_S,
+  );
+  return true;
+}
+
+/**
+ * Whether a sandbox was created with secrets kept out of its container env
+ * (marked by a label at create time). Sandboxes created before that change
+ * have secrets baked into their container spec, which a snapshot cannot
+ * scrub — so "snapshot and delete" must be refused for them.
+ */
+export async function isSandboxEnvScrubbable(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+): Promise<boolean> {
+  const daytona = createDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  return (
+    sandbox.labels?.[SANDBOX_ENV_SECRETS_EXCLUDED_LABEL] ===
+    SANDBOX_ENV_SECRETS_EXCLUDED_VALUE
+  );
+}
+
+function isDaytonaNotFound(err: unknown): boolean {
+  return err instanceof DaytonaError && err.statusCode === 404;
+}
+
+/**
+ * Create an image-derived snapshot, treating an already-existing name as
+ * success: create is idempotent, so a concurrent/earlier registration of the
+ * same name resolves to `null` rather than an error.
+ */
+export async function createDaytonaImageSnapshot(
+  config: DaytonaConfig,
+  input: CreateSnapshotInput,
+): Promise<DaytonaSnapshot | null> {
+  try {
+    return await createDaytonaSnapshot(config, input);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("already exists") || message.includes("409")) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/** Get a snapshot by name, mapping Daytona's 404 to `null`. */
+export async function getDaytonaSnapshotOrNull(
+  config: DaytonaConfig,
+  snapshotName: string,
+): Promise<DaytonaSnapshot | null> {
+  try {
+    return await getDaytonaSnapshot(config, snapshotName);
+  } catch (err) {
+    if (isDaytonaNotFound(err)) return null;
+    throw err;
+  }
+}
+
+/** Delete a snapshot by name; one that is already gone is a no-op. */
+export async function deleteDaytonaSnapshotIfExists(
+  config: DaytonaConfig,
+  snapshotName: string,
+): Promise<void> {
+  try {
+    await deleteDaytonaSnapshot(config, snapshotName);
+  } catch (err) {
+    if (isDaytonaNotFound(err)) return;
+    throw err;
+  }
+}

--- a/js/sandbox/src/providers/daytona/internal/test-support.ts
+++ b/js/sandbox/src/providers/daytona/internal/test-support.ts
@@ -1,0 +1,103 @@
+/**
+ * Test-only fake of the Daytona `process` session surface.
+ *
+ * Daytona commands run through a throwaway session (see `commands.ts`) so the
+ * two output streams stay separate, which means a test can no longer stub a
+ * single `process.executeCommand`. This fake records each session command and
+ * replays scripted stdout/stderr/exit codes. Deliberately free of any test-
+ * framework import so it stays a plain module.
+ */
+
+export interface FakeSessionCommand {
+  /** The full on-box command string the session was asked to run. */
+  command: string;
+  /** Bytes sent to the command's stdin, when the caller passed input. */
+  input?: string;
+}
+
+export interface FakeSessionResponse {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface FakeDaytonaSandbox {
+  /** Pass where a Daytona `Sandbox` is expected. */
+  sandbox: unknown;
+  /** Every session command run, in order. */
+  commands: FakeSessionCommand[];
+  /** Sessions created but never deleted; non-empty means a leak. */
+  openSessions: Set<string>;
+}
+
+/**
+ * Build a fake sandbox whose session commands resolve to `respond(command)`,
+ * defaulting to a clean zero-exit with empty streams. One command per session,
+ * matching how `commands.ts` uses the API.
+ */
+export function fakeDaytonaSandbox(
+  respond: (command: string) => FakeSessionResponse = () => ({}),
+): FakeDaytonaSandbox {
+  const commands: FakeSessionCommand[] = [];
+  const openSessions = new Set<string>();
+  let response: FakeSessionResponse = {};
+
+  const process = {
+    createSession(sessionId: string): Promise<void> {
+      openSessions.add(sessionId);
+      return Promise.resolve();
+    },
+    executeSessionCommand(
+      _sessionId: string,
+      request: { command: string; runAsync?: boolean },
+    ): Promise<{
+      cmdId: string;
+      exitCode?: number;
+      stdout?: string;
+      stderr?: string;
+    }> {
+      commands.push({ command: request.command });
+      response = respond(request.command);
+      const cmdId = `cmd-${commands.length}`;
+      // A detached run reports only the id; a synchronous one carries the
+      // finished command's streams, exactly as the Daytona API does.
+      return Promise.resolve(
+        request.runAsync
+          ? { cmdId }
+          : {
+              cmdId,
+              exitCode: response.exitCode ?? 0,
+              stdout: response.stdout ?? "",
+              stderr: response.stderr ?? "",
+            },
+      );
+    },
+    sendSessionCommandInput(
+      _sessionId: string,
+      _cmdId: string,
+      input: string,
+    ): Promise<void> {
+      commands[commands.length - 1]!.input = input;
+      return Promise.resolve();
+    },
+    getSessionCommandLogs(
+      _sessionId: string,
+      _cmdId: string,
+      onStdout: (chunk: string) => void,
+      onStderr: (chunk: string) => void,
+    ): Promise<void> {
+      if (response.stdout) onStdout(response.stdout);
+      if (response.stderr) onStderr(response.stderr);
+      return Promise.resolve();
+    },
+    getSessionCommand(): Promise<{ exitCode: number }> {
+      return Promise.resolve({ exitCode: response.exitCode ?? 0 });
+    },
+    deleteSession(sessionId: string): Promise<void> {
+      openSessions.delete(sessionId);
+      return Promise.resolve();
+    },
+  };
+
+  return { sandbox: { process }, commands, openSessions };
+}

--- a/js/sandbox/src/providers/daytona/internal/types.ts
+++ b/js/sandbox/src/providers/daytona/internal/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Daytona-internal type aliases.
+ *
+ * The provider-agnostic shapes live in `../provider` (the abstraction owns
+ * them). This module re-exports them under Daytona names for the Daytona
+ * implementation files and the package's public index, and defines the
+ * constants that are genuinely Daytona-specific.
+ */
+export {
+  RepositoryCloneError,
+  type McpIntegrationInput,
+  type SandboxService,
+  type CreateSandboxProviderInput as DaytonaCreateRequest,
+  type InitializeSandboxInput as DaytonaInitializeRequest,
+  type SandboxInitializeResult as DaytonaInitializeResult,
+} from "../../provider";
+
+export const DAYTONA_PROVIDER = "daytona";
+
+export const SIGNED_URL_EXPIRY_S = 24 * 60 * 60; // 24 hours (max allowed)

--- a/js/sandbox/src/providers/daytona/internal/vm.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/vm.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { DaytonaConfig } from "../config";
+
+// Mock the generated api-client: keep the real enums (SandboxState/SandboxClass)
+// but stub `SandboxApi` so we drive stop/start/snapshot/get from the test.
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    createSandbox: vi.fn(),
+    deleteSandbox: vi.fn(),
+    stopSandbox: vi.fn(),
+    startSandbox: vi.fn(),
+    createSandboxSnapshot: vi.fn(),
+    getSandbox: vi.fn(),
+  },
+}));
+
+vi.mock("@daytona/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@daytona/api-client")>();
+  return {
+    ...actual,
+    Configuration: vi.fn(),
+    // Regular function (not an arrow) so it works as a constructor with `new`.
+    SandboxApi: vi.fn(function () {
+      return apiMock;
+    }),
+  };
+});
+
+import { captureVmSandboxSnapshot, createVmSandbox } from "./vm";
+
+const config: DaytonaConfig = {
+  apiKey: "key",
+  apiUrl: "https://daytona.example",
+  target: "experimental",
+  organizationId: undefined,
+  useVm: true,
+};
+
+/** Queue the getSandbox states the poll loop will read, in order. */
+function queueStates(...states: string[]): void {
+  apiMock.getSandbox.mockReset();
+  for (const state of states) {
+    apiMock.getSandbox.mockResolvedValueOnce({ data: { state } });
+  }
+}
+
+describe("captureVmSandboxSnapshot", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    apiMock.stopSandbox.mockReset().mockResolvedValue({ data: {} });
+    apiMock.startSandbox.mockReset().mockResolvedValue({ data: {} });
+    apiMock.createSandboxSnapshot.mockReset().mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops the VM, snapshots it cold (no includeMemory), then restarts when keeping the source", async () => {
+    // stop → STOPPED; snapshot → SNAPSHOTTING then STOPPED; restart → STARTED.
+    queueStates("stopped", "snapshotting", "stopped", "started");
+
+    const promise = captureVmSandboxSnapshot(
+      config,
+      "sbx-1",
+      "org/sandbox/snap",
+      900,
+      true,
+    );
+    // One poll gap while the snapshot runs (SNAPSHOTTING → STOPPED).
+    await vi.advanceTimersByTimeAsync(1_000);
+    await promise;
+
+    expect(apiMock.stopSandbox).toHaveBeenCalledTimes(1);
+    // Snapshot body must NOT include memory — that is the whole point of the fix.
+    expect(apiMock.createSandboxSnapshot).toHaveBeenCalledWith(
+      "sbx-1",
+      { name: "org/sandbox/snap" },
+      undefined,
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+    expect(apiMock.createSandboxSnapshot.mock.calls[0][1]).not.toHaveProperty(
+      "includeMemory",
+    );
+    // Keep path restarts the source.
+    expect(apiMock.startSandbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not restart the source when restartAfterCapture is false", async () => {
+    queueStates("stopped", "snapshotting", "stopped");
+
+    const promise = captureVmSandboxSnapshot(
+      config,
+      "sbx-1",
+      "org/sandbox/snap",
+      900,
+      false,
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    await promise;
+
+    expect(apiMock.stopSandbox).toHaveBeenCalledTimes(1);
+    expect(apiMock.createSandboxSnapshot).toHaveBeenCalledTimes(1);
+    expect(apiMock.startSandbox).not.toHaveBeenCalled();
+  });
+
+  it("throws if the VM enters a terminal error state during capture", async () => {
+    // stop ok, then the snapshot phase reports a terminal error.
+    queueStates("stopped", "error");
+
+    const promise = captureVmSandboxSnapshot(
+      config,
+      "sbx-1",
+      "org/sandbox/snap",
+      900,
+      false,
+    );
+    // Surface the rejection without an unhandled-rejection warning.
+    const settled = promise.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(settled).resolves.toContain("terminal state");
+    expect(apiMock.startSandbox).not.toHaveBeenCalled();
+  });
+
+  it("restarts a kept source even when the stop phase fails", async () => {
+    // Regression guard: the stop + stop-wait run inside the try, so a failure
+    // there (here: the VM reports a terminal error during the stop wait) must
+    // still trigger the keep-path restart in the finally — otherwise a full
+    // capture would leave the source powered off while its row reads `active`.
+    // stop-wait → error (throws); restart-wait → started.
+    queueStates("error", "started");
+
+    const promise = captureVmSandboxSnapshot(
+      config,
+      "sbx-1",
+      "org/sandbox/snap",
+      900,
+      true,
+    );
+    const settled = promise.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(settled).resolves.toContain("terminal state");
+    // The snapshot never happened, but the source is restarted for the keep path.
+    expect(apiMock.createSandboxSnapshot).not.toHaveBeenCalled();
+    expect(apiMock.startSandbox).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createVmSandbox", () => {
+  const params = {
+    name: "kiln-worker",
+    snapshot: "org/sandbox/snap",
+    env: { AMIKA_AGENT_CWD: "/home/daytona/repo" },
+    labels: undefined,
+    autoStopInterval: 30,
+    autoDeleteInterval: 60,
+    timeoutSeconds: 300,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    apiMock.createSandbox
+      .mockReset()
+      .mockResolvedValue({ data: { id: "sbx-new" } });
+    apiMock.deleteSandbox.mockReset().mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for STARTED before returning the sandbox id", async () => {
+    // createSandbox resolves while the VM is still booting; the started-wait
+    // is what closes the race that otherwise fails initialize's first adapter exec
+    // against a not-yet-running VM ("sandbox is in stopped state").
+    queueStates("creating", "started");
+
+    const promise = createVmSandbox(config, params);
+    // One poll gap while the VM finishes booting (CREATING → STARTED).
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(promise).resolves.toBe("sbx-new");
+    expect(apiMock.createSandbox).toHaveBeenCalledTimes(1);
+    // No cleanup on the happy path.
+    expect(apiMock.deleteSandbox).not.toHaveBeenCalled();
+  });
+
+  it("deletes the orphaned VM and rethrows when the start wait fails", async () => {
+    // The VM was created but never reached STARTED. The caller's create-error
+    // path can't clean it up (it never got the id) and autoDeleteInterval is
+    // -1, so createVmSandbox must delete the VM itself before rethrowing.
+    queueStates("archived");
+
+    const promise = createVmSandbox(config, params);
+    const settled = promise.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+
+    // The original wait failure surfaces...
+    await expect(settled).resolves.toContain("terminal state");
+    // ...and the orphaned VM is deleted.
+    expect(apiMock.deleteSandbox).toHaveBeenCalledWith(
+      "sbx-new",
+      undefined,
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it("retries cleanup delete on a state-change-in-progress 400", async () => {
+    // A wait timeout often means Daytona is mid-transition, so the delete can
+    // hit `400 state change in progress`; it must retry rather than leak.
+    queueStates("archived");
+    // Real axios errors are Error instances with `.response` attached.
+    const stateChangeErr = Object.assign(
+      new Error("state change in progress"),
+      { response: { status: 400, data: "state change in progress" } },
+    );
+    apiMock.deleteSandbox
+      .mockRejectedValueOnce(stateChangeErr)
+      .mockResolvedValueOnce({ data: {} });
+
+    const promise = createVmSandbox(config, params);
+    const settled = promise.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+    // Advance through the retry backoff.
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(settled).resolves.toContain("terminal state");
+    expect(apiMock.deleteSandbox).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries cleanup delete on a structured state-change body", async () => {
+    // Daytona may send the reason as a structured body under a non-`message`
+    // key; the retry predicate must still recognize it.
+    queueStates("archived");
+    const structuredErr = Object.assign(new Error("Request failed"), {
+      response: { status: 400, data: { error: "state change in progress" } },
+    });
+    apiMock.deleteSandbox
+      .mockRejectedValueOnce(structuredErr)
+      .mockResolvedValueOnce({ data: {} });
+
+    const promise = createVmSandbox(config, params);
+    const settled = promise.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(settled).resolves.toContain("terminal state");
+    expect(apiMock.deleteSandbox).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-state-change cleanup failure", async () => {
+    // Best-effort cleanup: a non-retryable delete failure is swallowed after
+    // one attempt and must not mask the original wait error.
+    queueStates("archived");
+    apiMock.deleteSandbox.mockRejectedValue(new Error("delete boom"));
+
+    const promise = createVmSandbox(config, params);
+    const settled = promise.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+
+    await expect(settled).resolves.toContain("terminal state");
+    expect(apiMock.deleteSandbox).toHaveBeenCalledTimes(1);
+  });
+});

--- a/js/sandbox/src/providers/daytona/internal/vm.ts
+++ b/js/sandbox/src/providers/daytona/internal/vm.ts
@@ -1,0 +1,338 @@
+/**
+ * VM-mode Daytona operations, gated by `ENABLE_DAYTONA_VM`
+ * (`DaytonaConfig.useVm`).
+ *
+ * A Daytona "VM" is a sandbox whose class is `linux-vm` rather than the default
+ * `container`. The high-level `@daytonaio/sdk` wrapper hard-codes its request
+ * bodies and exposes neither the sandbox `class` (settable only at create time)
+ * nor `includeMemory` (required to snapshot a *running* VM), so these paths call
+ * the generated `@daytona/api-client` `SandboxApi` directly. The container paths
+ * still go through the SDK; the snapshot path here runs only for sandboxes that
+ * are actually `linux-vm` (see `isVmSandbox`), not merely because `useVm` is set.
+ */
+import pRetry from "p-retry";
+import {
+  SandboxApi,
+  Configuration,
+  SandboxClass,
+  SandboxState,
+  type CreateSandbox,
+} from "@daytona/api-client";
+import type { DaytonaConfig } from "../config";
+
+/** Poll cadence while waiting for a VM sandbox to reach a target state. */
+const VM_POLL_INTERVAL_MS = 1_000;
+
+/**
+ * Per-request timeout for a single state poll. Without it a hung `getSandbox`
+ * would block the wait loop forever, so the deadline check below never runs
+ * and, on the create path, the VM is never cleaned up. Bounded well above a
+ * healthy poll's latency so only a genuinely stuck request trips it.
+ */
+const VM_POLL_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * How long to wait for a VM to reach a power state (stop/start) during capture,
+ * in seconds. Generous — a cold boot re-runs the VM's init — but bounded so a
+ * wedged transition surfaces instead of hanging.
+ */
+const VM_STATE_TRANSITION_TIMEOUT_S = 5 * 60;
+
+/**
+ * Build the low-level generated `SandboxApi`, mirroring the SDK's auth: the
+ * Daytona API key as a Bearer token in the default request headers. The
+ * region/target is sent per-request in the create body (not on the client), and
+ * the snapshot-capture endpoint operates on an existing sandbox by id, so a
+ * single client serves both VM calls.
+ */
+function createSandboxApi(config: DaytonaConfig): SandboxApi {
+  return new SandboxApi(
+    new Configuration({
+      basePath: config.apiUrl,
+      baseOptions: { headers: { Authorization: `Bearer ${config.apiKey}` } },
+    }),
+  );
+}
+
+export interface CreateVmSandboxParams {
+  name: string;
+  snapshot: string;
+  /** Non-secret container env; mirrors the SDK `create({ envVars })` mapping. */
+  env: Record<string, string>;
+  labels: Record<string, string> | undefined;
+  autoStopInterval: number;
+  autoDeleteInterval: number;
+  timeoutSeconds: number;
+}
+
+/**
+ * Create a sandbox as a Daytona VM (`class: "linux-vm"`). Sends the same fields
+ * the SDK's `daytona.create({ snapshot })` would, plus the `class` field the SDK
+ * omits — `class` is not on the typed `CreateSandbox` body, so it is attached
+ * explicitly (the api-client serializes the whole object, so it reaches the
+ * server). Returns the new sandbox id.
+ *
+ * Waits for the VM to reach `STARTED` before returning, matching the contract
+ * the container path gets for free: `daytona.create()` blocks until the sandbox
+ * is started. The generated `createSandbox` does NOT — it resolves as soon as
+ * the row is created, while the VM is still creating/pulling/booting. Without
+ * this wait the caller proceeds to initialize immediately, and the first
+ * adapter call (an `exec`) hits a not-yet-running VM and fails with
+ * "sandbox is in stopped state" (503, `x-daytona-sandbox-state: stopped`). That
+ * race is usually won on a warm snapshot (boots in seconds) but lost once
+ * Daytona has archived the snapshot: restoring the multi-GB image runs minutes,
+ * so the same `params.timeoutSeconds` budget the create request uses is applied
+ * to the started-wait too.
+ */
+export async function createVmSandbox(
+  config: DaytonaConfig,
+  params: CreateVmSandboxParams,
+): Promise<string> {
+  const body: CreateSandbox & { class: SandboxClass } = {
+    name: params.name,
+    snapshot: params.snapshot,
+    env: params.env,
+    labels: params.labels,
+    public: false,
+    target: config.target,
+    autoStopInterval: params.autoStopInterval,
+    autoDeleteInterval: params.autoDeleteInterval,
+    class: SandboxClass.LINUX_VM,
+  };
+  const api = createSandboxApi(config);
+  const response = await api.createSandbox(body, undefined, {
+    timeout: params.timeoutSeconds * 1000,
+  });
+  const providerSandboxId = response.data.id;
+  try {
+    await waitForVmSandboxState(
+      api,
+      providerSandboxId,
+      "create",
+      params.timeoutSeconds,
+      (sandbox) => sandbox.state === SandboxState.STARTED,
+    );
+  } catch (waitErr) {
+    // The VM exists but never reached STARTED (timeout or terminal state).
+    // The caller's create-error path can't clean it up because we never
+    // returned the id, and the default autoDeleteInterval is -1 (never), so
+    // the VM would be orphaned. Delete it here. A wait timeout often means
+    // Daytona is mid-transition (e.g. still pulling/restoring a large
+    // snapshot), so the delete can hit `400 state change in progress` just
+    // like `deleteDaytonaSandbox`; retry that case rather than leak the VM.
+    // Best-effort: swallow any final cleanup failure so the original wait
+    // error is what surfaces.
+    try {
+      await pRetry(
+        () =>
+          api.deleteSandbox(providerSandboxId, undefined, {
+            timeout: VM_STATE_TRANSITION_TIMEOUT_S * 1000,
+          }),
+        {
+          retries: 3,
+          minTimeout: 3_000,
+          factor: 1,
+          shouldRetry: ({ error }) => isStateChangeInProgressError(error),
+        },
+      );
+    } catch {
+      // Ignore; rethrow the original wait failure below.
+    }
+    throw waitErr;
+  }
+  return providerSandboxId;
+}
+
+/**
+ * Whether `error` is Daytona's retryable `400 state change in progress`. The
+ * raw api-client surfaces axios errors rather than the SDK's `DaytonaError`
+ * (which `deleteDaytonaSandbox` matches on `instanceof`), so this inspects the
+ * axios response shape, falling back to the error's own status/message.
+ */
+function isStateChangeInProgressError(error: unknown): boolean {
+  const e = error as {
+    response?: { status?: number; data?: unknown };
+    status?: number;
+    message?: string;
+  };
+  const status = e?.response?.status ?? e?.status;
+  if (status !== 400) {
+    return false;
+  }
+  // Match against the error message plus the response body in whatever shape
+  // Daytona sends it: a plain string, or a structured object under any key
+  // (`{ message }`, `{ error }`, `{ code }`, ...). Stringifying the object
+  // rather than reading a fixed key keeps this robust to the exact envelope.
+  const data = e?.response?.data;
+  const body =
+    typeof data === "string" ? data : data != null ? JSON.stringify(data) : "";
+  const text = `${e?.message ?? ""} ${body}`.toLowerCase();
+  return text.includes("state change in progress");
+}
+
+/**
+ * Whether `providerSandboxId` is a Daytona VM (`class: linux-vm`) rather than
+ * the default container.
+ *
+ * The snapshot path must branch on the sandbox's real class, not on `useVm`: a
+ * sandbox created before the flag was enabled — or booted from a container base
+ * image — is still a container, and Daytona rejects VM-only snapshot behavior
+ * on it ("includeMemory is only supported for VM sandboxes").
+ */
+export async function isVmSandbox(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+): Promise<boolean> {
+  const { data: sandbox } =
+    await createSandboxApi(config).getSandbox(providerSandboxId);
+  return sandbox.sandboxClass === SandboxClass.LINUX_VM;
+}
+
+/** Throw if `sandbox` is in a terminal failure state during `phase`. */
+function assertNotTerminalState(
+  sandbox: { state?: SandboxState; errorReason?: string },
+  providerSandboxId: string,
+  phase: string,
+): void {
+  // ARCHIVED/DESTROYED are included so an auto-archive or teardown of the
+  // stopped VM mid-capture fails fast instead of spinning to the deadline.
+  if (
+    sandbox.state === SandboxState.ERROR ||
+    sandbox.state === SandboxState.BUILD_FAILED ||
+    sandbox.state === SandboxState.ARCHIVED ||
+    sandbox.state === SandboxState.DESTROYED
+  ) {
+    throw new Error(
+      `VM sandbox "${providerSandboxId}" entered terminal state "${sandbox.state}" during ${phase}` +
+        (sandbox.errorReason ? `: ${sandbox.errorReason}` : ""),
+    );
+  }
+}
+
+/**
+ * Poll `getSandbox` until `isDone` returns true, throwing if the sandbox
+ * reaches a terminal failure state or the deadline passes. `isDone` receives
+ * each polled sandbox (so a caller can track transitions across polls).
+ */
+async function waitForVmSandboxState(
+  api: SandboxApi,
+  providerSandboxId: string,
+  phase: string,
+  timeoutSeconds: number,
+  isDone: (sandbox: { state?: SandboxState }) => boolean,
+): Promise<void> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  for (;;) {
+    const { data: sandbox } = await api.getSandbox(
+      providerSandboxId,
+      undefined,
+      undefined,
+      { timeout: VM_POLL_REQUEST_TIMEOUT_MS },
+    );
+    assertNotTerminalState(sandbox, providerSandboxId, phase);
+    if (isDone(sandbox)) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `VM sandbox "${providerSandboxId}" did not reach the expected state during ${phase} within ${timeoutSeconds}s (last state: "${sandbox.state}")`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, VM_POLL_INTERVAL_MS));
+  }
+}
+
+/**
+ * Capture a *cold* snapshot from a VM sandbox: stop it, snapshot the stopped
+ * VM (live memory excluded), then restart it if the caller keeps the source.
+ *
+ * Why cold rather than hot: a snapshot taken with `includeMemory: true` bakes
+ * the running VM's RAM into the image, so a sandbox booted from it RESUMES that
+ * memory — including the source VM's frozen network stack and its old address.
+ * Restored into a new VM with a different network identity, egress is dead: any
+ * `git clone`/fetch fails with "connection reset by peer" (and it's systemic —
+ * every outbound connection, not repo- or token-specific). Stopping the VM
+ * first makes the restore a clean cold boot with fresh networking, exactly like
+ * a first-time sandbox. Stopping the whole VM also quiesces the inner Docker
+ * daemon, so the container-path `stopDockerForSnapshot` dance isn't needed here.
+ * Dropping `includeMemory` additionally means the snapshot can't carry live RAM
+ * (or secrets a process had read into it) — the concern the hot path documented.
+ *
+ * `restartAfterCapture` distinguishes the callers: the non-destructive "full"
+ * capture keeps the source, so it must be running again afterward (true); the
+ * scrub-and-delete caller deletes the source, so it skips the restart (false) —
+ * a stopped VM deletes fine, and a kept source on the failure path is released
+ * to its real (stopped) power state out of band.
+ *
+ * Throws if the sandbox reaches a terminal failure state or a phase exceeds its
+ * timeout. Snapshot *durability* is gated downstream by
+ * `waitForDaytonaSnapshotActive`; this only waits for the sandbox to finish its
+ * snapshotting phase.
+ *
+ * NOTE: confirm against live Daytona that a memory-excluded snapshot of a
+ * stopped `linux-vm` (a) captures cleanly and (b) surfaces SNAPSHOTTING before
+ * `createSandboxSnapshot` returns — the snapshot-phase wait assumes it, as the
+ * SDK does. No local harness exercises the real provider.
+ */
+export async function captureVmSandboxSnapshot(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+  snapshotName: string,
+  timeoutSeconds: number,
+  restartAfterCapture: boolean,
+): Promise<void> {
+  const api = createSandboxApi(config);
+
+  // The stop + snapshot are inside the try so the `finally`'s keep-path restart
+  // runs on EVERY failure after we begin stopping — otherwise a failed stop or
+  // stop-wait would leave a full-capture source powered off while its recorded
+  // state still reads `active`. Restarting a VM that never actually stopped is an
+  // idempotent no-op.
+  try {
+    // Stop the VM (graceful) so the snapshot is taken cold.
+    await api.stopSandbox(providerSandboxId, undefined, undefined, {
+      timeout: VM_STATE_TRANSITION_TIMEOUT_S * 1000,
+    });
+    await waitForVmSandboxState(
+      api,
+      providerSandboxId,
+      "stop",
+      VM_STATE_TRANSITION_TIMEOUT_S,
+      (sandbox) => sandbox.state === SandboxState.STOPPED,
+    );
+
+    await api.createSandboxSnapshot(
+      providerSandboxId,
+      // Memory excluded: the VM is stopped, so this is a cold snapshot.
+      { name: snapshotName },
+      undefined,
+      { timeout: timeoutSeconds * 1000 },
+    );
+    // Wait out the snapshotting phase. Daytona moves the sandbox into
+    // SNAPSHOTTING before this poll's first read (the create call returns after
+    // the transition is applied), so waiting until it is no longer SNAPSHOTTING
+    // is sufficient — the same shape the SDK's own `waitForSnapshotComplete`
+    // uses. Snapshot *durability* is gated downstream by
+    // `waitForDaytonaSnapshotActive`.
+    await waitForVmSandboxState(
+      api,
+      providerSandboxId,
+      "snapshot",
+      timeoutSeconds,
+      (sandbox) => sandbox.state !== SandboxState.SNAPSHOTTING,
+    );
+  } finally {
+    if (restartAfterCapture) {
+      await api.startSandbox(providerSandboxId, undefined, {
+        timeout: VM_STATE_TRANSITION_TIMEOUT_S * 1000,
+      });
+      await waitForVmSandboxState(
+        api,
+        providerSandboxId,
+        "restart",
+        VM_STATE_TRANSITION_TIMEOUT_S,
+        (sandbox) => sandbox.state === SandboxState.STARTED,
+      );
+    }
+  }
+}

--- a/js/sandbox/src/providers/daytona/provider.ts
+++ b/js/sandbox/src/providers/daytona/provider.ts
@@ -1,0 +1,134 @@
+/**
+ * Daytona provider definition: binds a {@link DaytonaConfig} and plugs the
+ * operation helpers in this directory into the capability namespaces. Daytona
+ * is the full-featured, control-plane provider — it backs every capability,
+ * including the image-derived snapshots and docker registries no other
+ * provider supports.
+ */
+import type { DaytonaConfig } from "./config";
+import { defineProvider } from "../shared/define-provider";
+import { DEFAULT_HOME_DIR } from "../../constants";
+import { daytonaCapabilities } from "./capabilities";
+import { SIGNED_URL_EXPIRY_S } from "./internal/types";
+import {
+  cloneDaytonaRepo,
+  createDaytonaSandbox,
+  createDaytonaSshAccess,
+  deleteDaytonaSandbox,
+  executeDaytonaCommand,
+  getDaytonaSandboxState,
+  listDaytonaSandboxes,
+  mapDaytonaSandboxState,
+  readSandboxFile,
+  writeSandboxFile,
+  refreshDaytonaUrls,
+  revokeDaytonaSshAccess,
+  startDaytonaSandbox,
+  stopDaytonaSandbox,
+  streamDaytonaCommandLogs,
+} from "./internal/operations";
+import {
+  captureDaytonaSandboxSnapshot,
+  createDaytonaImageSnapshot,
+  deleteDaytonaSnapshotIfExists,
+  findDaytonaSnapshot,
+  getDaytonaSnapshotOrNull,
+  isSandboxEnvScrubbable,
+  waitForDaytonaSnapshotActive,
+} from "./internal/snapshot-operations";
+import {
+  createDaytonaDockerRegistry,
+  deleteDaytonaDockerRegistry,
+  getDaytonaDockerRegistry,
+  listDaytonaDockerRegistries,
+} from "./internal/docker-registry";
+
+// Provider-root re-exports of the server-side surface the registry wires up.
+// The implementations live in `internal/`; routing them through `provider.ts`
+// keeps the folder root as the provider's only public entry.
+export { openDaytonaAdapter } from "./internal/operations";
+
+export default defineProvider(daytonaCapabilities, (config: DaytonaConfig) => ({
+  name: "daytona",
+  signedUrlTtlSeconds: SIGNED_URL_EXPIRY_S,
+  userHomeDir: DEFAULT_HOME_DIR,
+
+  sandbox: {
+    create: (ctx, input) => createDaytonaSandbox(ctx, config, input),
+    delete: (id) => deleteDaytonaSandbox(config, id),
+
+    // Daytona persists the auto-stop interval server-side (set at create), so
+    // it does not need to be re-applied on start.
+    start: (id) => startDaytonaSandbox(config, id),
+    stop: (id) => stopDaytonaSandbox(config, id),
+    getState: (id) => getDaytonaSandboxState(config, id),
+    mapState: mapDaytonaSandboxState,
+  },
+
+  // Daytona clones via the SDK's native `git.clone` (no shell `git` needed).
+  cloneRepo: (id, input) => cloneDaytonaRepo(config, id, input),
+
+  exec: {
+    stdin: true,
+    run: (id, command, opts) =>
+      executeDaytonaCommand(config, id, command, opts),
+    stream: (id, command, handlers) =>
+      streamDaytonaCommandLogs(config, id, command, handlers),
+  },
+
+  files: {
+    read: (id, filePath) => readSandboxFile(config, id, filePath),
+    write: (id, filePath, content) =>
+      writeSandboxFile(config, id, filePath, content),
+  },
+
+  ssh: {
+    // Narrow the SDK's access record to the minted contract — the raw response
+    // carries extra metadata (record ids, timestamps) callers must not rely on.
+    mint: async (id, expiresInMinutes) => {
+      const access = await createDaytonaSshAccess(config, id, expiresInMinutes);
+      return {
+        token: access.token,
+        sshDestination: access.sshDestination,
+        expiresAt: access.expiresAt,
+      };
+    },
+    revoke: (id, token) => revokeDaytonaSshAccess(config, id, token),
+  },
+
+  services: {
+    refreshUrls: (id, services) => refreshDaytonaUrls(config, id, services),
+    // Daytona serves signed preview URLs that self-expire at
+    // `signedUrlTtlSeconds`; a deleted service simply stops being re-signed,
+    // and the SDK exposes no port-unexpose primitive, so there is no route
+    // state to reconcile. The old URL lapses on its own at the signature TTL.
+    syncRoutes: () => Promise.resolve(),
+  },
+
+  listing: {
+    list: () => listDaytonaSandboxes(config),
+  },
+
+  snapshots: {
+    createImageSnapshot: (input) => createDaytonaImageSnapshot(config, input),
+    getSnapshot: (name) => getDaytonaSnapshotOrNull(config, name),
+    findSnapshot: (name) => findDaytonaSnapshot(config, name),
+    deleteSnapshot: (name) => deleteDaytonaSnapshotIfExists(config, name),
+    waitForSnapshotActive: (name) => waitForDaytonaSnapshotActive(config, name),
+    capture: async (id, snapshotName, opts) => {
+      await captureDaytonaSandboxSnapshot(config, id, snapshotName, opts);
+      // Daytona boots snapshots by their org-scoped name, so there is no
+      // separate bootable id to record.
+      return { providerSnapshotId: null };
+    },
+    isEnvScrubbable: (id) => isSandboxEnvScrubbable(config, id),
+  },
+
+  dockerRegistries: {
+    createRegistry: (input) => createDaytonaDockerRegistry(config, input),
+    listRegistries: () => listDaytonaDockerRegistries(config),
+    getRegistry: (registryId) => getDaytonaDockerRegistry(config, registryId),
+    deleteRegistry: (registryId) =>
+      deleteDaytonaDockerRegistry(config, registryId),
+  },
+}));

--- a/js/sandbox/src/providers/freestyle/capabilities.ts
+++ b/js/sandbox/src/providers/freestyle/capabilities.ts
@@ -1,0 +1,32 @@
+/**
+ * Freestyle capability flags. Colocated with the provider but kept SDK-free so
+ * the client-safe capabilities table (`../capabilities`) can aggregate it
+ * without pulling in the Freestyle SDK.
+ *
+ * Per-sandbox lifecycle + exec + SSH + snapshot parity with Daytona. Snapshots
+ * are captured from a running sandbox via `vm.snapshot` (the "Take Snapshot"
+ * flow). Docker registries stay Daytona-only — they're a control-plane concern
+ * Freestyle does not back. SSH rides on Freestyle's identity/token gateway
+ * (`vm-ssh.freestyle.sh`; see `./ssh`). Log streaming stays disabled:
+ * Freestyle's `vm.exec` buffers output (no incremental SSE), so advertising it
+ * would misrepresent the behavior.
+ */
+import type { SandboxProviderCapabilities } from "../provider";
+
+export const freestyleCapabilities: SandboxProviderCapabilities = {
+  lifecycle: true,
+  ssh: true,
+  services: true,
+  exec: true,
+  listSandboxes: true,
+  streaming: false,
+  snapshots: true,
+  scrubCapture: true,
+  fullSnapshotCapture: true,
+  dockerRegistries: false,
+  skipStartScript: false,
+  // `vm.snapshot` returns an opaque id distinct from the org-scoped name.
+  snapshotIdsAreOpaque: true,
+  // Persistent VMs suspend/resume rather than being auto-deleted.
+  supportsAutoDelete: false,
+};

--- a/js/sandbox/src/providers/freestyle/config.ts
+++ b/js/sandbox/src/providers/freestyle/config.ts
@@ -1,0 +1,15 @@
+import type { SandboxConfigBase } from "../../config";
+
+export interface FreestyleConfig extends SandboxConfigBase {
+  apiKey: string;
+  /**
+   * Persistence tier for snapshots captured from a sandbox. `"persistent"` (the
+   * production default) keeps a snapshot until the user deletes it; `"sticky"`
+   * is the platform's best-effort cache tier, which it may evict under storage
+   * pressure. Staging sets `"sticky"` so throwaway staging snapshots don't
+   * accumulate permanent storage. Omitted defaults to `"persistent"` at the
+   * capture call (the safe tier). Mirrors the `--staging` flag of
+   * `bin/freestyle-build-snapshots`.
+   */
+  snapshotPersistence?: "persistent" | "sticky";
+}

--- a/js/sandbox/src/providers/freestyle/internal/adapter.test.ts
+++ b/js/sandbox/src/providers/freestyle/internal/adapter.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { shellQuote } from "../../../util/shell";
+import { buildFreestyleCommand, FreestyleAdapter } from "./adapter";
+
+/**
+ * Minimal stand-in for a Freestyle `Vm` handle. `user()` returns a separate
+ * fake so a test can assert which handle (root vs. amika-scoped) ran a command.
+ */
+function fakeVm(execImpl: (opts: { command: string }) => unknown) {
+  const exec = vi.fn(execImpl);
+  const userVm = {
+    exec: vi.fn(execImpl),
+    fs: { readTextFile: vi.fn(), writeTextFile: vi.fn(), writeFile: vi.fn() },
+  };
+  const rootVm = {
+    exec,
+    user: vi.fn(() => userVm),
+    fs: { readTextFile: vi.fn(), writeTextFile: vi.fn(), writeFile: vi.fn() },
+  };
+  return { rootVm, userVm };
+}
+
+// Every command is prefixed with a guarded source of the Amika-managed
+// environment (see `buildFreestyleCommand`), so expectations include it.
+const ENV =
+  "[ -f /etc/environment ] && { set -a; . /etc/environment; set +a; }";
+
+describe("buildFreestyleCommand", () => {
+  it("sources the managed env before a bare command", () => {
+    expect(buildFreestyleCommand("ls -la")).toBe(`${ENV}\nls -la`);
+  });
+
+  it("prefixes a cd for cwd", () => {
+    expect(buildFreestyleCommand("ls", { cwd: "/home/amika/workspace" })).toBe(
+      `${ENV}\ncd ${shellQuote("/home/amika/workspace")} || exit 1\nls`,
+    );
+  });
+
+  it("exports env vars before the command", () => {
+    const result = buildFreestyleCommand("printenv FOO", {
+      env: { FOO: "bar", BAZ: "qux" },
+    });
+    expect(result).toBe(
+      `${ENV}\nexport FOO=${shellQuote("bar")}\nexport BAZ=${shellQuote("qux")}\nprintenv FOO`,
+    );
+  });
+
+  it("orders env source, then exports, then cd, then command", () => {
+    const result = buildFreestyleCommand("run", {
+      env: { A: "1" },
+      cwd: "/work",
+    });
+    expect(result).toBe(
+      `${ENV}\nexport A=${shellQuote("1")}\ncd ${shellQuote("/work")} || exit 1\nrun`,
+    );
+  });
+
+  it("shell-quotes values containing special characters", () => {
+    const tricky = "a'b c$d";
+    const result = buildFreestyleCommand("echo", { env: { X: tricky } });
+    expect(result).toBe(`${ENV}\nexport X=${shellQuote(tricky)}\necho`);
+  });
+
+  it("does not reflect the sudo flag in the command (handle selection does)", () => {
+    // `sudo: true` selects the root VM handle in `FreestyleAdapter.exec`; the
+    // command string itself is unchanged.
+    expect(buildFreestyleCommand("whoami", { sudo: true })).toBe(
+      `${ENV}\nwhoami`,
+    );
+  });
+});
+
+describe("FreestyleAdapter handle selection", () => {
+  it("scopes a user handle to amika at construction", () => {
+    const { rootVm } = fakeVm(() => ({ stdout: "", statusCode: 0 }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new FreestyleAdapter(rootVm as any);
+    expect(rootVm.user).toHaveBeenCalledWith({ username: "amika" });
+  });
+
+  it("runs ordinary execs as amika and sudo execs as root", async () => {
+    const { rootVm, userVm } = fakeVm(() => ({ stdout: "", statusCode: 0 }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapter = new FreestyleAdapter(rootVm as any);
+
+    await adapter.exec("whoami");
+    expect(userVm.exec).toHaveBeenCalledTimes(1);
+
+    await adapter.exec("install -m 0755 a b", { sudo: true });
+    // The sudo exec routes to root; the amika handle is untouched by it.
+    expect(rootVm.exec).toHaveBeenCalledTimes(1);
+    expect(userVm.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes uploads via the amika handle then chowns them to amika", async () => {
+    // Freestyle's `fs` write API runs as root regardless of the amika-scoped
+    // handle, so each upload is reassigned to amika via the root handle.
+    const { rootVm, userVm } = fakeVm(() => ({ stdout: "", statusCode: 0 }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapter = new FreestyleAdapter(rootVm as any);
+
+    await adapter.uploadFile("creds", "/home/amika/.git-credentials");
+
+    expect(userVm.fs.writeTextFile).toHaveBeenCalledWith(
+      "/home/amika/.git-credentials",
+      "creds",
+    );
+    // The chown runs as root (sudo handle) with the managed-env prefix.
+    expect(rootVm.exec).toHaveBeenCalledWith({
+      command: buildFreestyleCommand(
+        `chown amika:amika ${shellQuote("/home/amika/.git-credentials")}`,
+        { sudo: true },
+      ),
+    });
+  });
+
+  it("throws when the upload ownership repair fails", async () => {
+    const { rootVm } = fakeVm(() => ({ stdout: "", statusCode: 1 }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapter = new FreestyleAdapter(rootVm as any);
+
+    await expect(
+      adapter.uploadFile("creds", "/home/amika/.git-credentials"),
+    ).rejects.toThrow(/Failed to chown/);
+  });
+});

--- a/js/sandbox/src/providers/freestyle/internal/adapter.ts
+++ b/js/sandbox/src/providers/freestyle/internal/adapter.ts
@@ -1,0 +1,233 @@
+/**
+ * Freestyle adapter for the provider-agnostic {@link SandboxAdapter} port.
+ *
+ * Wraps a Freestyle `Vm` handle and maps the four adapter primitives onto the
+ * SDK. Two impedance mismatches with the Daytona model are handled here:
+ *
+ *  - `vm.exec` takes only a command string (no `cwd`/`env` parameters), so
+ *    those are folded into a single shell script.
+ *  - Freestyle's default exec runs as **root**, but the shared lifecycle
+ *    expects the Daytona contract: unprivileged work as the `amika` user, with
+ *    `sudo: true` for system-level steps. We honor that by running ordinary
+ *    execs/file writes through an `amika`-scoped handle and reserving the root
+ *    handle for `sudo: true` commands.
+ */
+import type { Freestyle } from "freestyle";
+import { shellQuote } from "../../../util/shell";
+import {
+  execFailureText,
+  type ExecOptions,
+  type ExecResult,
+  type SandboxAdapter,
+} from "../../shared/adapter";
+
+// `Vm` isn't a named export of `freestyle`; derive it from the client surface.
+type FreestyleVm = ReturnType<Freestyle["vms"]["ref"]>;
+
+/**
+ * The unprivileged user the Amika preset VMs provision (`useradd amika`, with
+ * passwordless sudo; see `bin/freestyle-build-snapshots.mjs`). Adapter execs
+ * run as this user so the lifecycle matches the Daytona contract — repos land
+ * in `/home/amika/workspace`, the uploaded dotfiles apply, and `claude
+ * --dangerously-skip-permissions` (which refuses to run as root) works.
+ */
+const AMIKA_USER = "amika";
+
+/**
+ * `vm.user({ username })` returns a VM handle whose exec/fs/pty calls run as the
+ * given Linux user (it attaches the `X-Freestyle-Vm-Linux-User-Id` header to
+ * each request). The method is present in the SDK runtime (freestyle@0.1.63)
+ * but missing from its published type declarations, so we type it locally. The
+ * pinned SDK version guards against it changing underfoot.
+ */
+type UserScopable = { user(opts: { username: string }): FreestyleVm };
+
+function scopeToUser(vm: FreestyleVm, username: string): FreestyleVm {
+  return (vm as FreestyleVm & UserScopable).user({ username });
+}
+
+/**
+ * Load the Amika-managed environment that provisioning persists to
+ * `/etc/environment` (`AMIKA_AGENT_CWD`, `OPENCODE_*`, injected vars). Daytona
+ * gets these from the container env baked at create time, not by sourcing this
+ * file: a Daytona `process.exec` runs a non-login shell, and `BASH_ENV` (which
+ * would make bash source the file) lives only inside `/etc/environment`, not
+ * the ambient env, so it never triggers. A var that lives only in
+ * `/etc/environment` is thus invisible to a Daytona `process.exec`. Freestyle
+ * has no container env to inherit, so its `vm.exec` must source the file here.
+ * Guarded with `[ -f ... ]` so it's a harmless no-op before the file exists
+ * (early in init).
+ */
+const SOURCE_MANAGED_ENV =
+  "[ -f /etc/environment ] && { set -a; . /etc/environment; set +a; }";
+
+/**
+ * Fold the adapter {@link ExecOptions} into a single shell script for
+ * `vm.exec`. The managed env is sourced first, then any explicit env vars are
+ * exported (so they win), then the working directory is changed before the
+ * command runs. The `sudo` flag is not reflected in the command string —
+ * {@link FreestyleAdapter.exec} selects a root vs. `amika`-scoped VM handle
+ * instead.
+ */
+export function buildFreestyleCommand(
+  command: string,
+  opts?: ExecOptions,
+): string {
+  const segments: string[] = [SOURCE_MANAGED_ENV];
+  if (opts?.env) {
+    for (const [name, value] of Object.entries(opts.env)) {
+      segments.push(`export ${name}=${shellQuote(value)}`);
+    }
+  }
+  if (opts?.cwd) {
+    // Fail fast if the working directory is missing/inaccessible, so the
+    // command can't silently run in the VM's previous cwd and let a successful
+    // command mask the failed `cd` (e.g. a destructive command hitting the
+    // wrong directory).
+    segments.push(`cd ${shellQuote(opts.cwd)} || exit 1`);
+  }
+  segments.push(command);
+  return segments.join("\n");
+}
+
+export class FreestyleAdapter implements SandboxAdapter {
+  /** Handle whose exec/fs calls run as `amika` — the default for adapter work. */
+  private readonly userVm: FreestyleVm;
+
+  // Round-trip accounting for diagnosing slow provisions. Every adapter op is
+  // a separate HTTPS call to the Freestyle API; on a chatty path (a new sandbox
+  // makes ~dozens) the sum of these dominates boot time. Tracked here so the
+  // orchestrators can log a per-provision breakdown via {@link roundTripStats}.
+  private roundTripCount = 0;
+  private roundTripMs = 0;
+  private slowestMs = 0;
+  private slowestLabel = "";
+
+  /**
+   * @param rootVm a VM handle that execs as root. Used only for `sudo: true`
+   *   commands (system-level setup); everything else runs via {@link userVm}.
+   * @param client the Freestyle SDK client the VM handle was derived from,
+   *   retained so callers can reuse the one already-constructed client for
+   *   further SDK work instead of building a fresh one. Optional —
+   *   provider-specific and off the SDK-free {@link SandboxAdapter} port
+   *   (Vercel's static SDK has no client).
+   */
+  constructor(
+    private readonly rootVm: FreestyleVm,
+    readonly client?: Freestyle,
+  ) {
+    this.userVm = scopeToUser(rootVm, AMIKA_USER);
+  }
+
+  /**
+   * Time one provider round-trip, accumulating count + total time and tracking
+   * the single slowest call. The label identifies the call (a truncated command
+   * or `op:path`) so the slowest one is actionable in logs.
+   */
+  private async timed<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    const start = performance.now();
+    try {
+      return await fn();
+    } finally {
+      const ms = performance.now() - start;
+      this.roundTripCount += 1;
+      this.roundTripMs += ms;
+      if (ms > this.slowestMs) {
+        this.slowestMs = ms;
+        this.slowestLabel = label;
+      }
+    }
+  }
+
+  /**
+   * Cumulative provider round-trip stats for this adapter since construction
+   * (a fresh adapter is built per provision/restart, so this scopes to one
+   * operation). Lets the orchestrators see whether a slow provision is many
+   * cheap round-trips (chattiness) or a few slow commands (e.g. a setup script).
+   */
+  get roundTripStats(): {
+    count: number;
+    totalMs: number;
+    slowestMs: number;
+    slowestLabel: string;
+  } {
+    return {
+      count: this.roundTripCount,
+      totalMs: Math.round(this.roundTripMs),
+      slowestMs: Math.round(this.slowestMs),
+      slowestLabel: this.slowestLabel,
+    };
+  }
+
+  async exec(command: string, opts?: ExecOptions): Promise<ExecResult> {
+    // `sudo: true` runs as root for system-level setup; everything else runs as
+    // amika so repos, dotfiles, and agent processes are owned by the lifecycle
+    // user rather than root.
+    const vm = opts?.sudo ? this.rootVm : this.userVm;
+    const res = await this.timed(command.slice(0, 80), () =>
+      vm.exec({
+        command: buildFreestyleCommand(command, opts),
+      }),
+    );
+    return {
+      exitCode: res.statusCode ?? 0,
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+    };
+  }
+
+  async uploadFile(content: Buffer | string, path: string): Promise<void> {
+    await this.ensureParentDir(path);
+    if (typeof content === "string") {
+      await this.timed(`write ${path}`, () =>
+        this.userVm.fs.writeTextFile(path, content),
+      );
+    } else {
+      await this.timed(`write ${path}`, () =>
+        this.userVm.fs.writeFile(path, content),
+      );
+    }
+    // Freestyle's `fs` write API runs as **root** regardless of the
+    // amika-scoped handle, so the file lands root-owned. The shared lifecycle
+    // then operates on these paths as `amika` (e.g. `chmod 600` on
+    // `~/.git-credentials`, the credential-store read, the agent process), which
+    // fails with "Operation not permitted" on a root-owned file. Reassign the
+    // file to `amika` so writes match the Daytona contract, where user-scoped
+    // writes are already user-owned. Fail loudly if the repair doesn't take —
+    // a silently root-owned file reproduces exactly the bug this prevents.
+    const chownResult = await this.exec(
+      `chown ${AMIKA_USER}:${AMIKA_USER} ${shellQuote(path)}`,
+      { sudo: true },
+    );
+    if (chownResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to chown ${path} to ${AMIKA_USER}: ${execFailureText(chownResult)}`,
+      );
+    }
+  }
+
+  async downloadFile(path: string): Promise<string | null> {
+    try {
+      return await this.timed(`read ${path}`, () =>
+        this.userVm.fs.readTextFile(path),
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  private async ensureParentDir(path: string): Promise<void> {
+    const idx = path.lastIndexOf("/");
+    if (idx <= 0) return;
+    const dir = path.slice(0, idx);
+    // `fs.mkdir` is non-recursive in the SDK, so use `mkdir -p` to create
+    // intermediate dirs. Best-effort: a real failure surfaces on the write.
+    try {
+      await this.timed(`mkdir ${dir}`, () =>
+        this.userVm.exec({ command: `mkdir -p ${shellQuote(dir)}` }),
+      );
+    } catch {
+      // ignore — the subsequent write surfaces a real failure.
+    }
+  }
+}

--- a/js/sandbox/src/providers/freestyle/internal/client.ts
+++ b/js/sandbox/src/providers/freestyle/internal/client.ts
@@ -1,0 +1,52 @@
+/**
+ * Freestyle SDK client construction.
+ *
+ * A fresh client per operation, mirroring the per-call pattern the Daytona
+ * provider uses. The `Freestyle` class reads its API key from the constructor
+ * (we pass the configured key explicitly rather than relying on the
+ * `FREESTYLE_API_KEY` env-var singleton).
+ */
+import { Freestyle } from "freestyle";
+import type { FreestyleConfig } from "../config";
+
+/**
+ * Generous client-side cap for a single Freestyle HTTP request. The SDK issues
+ * bare `fetch` calls with no timeout, so a request that never returns — a
+ * `vm.exec` against a VM that never becomes exec-ready, a `vms.delete` on a VM
+ * wedged mid-init — blocks forever, stranding a sandbox in `initializing` or
+ * hanging a delete with no error. This bounds every call so a hang surfaces as
+ * a failure (the error names the operation) instead of an infinite wait.
+ *
+ * This is a client-side `AbortSignal`, NOT the `timeoutMs` body param `vm.exec`
+ * accepts: that param is checked against the account's plan maximum and a
+ * request over it is rejected with `TIMEOUT_LIMIT_EXCEEDED` (403), which would
+ * break every exec. An abort signal has no such limit. The value is generous
+ * enough to cover legitimately slow work (a user setup script's `apt`/`npm`
+ * install); it only bites on a genuine hang.
+ */
+export const FREESTYLE_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Tighter cap for fast control-plane calls (delete, stop, start, state). These
+ * complete in seconds, sit on user-facing paths (a delete click, the sandbox
+ * list/detail poll), and have no long-running variant, so they should fail fast
+ * on a hang rather than wait out the full {@link FREESTYLE_REQUEST_TIMEOUT_MS}.
+ */
+export const FREESTYLE_CONTROL_PLANE_TIMEOUT_MS = 2 * 60 * 1000;
+
+export function createFreestyleClient(
+  config: FreestyleConfig,
+  timeoutMs: number = FREESTYLE_REQUEST_TIMEOUT_MS,
+): Freestyle {
+  return new Freestyle({
+    apiKey: config.apiKey,
+    baseUrl: config.apiUrl,
+    // Bound every request with a client-side timeout. The SDK never passes its
+    // own signal, but honor one if it ever does rather than clobbering it.
+    fetch: (url, init) =>
+      fetch(url, {
+        ...init,
+        signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+      }),
+  });
+}

--- a/js/sandbox/src/providers/freestyle/internal/operations.test.ts
+++ b/js/sandbox/src/providers/freestyle/internal/operations.test.ts
@@ -1,0 +1,473 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import pino from "pino";
+import type { SandboxCtx } from "../../../logger";
+import { SANDBOX_ORG_ID_LABEL } from "../../../constants";
+import type { FreestyleConfig } from "../config";
+import type {
+  CreateSandboxProviderInput,
+  SandboxService,
+} from "../../provider";
+import {
+  createFreestyleSandbox,
+  listFreestyleSandboxes,
+  mapFreestyleSandboxState,
+  refreshFreestyleUrls,
+  syncFreestyleRoutes,
+} from "./operations";
+
+const createVm = vi.fn();
+const refVm = vi.fn();
+const listVms = vi.fn();
+const listSnapshots = vi.fn();
+const deleteMapping = vi.fn();
+const listMappings = vi.fn();
+const createMapping = vi.fn();
+
+vi.mock("./client", () => ({
+  createFreestyleClient: () => ({
+    vms: {
+      create: createVm,
+      ref: refVm,
+      list: listVms,
+      snapshots: { list: listSnapshots },
+    },
+    domains: {
+      mappings: {
+        delete: deleteMapping,
+        list: listMappings,
+        create: createMapping,
+      },
+    },
+  }),
+  FREESTYLE_CONTROL_PLANE_TIMEOUT_MS: 1000,
+}));
+
+function svc(name: string, containerPort: number): SandboxService {
+  return {
+    name,
+    url: "",
+    hostPort: containerPort,
+    containerPort,
+    protocol: "tcp",
+  };
+}
+
+const config: FreestyleConfig = { apiKey: "test-key" };
+
+function ctx(): SandboxCtx {
+  return { logger: pino({ enabled: false }), childCtx: () => ctx() };
+}
+
+function createInput(
+  overrides?: Partial<CreateSandboxProviderInput>,
+): CreateSandboxProviderInput {
+  return {
+    name: "my-sandbox",
+    snapshot: "snap_123",
+    services: [],
+    labels: { [SANDBOX_ORG_ID_LABEL]: "org_abc123" },
+    ...overrides,
+  };
+}
+
+describe("createFreestyleSandbox org gating", () => {
+  beforeEach(() => {
+    createVm.mockReset();
+    refVm.mockReset();
+    listSnapshots.mockReset();
+    // No snapshot matches by name, so the ref is used as the snapshot id.
+    listSnapshots.mockResolvedValue({ snapshots: [] });
+    createVm.mockResolvedValue({ vmId: "vm_1", domains: [] });
+  });
+
+  it("folds the org id into the VM name", async () => {
+    await createFreestyleSandbox(ctx(), config, createInput());
+
+    expect(createVm).toHaveBeenCalledTimes(1);
+    expect(createVm.mock.calls[0][0]).toMatchObject({
+      name: "org_abc123/my-sandbox",
+      snapshotId: "snap_123",
+    });
+  });
+
+  it("falls back to the bare name when no org label is present", async () => {
+    await createFreestyleSandbox(
+      ctx(),
+      config,
+      createInput({ labels: undefined }),
+    );
+
+    expect(createVm.mock.calls[0][0]).toMatchObject({ name: "my-sandbox" });
+  });
+
+  it("never resizes the VM (size is baked into the snapshot)", async () => {
+    await createFreestyleSandbox(ctx(), config, createInput({ size: "l" }));
+
+    expect(refVm).not.toHaveBeenCalled();
+  });
+});
+
+describe("createFreestyleSandbox snapshot resolution", () => {
+  beforeEach(() => {
+    createVm.mockReset();
+    refVm.mockReset();
+    listSnapshots.mockReset();
+    createVm.mockResolvedValue({ vmId: "vm_1", domains: [] });
+  });
+
+  it("resolves a preset snapshot name to its bootable id", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [
+        {
+          snapshotId: "snap_real",
+          name: "amika-coder-m",
+          state: "ready",
+          createdAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    await createFreestyleSandbox(
+      ctx(),
+      config,
+      createInput({ snapshot: "amika-coder-m" }),
+    );
+
+    expect(createVm.mock.calls[0][0]).toMatchObject({
+      snapshotId: "snap_real",
+    });
+  });
+
+  it("uses a non-preset reference verbatim as the snapshot id", async () => {
+    listSnapshots.mockResolvedValue({ snapshots: [] });
+
+    await createFreestyleSandbox(
+      ctx(),
+      config,
+      createInput({ snapshot: "snap_captured" }),
+    );
+
+    expect(createVm.mock.calls[0][0]).toMatchObject({
+      snapshotId: "snap_captured",
+    });
+  });
+
+  it("throws a clear error when a preset snapshot has not been built", async () => {
+    listSnapshots.mockResolvedValue({ snapshots: [] });
+
+    await expect(
+      createFreestyleSandbox(
+        ctx(),
+        config,
+        createInput({ snapshot: "amika-coder-xl" }),
+      ),
+    ).rejects.toThrow(/amika-coder-xl.*not found/);
+    expect(createVm).not.toHaveBeenCalled();
+  });
+
+  // An opaque `vms.create` 500 (the "Background provisioning failed" path)
+  // should name the failing step and keep the original error as `cause` so the
+  // provider trace id survives into the logs.
+  it("labels a clone-snapshot failure and preserves the original error", async () => {
+    listSnapshots.mockResolvedValue({ snapshots: [] });
+    const providerError = new Error("INTERNAL_ERROR: Internal server error");
+    createVm.mockRejectedValue(providerError);
+
+    await expect(
+      createFreestyleSandbox(ctx(), config, createInput()),
+    ).rejects.toMatchObject({
+      message:
+        "freestyle create: clone snapshot: INTERNAL_ERROR: Internal server error",
+      cause: providerError,
+    });
+  });
+});
+
+describe("mapFreestyleSandboxState", () => {
+  it("maps every raw Freestyle VM state onto the canonical vocabulary", () => {
+    const cases: Record<string, string> = {
+      building: "creating",
+      starting: "starting",
+      running: "running",
+      suspending: "suspending",
+      suspended: "suspended",
+      stopped: "suspended",
+      lost: "failed",
+    };
+    for (const [raw, expected] of Object.entries(cases)) {
+      expect(mapFreestyleSandboxState(raw), raw).toBe(expected);
+    }
+  });
+
+  it("maps the synthesized absent-VM sentinel and junk to unknown", () => {
+    expect(mapFreestyleSandboxState("unknown")).toBe("unknown");
+    expect(mapFreestyleSandboxState("")).toBe("unknown");
+  });
+});
+
+describe("listFreestyleSandboxes", () => {
+  beforeEach(() => listVms.mockReset());
+
+  const sizing = { vcpuCount: 2, memSizeMib: 4096, rootfsSizeMb: 10240 };
+
+  it("maps each VM to its org (from the name), state, and GiB sizing", async () => {
+    listVms.mockResolvedValue({
+      vms: [
+        { id: "vm_1", name: `${"org_abc"}/my-box`, state: "running", sizing },
+      ],
+    });
+
+    const listings = await listFreestyleSandboxes(config);
+
+    expect(listings).toEqual([
+      {
+        providerSandboxId: "vm_1",
+        orgId: "org_abc",
+        state: "running",
+        // 4096 MiB → 4 GiB, 10240 MiB → 10 GiB.
+        sizing: { vcpus: 2, memoryGib: 4, diskGib: 10 },
+      },
+    ]);
+  });
+
+  it("reports a null org for a VM name with no org prefix", async () => {
+    listVms.mockResolvedValue({
+      vms: [{ id: "vm_1", name: "legacy-box", state: "running", sizing }],
+    });
+
+    expect((await listFreestyleSandboxes(config))[0]?.orgId).toBeNull();
+  });
+
+  it("skips soft-deleted VMs still lingering in the list", async () => {
+    listVms.mockResolvedValue({
+      vms: [
+        { id: "vm_live", name: "org_a/live", state: "running", sizing },
+        {
+          id: "vm_gone",
+          name: "org_a/gone",
+          state: "suspended",
+          deleted: true,
+          sizing,
+        },
+      ],
+    });
+
+    const ids = (await listFreestyleSandboxes(config)).map(
+      (l) => l.providerSandboxId,
+    );
+    expect(ids).toEqual(["vm_live"]);
+  });
+
+  it("skips VMs whose sizing the API omits", async () => {
+    listVms.mockResolvedValue({
+      vms: [
+        { id: "vm_sized", name: "org_a/ok", state: "running", sizing },
+        { id: "vm_unsized", name: "org_a/no-size", state: "running" },
+      ],
+    });
+
+    const ids = (await listFreestyleSandboxes(config)).map(
+      (l) => l.providerSandboxId,
+    );
+    expect(ids).toEqual(["vm_sized"]);
+  });
+});
+
+describe("syncFreestyleRoutes", () => {
+  const mapping = (
+    vmId: string,
+    port: number,
+    overrides: Record<string, unknown> = {},
+  ) => ({
+    id: `map_${vmId}_${port}`,
+    domain: `amika-${vmId}-${port}.style.dev`,
+    vmId,
+    vmPort: port,
+    ownershipId: "own_1",
+    createdAt: "2026-01-01",
+    unmappedAt: null,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    deleteMapping.mockReset();
+    deleteMapping.mockResolvedValue({});
+    listMappings.mockReset();
+    createMapping.mockReset();
+    createMapping.mockResolvedValue({});
+  });
+
+  it("deletes a stale Amika mapping and leaves desired + foreign ones alone", async () => {
+    // The account-wide enumeration: a stale Amika mapping (port 3000, no
+    // longer desired), a live desired one, another VM's mapping, and a
+    // user's custom domain on THIS vm (not the deterministic shape).
+    const account = [
+      mapping("vm_abc", 3000),
+      mapping("vm_abc", 60998),
+      mapping("vm_other", 3000),
+      { ...mapping("vm_abc", 8080), domain: "myapp.example.com" },
+    ];
+    listMappings.mockImplementation(
+      (opts?: { domain?: string; cursor?: string }) => {
+        if (opts?.domain) {
+          // Per-domain existence probes in the create pass: everything desired
+          // already has a live mapping.
+          return Promise.resolve({
+            mappings: [mapping("vm_abc", 60998)].filter(
+              (m) => m.domain === opts.domain,
+            ),
+          });
+        }
+        const offset = opts?.cursor ? parseInt(opts.cursor, 10) : 0;
+        return Promise.resolve({ mappings: account.slice(offset) });
+      },
+    );
+
+    await syncFreestyleRoutes({ apiKey: "test-key" }, "vm_abc", [
+      svc("Coding Agent", 60998),
+    ]);
+
+    // Only the stale Amika-owned mapping for THIS vm is torn down — never
+    // another VM's mapping, never a custom domain a user mapped out-of-band.
+    expect(deleteMapping).toHaveBeenCalledTimes(1);
+    expect(deleteMapping).toHaveBeenCalledWith({
+      domain: "amika-vm_abc-3000.style.dev",
+    });
+  });
+
+  it("keeps a shared-port domain while any desired service uses the port", async () => {
+    listMappings.mockImplementation(
+      (opts?: { domain?: string; cursor?: string }) => {
+        const offset =
+          !opts?.domain && opts?.cursor ? parseInt(opts.cursor, 10) : 0;
+        return Promise.resolve({
+          mappings: [mapping("vm_abc", 3000)]
+            .filter((m) => !opts?.domain || m.domain === opts.domain)
+            .slice(offset),
+        });
+      },
+    );
+
+    // Two services share port 3000; one was deleted, the survivor keeps it in
+    // the desired set — the per-port domain must survive.
+    await syncFreestyleRoutes({ apiKey: "test-key" }, "vm_abc", [
+      svc("web-2", 3000),
+    ]);
+    expect(deleteMapping).not.toHaveBeenCalled();
+  });
+
+  it("creates a missing mapping for a desired port (soft-deleted re-created)", async () => {
+    listMappings.mockImplementation((opts?: { domain?: string }) => {
+      if (opts?.domain) {
+        // The domain only has a soft-deleted record — must be re-created.
+        return Promise.resolve({
+          mappings: [
+            mapping("vm_abc", 3000, { unmappedAt: "2026-01-02" }),
+          ].filter((m) => m.domain === opts.domain),
+        });
+      }
+      // Account-wide enumeration: empty on every page.
+      return Promise.resolve({ mappings: [] });
+    });
+
+    await syncFreestyleRoutes({ apiKey: "test-key" }, "vm_abc", [
+      svc("web", 3000),
+    ]);
+    expect(createMapping).toHaveBeenCalledWith({
+      domain: "amika-vm_abc-3000.style.dev",
+      vmId: "vm_abc",
+      vmPort: 3000,
+    });
+  });
+
+  it("paginates the account-wide enumeration to exhaustion (offset-based)", async () => {
+    // The SDK's `cursor` is a stringified OFFSET (`parseInt(cursor, 10)` in
+    // freestyle@0.1.63) and its response carries no continuation token. The
+    // stale mapping only appears past the first full page — reconciling from
+    // page one alone would leave it publicly routed.
+    const account = [
+      ...Array.from({ length: 100 }, (_, i) => mapping("vm_other", 10_000 + i)),
+      mapping("vm_abc", 3000),
+    ];
+    listMappings.mockImplementation(
+      (opts?: { domain?: string; cursor?: string; limit?: number }) => {
+        if (opts?.domain) return Promise.resolve({ mappings: [] });
+        const offset = opts?.cursor ? parseInt(opts.cursor, 10) : 0;
+        return Promise.resolve({
+          mappings: account.slice(offset, offset + (opts?.limit ?? 10)),
+        });
+      },
+    );
+
+    await syncFreestyleRoutes({ apiKey: "test-key" }, "vm_abc", []);
+    expect(deleteMapping).toHaveBeenCalledWith({
+      domain: "amika-vm_abc-3000.style.dev",
+    });
+  });
+
+  it("does not treat a clamped short page as exhaustion", async () => {
+    // A server that clamps `limit` (here to 10) returns short pages long
+    // before the listing is drained; termination must be on an EMPTY page or
+    // the stale mapping past the clamp horizon is never seen.
+    const account = [
+      ...Array.from({ length: 25 }, (_, i) => mapping("vm_other", 10_000 + i)),
+      mapping("vm_abc", 3000),
+    ];
+    listMappings.mockImplementation(
+      (opts?: { domain?: string; cursor?: string }) => {
+        if (opts?.domain) return Promise.resolve({ mappings: [] });
+        const offset = opts?.cursor ? parseInt(opts.cursor, 10) : 0;
+        return Promise.resolve({
+          mappings: account.slice(offset, offset + 10),
+        });
+      },
+    );
+
+    await syncFreestyleRoutes({ apiKey: "test-key" }, "vm_abc", []);
+    expect(deleteMapping).toHaveBeenCalledWith({
+      domain: "amika-vm_abc-3000.style.dev",
+    });
+  });
+});
+
+describe("refreshFreestyleUrls", () => {
+  const domain = "amika-vm_abc-3000.style.dev";
+
+  beforeEach(() => {
+    listMappings.mockReset();
+    createMapping.mockReset();
+    createMapping.mockResolvedValue({});
+  });
+
+  it("skips create when a live mapping already exists", async () => {
+    listMappings.mockResolvedValue({
+      mappings: [{ id: "m1", domain, createdAt: "2026-01-01T00:00:00Z" }],
+    });
+    const { services } = await refreshFreestyleUrls(config, "vm_abc", [
+      svc("web", 3000),
+    ]);
+    expect(createMapping).not.toHaveBeenCalled();
+    expect(services[0].url).toBe(`https://${domain}`);
+  });
+
+  it("recreates the mapping when the only match is soft-deleted (unmappedAt)", async () => {
+    // A mapping torn down by the route reconcile lingers with
+    // `unmappedAt` set; a service recreated on the same port must re-map it.
+    listMappings.mockResolvedValue({
+      mappings: [
+        {
+          id: "m1",
+          domain,
+          createdAt: "2026-01-01T00:00:00Z",
+          unmappedAt: "2026-01-02T00:00:00Z",
+        },
+      ],
+    });
+    await refreshFreestyleUrls(config, "vm_abc", [svc("web", 3000)]);
+    expect(createMapping).toHaveBeenCalledWith({
+      domain,
+      vmId: "vm_abc",
+      vmPort: 3000,
+    });
+  });
+});

--- a/js/sandbox/src/providers/freestyle/internal/operations.ts
+++ b/js/sandbox/src/providers/freestyle/internal/operations.ts
@@ -1,0 +1,643 @@
+/**
+ * Sandbox-level operations against the Freestyle API: create (by cloning a
+ * preset VM snapshot), start/stop/delete, SSH access, preview-URL refresh,
+ * exec, and file reads. The provisioning lifecycle lives in
+ * `@amika/sandbox-provisioning`; this module keeps the generic provider
+ * mechanics, including {@link openFreestyleAdapter} (the adapter the
+ * provisioning layer drives; it clones over that adapter's exec port, so
+ * Freestyle needs no native clone primitive here).
+ */
+import { SANDBOX_ORG_ID_LABEL } from "../../../constants";
+import { withStepContext } from "../../../util/errorutils";
+import type { SandboxCtx } from "../../../logger";
+import type { FreestyleConfig } from "../config";
+import {
+  type CreateSandboxProviderInput,
+  type CreatedProviderSandbox,
+  type ExecCommandOptions,
+  type ProviderSandboxListing,
+  type RefreshUrlsResult,
+  type SandboxExecResult,
+  type SandboxService,
+} from "../../provider";
+import type { SandboxStatus } from "../../../sandbox-status";
+import type { SandboxAdapter } from "../../shared/adapter";
+import { execWithStagedInput } from "../../shared/exec-input";
+import {
+  createFreestyleClient,
+  FREESTYLE_CONTROL_PLANE_TIMEOUT_MS,
+} from "./client";
+import { FreestyleAdapter } from "./adapter";
+import { buildFreestyleVmName, freestyleVmNameOrgId } from "../naming";
+import { resolveFreestyleSnapshotRef } from "./snapshot-operations";
+
+/**
+ * Preview URLs are backed by Freestyle domain mappings, which are stable and do
+ * not expire (unlike Daytona's signed URLs). Use a long TTL so a sandbox's
+ * `urls_expire_at` stays far in the future and the refresh path rarely churns.
+ */
+export const FREESTYLE_URL_TTL_S = 365 * 24 * 60 * 60;
+
+/**
+ * "Never idle-suspend" expressed as a very large timeout. `vm.start` only
+ * accepts a numeric `idleTimeoutSeconds` (no `null`), so a 1-year timeout is the
+ * effective never — the VM won't suspend within any real session.
+ */
+const NEVER_IDLE_TIMEOUT_SECONDS = 365 * 24 * 60 * 60;
+
+/**
+ * Translate Daytona-style `auto_stop_interval` (minutes) into Freestyle's
+ * `idleTimeoutSeconds`, applied identically at create and on every restart so
+ * the user's choice survives stop/start (Freestyle resets idle timeout per
+ * start otherwise):
+ *   - `0`  → "never" (a 1-year timeout; the API has no null on start)
+ *   - `>0` → seconds
+ *   - absent/`null` → `undefined` (omit the field → Freestyle default)
+ */
+function freestyleIdleTimeoutSeconds(
+  autoStopInterval?: number | null,
+): number | undefined {
+  if (autoStopInterval === 0) return NEVER_IDLE_TIMEOUT_SECONDS;
+  if (autoStopInterval != null && autoStopInterval > 0) {
+    return autoStopInterval * 60;
+  }
+  return undefined;
+}
+
+/**
+ * Deterministic preview domain for a (vm, port). Stable across restarts and
+ * refreshes so re-creating the mapping is idempotent. VM IDs are 20 lowercase
+ * alphanumeric chars, so the result is a valid subdomain.
+ */
+function previewDomainFor(vmId: string, port: number): string {
+  return `amika-${vmId}-${port}.style.dev`;
+}
+
+export async function createFreestyleSandbox(
+  ctx: SandboxCtx,
+  config: FreestyleConfig,
+  input: CreateSandboxProviderInput,
+): Promise<CreatedProviderSandbox> {
+  const client = createFreestyleClient(config);
+
+  const idleTimeoutSeconds = freestyleIdleTimeoutSeconds(
+    input.autoStopInterval,
+  );
+
+  // Freestyle's `vms.create` has no label facet (unlike Daytona, which stamps
+  // `amika-org-id`), so org-gate the VM by folding the org id into its name.
+  // The org id rides along in `input.labels`; absent it (no expected caller),
+  // fall back to the bare name rather than minting an unscoped `/`-prefixed one.
+  const orgId = input.labels?.[SANDBOX_ORG_ID_LABEL];
+  const vmName = orgId ? buildFreestyleVmName(orgId, input.name) : input.name;
+
+  // Resolve the snapshot reference to a bootable snapshot id. Preset references
+  // are deterministic names (`amika-<preset>-<size>`); captured snapshots arrive
+  // already resolved to ids. A preset name that resolves to nothing means the
+  // snapshot has not been built yet — fail with a clear, actionable message
+  // rather than passing a name to `vms.create` (which would 404 opaquely).
+  const snapshotId = await withStepContext(
+    "freestyle create: resolve snapshot ref",
+    () => resolveFreestyleSnapshotRef(config, input.snapshot),
+  );
+  if (snapshotId === input.snapshot && input.snapshot.startsWith("amika-")) {
+    throw new Error(
+      `Freestyle preset snapshot "${input.snapshot}" not found. ` +
+        "Build it with `bin/freestyle-build-snapshots`.",
+    );
+  }
+
+  ctx.logger.info(
+    { name: vmName, snapshot: input.snapshot, snapshotId },
+    "Creating Freestyle sandbox (cloning snapshot)",
+  );
+
+  // Clone the preset VM snapshot into a fresh VM. `persistent` so the sandbox
+  // survives stop/suspend. The org-scoped name is carried onto the VM so it's
+  // attributable to its org in `vms.get` and the dashboard. Service ports are
+  // exposed via domain mappings in `refreshFreestyleUrls`, not at create time.
+  //
+  // No post-create `vm.resize`: the requested size is baked into the per-size
+  // snapshot (`amika-<preset>-<size>`, built by `bin/freestyle-build-snapshots`,
+  // which resizes the VM before snapshotting), so the clone boots at that size —
+  // mirroring Daytona's per-size image tags and removing the slow rootfs-grow the
+  // runtime resize incurred.
+  const created = await withStepContext(
+    "freestyle create: clone snapshot",
+    () =>
+      client.vms.create({
+        snapshotId,
+        name: vmName,
+        persistence: { type: "persistent" },
+        ...(idleTimeoutSeconds !== undefined ? { idleTimeoutSeconds } : {}),
+      }),
+  );
+
+  return {
+    provider: "freestyle",
+    providerSandboxId: created.vmId,
+    providerUrl: null,
+    services: input.services,
+    envVars: {},
+  };
+}
+
+/**
+ * Ensure a stable preview-domain mapping for each service and return the
+ * resulting `https://` URLs. The deterministic domain makes re-creating the
+ * mapping idempotent, so an "already exists" conflict is suppressed; any other
+ * mapping failure is propagated (the hostname wouldn't route), failing the
+ * provision rather than recording a dead URL.
+ */
+export async function refreshFreestyleUrls(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  services: SandboxService[],
+): Promise<RefreshUrlsResult> {
+  const client = createFreestyleClient(config);
+  const refreshed: SandboxService[] = [];
+  let providerUrl: string | null = null;
+
+  for (const service of services) {
+    const domain = previewDomainFor(providerSandboxId, service.containerPort);
+    // Create the mapping only if a *live* one doesn't already exist. The domain
+    // is deterministic per (vm, port), so on a refresh/restart it's already
+    // present — skipping avoids a spurious conflict. But a mapping torn down by
+    // the route reconcile (`syncFreestyleRoutes`) lingers as a soft-deleted record
+    // (`unmappedAt` set), so a service recreated on the same port must ignore
+    // those and re-create, or its URL would resolve to nothing. Any failure of
+    // the list or create (auth/quota, invalid port, VM not ready) propagates and
+    // fails provisioning rather than recording a dead URL behind the long TTL.
+    const { mappings } = await client.domains.mappings.list({ domain });
+    if (!mappings.some((m) => m.domain === domain && !m.unmappedAt)) {
+      await client.domains.mappings.create({
+        domain,
+        vmId: providerSandboxId,
+        vmPort: service.containerPort,
+      });
+    }
+    const url = `https://${domain}`;
+    refreshed.push({ ...service, url });
+    if (service.name === "Coding Agent") {
+      providerUrl = url;
+    }
+  }
+
+  return { providerUrl, services: refreshed };
+}
+
+/** Page size for the account-wide mapping enumeration in {@link syncFreestyleRoutes}. */
+const MAPPINGS_LIST_PAGE_SIZE = 100;
+
+/**
+ * Fail-loud backstop for {@link listAllMappings}: a server that ignored the
+ * offset param would return the same non-empty page forever, and without a
+ * bound the loop would spin and accumulate duplicates unboundedly. 1000 pages
+ * of 100 is far beyond any plausible account.
+ */
+const MAPPINGS_LIST_MAX_PAGES = 1000;
+
+/**
+ * Enumerate ALL of the account's domain mappings, paginating to exhaustion.
+ * `domains.mappings.list` is account-wide with a small default page (10), so
+ * reconciling from a partial first page could leave a deleted service
+ * publicly routed.
+ *
+ * Pagination is OFFSET-based: the SDK parses the `cursor` option as an
+ * integer offset (`parseInt(cursor, 10)` in freestyle@0.1.63) and its
+ * response carries no continuation token, so the next offset is synthesized
+ * from the count fetched so far. Termination is on an EMPTY page, not a
+ * short one — a server that clamps `limit` below the requested page size
+ * would make a short page look like exhaustion and silently strand stale
+ * routes. Provided the server honors the offset, each non-empty page
+ * strictly advances it; {@link MAPPINGS_LIST_MAX_PAGES} fails loud rather
+ * than spinning if it ever doesn't.
+ */
+async function listAllMappings(
+  client: ReturnType<typeof createFreestyleClient>,
+): Promise<
+  Awaited<ReturnType<typeof client.domains.mappings.list>>["mappings"]
+> {
+  const all: Awaited<
+    ReturnType<typeof client.domains.mappings.list>
+  >["mappings"] = [];
+  for (let page = 0; page < MAPPINGS_LIST_MAX_PAGES; page++) {
+    const res = await client.domains.mappings.list({
+      limit: MAPPINGS_LIST_PAGE_SIZE,
+      cursor: String(all.length),
+    });
+    if (res.mappings.length === 0) return all;
+    all.push(...res.mappings);
+  }
+  throw new Error(
+    `Freestyle domain-mapping enumeration exceeded ${MAPPINGS_LIST_MAX_PAGES} ` +
+      "pages without draining; refusing to reconcile routes from a listing " +
+      "that never terminates.",
+  );
+}
+
+/**
+ * Reconcile the VM's preview-domain mappings to exactly the desired service
+ * set: delete the Amika-owned mappings whose port no longer has a desired
+ * service, create the missing ones. Freestyle mappings persist
+ * for their long TTL untied to run state, so without the delete pass a
+ * removed service's URL keeps routing to the VM (a restart does not clear
+ * it). The shared-port guard falls out of the declarative shape: a per-port
+ * domain is deleted iff NO desired service uses that port.
+ *
+ * Reconciliation touches only Amika-OWNED mappings: filtered by `vmId` AND
+ * the deterministic `amika-<vmId>-<port>.style.dev` shape (soft-deleted
+ * records ignored), so a custom domain a user independently mapped to the
+ * same VM is never classified as reconcilable state and cannot be deleted.
+ *
+ * Concurrency caveat (same in kind as `refreshAll`'s mapping creation): the
+ * create pass works from a desired set computed before this call, so two
+ * concurrent syncs of the same VM can interleave — one's create pass may
+ * re-create a mapping the other's delete pass just tore down, until the next
+ * sync reconciles it. Not serialized here; acceptable for the current usage.
+ */
+export async function syncFreestyleRoutes(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  desired: SandboxService[],
+): Promise<void> {
+  const client = createFreestyleClient(
+    config,
+    FREESTYLE_CONTROL_PLANE_TIMEOUT_MS,
+  );
+  const desiredPorts = new Set(desired.map((s) => s.containerPort));
+
+  // Delete pass: live Amika-owned mappings for this VM whose port lost its
+  // last desired service.
+  const mappings = await listAllMappings(client);
+  const stale = mappings.filter(
+    (m) =>
+      m.vmId === providerSandboxId &&
+      !m.unmappedAt &&
+      m.vmPort != null &&
+      m.domain === previewDomainFor(providerSandboxId, m.vmPort) &&
+      !desiredPorts.has(m.vmPort),
+  );
+  // Dedupe by domain: offset pagination can surface a record twice when the
+  // listing shifts between pages, and the delete is per-domain anyway. The
+  // mirror hazard — a concurrent delete elsewhere in the account shifting a
+  // record BELOW the walked boundary, skipping this VM's stale mapping — is
+  // accepted: the window needs a 100+-mapping account plus a racing delete
+  // between page fetches, and the skip only defers the teardown to this
+  // sandbox's next service mutation.
+  for (const domain of new Set(stale.map((m) => m.domain))) {
+    await client.domains.mappings.delete({ domain });
+  }
+
+  // Create pass: expose desired ports that have no live mapping yet. The
+  // per-domain existence check mirrors `refreshFreestyleUrls` (a soft-deleted
+  // record lingers with `unmappedAt` set and must be re-created over).
+  for (const port of desiredPorts) {
+    const domain = previewDomainFor(providerSandboxId, port);
+    const { mappings: existing } = await client.domains.mappings.list({
+      domain,
+    });
+    if (!existing.some((m) => m.domain === domain && !m.unmappedAt)) {
+      await client.domains.mappings.create({
+        domain,
+        vmId: providerSandboxId,
+        vmPort: port,
+      });
+    }
+  }
+}
+
+export async function getFreestyleSandboxState(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+): Promise<string> {
+  const client = createFreestyleClient(
+    config,
+    FREESTYLE_CONTROL_PLANE_TIMEOUT_MS,
+  );
+  // The VM handle has no get-info; state comes from the VM list.
+  const { vms } = await client.vms.list();
+  return vms.find((vm) => vm.id === providerSandboxId)?.state ?? "unknown";
+}
+
+/**
+ * One item of Freestyle's `vms.list()` with the fields the spend meter needs.
+ * The public SDK types (freestyle@0.1.63) omit `name` and `sizing`, but both are
+ * present at runtime in the `GET /v1/vms` response (see the SDK's `private.d.ts`
+ * `ResponseGetV1Vms200`); the pinned SDK version guards against the shape
+ * changing.
+ */
+interface FreestyleVmListItem {
+  id: string;
+  name?: string | null;
+  state: string;
+  // Soft-delete flag, independent of `state`: a deleted VM keeps appearing in
+  // vms.list() as stopped/suspended with `deleted: true`. There is no "deleted"
+  // state value, so this is the only signal that a VM is gone.
+  deleted?: boolean | null;
+  sizing?: {
+    /** Provisioned vCPU count. */
+    vcpuCount: number;
+    /** Provisioned memory, mebibytes. */
+    memSizeMib: number;
+    /** Provisioned root filesystem, mebibytes. */
+    rootfsSizeMb: number;
+  } | null;
+}
+
+const MIB_PER_GIB = 1024;
+
+/**
+ * Enumerate every live VM in the Freestyle account with its org stamp (folded
+ * into the VM name), raw state, and provisioned sizing (converted MiB→GiB).
+ * Soft-deleted VMs still lingering in the list, and VMs whose sizing the API
+ * omits, are excluded — a deleted VM must stop billing, and an unsizeable one
+ * can't be priced.
+ */
+export async function listFreestyleSandboxes(
+  config: FreestyleConfig,
+): Promise<ProviderSandboxListing[]> {
+  const client = createFreestyleClient(
+    config,
+    FREESTYLE_CONTROL_PLANE_TIMEOUT_MS,
+  );
+  const { vms } = await client.vms.list();
+  const items = vms as unknown as FreestyleVmListItem[];
+  const listings: ProviderSandboxListing[] = [];
+  for (const vm of items) {
+    if (vm.deleted) continue;
+    if (!vm.sizing) continue;
+    listings.push({
+      providerSandboxId: vm.id,
+      orgId: freestyleVmNameOrgId(vm.name ?? null),
+      state: vm.state,
+      sizing: {
+        vcpus: vm.sizing.vcpuCount,
+        memoryGib: vm.sizing.memSizeMib / MIB_PER_GIB,
+        diskGib: vm.sizing.rootfsSizeMb / MIB_PER_GIB,
+      },
+    });
+  }
+  return listings;
+}
+
+/**
+ * Map a raw Freestyle VM state into the canonical lifecycle vocabulary. Raw
+ * values are the `freestyle` SDK's VM `state` union plus the synthesized
+ * `"unknown"` for a VM absent from the list. `stopped` and `suspended` both
+ * read as `suspended` (either is resumable via start); `lost` is terminal.
+ */
+export function mapFreestyleSandboxState(rawState: string): SandboxStatus {
+  switch (rawState) {
+    case "building":
+      return "creating";
+    case "starting":
+      return "starting";
+    case "running":
+      return "running";
+    case "suspending":
+      return "suspending";
+    case "suspended":
+    case "stopped":
+      return "suspended";
+    case "lost":
+      return "failed";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * How long to wait for a Freestyle VM to reach a settled (suspended/stopped)
+ * state, and the poll cadence. `vm.suspend`/`vm.stop` resolve once the request
+ * is *accepted*, not once the VM has settled, so callers that must observe the
+ * settled state poll the VM list.
+ */
+const FREESTYLE_VM_SETTLE_TIMEOUT_S = 2 * 60;
+const FREESTYLE_VM_SETTLE_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Block until the VM's state satisfies `isSettled`, throwing if the timeout
+ * elapses first. `vm.suspend`/`vm.stop` resolve once the request is accepted,
+ * not once the VM has settled (unlike `vm.start`/`vms.create`, which resolve
+ * only when the VM is running), so any operation that must not race a still
+ * transitioning VM polls here first.
+ */
+async function waitForFreestyleVmState(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  isSettled: (state: string) => boolean,
+  description: string,
+  timeoutS: number = FREESTYLE_VM_SETTLE_TIMEOUT_S,
+): Promise<void> {
+  const deadline = Date.now() + timeoutS * 1000;
+  for (;;) {
+    const state = await getFreestyleSandboxState(config, providerSandboxId);
+    if (isSettled(state)) return;
+    // `lost` is terminal and `unknown` means the VM is absent from the list
+    // (deleted/never existed); neither will ever reach the target state, so fail
+    // fast with a clear error rather than polling out to the deadline.
+    if (state === "lost" || state === "unknown") {
+      throw new Error(
+        `Freestyle VM "${providerSandboxId}" is "${state}" and will not ` +
+          `reach ${description}`,
+      );
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Freestyle VM "${providerSandboxId}" did not reach ${description} ` +
+          `within ${timeoutS}s (last state: "${state}")`,
+      );
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, FREESTYLE_VM_SETTLE_POLL_INTERVAL_MS),
+    );
+  }
+}
+
+/**
+ * Block until the VM is fully `stopped` (a cold power-off). Used by the
+ * stop/start lifecycle to wait out an in-flight cold stop before `vm.start`
+ * resumes the VM (see {@link startFreestyleSandbox}).
+ */
+export async function waitForFreestyleVmStopped(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  timeoutS?: number,
+): Promise<void> {
+  await waitForFreestyleVmState(
+    config,
+    providerSandboxId,
+    (state) => state === "stopped",
+    "stopped",
+    timeoutS,
+  );
+}
+
+/**
+ * Block until the VM is `suspended` (a warm suspend-to-disk that `vm.start`
+ * resumes from). Used by the stop/start lifecycle.
+ */
+async function waitForFreestyleVmSuspended(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  timeoutS?: number,
+): Promise<void> {
+  await waitForFreestyleVmState(
+    config,
+    providerSandboxId,
+    (state) => state === "suspended",
+    "suspended",
+    timeoutS,
+  );
+}
+
+export async function startFreestyleSandbox(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  autoStopInterval?: number | null,
+): Promise<void> {
+  const client = createFreestyleClient(
+    config,
+    FREESTYLE_CONTROL_PLANE_TIMEOUT_MS,
+  );
+  const vm = client.vms.ref({ vmId: providerSandboxId });
+  // A suspend/stop issued moments earlier may still be settling (`vm.suspend`/
+  // `vm.stop` resolve on accept). Resuming a VM mid-transition wedges it in
+  // `starting`, which strands the sandbox in `initializing`. Wait for the VM to
+  // settle so `vm.start` always acts on a `suspended`/`stopped` VM.
+  const state = await getFreestyleSandboxState(config, providerSandboxId);
+  if (state === "suspending") {
+    await waitForFreestyleVmSuspended(config, providerSandboxId);
+  } else if (state === "stopping") {
+    await waitForFreestyleVmStopped(config, providerSandboxId);
+  }
+  // Freestyle resets idle timeout per start, so re-apply the persisted choice
+  // (omitting the field falls back to the provider default).
+  const idleTimeoutSeconds = freestyleIdleTimeoutSeconds(autoStopInterval);
+  await vm.start(
+    idleTimeoutSeconds !== undefined ? { idleTimeoutSeconds } : {},
+  );
+}
+
+export async function stopFreestyleSandbox(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  const client = createFreestyleClient(
+    config,
+    FREESTYLE_CONTROL_PLANE_TIMEOUT_MS,
+  );
+  const vm = client.vms.ref({ vmId: providerSandboxId });
+  // Suspend rather than stop. `vm.stop` is a cold power-off, and resuming a
+  // `stopped` VM via `vm.start` cold-boots it — which wedges it in `starting`
+  // forever, stranding the sandbox in `initializing`. `vm.suspend` snapshots the
+  // VM to disk (the same warm path the idle timeout uses), and `vm.start`
+  // resumes from that layer reliably. `suspend` is present in the
+  // freestyle@0.1.63 runtime but absent from its published types (like
+  // `vm.user`), so it is typed locally here. Safe because Amika creates VMs with
+  // `persistence: "persistent"`; an `ephemeral` VM can carry `deleteEvent:
+  // "OnSuspend"` and would be deleted by a suspend.
+  const state = await getFreestyleSandboxState(config, providerSandboxId);
+  // Already idle (or being made idle by an earlier request) — nothing to do but
+  // let it settle. `vm.suspend` on an already-suspended VM is a 409.
+  if (state !== "suspended" && state !== "stopped" && state !== "suspending") {
+    await (vm as typeof vm & { suspend(): Promise<unknown> }).suspend();
+  }
+  // `vm.suspend` resolves once accepted, not once suspended; wait so the row
+  // isn't marked `stopped` while the VM is still suspending (a resume issued
+  // right after would otherwise race the in-flight suspend).
+  if (state !== "stopped") {
+    await waitForFreestyleVmSuspended(config, providerSandboxId);
+  }
+}
+
+export async function deleteFreestyleSandbox(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  const client = createFreestyleClient(
+    config,
+    FREESTYLE_CONTROL_PLANE_TIMEOUT_MS,
+  );
+  await client.vms.delete({ vmId: providerSandboxId });
+}
+
+/**
+ * Capture an immutable snapshot of a VM's current state (memory, disk, CPU
+ * registers) and return the new snapshot id. Works on running, suspended, or
+ * stopped VMs. The resulting snapshot can be cloned into fresh VMs via
+ * {@link createFreestyleSandbox} (`vms.create({ snapshotId })`). An optional
+ * `name` makes the snapshot easier to identify in the dashboard and in
+ * `vms.snapshots.list`.
+ */
+export async function snapshotFreestyleSandbox(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  name?: string | null,
+): Promise<string> {
+  const client = createFreestyleClient(config);
+  const vm = client.vms.ref({ vmId: providerSandboxId });
+  const { snapshotId } = await vm.snapshot(name != null ? { name } : {});
+  return snapshotId;
+}
+
+export async function readFreestyleFile(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  filePath: string,
+): Promise<string | null> {
+  const client = createFreestyleClient(config);
+  const adapter = new FreestyleAdapter(
+    client.vms.ref({ vmId: providerSandboxId }),
+    client,
+  );
+  return adapter.downloadFile(filePath);
+}
+
+export async function writeFreestyleFile(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  filePath: string,
+  content: Buffer | string,
+): Promise<void> {
+  const client = createFreestyleClient(config);
+  const adapter = new FreestyleAdapter(
+    client.vms.ref({ vmId: providerSandboxId }),
+    client,
+  );
+  await adapter.uploadFile(content, filePath);
+}
+
+export async function executeFreestyleCommand(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  command: string,
+  opts?: ExecCommandOptions,
+): Promise<SandboxExecResult> {
+  const client = createFreestyleClient(config);
+  const adapter = new FreestyleAdapter(
+    client.vms.ref({ vmId: providerSandboxId }),
+    client,
+  );
+  if (opts?.input !== undefined) {
+    return execWithStagedInput(adapter, command, opts.input, opts);
+  }
+  return adapter.exec(command, opts);
+}
+
+/**
+ * Open a Freestyle adapter handle (the core provisioning seam). `vms.ref` is a
+ * local reference builder — no round-trip — so there is no fetched-once cost to
+ * amortize here.
+ */
+export function openFreestyleAdapter(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+): SandboxAdapter {
+  const client = createFreestyleClient(config);
+  return new FreestyleAdapter(
+    client.vms.ref({ vmId: providerSandboxId }),
+    client,
+  );
+}

--- a/js/sandbox/src/providers/freestyle/internal/snapshot-operations.test.ts
+++ b/js/sandbox/src/providers/freestyle/internal/snapshot-operations.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FreestyleConfig } from "../config";
+import {
+  captureFreestyleSandboxSnapshot,
+  deleteFreestyleSnapshotByName,
+  getFreestyleSnapshotByName,
+  resolveFreestyleSnapshotRef,
+  waitForFreestyleSnapshotActive,
+} from "./snapshot-operations";
+
+const listSnapshots = vi.fn(); // client.vms.snapshots.list
+const listVms = vi.fn(); // client.vms.list (drives getFreestyleSandboxState)
+const vmSnapshot = vi.fn(); // vm.snapshot
+const vmStop = vi.fn(); // vm.stop
+const rootExec = vi.fn(); // rootVm.exec (sudo cmds, getent, ls verify)
+const userExec = vi.fn(); // amika-scoped exec (credential rm)
+const readTextFile = vi.fn(); // fs.readTextFile (/etc/environment)
+const fakeUserVm = {
+  exec: userExec,
+  fs: { readTextFile, writeTextFile: vi.fn(), writeFile: vi.fn() },
+};
+const fakeVm = {
+  snapshot: vmSnapshot,
+  stop: vmStop,
+  exec: rootExec,
+  user: vi.fn(() => fakeUserVm),
+  fs: { readTextFile, writeTextFile: vi.fn(), writeFile: vi.fn() },
+};
+const vmRef = vi.fn(() => fakeVm);
+const clientFetch = vi.fn();
+
+vi.mock("./client", () => ({
+  createFreestyleClient: () => ({
+    vms: { snapshots: { list: listSnapshots }, ref: vmRef, list: listVms },
+    fetch: clientFetch,
+  }),
+  FREESTYLE_CONTROL_PLANE_TIMEOUT_MS: 120000,
+}));
+
+const config: FreestyleConfig = { apiKey: "test-key" };
+const NAME = "org_abc123/sandbox/my-snap";
+
+// The scrub targets the control plane computes and passes in. The mechanism
+// removes exactly these paths and echoes the env-var names into the disclosure.
+
+function snap(overrides: Record<string, unknown>) {
+  return {
+    snapshotId: "sc-default",
+    name: NAME,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    deleted: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  listSnapshots.mockReset();
+  listVms.mockReset();
+  vmSnapshot.mockReset();
+  vmStop.mockReset();
+  rootExec.mockReset();
+  userExec.mockReset();
+  readTextFile.mockReset();
+  vmRef.mockClear();
+  clientFetch.mockReset();
+});
+
+describe("getFreestyleSnapshotByName", () => {
+  it("returns null when no snapshot carries the name", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-1", name: "someone-elses" })],
+    });
+    expect(await getFreestyleSnapshotByName(config, NAME)).toBeNull();
+  });
+
+  it("ignores deleted snapshots", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-1", deleted: true, state: "ready" })],
+    });
+    expect(await getFreestyleSnapshotByName(config, NAME)).toBeNull();
+  });
+
+  it.each([
+    ["ready", "active"],
+    ["building", "building"],
+    ["failed", "build_failed"],
+    ["cancelled", "build_failed"],
+    ["lost", "error"],
+  ])("maps Freestyle state %s to %s", async (freestyleState, expected) => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-1", state: freestyleState })],
+    });
+    const result = await getFreestyleSnapshotByName(config, NAME);
+    expect(result).toMatchObject({ name: NAME, state: expected });
+  });
+
+  it("surfaces the bootable snapshot id (for backfill/boot)", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-99", state: "ready" })],
+    });
+    const result = await getFreestyleSnapshotByName(config, NAME);
+    expect(result?.providerSnapshotId).toBe("sc-99");
+  });
+
+  it("prefers a ready snapshot over a building one with the same name", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [
+        snap({
+          snapshotId: "sc-building",
+          state: "building",
+          createdAt: "2026-06-02T00:00:00.000Z",
+        }),
+        snap({
+          snapshotId: "sc-ready",
+          state: "ready",
+          createdAt: "2026-06-01T00:00:00.000Z",
+        }),
+      ],
+    });
+    const result = await getFreestyleSnapshotByName(config, NAME);
+    expect(result?.state).toBe("active");
+  });
+});
+
+describe("resolveFreestyleSnapshotRef", () => {
+  it("resolves a snapshot name to its bootable id", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-77", state: "ready" })],
+    });
+    expect(await resolveFreestyleSnapshotRef(config, NAME)).toBe("sc-77");
+  });
+
+  it("returns the ref unchanged when no snapshot carries the name", async () => {
+    listSnapshots.mockResolvedValue({ snapshots: [] });
+    expect(await resolveFreestyleSnapshotRef(config, "sc-already-an-id")).toBe(
+      "sc-already-an-id",
+    );
+  });
+});
+
+describe("deleteFreestyleSnapshotByName", () => {
+  it("deletes every non-deleted snapshot carrying the name via the DELETE route", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [
+        snap({ snapshotId: "sc-1", state: "ready" }),
+        snap({ snapshotId: "sc-2", deleted: true }),
+        snap({ snapshotId: "sc-3", name: "other" }),
+      ],
+    });
+    clientFetch.mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+
+    await deleteFreestyleSnapshotByName(config, NAME);
+
+    expect(clientFetch).toHaveBeenCalledTimes(1);
+    expect(clientFetch).toHaveBeenCalledWith("/v1/vms/snapshots/sc-1", {
+      method: "DELETE",
+    });
+  });
+
+  it("is a no-op when no snapshot carries the name", async () => {
+    listSnapshots.mockResolvedValue({ snapshots: [] });
+    await deleteFreestyleSnapshotByName(config, NAME);
+    expect(clientFetch).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a 404 from the delete route (already gone)", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-1", state: "ready" })],
+    });
+    clientFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+    await expect(
+      deleteFreestyleSnapshotByName(config, NAME),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws on a non-404 delete failure", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-1", state: "ready" })],
+    });
+    clientFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+    await expect(deleteFreestyleSnapshotByName(config, NAME)).rejects.toThrow(
+      /Failed to delete/,
+    );
+  });
+});
+
+describe("captureFreestyleSandboxSnapshot", () => {
+  it("snapshots the referenced VM and returns the bootable id", async () => {
+    vmSnapshot.mockResolvedValue({ snapshotId: "sc-new", sourceVmId: "vm_1" });
+    const result = await captureFreestyleSandboxSnapshot(config, "vm_1", NAME);
+    expect(vmRef).toHaveBeenCalledWith({ vmId: "vm_1" });
+    // Captured as `persistent` so the platform never evicts a user's saved
+    // snapshot (the default `sticky` tier is best-effort and can be reclaimed).
+    expect(vmSnapshot).toHaveBeenCalledWith({
+      name: NAME,
+      persistence: { type: "persistent" },
+    });
+    expect(result).toEqual({ providerSnapshotId: "sc-new" });
+  });
+
+  it("captures a `sticky` snapshot when the config opts into staging", async () => {
+    // Staging (FREESTYLE_STAGING_SNAPSHOTS) carries `snapshotPersistence:
+    // "sticky"` on the config so throwaway staging snapshots stay on the
+    // evictable cache tier instead of accumulating permanent storage.
+    vmSnapshot.mockResolvedValue({ snapshotId: "sc-new", sourceVmId: "vm_1" });
+    await captureFreestyleSandboxSnapshot(
+      { ...config, snapshotPersistence: "sticky" },
+      "vm_1",
+      NAME,
+    );
+    expect(vmSnapshot).toHaveBeenCalledWith({
+      name: NAME,
+      persistence: { type: "sticky" },
+    });
+  });
+});
+
+describe("waitForFreestyleSnapshotActive", () => {
+  it("returns immediately once the snapshot is ready", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-1", state: "ready" })],
+    });
+    const result = await waitForFreestyleSnapshotActive(config, NAME);
+    expect(result.state).toBe("active");
+  });
+
+  it("throws when the snapshot enters a terminal state", async () => {
+    listSnapshots.mockResolvedValue({
+      snapshots: [snap({ snapshotId: "sc-1", state: "failed" })],
+    });
+    await expect(waitForFreestyleSnapshotActive(config, NAME)).rejects.toThrow(
+      /terminal state "failed"/,
+    );
+  });
+});
+
+describe("captureFreestyleSandboxSnapshot failure attribution", () => {
+  it("never stops the VM (a stopped-VM snapshot 500s on Freestyle)", async () => {
+    vmSnapshot.mockResolvedValue({ snapshotId: "sc-new" });
+    await captureFreestyleSandboxSnapshot(config, "vm_1", NAME);
+    expect(vmStop).not.toHaveBeenCalled();
+  });
+
+  it("attributes a snapshot failure to the VM state and preserves the cause", async () => {
+    listVms.mockResolvedValue({ vms: [{ id: "vm_1", state: "running" }] });
+    const providerError = new Error("INTERNAL_ERROR: Internal server");
+    vmSnapshot.mockRejectedValue(providerError);
+
+    // The wrapper turns the opaque provider error into one naming the failing
+    // step and the VM's state at failure...
+    const err = await captureFreestyleSandboxSnapshot(
+      config,
+      "vm_1",
+      NAME,
+    ).then(
+      () => {
+        throw new Error("expected captureFreestyleSandboxSnapshot to reject");
+      },
+      (e: unknown) => e as Error,
+    );
+    expect(err.message).toMatch(
+      /"snapshot" step.*VM state: "running".*INTERNAL_ERROR/,
+    );
+    // ...and preserves the original provider error as `cause` for debugging.
+    expect(err.cause).toBe(providerError);
+  });
+});

--- a/js/sandbox/src/providers/freestyle/internal/snapshot-operations.ts
+++ b/js/sandbox/src/providers/freestyle/internal/snapshot-operations.ts
@@ -1,0 +1,314 @@
+/**
+ * Snapshot operations against the Freestyle VM API.
+ *
+ * Freestyle captures a snapshot from a VM with `vm.snapshot({ name, ... })`,
+ * which returns an opaque `snapshotId`; the *name* is an optional, mutable label
+ * that is NOT a primary key. To slot into Amika's name-keyed snapshot model
+ * (where the org-scoped name identifies the snapshot and every consumer
+ * addresses snapshots by it), we always capture with the org-scoped name and
+ * look snapshots up by scanning `vms.snapshots.list()` for that name. Names are
+ * unique within Amika's usage (enforced by the caller plus name-reuse refusal),
+ * so the scan resolves to a single snapshot in practice.
+ *
+ * Lookups/deletes are therefore O(account snapshot list) rather than a direct
+ * get — acceptable for these infrequent control operations (capture, delete,
+ * activation poll), and the list is the only by-name access the API offers.
+ *
+ * Snapshot deletion uses the `DELETE /v1/vms/snapshots/{id}` endpoint via the
+ * SDK's public `fetch` (the typed `VmSnapshotsNamespace` surface in
+ * freestyle@0.1.63 exposes only `list`/`get`; the delete route is present at
+ * runtime but undeclared, so we call it through `fetch`, which resolves the
+ * relative path against the base URL and attaches the API key).
+ */
+import { createFreestyleClient } from "./client";
+import { getFreestyleSandboxState } from "./operations";
+import type { CapturedSnapshot, ProviderSnapshot } from "../../provider";
+import type { Freestyle } from "freestyle";
+import type { FreestyleConfig } from "../config";
+import { withStepContext } from "../../../util/errorutils";
+
+// `VmSnapshot` is not a named export of `freestyle`; derive the record type from
+// the client surface so we don't restate it (and stay pinned to the SDK shape).
+type FreestyleVmSnapshot = Awaited<
+  ReturnType<Freestyle["vms"]["snapshots"]["list"]>
+>["snapshots"][number];
+
+/**
+ * How long to wait for a freshly captured Freestyle snapshot to reach `ready`,
+ * in seconds. `vm.snapshot` returns once the capture is registered; the
+ * snapshot then builds asynchronously, which for large filesystems takes
+ * minutes. Mirrors the Daytona activation window so the background-capture
+ * lifecycle behaves the same across providers.
+ */
+const FREESTYLE_SNAPSHOT_ACTIVE_TIMEOUT_S = 10 * 60;
+
+/** Poll cadence for {@link waitForFreestyleSnapshotActive}. */
+const FREESTYLE_SNAPSHOT_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Build the `vm.snapshot()` body for a user-generated snapshot.
+ *
+ * Freestyle's default snapshot persistence tier is `sticky` — a best-effort
+ * cache the platform may evict under storage pressure, which would silently
+ * destroy a snapshot the user deliberately saved. User-generated snapshots must
+ * survive until the user deletes them, so production captures them as
+ * `persistent` (retained indefinitely), mirroring the preset builder in
+ * `bin/freestyle-build-snapshots.mjs`. The tier is taken from
+ * `config.snapshotPersistence`: staging sets `"sticky"` (via
+ * `FREESTYLE_STAGING_SNAPSHOTS`) so throwaway staging snapshots don't accumulate
+ * permanent storage; an unset config defaults to the safe `"persistent"` tier.
+ *
+ * The SDK's typed `snapshot()` signature documents only `{ name }`, but the
+ * runtime forwards the whole body to `POST /v1/vms/{vm_id}/snapshot`, which
+ * accepts `persistence` (the same tiers as `vms.create`). The return type keeps
+ * the extra field so the structural-typed call site type-checks while still
+ * sending it on the wire.
+ */
+function snapshotOptions(
+  config: FreestyleConfig,
+  name: string,
+): {
+  name: string;
+  persistence: { type: "persistent" | "sticky" };
+} {
+  return {
+    name,
+    persistence: { type: config.snapshotPersistence ?? "persistent" },
+  };
+}
+
+/**
+ * Normalize a Freestyle snapshot state onto the provider-agnostic vocabulary
+ * consumers reconcile against (`active` / `building` / terminal).
+ * Freestyle: `ready` is durable; `building` is in flight; `failed`/`cancelled`/
+ * `lost` are terminal. `build_failed`/`error` are both treated as terminal by
+ * consumers, so the exact terminal label is informational only.
+ */
+function mapFreestyleSnapshotState(
+  state: string | undefined,
+): string | undefined {
+  switch (state) {
+    case "ready":
+      return "active";
+    case "building":
+      return "building";
+    case "failed":
+    case "cancelled":
+      return "build_failed";
+    case "lost":
+      return "error";
+    default:
+      return state;
+  }
+}
+
+function isTerminalFreestyleState(state: string | undefined): boolean {
+  return state === "failed" || state === "cancelled" || state === "lost";
+}
+
+function toProviderSnapshot(snap: FreestyleVmSnapshot): ProviderSnapshot {
+  return {
+    // Our snapshots always carry the org-scoped name; fall back to the id only
+    // for the degenerate case of a name-less snapshot so the field stays a
+    // non-empty string (the API schema requires `name: string`).
+    name: snap.name ?? snap.snapshotId,
+    // The bootable handle, so a live lookup can backfill a row whose capture
+    // never recorded `provider_snapshot_id` (`vms.create({ snapshotId })`).
+    providerSnapshotId: snap.snapshotId,
+    state: mapFreestyleSnapshotState(snap.state),
+    createdAt: snap.createdAt,
+    updatedAt: snap.updatedAt ?? undefined,
+  };
+}
+
+/**
+ * List every non-deleted snapshot, including in-flight and terminal ones, so a
+ * by-name scan can surface a snapshot in any lifecycle state (the service needs
+ * to see `building`/terminal states to reconcile in-flight rows). Deleted
+ * snapshots are excluded (the API default) so a freed name reads as absent.
+ */
+async function listFreestyleSnapshots(
+  client: Freestyle,
+): Promise<FreestyleVmSnapshot[]> {
+  const { snapshots } = await client.vms.snapshots.list({
+    includeFailed: true,
+    includeBuilding: true,
+    includeCancelled: true,
+    includeLost: true,
+  });
+  return snapshots;
+}
+
+/**
+ * Find the snapshot record carrying `name`, preferring a `ready` one and then
+ * the most recently created. Returns `null` when no non-deleted snapshot has
+ * the name. (Amika never creates two live snapshots under one name, so the
+ * preference rules only matter for degraded/leftover states.)
+ */
+function pickSnapshotByName(
+  snapshots: FreestyleVmSnapshot[],
+  name: string,
+): FreestyleVmSnapshot | null {
+  const matches = snapshots.filter((s) => s.name === name && !s.deleted);
+  if (matches.length === 0) return null;
+  const ready = matches.filter((s) => s.state === "ready");
+  const pool = ready.length > 0 ? ready : matches;
+  return pool.reduce((latest, s) =>
+    new Date(s.createdAt).getTime() > new Date(latest.createdAt).getTime()
+      ? s
+      : latest,
+  );
+}
+
+/**
+ * Look up a snapshot by its org-scoped name, mapped onto the provider-agnostic
+ * shape. Returns `null` when absent. Freestyle has no get-by-name, so this (and
+ * `find`, which is identical here) scans the snapshot list.
+ */
+export async function getFreestyleSnapshotByName(
+  config: FreestyleConfig,
+  name: string,
+): Promise<ProviderSnapshot | null> {
+  const client = createFreestyleClient(config);
+  const rec = pickSnapshotByName(await listFreestyleSnapshots(client), name);
+  return rec ? toProviderSnapshot(rec) : null;
+}
+
+/**
+ * Resolve a snapshot reference to a bootable snapshot id. Freestyle preset
+ * references are deterministic **names** (`amika-<preset>-<size>`, see
+ * {@link buildFreestyleSnapshotName}); captured-snapshot references arrive
+ * already resolved to ids by `create.ts`. If a snapshot carries `ref` as its
+ * name (preferring `ready`), return that snapshot's id; otherwise return `ref`
+ * unchanged — it is already an id, or a name with no built snapshot (the caller
+ * surfaces a clear error for the latter). Costs one snapshot-list scan, far
+ * cheaper than the post-create `vm.resize` it replaces.
+ */
+export async function resolveFreestyleSnapshotRef(
+  config: FreestyleConfig,
+  ref: string,
+): Promise<string> {
+  const byName = await getFreestyleSnapshotByName(config, ref);
+  return byName?.providerSnapshotId ?? ref;
+}
+
+/**
+ * Delete every non-deleted snapshot carrying `name`. Idempotent: no matches is
+ * a no-op, and an already-deleted snapshot (404) is tolerated. Deleting all
+ * matches fully frees the name even in the (unexpected) event of duplicates.
+ */
+export async function deleteFreestyleSnapshotByName(
+  config: FreestyleConfig,
+  name: string,
+): Promise<void> {
+  const client = createFreestyleClient(config);
+  const matches = (await listFreestyleSnapshots(client)).filter(
+    (s) => s.name === name && !s.deleted,
+  );
+  for (const snap of matches) {
+    const res = await client.fetch(
+      `/v1/vms/snapshots/${encodeURIComponent(snap.snapshotId)}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok && res.status !== 404) {
+      throw new Error(
+        `Failed to delete Freestyle snapshot "${name}" (${snap.snapshotId}): ` +
+          `${res.status} ${res.statusText}`,
+      );
+    }
+  }
+}
+
+/**
+ * Block until the snapshot named `name` reaches `ready`. Throws on a terminal
+ * state (`failed`/`cancelled`/`lost`) or when the timeout elapses without it
+ * becoming ready. Tolerates the snapshot being briefly absent from the list
+ * right after capture.
+ */
+export async function waitForFreestyleSnapshotActive(
+  config: FreestyleConfig,
+  name: string,
+  timeoutS: number = FREESTYLE_SNAPSHOT_ACTIVE_TIMEOUT_S,
+): Promise<ProviderSnapshot> {
+  const client = createFreestyleClient(config);
+  const deadline = Date.now() + timeoutS * 1000;
+  for (;;) {
+    const rec = pickSnapshotByName(await listFreestyleSnapshots(client), name);
+    if (rec?.state === "ready") {
+      return toProviderSnapshot(rec);
+    }
+    if (rec && isTerminalFreestyleState(rec.state)) {
+      throw new Error(
+        `Snapshot "${name}" entered terminal state "${rec.state}"`,
+      );
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Snapshot "${name}" did not become ready within ${timeoutS}s ` +
+          (rec
+            ? `(last state: "${rec.state}")`
+            : "(never appeared in the snapshot list)"),
+      );
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, FREESTYLE_SNAPSHOT_POLL_INTERVAL_MS),
+    );
+  }
+}
+
+/**
+ * Capture a snapshot of the VM as it stands under `name` (the spec-018 raw
+ * capture primitive — any scrub already ran above in core). Returns the
+ * snapshot id so the caller can persist it as the bootable handle (a sandbox
+ * is later created from this id via `vms.create`).
+ *
+ * Captures the VM *while it is still running* — Freestyle's API returns
+ * `INTERNAL_ERROR` (500) when snapshotting a `stopped` VM (KAPRO-482) — so
+ * `keepSourceRunning` needs no branch at this layer; the destructive caller
+ * deletes the source afterward itself.
+ *
+ * SECURITY CAVEAT: a Freestyle snapshot of a running VM is a "live" snapshot
+ * that includes RAM and CPU state, and a VM created from it resumes that
+ * memory (Freestyle docs: "restoring the entire saved memory image"). A disk
+ * scrub run before this capture removes the injected credential files and
+ * managed env, but secrets already loaded into memory (the OpenCode server's
+ * API keys, an agent's process environment, page cache of the scrubbed files)
+ * survive the image and come back when it is cloned. Acceptable for the
+ * current dev-gated, org-scoped Freestyle usage (a snapshot only boots within
+ * its owning org); the robust cold, disk-only capture is blocked until
+ * Freestyle supports snapshotting a stopped VM (KAPRO-482).
+ */
+export async function captureFreestyleSandboxSnapshot(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  name: string,
+): Promise<CapturedSnapshot> {
+  const client = createFreestyleClient(config);
+  const vm = client.vms.ref({ vmId: providerSandboxId });
+  const { snapshotId } = await captureStep(config, providerSandboxId, () =>
+    vm.snapshot(snapshotOptions(config, name)),
+  );
+  return { providerSnapshotId: snapshotId };
+}
+
+/**
+ * Run the snapshot call, re-throwing a failure tagged with the VM's last-known
+ * state. Freestyle surfaces opaque `INTERNAL_ERROR` 500s carrying only a
+ * provider trace id, so without this an operator can't correlate the failure
+ * with the VM state. The VM-state read runs only on failure (the lazy
+ * {@link withStepContext} label) and degrades to "unknown" rather than masking
+ * the original error, which is preserved as `cause`.
+ */
+function captureStep<T>(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  return withStepContext(async () => {
+    const state = await getFreestyleSandboxState(
+      config,
+      providerSandboxId,
+    ).catch(() => "unknown");
+    return `Freestyle snapshot capture failed at the "snapshot" step (VM state: "${state}")`;
+  }, run);
+}

--- a/js/sandbox/src/providers/freestyle/internal/ssh.test.ts
+++ b/js/sandbox/src/providers/freestyle/internal/ssh.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FreestyleConfig } from "../config";
+import {
+  _buildFreestyleSshDestination,
+  _decodeFreestyleSshHandle,
+  _encodeFreestyleSshHandle,
+  createFreestyleSshAccess,
+  revokeFreestyleSshAccess,
+} from "./ssh";
+
+const grantVm = vi.fn();
+const createToken = vi.fn();
+const revokeToken = vi.fn();
+const createIdentity = vi.fn();
+const refIdentity = vi.fn();
+const deleteIdentity = vi.fn();
+
+vi.mock("./client", () => ({
+  createFreestyleClient: () => ({
+    identities: {
+      create: createIdentity,
+      ref: refIdentity,
+      delete: deleteIdentity,
+    },
+  }),
+}));
+
+const config: FreestyleConfig = { apiKey: "test-key" };
+
+beforeEach(() => {
+  for (const fn of [
+    grantVm,
+    createToken,
+    revokeToken,
+    createIdentity,
+    refIdentity,
+    deleteIdentity,
+  ]) {
+    fn.mockReset();
+  }
+  createIdentity.mockResolvedValue({
+    identityId: "id_1",
+    identity: {
+      permissions: { vms: { grant: grantVm } },
+      tokens: { create: createToken },
+    },
+  });
+  createToken.mockResolvedValue({ tokenId: "tok_1", token: "secret-xyz" });
+  refIdentity.mockReturnValue({ tokens: { revoke: revokeToken } });
+  grantVm.mockResolvedValue(undefined);
+  revokeToken.mockResolvedValue(undefined);
+  deleteIdentity.mockResolvedValue(undefined);
+});
+
+describe("_buildFreestyleSshDestination", () => {
+  it("builds a vmId+user:token@host destination for the amika user", () => {
+    expect(_buildFreestyleSshDestination("vm_abc", "tok123")).toBe(
+      "vm_abc+amika:tok123@vm-ssh.freestyle.sh",
+    );
+  });
+});
+
+describe("Freestyle SSH revocation handle", () => {
+  it("round-trips identity and token ids", () => {
+    const handle = _encodeFreestyleSshHandle({
+      identityId: "id_1",
+      tokenId: "tok_1",
+    });
+    expect(_decodeFreestyleSshHandle(handle)).toEqual({
+      identityId: "id_1",
+      tokenId: "tok_1",
+    });
+  });
+
+  it("encodes to a URL/SSH-safe string (no secret token inside)", () => {
+    const handle = _encodeFreestyleSshHandle({
+      identityId: "id_1",
+      tokenId: "tok_1",
+    });
+    expect(handle).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(handle).not.toContain("secret-xyz");
+  });
+
+  it("throws on a malformed handle", () => {
+    expect(() => _decodeFreestyleSshHandle("not-base64-json!!")).toThrow(
+      /Malformed/,
+    );
+  });
+});
+
+describe("createFreestyleSshAccess", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-21T00:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("mints an identity, grants the VM, and returns a usable destination", async () => {
+    const access = await createFreestyleSshAccess(config, "vm_abc", 8 * 60);
+
+    // Grant is scoped to one VM and only the amika user (least privilege).
+    expect(grantVm).toHaveBeenCalledWith({
+      vmId: "vm_abc",
+      allowedUsers: ["amika"],
+    });
+    // The secret token lives only in the destination.
+    expect(access.sshDestination).toBe(
+      "vm_abc+amika:secret-xyz@vm-ssh.freestyle.sh",
+    );
+    // `token` is the revocation handle (identity + token ids), not the secret.
+    expect(_decodeFreestyleSshHandle(access.token)).toEqual({
+      identityId: "id_1",
+      tokenId: "tok_1",
+    });
+    // Advisory expiry derived from the requested window.
+    expect(access.expiresAt.toISOString()).toBe("2026-06-21T08:00:00.000Z");
+  });
+
+  // An opaque provider 500 (e.g. granting access to a VM that isn't ready)
+  // should name the failing step and keep the original error as `cause` so the
+  // provider trace id survives into the logs.
+  it("labels the failing step and preserves the original error as cause", async () => {
+    const providerError = new Error("INTERNAL_ERROR: Internal server error");
+    grantVm.mockRejectedValue(providerError);
+
+    await expect(
+      createFreestyleSshAccess(config, "vm_abc", 8 * 60),
+    ).rejects.toMatchObject({
+      message:
+        "freestyle ssh: grant vm access: INTERNAL_ERROR: Internal server error",
+      cause: providerError,
+    });
+    // The step that fails first short-circuits the rest.
+    expect(createToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("revokeFreestyleSshAccess", () => {
+  it("revokes the token and deletes the identity from the handle", async () => {
+    const handle = _encodeFreestyleSshHandle({
+      identityId: "id_1",
+      tokenId: "tok_1",
+    });
+
+    await revokeFreestyleSshAccess(config, handle);
+
+    expect(refIdentity).toHaveBeenCalledWith({ identityId: "id_1" });
+    expect(revokeToken).toHaveBeenCalledWith({ tokenId: "tok_1" });
+    expect(deleteIdentity).toHaveBeenCalledWith({ identityId: "id_1" });
+  });
+
+  it("still deletes the identity when the token revoke fails", async () => {
+    revokeToken.mockRejectedValue(new Error("already revoked"));
+    const handle = _encodeFreestyleSshHandle({
+      identityId: "id_1",
+      tokenId: "tok_1",
+    });
+
+    await revokeFreestyleSshAccess(config, handle);
+
+    expect(deleteIdentity).toHaveBeenCalledWith({ identityId: "id_1" });
+  });
+});

--- a/js/sandbox/src/providers/freestyle/internal/ssh.ts
+++ b/js/sandbox/src/providers/freestyle/internal/ssh.ts
@@ -1,0 +1,164 @@
+/**
+ * Freestyle SSH access: mint and revoke SSH credentials for a VM.
+ *
+ * Freestyle has no Daytona-style server-side SSH session API. Instead SSH auth
+ * rides on the identity/token system (docs.freestyle.sh/vms/ssh):
+ *
+ *   1. create an identity,
+ *   2. grant that identity access to the VM,
+ *   3. mint a token for the identity.
+ *
+ * You then connect as `ssh <vmId>+<user>:<token>@vm-ssh.freestyle.sh`. The token
+ * is the SSH credential and lives inside the destination string.
+ *
+ * Two differences from Daytona shape this module:
+ *
+ *  - **No native expiry.** Freestyle tokens are valid until revoked, so the
+ *    `expiresAt` we return is advisory (computed from the requested window). The
+ *    credential is actually retired when the revoke endpoint runs — the
+ *    `amika` CLI calls it on disconnect, the same way Freestyle's own `vm ssh`
+ *    CLI revokes the token and deletes the identity when the session ends.
+ *  - **Revoke needs ids, not the token string.** A token string can't be mapped
+ *    back to its id (`tokens.list()` returns only ids), so revocation needs the
+ *    `identityId` + `tokenId` learned at mint time. We carry those forward by
+ *    encoding them into the opaque `token` field the SSH service round-trips to
+ *    the revoke endpoint (see {@link MintedSshAccess}). That field is therefore
+ *    a revocation handle, not the SSH secret — the secret only ever appears in
+ *    `sshDestination`.
+ */
+import type { FreestyleConfig } from "../config";
+import type { MintedSshAccess } from "../../provider";
+import { withStepContext } from "../../../util/errorutils";
+import { createFreestyleClient } from "./client";
+
+/** Freestyle's SSH gateway host; auth is the token embedded in the username. */
+const FREESTYLE_SSH_HOST = "vm-ssh.freestyle.sh";
+
+/**
+ * Linux user the SSH session lands as. Matches the unprivileged sandbox user the
+ * Amika presets provision (see `adapter.ts`) so an SSH session sees the same
+ * home, repos (`/home/amika/workspace`), and dotfiles as the agent — the
+ * Freestyle analogue of Daytona logging in as its sandbox user. Doubles as the
+ * sole `allowedUsers` entry on the VM grant, so a minted token can only log in
+ * as this user.
+ */
+const FREESTYLE_SSH_USER = "amika";
+
+interface FreestyleSshHandle {
+  identityId: string;
+  tokenId: string;
+}
+
+/**
+ * Encode the revocation handle ({@link FreestyleSshHandle}) into the opaque
+ * `token` string the SSH service returns to the client and later passes back to
+ * revoke. base64url(JSON) keeps it a single URL/SSH-safe value and is robust to
+ * whatever characters provider ids contain (a bare delimiter could collide).
+ * This is NOT the SSH credential — the secret token lives only in
+ * `sshDestination`.
+ */
+export function _encodeFreestyleSshHandle(handle: FreestyleSshHandle): string {
+  const json = JSON.stringify({ v: 1, ...handle });
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+/** Inverse of {@link _encodeFreestyleSshHandle}; throws on a malformed handle. */
+export function _decodeFreestyleSshHandle(encoded: string): FreestyleSshHandle {
+  let parsed: unknown;
+  try {
+    const json = Buffer.from(encoded, "base64url").toString("utf8");
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("Malformed Freestyle SSH revocation handle");
+  }
+  const record = parsed as Record<string, unknown> | null;
+  if (
+    typeof record !== "object" ||
+    record === null ||
+    typeof record.identityId !== "string" ||
+    typeof record.tokenId !== "string"
+  ) {
+    throw new Error("Malformed Freestyle SSH revocation handle");
+  }
+  return { identityId: record.identityId, tokenId: record.tokenId };
+}
+
+/**
+ * Build the SSH destination (`[user@]host` — the parsed shape the SSH service
+ * expects, mirroring Daytona's `_parseSshDestination`) for a VM and a freshly
+ * minted token. Connecting as `vmId+user:token` logs in as
+ * {@link FREESTYLE_SSH_USER} over Freestyle's gateway on the default port.
+ * Exported for testing.
+ */
+export function _buildFreestyleSshDestination(
+  vmId: string,
+  token: string,
+): string {
+  return `${vmId}+${FREESTYLE_SSH_USER}:${token}@${FREESTYLE_SSH_HOST}`;
+}
+
+/**
+ * Mint SSH access to a Freestyle VM: create an identity, grant it access to the
+ * VM, and issue a token. Returns the connect destination (carrying the secret
+ * token) plus an opaque revocation handle in `token` and an advisory `expiresAt`
+ * derived from `expiresInMinutes` (Freestyle does not expire tokens itself).
+ */
+export async function createFreestyleSshAccess(
+  config: FreestyleConfig,
+  providerSandboxId: string,
+  expiresInMinutes: number,
+): Promise<MintedSshAccess> {
+  const client = createFreestyleClient(config);
+  // Each Freestyle call is wrapped so an opaque INTERNAL_ERROR identifies which
+  // step failed (see `withStepContext`); the original SDK error and its trace id
+  // are preserved as `cause`.
+  const { identity, identityId } = await withStepContext(
+    "freestyle ssh: create identity",
+    () => client.identities.create(),
+  );
+  // Scope the grant to a single VM and a single Linux user: the identity (and
+  // thus its token) can SSH only into this sandbox, and only as the
+  // unprivileged `amika` user the destination connects as. This is the same
+  // user the destination's `+amika` selects, kept on one constant so they can't
+  // drift. Cross-sandbox isolation already holds from the org-scoped endpoint
+  // lookup and the per-grant identity; `allowedUsers` adds least privilege
+  // within the VM on top.
+  await withStepContext("freestyle ssh: grant vm access", () =>
+    identity.permissions.vms.grant({
+      vmId: providerSandboxId,
+      allowedUsers: [FREESTYLE_SSH_USER],
+    }),
+  );
+  const { token, tokenId } = await withStepContext(
+    "freestyle ssh: create token",
+    () => identity.tokens.create(),
+  );
+
+  return {
+    token: _encodeFreestyleSshHandle({ identityId, tokenId }),
+    sshDestination: _buildFreestyleSshDestination(providerSandboxId, token),
+    expiresAt: new Date(Date.now() + expiresInMinutes * 60_000),
+  };
+}
+
+/**
+ * Revoke SSH access previously minted by {@link createFreestyleSshAccess}. The
+ * `handle` is the opaque value returned in `token`; it decodes to the identity
+ * and token ids. Deleting the identity is the authoritative kill (it invalidates
+ * every token under it), so the explicit token revoke is best-effort and a
+ * stale/already-revoked token still tears the identity down.
+ */
+export async function revokeFreestyleSshAccess(
+  config: FreestyleConfig,
+  handle: string,
+): Promise<void> {
+  const { identityId, tokenId } = _decodeFreestyleSshHandle(handle);
+  const client = createFreestyleClient(config);
+  const identity = client.identities.ref({ identityId });
+  try {
+    await identity.tokens.revoke({ tokenId });
+  } catch {
+    // Ignore — deleting the identity below still removes access.
+  }
+  await client.identities.delete({ identityId });
+}

--- a/js/sandbox/src/providers/freestyle/internal/start-stop.test.ts
+++ b/js/sandbox/src/providers/freestyle/internal/start-stop.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FreestyleConfig } from "../config";
+import { startFreestyleSandbox, stopFreestyleSandbox } from "./operations";
+
+const startVm = vi.fn();
+const stopVm = vi.fn();
+const suspendVm = vi.fn();
+const listVms = vi.fn();
+
+vi.mock("./client", () => ({
+  FREESTYLE_CONTROL_PLANE_TIMEOUT_MS: 1,
+  createFreestyleClient: () => ({
+    vms: {
+      ref: () => ({ start: startVm, stop: stopVm, suspend: suspendVm }),
+      list: listVms,
+    },
+  }),
+}));
+
+const config: FreestyleConfig = { apiKey: "test-key" };
+
+// `getFreestyleSandboxState` reads the VM's state from `vms.list`. Queue a state
+// per poll; the last value repeats so a loop that polls more than once settles.
+function queueStates(...states: string[]): void {
+  listVms.mockReset();
+  states.forEach((state, i) => {
+    const value = { vms: [{ id: "vm_1", state }] };
+    if (i === states.length - 1) listVms.mockResolvedValue(value);
+    else listVms.mockResolvedValueOnce(value);
+  });
+}
+
+beforeEach(() => {
+  startVm.mockReset().mockResolvedValue(undefined);
+  stopVm.mockReset().mockResolvedValue(undefined);
+  suspendVm.mockReset().mockResolvedValue(undefined);
+  listVms.mockReset();
+});
+
+describe("stopFreestyleSandbox", () => {
+  it("suspends (not stops) a running VM and waits for it to settle", async () => {
+    queueStates("running", "suspended");
+
+    await stopFreestyleSandbox(config, "vm_1");
+
+    // Suspend, not stop: a stopped VM cold-boots on resume and wedges in
+    // `starting`; a suspended VM resumes from its suspend layer.
+    expect(suspendVm).toHaveBeenCalledTimes(1);
+    expect(stopVm).not.toHaveBeenCalled();
+    // Polled the state at least once after suspending, to confirm it settled.
+    expect(listVms.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("is a no-op when the VM is already suspended", async () => {
+    queueStates("suspended");
+
+    await stopFreestyleSandbox(config, "vm_1");
+
+    // `vm.suspend` on an already-suspended VM is a 409, so it must be skipped.
+    expect(suspendVm).not.toHaveBeenCalled();
+  });
+
+  it("skips both the suspend and the wait when the VM is already stopped", async () => {
+    queueStates("stopped");
+
+    await stopFreestyleSandbox(config, "vm_1");
+
+    expect(suspendVm).not.toHaveBeenCalled();
+    expect(stopVm).not.toHaveBeenCalled();
+    // Only the guard read — no settle-poll loop for an already-idle VM.
+    expect(listVms).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails fast (no 2-minute poll) when the VM has gone missing", async () => {
+    // Guard sees the VM running → suspends; the settle poll then finds it absent.
+    queueStates("running", "unknown");
+
+    await expect(stopFreestyleSandbox(config, "vm_1")).rejects.toThrow(
+      /unknown/,
+    );
+    expect(suspendVm).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("startFreestyleSandbox", () => {
+  it("resumes immediately when the VM is suspended", async () => {
+    queueStates("suspended");
+
+    await startFreestyleSandbox(config, "vm_1");
+
+    expect(startVm).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for an in-flight suspend to settle before resuming", async () => {
+    // First poll (the guard) sees the VM still suspending; the next sees it
+    // settled. `vm.start` must only fire once the VM is fully suspended —
+    // resuming mid-transition is what wedges the VM in `starting`.
+    queueStates("suspending", "suspended");
+
+    await startFreestyleSandbox(config, "vm_1");
+
+    expect(startVm).toHaveBeenCalledTimes(1);
+    expect(listVms.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("waits for an in-flight stop to settle before resuming", async () => {
+    // A VM mid cold-stop (e.g. a suspend that fell back to stopping) must
+    // finish stopping before `vm.start` resumes it.
+    queueStates("stopping", "stopped");
+
+    await startFreestyleSandbox(config, "vm_1");
+
+    expect(startVm).toHaveBeenCalledTimes(1);
+    expect(listVms.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/js/sandbox/src/providers/freestyle/naming.test.ts
+++ b/js/sandbox/src/providers/freestyle/naming.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFreestyleSnapshotName,
+  buildFreestyleVmName,
+  freestyleVmBelongsToOrg,
+  freestyleVmNameOrgId,
+} from "./naming";
+
+describe("buildFreestyleSnapshotName", () => {
+  it("builds an `amika-<preset>-<size>` name", () => {
+    expect(buildFreestyleSnapshotName("coder", "m")).toBe("amika-coder-m");
+  });
+
+  it("preserves a hyphenated preset", () => {
+    expect(buildFreestyleSnapshotName("coder-dind", "xl")).toBe(
+      "amika-coder-dind-xl",
+    );
+  });
+});
+
+describe("buildFreestyleVmName", () => {
+  it("prefixes the org id onto the sandbox name", () => {
+    expect(buildFreestyleVmName("org_abc123", "my-sandbox")).toBe(
+      "org_abc123/my-sandbox",
+    );
+  });
+
+  it("round-trips through freestyleVmNameOrgId", () => {
+    const name = buildFreestyleVmName("org_abc123", "my-sandbox");
+    expect(freestyleVmNameOrgId(name)).toBe("org_abc123");
+  });
+});
+
+describe("freestyleVmNameOrgId", () => {
+  it("recovers the org id from a scoped name", () => {
+    expect(freestyleVmNameOrgId("org_abc123/my-sandbox")).toBe("org_abc123");
+  });
+
+  it("splits on the first separator so the name may contain slashes", () => {
+    expect(freestyleVmNameOrgId("org_abc123/team/my-sandbox")).toBe(
+      "org_abc123",
+    );
+  });
+
+  it("returns null for an unscoped name", () => {
+    expect(freestyleVmNameOrgId("legacy-sandbox")).toBeNull();
+  });
+
+  it("returns null for a null or empty name", () => {
+    expect(freestyleVmNameOrgId(null)).toBeNull();
+    expect(freestyleVmNameOrgId("")).toBeNull();
+  });
+
+  it("returns null when the name starts with the separator (no org)", () => {
+    expect(freestyleVmNameOrgId("/my-sandbox")).toBeNull();
+  });
+});
+
+describe("freestyleVmBelongsToOrg", () => {
+  it("is true when the org prefix matches", () => {
+    expect(freestyleVmBelongsToOrg("org_abc123/my-sandbox", "org_abc123")).toBe(
+      true,
+    );
+  });
+
+  it("is false for a different org", () => {
+    expect(freestyleVmBelongsToOrg("org_abc123/my-sandbox", "org_other")).toBe(
+      false,
+    );
+  });
+
+  it("fails closed for an unscoped name", () => {
+    expect(freestyleVmBelongsToOrg("legacy-sandbox", "org_abc123")).toBe(false);
+  });
+});

--- a/js/sandbox/src/providers/freestyle/naming.ts
+++ b/js/sandbox/src/providers/freestyle/naming.ts
@@ -1,0 +1,77 @@
+/**
+ * Org-scoped naming for Freestyle VMs.
+ *
+ * Daytona stamps each sandbox with `amika-org-id` / `amika-user-id` labels so
+ * the owning org is recorded on the provider resource (see `create.ts` and the
+ * `${orgId}/sandbox/...` snapshot scheme in `daytona/snapshot-operations.ts`).
+ * Freestyle's `vms.create` has no label or metadata facet — only a freeform
+ * `name` — so we fold the org id into the VM name instead, using the same
+ * `${orgId}/...` convention. This keeps every Freestyle VM attributable to an
+ * org in `vms.get` and the dashboard, mirroring Daytona's ownership stamp.
+ *
+ * The stored `org_id` remains the security boundary; this name is the
+ * provider-side stamp, not the access-control gate.
+ */
+import type { SandboxPreset, SandboxSize } from "../../enums";
+
+/** Separator between the org id and the user-facing sandbox name. */
+const ORG_NAME_SEPARATOR = "/";
+
+/**
+ * Canonical name of the pre-built Freestyle preset snapshot for a (preset, size),
+ * e.g. `amika-coder-m`, `amika-coder-dind-xl`. This is the single source of truth
+ * for the scheme: `server-env.ts` resolves `freestyleSnapshots[preset][size]` to
+ * these names, and `bin/freestyle-build-snapshots` snapshots each VM under the
+ * matching name (the script mirrors this template — keep them in sync).
+ *
+ * Freestyle bakes the requested size into the snapshot itself (the build script
+ * resizes the VM before snapshotting), mirroring Daytona's per-size image tags
+ * (`amika/daytona-coder-m`). At create time the name is resolved to a bootable
+ * snapshot id via the snapshot list (see `resolveFreestyleSnapshotRef`), so no
+ * post-create `vm.resize` is needed.
+ */
+export function buildFreestyleSnapshotName(
+  preset: SandboxPreset,
+  size: SandboxSize,
+): string {
+  return `amika-${preset}-${size}`;
+}
+
+/**
+ * Build an org-scoped VM name by prefixing the org id. Mirrors Daytona's
+ * `buildSandboxSnapshotName` (`${orgId}/sandbox/${slug}`); the org id (rather
+ * than a mutable display value) keeps the prefix stable if the org is renamed.
+ * Org ids never contain `/`, so the prefix is unambiguously recoverable by
+ * {@link freestyleVmNameOrgId}.
+ *
+ * Example: buildFreestyleVmName("org_abc123", "my-sandbox")
+ *       → "org_abc123/my-sandbox"
+ */
+export function buildFreestyleVmName(orgId: string, name: string): string {
+  return `${orgId}${ORG_NAME_SEPARATOR}${name}`;
+}
+
+/**
+ * Recover the org id stamped onto a VM name by {@link buildFreestyleVmName},
+ * or `null` for a name with no org prefix (e.g. a VM created before this scheme
+ * or named directly in the Freestyle dashboard). Splits on the first separator
+ * since org ids contain no `/` while the user-facing name may.
+ */
+export function freestyleVmNameOrgId(vmName: string | null): string | null {
+  if (!vmName) return null;
+  const idx = vmName.indexOf(ORG_NAME_SEPARATOR);
+  if (idx <= 0) return null;
+  return vmName.slice(0, idx);
+}
+
+/**
+ * Whether a VM (by its name) is owned by the given org. A name carrying no org
+ * prefix is treated as not belonging to any org (returns `false`) so callers
+ * can fail closed.
+ */
+export function freestyleVmBelongsToOrg(
+  vmName: string | null,
+  orgId: string,
+): boolean {
+  return freestyleVmNameOrgId(vmName) === orgId;
+}

--- a/js/sandbox/src/providers/freestyle/provider.test.ts
+++ b/js/sandbox/src/providers/freestyle/provider.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  getProviderLabel,
+  SANDBOX_PROVIDER_CAPABILITIES,
+} from "../capabilities";
+import {
+  createSandboxProvider,
+  isSandboxProviderName,
+  type SandboxProviderDeps,
+} from "../registry";
+
+function deps(overrides: Partial<SandboxProviderDeps>): SandboxProviderDeps {
+  return {
+    daytona: {
+      apiKey: "",
+      apiUrl: "",
+      target: undefined,
+      organizationId: undefined,
+      useVm: false,
+    },
+    freestyle: null,
+    vercel: null,
+    resolveSnapshotId: async () => null,
+    ...overrides,
+  };
+}
+
+describe("freestyle provider wiring", () => {
+  it("is a recognized provider name", () => {
+    expect(isSandboxProviderName("freestyle")).toBe(true);
+    expect(isSandboxProviderName("nope")).toBe(false);
+  });
+
+  it("advertises lifecycle + exec + ssh + snapshots, with streaming and docker registries off", () => {
+    expect(SANDBOX_PROVIDER_CAPABILITIES.freestyle).toEqual({
+      lifecycle: true,
+      ssh: true,
+      services: true,
+      exec: true,
+      listSandboxes: true,
+      streaming: false,
+      snapshots: true,
+      scrubCapture: true,
+      fullSnapshotCapture: true,
+      dockerRegistries: false,
+      skipStartScript: false,
+      snapshotIdsAreOpaque: true,
+      supportsAutoDelete: false,
+    });
+  });
+
+  it("has a display label", () => {
+    expect(getProviderLabel("freestyle")).toBe("Freestyle");
+  });
+
+  it("resolves to the freestyle provider when configured", () => {
+    const provider = createSandboxProvider(
+      "freestyle",
+      deps({ freestyle: { apiKey: "test-key" } }),
+    );
+    expect(provider.name).toBe("freestyle");
+    // Sandbox-capture snapshots are supported; docker registries (control-plane)
+    // are intentionally absent.
+    expect(provider.snapshots).not.toBeNull();
+    expect(provider.docker).toBeNull();
+  });
+
+  it("throws a clear error when Freestyle is not configured", () => {
+    expect(() =>
+      createSandboxProvider("freestyle", deps({ freestyle: null })),
+    ).toThrow(/not configured/);
+  });
+});

--- a/js/sandbox/src/providers/freestyle/provider.ts
+++ b/js/sandbox/src/providers/freestyle/provider.ts
@@ -1,0 +1,130 @@
+/**
+ * Freestyle provider definition: binds a {@link FreestyleConfig} and plugs the
+ * operation helpers in this directory into the capability namespaces.
+ *
+ * ⚠️ EXPERIMENTAL — not production-ready. Daytona (VM) is the primary,
+ * supported provider; Freestyle is a work in progress and may not fully work
+ * (provisioning, snapshots, SSH, and preview URLs are all subject to change and
+ * are not exercised as thoroughly as Daytona). Prefer Daytona for anything that
+ * must work reliably.
+ *
+ * Freestyle supports capturing snapshots from a running sandbox (the "Take
+ * Snapshot" flow) but does NOT back the org-level control plane: image-derived
+ * snapshots and docker registries stay Daytona-only (`dockerRegistries` and
+ * `snapshots.createImageSnapshot` are omitted → unsupported). Streaming is
+ * unsupported (`vm.exec` buffers), so `exec.stream` is omitted. Its presets are
+ * pre-made VM snapshots supplied via config and cloned on create.
+ */
+import type { FreestyleConfig } from "./config";
+import { defineProvider } from "../shared/define-provider";
+import { DEFAULT_HOME_DIR } from "../../constants";
+import { freestyleCapabilities } from "./capabilities";
+import {
+  createFreestyleSandbox,
+  deleteFreestyleSandbox,
+  executeFreestyleCommand,
+  FREESTYLE_URL_TTL_S,
+  getFreestyleSandboxState,
+  listFreestyleSandboxes,
+  mapFreestyleSandboxState,
+  readFreestyleFile,
+  writeFreestyleFile,
+  refreshFreestyleUrls,
+  syncFreestyleRoutes,
+  startFreestyleSandbox,
+  stopFreestyleSandbox,
+} from "./internal/operations";
+import {
+  captureFreestyleSandboxSnapshot,
+  deleteFreestyleSnapshotByName,
+  getFreestyleSnapshotByName,
+  waitForFreestyleSnapshotActive,
+} from "./internal/snapshot-operations";
+import {
+  createFreestyleSshAccess,
+  revokeFreestyleSshAccess,
+} from "./internal/ssh";
+
+// Provider-root re-exports of the server-side surface the registry wires up.
+// The implementations live in `internal/`; routing them through `provider.ts`
+// keeps the folder root as the provider's only public entry.
+export { openFreestyleAdapter } from "./internal/operations";
+
+export default defineProvider(
+  freestyleCapabilities,
+  (config: FreestyleConfig) => ({
+    name: "freestyle",
+    signedUrlTtlSeconds: FREESTYLE_URL_TTL_S,
+    userHomeDir: DEFAULT_HOME_DIR,
+
+    sandbox: {
+      create: (ctx, input) => createFreestyleSandbox(ctx, config, input),
+      delete: (id) => deleteFreestyleSandbox(config, id),
+
+      start: (id, autoStopInterval) =>
+        startFreestyleSandbox(config, id, autoStopInterval),
+      stop: (id) => stopFreestyleSandbox(config, id),
+      getState: (id) => getFreestyleSandboxState(config, id),
+      mapState: mapFreestyleSandboxState,
+    },
+
+    // No `cloneRepo` override: Freestyle has no first-class git primitive, so
+    // `Sandbox.git` is `null` and the provisioning layer clones by running
+    // shell `git` over the adapter exec port.
+
+    // `vm.exec` buffers (no incremental output), so `stream` is omitted and
+    // `exec.streaming` derives to false.
+    exec: {
+      stdin: true,
+      run: (id, command, opts) =>
+        executeFreestyleCommand(config, id, command, opts),
+    },
+
+    files: {
+      read: (id, filePath) => readFreestyleFile(config, id, filePath),
+      write: (id, filePath, content) =>
+        writeFreestyleFile(config, id, filePath, content),
+    },
+
+    ssh: {
+      // SSH rides on Freestyle's identity/token system via the
+      // `vm-ssh.freestyle.sh` gateway; see `./internal/ssh` for the mint/revoke details
+      // and the expiry caveat.
+      mint: (id, expiresInMinutes) =>
+        createFreestyleSshAccess(config, id, expiresInMinutes),
+      // Freestyle revokes by the identity/token ids encoded in `token` at mint
+      // time (the token string can't be mapped back to its id), not the
+      // sandbox id.
+      revoke: (_id, token) => revokeFreestyleSshAccess(config, token),
+    },
+
+    services: {
+      refreshUrls: (id, services) => refreshFreestyleUrls(config, id, services),
+      syncRoutes: (id, desired) => syncFreestyleRoutes(config, id, desired),
+    },
+
+    listing: {
+      list: () => listFreestyleSandboxes(config),
+    },
+
+    snapshots: {
+      // The by-name lookup is a list scan that already tolerates a
+      // still-registering snapshot, so the default `findSnapshot` →
+      // `getSnapshot` fallback is exactly right.
+      getSnapshot: (name) => getFreestyleSnapshotByName(config, name),
+      deleteSnapshot: (name) => deleteFreestyleSnapshotByName(config, name),
+      waitForSnapshotActive: (name) =>
+        waitForFreestyleSnapshotActive(config, name),
+      // Freestyle snapshots the RUNNING VM either way (a stopped-VM snapshot
+      // 500s, KAPRO-482), so `keepSourceRunning` needs no branching: the
+      // capture never stops the source, and the destructive caller deletes it
+      // afterward.
+      capture: (id, snapshotName) =>
+        captureFreestyleSandboxSnapshot(config, id, snapshotName),
+      // Freestyle never bakes Amika secrets into an un-scrubbable container
+      // env spec — injected env vars live only in `/etc/environment`, which
+      // the scrub removes — so every Freestyle sandbox is scrub-safe.
+      isEnvScrubbable: () => Promise.resolve(true),
+    },
+  }),
+);

--- a/js/sandbox/src/providers/freestyle/sizing.test.ts
+++ b/js/sandbox/src/providers/freestyle/sizing.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { freestyleSizingForSize } from "./sizing";
+
+describe("freestyleSizingForSize", () => {
+  it("maps each size to power-of-two CPU/memory and a storage target", () => {
+    expect(freestyleSizingForSize("xs")).toEqual({
+      cpu: 1,
+      memory: 1,
+      storage: 3,
+    });
+    expect(freestyleSizingForSize("m")).toEqual({
+      cpu: 2,
+      memory: 8,
+      storage: 10,
+    });
+    // L's canonical 12 GB is rounded up to the next power of two.
+    expect(freestyleSizingForSize("l")).toEqual({
+      cpu: 2,
+      memory: 16,
+      storage: 24,
+    });
+    expect(freestyleSizingForSize("xl")).toEqual({
+      cpu: 4,
+      memory: 16,
+      storage: 32,
+    });
+  });
+});

--- a/js/sandbox/src/providers/freestyle/sizing.ts
+++ b/js/sandbox/src/providers/freestyle/sizing.ts
@@ -1,0 +1,47 @@
+/**
+ * Translate a canonical sandbox size (xs/m/l/xl, see {@link SANDBOX_SIZE_SPECS})
+ * into the `{ cpu, memory, storage }` arguments Freestyle's `vm.resize` accepts.
+ *
+ * Daytona encodes size in the chosen image; Freestyle has no image-per-size
+ * concept, so the size is baked into a per-size snapshot at build time:
+ * `bin/freestyle-build-snapshots` resizes a VM to these dimensions before
+ * snapshotting it as `amika-<preset>-<size>`, and the create flow clones that
+ * snapshot with no runtime resize. This function defines the dimensions for
+ * that build step and for the size picker's display; Freestyle enforces two
+ * constraints the canonical specs don't honor, which it reconciles:
+ *
+ *   - vCPU and memory (MiB) must be powers of two. Our `vcpus` are already
+ *     powers of two (1/2/2/4), but `memoryGb` is not for every size — L is
+ *     12 GB. We round memory UP to the next power-of-two GiB so a size is never
+ *     under-provisioned (L's 12 GB → 16 GB).
+ *   - The rootfs can only grow, never shrink, below the VM's base size. The
+ *     build script passes `storage` as the desired target and tolerates a
+ *     `RESIZE_VM_ROOTFS_SHRINK_NOT_SUPPORTED` rejection, keeping the base.
+ */
+import { SANDBOX_SIZE_SPECS } from "../../constants";
+import type { SandboxSize } from "../../enums";
+
+export interface FreestyleSizing {
+  /** vCPU count (power of two). */
+  cpu: number;
+  /** Memory in GiB (power of two). */
+  memory: number;
+  /** Root filesystem target in GB (grow-only; smaller-than-base is a no-op). */
+  storage: number;
+}
+
+/** Smallest power of two >= n (n is a small positive integer here). */
+function roundUpToPowerOfTwo(n: number): number {
+  let p = 1;
+  while (p < n) p *= 2;
+  return p;
+}
+
+export function freestyleSizingForSize(size: SandboxSize): FreestyleSizing {
+  const spec = SANDBOX_SIZE_SPECS[size];
+  return {
+    cpu: roundUpToPowerOfTwo(spec.vcpus),
+    memory: roundUpToPowerOfTwo(spec.memoryGb),
+    storage: spec.diskGb,
+  };
+}

--- a/js/sandbox/src/providers/provider.ts
+++ b/js/sandbox/src/providers/provider.ts
@@ -1,0 +1,1155 @@
+/**
+ * Amika-agnostic primitive sandbox-provider interfaces.
+ *
+ * `@amika/sandbox` is a standalone package for provisioning and manipulating
+ * provider sandboxes. It deliberately knows nothing about Amika workflows or
+ * product features. Concrete providers implement {@link SandboxProvider};
+ * consumers resolve one through the registry and compose these primitives.
+ * Higher-level Amika lifecycle and agent behavior belongs in
+ * `@amika/sandbox-provisioning`, which wraps this package.
+ *
+ * Nothing here may import a provider SDK (`@daytonaio/sdk`, etc.) or a
+ * provider-specific module. Shared types are defined here so the abstraction
+ * owns them.
+ */
+import type { SandboxCtx } from "../logger";
+import type { SandboxProviderName, SandboxService } from "../types";
+import type { SandboxStatus } from "../sandbox-status";
+import type { GithubAuthMode, SandboxSize } from "../enums";
+
+export type { SandboxProviderName, SandboxService } from "../types";
+
+/**
+ * Raised when a consumer invokes an operation a provider does not implement.
+ * Capability flags (see {@link SandboxProviderCapabilities}) let callers avoid
+ * this for the gated operations (ssh, lifecycle, exec, snapshots, …); it is the
+ * backstop for everything else.
+ */
+export class SandboxProviderUnsupportedError extends Error {
+  readonly provider: string;
+  readonly operation: string;
+  constructor(provider: string, operation: string) {
+    super(
+      `Sandbox provider "${provider}" does not support operation "${operation}"`,
+    );
+    this.name = "SandboxProviderUnsupportedError";
+    this.provider = provider;
+    this.operation = operation;
+  }
+}
+
+/**
+ * Thrown when a repository clone fails inside a freshly provisioned sandbox.
+ * Carries the original cause so the create flow can map known git errors onto
+ * actionable API errors. Provider-agnostic: any provider that clones a repo
+ * during initialization throws this.
+ */
+export class RepositoryCloneError extends Error {
+  constructor(repoUrl: string, cause: unknown) {
+    const inner =
+      cause instanceof Error ? cause.message : "Unknown clone error";
+    super(
+      `Failed to clone repository ${repoUrl} inside the sandbox: ${inner}. ` +
+        "Check that your GitHub token has access to this repository.",
+    );
+    this.name = "RepositoryCloneError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Thrown by the shared lifecycle-script runner when a *user* lifecycle script
+ * (`setup.sh` on create, `start.sh` on start) exits non-zero. The system hooks
+ * around it (pre-setup/post-setup) still run before this is raised, so the
+ * sandbox's agent server comes up and the VM stays usable; failures of the
+ * hooks themselves surface as plain errors (a system-setup problem, not a
+ * user-script one).
+ */
+export class SetupScriptError extends Error {
+  /** Which user lifecycle script failed. */
+  readonly phase: "setup" | "start";
+  constructor(phase: "setup" | "start", cause: unknown) {
+    const inner =
+      cause instanceof Error ? cause.message : "Unknown script error";
+    super(
+      phase === "setup"
+        ? `Setup script failed: ${inner}`
+        : `Start script failed: ${inner}`,
+    );
+    this.name = "SetupScriptError";
+    this.phase = phase;
+    this.cause = cause;
+  }
+}
+
+/**
+ * A setup problem an initialization / lifecycle-rerun hit while the VM itself
+ * stayed usable. Providers record it and *finish* initializing (agent server,
+ * signed URLs) instead of aborting, so the caller can mark the sandbox running
+ * with this as its setup sub-status rather than tearing the VM down.
+ *
+ * `git-failed` strictly means the *primary* repo is missing (the agent's cwd
+ * doesn't exist) — consumers make control decisions on that (skipping the
+ * workflow kickoff, failing a Slack turn fast). Everything else that leaves
+ * the workspace usable but incompletely set up — a failed user script or a
+ * failed additional-repo clone — is `setup-failed`. System-setup failures are
+ * not represented here — providers can't always finish after those, so they
+ * throw and the caller classifies the error.
+ */
+export interface SandboxSetupFailure {
+  kind: "git-failed" | "setup-failed";
+  message: string;
+}
+
+/**
+ * A service-derived env var definition from `.amika/config.toml`:
+ *   `MY_URL = { service = "web", field = "url" }`
+ * Resolved against live service URLs/ports after a sandbox is provisioned.
+ */
+export interface ServiceEnvVarDef {
+  name: string;
+  service: string;
+  field: "url" | "host" | "port";
+}
+
+/** An MCP integration to wire into the sandbox's agent config. */
+export interface McpIntegrationInput {
+  name: string;
+  mcpServerType: string;
+  mcpServerUrl: string;
+  // Required for OAuth (http) integrations; omitted for stdio MCPs that
+  // run locally in the sandbox with no auth (e.g. Playwright).
+  accessToken?: string;
+}
+
+/** Lazy resolver for an agent credential (lazy keeps OAuth tokens fresh). */
+export type AgentCredentialResolver = () => Promise<{
+  value: string;
+  type: "oauth" | "api_key";
+} | null>;
+
+/**
+ * Request to provision a new provider sandbox.
+ *
+ * The Amika-flavored fields are documented in place: `services` is load-bearing on
+ * Vercel (the exposed-port set is fixed at create), and
+ * `amikaOpenCodeWeb`/`scrubSafe`/`labels` are an accepted residual exception
+ * (Daytona's non-login exec inherits the container env, so the
+ * non-secret operational keys are baked at create).
+ */
+export interface CreateSandboxProviderInput {
+  name: string;
+  snapshot: string;
+  /**
+   * Requested size (xs/m/l/xl). Informational for both providers that bake size
+   * into the chosen `snapshot`: Daytona via per-size image tags, Freestyle via
+   * per-size snapshots (`amika-<preset>-<size>`, built by
+   * `bin/freestyle-build-snapshots`). The size is selected upstream when
+   * resolving `snapshot`; providers do not resize at create time.
+   */
+  size?: SandboxSize;
+  githubUrl?: string;
+  repoName?: string | null;
+  amikaOpenCodeWeb?: string | null;
+  autoStopInterval?: number;
+  autoDeleteInterval?: number;
+  /**
+   * The full service list to seed the sandbox with — including Amika's default
+   * "Coding Agent" (OpenCode) service. Built by the caller and passed in;
+   * the provider records it rather than deciding services of its own.
+   */
+  services: SandboxService[];
+  labels?: Record<string, string>;
+  /**
+   * Whether the base snapshot is known to have no Amika-injected secrets
+   * baked into its container env. Only when true is the sandbox stamped
+   * with the scrub-safe marker that gates "snapshot and delete". Defaults
+   * to false (untrusted) when omitted.
+   */
+  scrubSafe?: boolean;
+}
+
+/** Result of provisioning a provider sandbox (pre-initialization). */
+export interface CreatedProviderSandbox {
+  provider: string;
+  providerSandboxId: string;
+  providerUrl: string | null;
+  services: SandboxService[];
+  /** Operational (non-secret) env vars baked into the container, if any. */
+  envVars?: Record<string, string>;
+}
+
+/** Full initialization request: clone, credentials, lifecycle scripts, URLs. */
+export interface InitializeSandboxInput {
+  providerSandboxId: string;
+  /**
+   * The Amika sandbox name. Persisted into the managed base env as
+   * `AMIKA_SANDBOX_NAME` so every shell session and the launched agent can
+   * identify which sandbox they're running in. Threaded through (rather than
+   * read from the provider) because the name is owned by the caller, not stored
+   * in the provider's sandbox metadata.
+   */
+  sandboxName: string;
+  /** Lifecycle/base env vars that should be present in shell sessions. */
+  envVars: Record<string, string> | null;
+  setupScript: string;
+  githubUrl?: string;
+  branch?: string;
+  /** When set, create this branch (off the cloned branch) and check it out. */
+  newBranch?: string;
+  /**
+   * Extra repos to clone alongside the primary repo, from `[filesystem] repos`
+   * in `.amika/config.toml`. Each is cloned at its default branch into
+   * `~/workspace/<repoName>`. Only cloned during initialization; restart does
+   * not re-clone (repos are already on disk), so this is unused on the rerun
+   * path. Only the Daytona provider honors this today.
+   */
+  additionalRepos?: string[];
+  repoName?: string | null;
+  githubToken?: string | null;
+  /**
+   * GitHub runtime auth mode. `"pat"` (default when absent)
+   * writes the static credential files; `"app_token"` installs a
+   * callback-based credential helper + gh shim instead, and strips
+   * the one-shot clone token from persisted git remotes. Creation-only:
+   * the rerun path never re-installs.
+   */
+  githubAuthMode?: GithubAuthMode;
+  resolveClaudeCredentials?: AgentCredentialResolver;
+  resolveCodexCredentials?: AgentCredentialResolver;
+  /** Resolver for the OpenCode OpenAI credential (lazy for OAuth freshness). */
+  resolveOpenCodeOpenaiCredential?: AgentCredentialResolver;
+  /** Anthropic API key for OpenCode (API key credentials only). */
+  openCodeAnthropicApiKey?: string;
+  /** OpenAI API key for OpenCode (eagerly resolved from api_key credential). */
+  openCodeOpenaiApiKey?: string;
+  openCodePort?: number;
+  openCodePassword: string;
+  amikaOpenCodeWeb?: string | null;
+  injectedEnvVars?: Record<string, string>;
+  gitUserName?: string;
+  gitUserEmail?: string;
+  mcpIntegrations?: McpIntegrationInput[];
+  /** Service definitions created at sandbox provision time (with empty URLs). */
+  services: SandboxService[];
+  /** Service-derived env var definitions to resolve after URL refresh. */
+  serviceEnvVars?: ServiceEnvVarDef[];
+}
+
+/**
+ * Re-run the lifecycle on a restarted sandbox. Same shape as initialization
+ * minus the create-only inputs (the repo is already cloned), plus the start
+ * script to (re)upload.
+ */
+export type RerunLifecycleInput = Omit<
+  InitializeSandboxInput,
+  "setupScript" | "githubUrl" | "githubToken"
+> & {
+  startScript: string;
+  /**
+   * When true, skip re-running the start script (the start-phase lifecycle
+   * step) on this restart. Honored by the Daytona and Vercel providers;
+   * providers that don't wire it through always run the start script.
+   */
+  skipStartScript?: boolean;
+};
+
+/** Result of initialization / lifecycle re-run: the signed URLs to persist. */
+export interface SandboxInitializeResult {
+  providerUrl: string | null;
+  services: SandboxService[];
+  /**
+   * A repo-clone or user-script failure the run absorbed while completing the
+   * rest of initialization (see {@link SandboxSetupFailure}). Absent when
+   * everything set up cleanly.
+   */
+  setupFailure?: SandboxSetupFailure;
+}
+
+/** Result of refreshing signed preview URLs for a sandbox's services. */
+export interface RefreshUrlsResult {
+  providerUrl: string | null;
+  services: SandboxService[];
+}
+
+/**
+ * Result of running a one-shot command inside a sandbox.
+ *
+ * The two streams are kept separate on purpose. Callers that parse a
+ * command's *value* (a host key, a JSON document, a PID) must read
+ * {@link stdout} only: a zero-exit command can still write to stderr
+ * (`sudo` emits `unable to resolve host …` on many sandbox images), and
+ * folding that into the value stream corrupts every such parser. Callers
+ * reporting a *failure* should surface {@link stderr}, which is where the
+ * diagnosis usually is.
+ */
+export interface SandboxExecResult {
+  exitCode: number;
+  /** Standard output only; never carries stderr text. */
+  stdout: string;
+  /** Standard error only; empty when the command wrote nothing to it. */
+  stderr: string;
+}
+
+/**
+ * Options for {@link SandboxProvider.executeCommand}. Every field is optional
+ * and only the providers it applies to honor it; the rest ignore it (so an
+ * omitted third argument is always safe).
+ *
+ * Both fields exist for providers whose sandboxes suspend and resume between
+ * calls (Vercel). They let a caller that only needs a bare command run — an
+ * agent launch, an exit probe — opt out of the full interactive-exec behavior
+ * interactive/editor callers want:
+ *
+ *   - `resumeMode` — on a cold resume, `"restart-services"` (the default)
+ *     relaunches the sandbox's lifecycle services (OpenCode, preview servers)
+ *     so an interactive session is fully live; `"bare"` skips that relaunch,
+ *     resuming only the filesystem. Use `"bare"` when the command doesn't need
+ *     those services up and the relaunch would just add latency.
+ *   - `sessionTimeoutMs` — reapply this idle-suspend timeout before running the
+ *     command. A resumed sandbox otherwise reverts to the provider's short
+ *     default and could suspend mid-command; set this on long-running work
+ *     (e.g. an agent turn) whose caller can't re-drive the persisted interval.
+ *   - `cwd` — working directory to run the command in.
+ *   - `env` — extra environment variables to expose to the command (exported so
+ *     they win over the managed base env).
+ *   - `sudo` — run with root privileges. Providers whose default user is
+ *     unprivileged (Daytona's/Vercel's sandbox user) translate this to `sudo`;
+ *     providers that already exec as root (Freestyle) route it to a root handle.
+ */
+export interface ExecCommandOptions {
+  resumeMode?: "restart-services" | "bare";
+  sessionTimeoutMs?: number;
+  cwd?: string;
+  env?: Record<string, string>;
+  sudo?: boolean;
+  /** Bytes delivered on stdin without embedding them in argv or logs. */
+  input?: string;
+}
+
+/**
+ * Provisioned sizing of a sandbox, normalized to the units the spend meter
+ * bills in — GiB for memory and disk. Providers convert from their native SDK
+ * units so the consumer prices every provider off one shape: Daytona already
+ * reports GiB, Freestyle reports MiB (÷1024), and Vercel exposes only the vCPU
+ * count and derives the rest from its fixed 2 GB-per-vCPU / 32 GB-disk coupling.
+ */
+export interface ProviderSandboxSizing {
+  /** Provisioned vCPU count. */
+  vcpus: number;
+  /** Provisioned memory, gibibytes. */
+  memoryGib: number;
+  /** Provisioned disk, gibibytes. */
+  diskGib: number;
+}
+
+/**
+ * One account-wide sandbox as reported by {@link SandboxProvider.listSandboxes}.
+ * Carries only what an out-of-band enumerator (e.g. a spend meter)
+ * needs to attribute and price it: the provider handle, the org the create path
+ * stamped on the resource (label/tag/name — `null` for an unstamped resource),
+ * the raw provider state/status string (the consumer maps it to a bill mode),
+ * and the normalized {@link ProviderSandboxSizing}. Resources whose size the
+ * provider can't determine, and Freestyle's soft-deleted VMs, are omitted rather
+ * than reported with a zero sizing.
+ */
+export interface ProviderSandboxListing {
+  providerSandboxId: string;
+  orgId: string | null;
+  state: string;
+  sizing: ProviderSandboxSizing;
+}
+
+/**
+ * Resolves an org-scoped snapshot name to the provider's bootable handle
+ * (`provider_snapshot_id`), or `null` when no handle is recorded yet or the name
+ * is absent. Injected by the caller, which owns the name↔handle mapping.
+ *
+ * Name-native providers (Daytona, Freestyle) address snapshots by name and never
+ * need this. Vercel snapshots are id-only, so its snapshot capability resolves the
+ * id through this port, keeping the provider layer free of any storage coupling.
+ * The resolver is invoked on demand (including per-poll in
+ * `waitForSnapshotActive`), so it reflects a handle recorded asynchronously after
+ * a capture starts.
+ */
+export type SnapshotIdResolver = (name: string) => Promise<string | null>;
+
+/** Callbacks for streamed command output. */
+export interface StreamCommandHandlers {
+  onStdout: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+}
+
+/**
+ * The access a provider has minted: a bearer token, the SSH destination
+ * (`[user@]host`) already parsed by the provider, and the expiry. Providers
+ * own the command-shape parsing so consumers never re-parse a provider string.
+ *
+ * The two optional fields describe a WebSocket-tunneled SSH transport (Vercel):
+ * the sandbox runs a real `sshd` reached through a `websocat` `ProxyCommand`
+ * rather than a direct-dial gateway. They are absent for gateway providers
+ * (Daytona, Freestyle), which embed the credential in `sshDestination` and dial
+ * the host directly.
+ */
+export interface MintedSshAccess {
+  token: string;
+  sshDestination: string;
+  expiresAt: Date;
+  /**
+   * The `wss://…` URL the client bridges SSH stdio through (via `websocat` as an
+   * OpenSSH `ProxyCommand`). Present for WebSocket-tunneled SSH (Vercel exposes
+   * the sandbox's `sshd` on a public port addressed over a WebSocket); absent
+   * for direct-dial gateways whose `sshDestination` is itself a reachable host.
+   */
+  webSocketProxyUrl?: string;
+  /**
+   * An ephemeral PEM private key the client authenticates with, for providers
+   * that mint a per-access keypair (Vercel injects the matching public key into
+   * the sandbox user's `authorized_keys`). Absent for gateway providers that
+   * embed the credential directly in `sshDestination`.
+   */
+  privateKey?: string;
+}
+
+/**
+ * Inputs to {@link SandboxGitNamespace.clone}: clone one git repo into a
+ * provisioned sandbox. `branch` falls back to the repo's default branch,
+ * creating it if the requested branch is absent on the remote; an omitted
+ * `repoName` clones directly into `~/workspace`.
+ */
+export interface CloneRepoInput {
+  /** The sandbox user's home directory (repos land under `~/workspace`). */
+  homeDir: string;
+  githubUrl: string;
+  repoName?: string | null;
+  githubToken?: string | null;
+  branch?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot capability
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider-agnostic snapshot metadata. Describes the load-bearing fields the
+ * UI/CLI use. Concrete provider objects typically carry more fields than this;
+ * those extras flow through to API responses, which validate the snapshot
+ * shape loosely (`.passthrough()`), so this type need only name what consumers
+ * read — not mirror a provider's full DTO.
+ */
+export interface ProviderSnapshot {
+  name: string;
+  /**
+   * The provider's own bootable handle for the snapshot, when distinct from the
+   * name. Undefined for providers that boot by name (Daytona); the opaque
+   * snapshot id for Freestyle. Lets consumers backfill a missing
+   * `provider_snapshot_id` from a live lookup if the capture never recorded it.
+   */
+  providerSnapshotId?: string | null;
+  state?: string;
+  imageName?: string;
+  errorReason?: string | null;
+  cpu?: number;
+  mem?: number;
+  disk?: number;
+  size?: number | null;
+  createdAt?: Date | string;
+  updatedAt?: Date | string;
+}
+
+/** Create an image-derived snapshot. */
+export interface CreateImageSnapshotInput {
+  name: string;
+  image: string;
+  entrypoint?: string[];
+  regionId?: string;
+}
+
+export interface ScrubResult {
+  /** Credential files targeted for removal. */
+  removedFiles: string[];
+  /** Env var names removed from the sandbox environment. */
+  removedEnvVars: string[];
+}
+
+/**
+ * The concrete paths and env-var names a pre-snapshot scrub removes, computed by
+ * the caller and passed to a provider's scrub capability. Keeping the "what is a
+ * secret" knowledge out of core lets `@amika/sandbox` stay a generic provider
+ * mechanics layer: it removes exactly the paths it is handed, per its own
+ * mechanism, and never decides which files/env vars are Amika secrets.
+ */
+export interface ScrubTargets {
+  /** Home-dir paths to remove as the sandbox user (credential files/dirs). */
+  files: string[];
+  /** System paths to remove with sudo (the managed env files). */
+  sudoFiles: string[];
+  /**
+   * Root-owned baseline files restored immediately before capture. These are
+   * declared by the provisioning layer; core only performs the mechanics.
+   *
+   * Required rather than optional, and passed as `[]` when a producer genuinely
+   * restores nothing: `/etc/environment` is restored here instead of being
+   * deleted via {@link sudoFiles}, so a producer that omitted this field would
+   * capture that file intact, with its injected secrets, and no verification
+   * would fire because the path was never in the removal set.
+   */
+  sudoFileRestores: Array<{ sourcePath: string; destinationPath: string }>;
+  /** Env var names that were removed — for the returned disclosure only. */
+  envVarNames: string[];
+  /**
+   * Workspace root under which tokenized git remotes are sanitized: every
+   * `.git/config` beneath it has `https://x-access-token:<token>@` stripped
+   * back to plain `https://`, verified fail-closed. Declarative — where repos
+   * live is Amika layout knowledge, so the caller passes the root rather than
+   * core hardcoding it. Omit to skip the git-remote pass.
+   */
+  gitTokenWorkspaceRoot?: string;
+}
+
+/**
+ * Outcome of capturing a snapshot from a running sandbox.
+ *
+ * `providerSnapshotId` is the provider's own bootable handle for the new
+ * snapshot, or `null` when the provider boots snapshots by their org-scoped
+ * name (Daytona). Freestyle returns the opaque id from `vm.snapshot`, which the
+ * caller persists so a sandbox can later be created from it (`vms.create`).
+ */
+export interface CapturedSnapshot {
+  providerSnapshotId: string | null;
+}
+
+export interface ScrubPreview {
+  /** Credential files that currently exist and would be removed. */
+  files: string[];
+  /** Files that would be reset to a retained clean baseline. */
+  restoredFiles: string[];
+  /** Env var names that would be removed (names only, never values). */
+  envVars: string[];
+}
+
+/**
+ * Thrown when one or more scrubbed paths are still present after the scrub.
+ * Carries the leftover paths so the caller can surface them to the user (the
+ * most common cause is an active agent process recreating its config dir
+ * between rm and verification).
+ */
+export class ScrubVerificationError extends Error {
+  public readonly leftover: string[];
+  constructor(leftover: string[]) {
+    super(
+      `Scrub verification failed; paths still present after scrub: [${leftover.join(", ")}]`,
+    );
+    this.name = "ScrubVerificationError";
+    this.leftover = leftover;
+  }
+}
+
+/**
+ * A declared baseline restore failed or did not verify. Distinct from
+ * {@link ScrubVerificationError}: that one means a path that should be gone is
+ * still there. This one means a file that should be present and identical to
+ * its source could not be restored safely.
+ */
+export class ScrubRestoreError extends Error {
+  public readonly sourcePath: string;
+  public readonly destinationPath: string;
+  constructor(sourcePath: string, destinationPath: string, detail?: string) {
+    super(
+      `Scrub restore failed; ${destinationPath} could not be restored from ${sourcePath}${detail ? `: ${detail}` : ""}`,
+    );
+    this.name = "ScrubRestoreError";
+    this.sourcePath = sourcePath;
+    this.destinationPath = destinationPath;
+  }
+}
+
+/**
+ * Snapshot management for providers that support it. `getSnapshot` returns
+ * `null` for a missing snapshot (rather than throwing) so consumers don't
+ * couple to provider-specific not-found errors; real failures still throw.
+ * `deleteSnapshot` is idempotent (a missing snapshot is a no-op).
+ * `createImageSnapshot` returns `null` when the snapshot already exists.
+ */
+export interface SnapshotCapability {
+  createImageSnapshot(
+    input: CreateImageSnapshotInput,
+  ): Promise<ProviderSnapshot | null>;
+  getSnapshot(name: string): Promise<ProviderSnapshot | null>;
+  /**
+   * Like `getSnapshot`, but tolerates a snapshot that is still registering: a
+   * freshly captured sandbox snapshot can be absent from a bare by-name lookup
+   * while already present in the provider's listing. Use this when "does any
+   * snapshot still occupy this name?" must account for in-flight captures
+   * (name-reuse checks, reconciling stranded rows). Returns `null` when
+   * genuinely absent.
+   */
+  findSnapshot(name: string): Promise<ProviderSnapshot | null>;
+  /**
+   * `providerSnapshotId` on `deleteSnapshot`/`waitForSnapshotActive` is the
+   * provider's bootable handle when the caller already holds it (a freshly
+   * captured {@link Snapshot} carries one). Id-only providers (Vercel) use it
+   * directly instead of resolving the name through the injected
+   * {@link SnapshotIdResolver} — which cannot know about a capture the caller
+   * hasn't persisted yet. Name-native providers (Daytona, Freestyle) ignore it.
+   */
+  deleteSnapshot(
+    name: string,
+    providerSnapshotId?: string | null,
+  ): Promise<void>;
+  waitForSnapshotActive(
+    name: string,
+    providerSnapshotId?: string | null,
+  ): Promise<ProviderSnapshot>;
+  /**
+   * Capture a snapshot of the sandbox as it stands — the one raw capture
+   * primitive; scrubbing is layered above in core. All capture
+   * mechanics stay inside: Daytona picks cold-VM vs container capture
+   * (through its experimental client, whose target alone exposes the capture
+   * endpoint) and quiesces/restarts dind; Vercel calls `sandbox.snapshot()`;
+   * Freestyle snapshots the running VM.
+   *
+   * `keepSourceRunning: false` declares the caller's INTENT to delete the
+   * source afterwards — deletion is not guaranteed (activation can time out,
+   * deletion can fail, and the caller then retains and releases the
+   * source), so the flag only relaxes keep-alive where a retained source
+   * stays recoverable. Daytona's cold-VM branch skips the power-restart (a
+   * stopped VM is user-restartable), but its container branch keeps the
+   * unconditional dind restore-in-finally — a retained source must never come
+   * back with Docker quiesced. `true` is the non-destructive full-capture
+   * mode, gated by `capabilities.fullSnapshotCapture`.
+   */
+  capture(
+    providerSandboxId: string,
+    snapshotName: string,
+    opts: { keepSourceRunning: boolean },
+  ): Promise<CapturedSnapshot>;
+  /**
+   * Remove secrets the PROVIDER itself injected into the sandbox, ahead of a
+   * capture. Vercel removes its resume-context file (which carries the source
+   * OpenCode password); Daytona and Freestyle are no-ops. Amika-injected
+   * secrets are not this method's concern — those are scrubbed above by the
+   * core-synthesized `scrubAndCreate`.
+   */
+  removeInjectedSecrets(providerSandboxId: string): Promise<void>;
+  /** Whether the sandbox was created with secrets kept out of container env. */
+  isEnvScrubbable(providerSandboxId: string): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// Docker registry capability
+// ---------------------------------------------------------------------------
+
+/** Provider-agnostic docker registry metadata. */
+export interface ProviderDockerRegistry {
+  id: string;
+  name: string;
+  url: string;
+  username: string;
+  project?: string;
+  registryType: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateDockerRegistryInput {
+  name: string;
+  url: string;
+  username: string;
+  password: string;
+  project?: string;
+}
+
+/** Docker registry management for providers that support it. */
+export interface DockerRegistryCapability {
+  createRegistry(
+    input: CreateDockerRegistryInput,
+  ): Promise<ProviderDockerRegistry>;
+  listRegistries(): Promise<ProviderDockerRegistry[]>;
+  getRegistry(registryId: string): Promise<ProviderDockerRegistry>;
+  deleteRegistry(registryId: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/**
+ * What a provider can do beyond the always-present create/delete. Consumers
+ * check these before invoking a gated operation, surfacing a clean
+ * "unsupported for this provider" message instead of hitting
+ * {@link SandboxProviderUnsupportedError}.
+ */
+export interface SandboxProviderCapabilities {
+  /** Full provisioning lifecycle: initialize, start, stop, rerun-lifecycle. */
+  lifecycle: boolean;
+  /** Mint/revoke short-lived SSH access. */
+  ssh: boolean;
+  /** Expose sandbox services through provider-managed routes. */
+  services: boolean;
+  /** Run one-shot commands inside the sandbox. */
+  exec: boolean;
+  /** Enumerate account-wide sandboxes with sizing (spend metering). */
+  listSandboxes: boolean;
+  /** Stream a long-running command's output (e.g. for SSE). */
+  streaming: boolean;
+  /** Snapshot management (`provider.snapshots` is non-null iff true). */
+  snapshots: boolean;
+  /**
+   * Whether the provider supports the non-destructive "full" capture mode
+   * (snapshot the sandbox as-is, secrets included, source kept running). A
+   * provider can support `snapshots` yet offer only the destructive
+   * scrub-and-delete path — e.g. Vercel, whose per-sandbox retention would evict
+   * a kept-alive full capture — so this is a separate flag. Always false when
+   * `snapshots` is false; the create-snapshot API rejects `mode: "full"` for
+   * providers where this is false.
+   */
+  fullSnapshotCapture: boolean;
+  /**
+   * Whether the destructive scrub-and-capture path (`sandbox.snapshots
+   * .scrubAndCreate`) is available. The scrub is synthesized in core and runs
+   * its removal/verification commands through the exec primitive, so this is
+   * true iff the provider declares BOTH `snapshots` and `exec` — a provider
+   * can support snapshots without exec and then offers only the raw captures.
+   */
+  scrubCapture: boolean;
+  /** Docker registry management (`provider.docker` non-null iff true). */
+  dockerRegistries: boolean;
+  /**
+   * Whether starting the sandbox can skip re-running the start script (the
+   * start-phase lifecycle step). Only providers that honor
+   * {@link RerunLifecycleInput.skipStartScript} set this true; the UI hides the
+   * "start without start script" option otherwise so it can't be a silent no-op.
+   */
+  skipStartScript: boolean;
+  /**
+   * Whether the provider's bootable snapshot handle is an opaque id
+   * (`sc-…`/`snap_…`) distinct from the org-scoped snapshot *name* — the
+   * consumer-side mirror of {@link ProviderSnapshot.providerSnapshotId} /
+   * {@link SnapshotIdResolver}. When true (Freestyle, Vercel), the snapshot
+   * column stores an id the consumer must reverse-look-up to a display name and
+   * cannot verify by name through a control-plane listing. When false (Daytona),
+   * snapshots are addressed by their name directly. Lets consumers gate the
+   * id-resolution/display path on a fact instead of the provider name.
+   */
+  snapshotIdsAreOpaque: boolean;
+  /**
+   * Whether the provider honors a time-based auto-delete interval. Daytona
+   * deletes idle sandboxes on the interval; Freestyle and Vercel back
+   * persistent VMs that suspend/resume instead of being deleted, so an
+   * auto-delete request is rejected at create rather than silently ignored.
+   */
+  supportsAutoDelete: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Capability namespaces
+// ---------------------------------------------------------------------------
+//
+// The shape a provider author writes via `defineProvider`: cohesive capability
+// namespaces, omitted (null) when the provider does not back them. These are
+// provider-side only — `buildProvider` synthesizes the public resource objects
+// over them; consumers gate on the `capabilities` descriptor or a nullable
+// object namespace's presence.
+
+/**
+ * Manage a sandbox's existence and run state. create/delete is the one
+ * always-present capability — a provider that can't create and delete a sandbox
+ * isn't a sandbox provider. The run-state ops (start/stop/getState/mapState)
+ * are optional and present as a unit: a minimal provider can create and delete
+ * without being able to power-cycle.
+ *
+ * Run state (on/off/resumed) is distinct from the *lifecycle scripts*
+ * (`setup.sh`/`start.sh`) run via provisioning's `initialize`/`rerun` — those
+ * operate inside an already-running sandbox.
+ */
+export interface SandboxCapability {
+  create(
+    ctx: SandboxCtx,
+    input: CreateSandboxProviderInput,
+  ): Promise<CreatedProviderSandbox>;
+  delete(providerSandboxId: string): Promise<void>;
+
+  // Run-state control: start (power on / resume), stop (suspend), read the raw
+  // run state, and map it to the canonical status vocabulary. Present as a unit
+  // on a lifecycle provider; all absent on a create/delete-only one.
+  start?(
+    providerSandboxId: string,
+    autoStopInterval?: number | null,
+  ): Promise<void>;
+  stop?(providerSandboxId: string): Promise<void>;
+  getState?(providerSandboxId: string): Promise<string>;
+  mapState?(rawState: string): SandboxStatus;
+}
+
+/** Run one-shot commands inside the sandbox. `stream` is present iff `streaming`. */
+export interface ExecCapability {
+  run(
+    providerSandboxId: string,
+    command: string,
+    opts?: ExecCommandOptions,
+  ): Promise<SandboxExecResult>;
+  readonly streaming: boolean;
+  /** Whether `run(..., { input })` is supported without an argv/env fallback. */
+  readonly stdin?: boolean;
+  stream?(
+    providerSandboxId: string,
+    command: string,
+    handlers: StreamCommandHandlers,
+  ): Promise<void>;
+}
+
+/** Read/write files inside the sandbox. */
+export interface FileCapability {
+  read(providerSandboxId: string, filePath: string): Promise<string | null>;
+  write(
+    providerSandboxId: string,
+    filePath: string,
+    content: Buffer | string,
+  ): Promise<void>;
+}
+
+/** Mint/revoke short-lived SSH access. */
+export interface SshCapability {
+  mint(
+    providerSandboxId: string,
+    expiresInMinutes: number,
+    services?: SandboxService[],
+  ): Promise<MintedSshAccess>;
+  revoke(providerSandboxId: string, token: string): Promise<void>;
+}
+
+/**
+ * (Re)generate service preview URLs and reconcile service routes.
+ *
+ * `syncRoutes` is declarative: reconcile the provider's
+ * routes to exactly the `desired` service set — expose what is missing, tear
+ * down what no longer appears — rather than imperatively revoking one route
+ * with the surviving set threaded alongside. Revoking a service is
+ * `syncRoutes(remaining)`. Reconciliation must only ever touch state the
+ * provider (or Amika's deterministic naming) owns; a route a user mapped to
+ * the same sandbox out-of-band is never reconcilable state.
+ */
+export interface ServiceCapability {
+  refreshUrls(
+    providerSandboxId: string,
+    services: SandboxService[],
+  ): Promise<RefreshUrlsResult>;
+  syncRoutes(
+    providerSandboxId: string,
+    desired: SandboxService[],
+  ): Promise<void>;
+}
+
+/** Enumerate account-wide sandboxes with sizing. */
+export interface ListingCapability {
+  list(): Promise<ProviderSandboxListing[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Resource-object surface
+// ---------------------------------------------------------------------------
+//
+// The consumer-facing API. Instead of calling a flat
+// `provider.<capability>.<verb>(providerSandboxId, …)`, a consumer resolves a
+// resource object — a {@link Sandbox}, {@link Snapshot}, or {@link
+// DockerRegistry} — and calls methods on it. The object encapsulates the provider
+// handle (so the id isn't re-threaded through every call) and any hidden state.
+//
+// These objects are synthesized in core (`./shared/resources`) over the
+// capability namespaces above; providers author only the low-level primitives
+// and {@link defineProvider} attaches the resource namespaces. Presence gating
+// is unchanged: a
+// method whose backing capability is absent throws {@link
+// SandboxProviderUnsupportedError}, and richer sub-namespaces are `null` when
+// unsupported — callers presence-check `sandbox.ssh` / `sandbox.services` /
+// `sandbox.snapshots` exactly as they gate on `provider.<capability>` today.
+
+/**
+ * SSH access minted for a sandbox, with a `revoke()` bound to it. Extends the
+ * {@link MintedSshAccess} data the provider returns with the method to tear it
+ * back down, so a caller holding the handle need not re-supply the token.
+ */
+export interface MintedSshHandle extends MintedSshAccess {
+  /** Revoke this access (idempotent per the provider). */
+  revoke(): Promise<void>;
+}
+
+/** A sandbox's SSH sub-namespace. `null` on providers without SSH. */
+export interface SandboxSshNamespace {
+  /** Mint short-lived SSH access to this sandbox. */
+  mint(
+    expiresInMinutes: number,
+    services?: SandboxService[],
+  ): Promise<MintedSshHandle>;
+  /**
+   * Revoke previously-minted access by its token. `MintedSshHandle.revoke()`
+   * is the same operation bound to a freshly minted handle; this form serves
+   * callers that revoke a token they persisted rather than a live handle.
+   */
+  revoke(token: string): Promise<void>;
+}
+
+/**
+ * A service of a loaded set: its authored/live fields plus
+ * the mutations that need the surrounding set to reconcile. The methods
+ * derive `desired` from the {@link LoadedServices} snapshot this object came
+ * from — the caller never hand-computes a removed/remaining split.
+ */
+export interface Service extends SandboxService {
+  /**
+   * Tear down this service's route: reconcile the provider's routes to the
+   * loaded set minus this service (idempotent; a shared port survives while
+   * any other loaded service uses it).
+   */
+  revoke(): Promise<void>;
+  /**
+   * Reconcile + re-mint with `next` in this service's place: routes sync to
+   * the set with the replacement, then URLs refresh over that set. The
+   * loaded snapshot itself is NOT updated — `load()` is point-in-time, so
+   * re-load after a mutation before chaining further calls.
+   */
+  update(next: SandboxService): Promise<RefreshUrlsResult>;
+}
+
+/**
+ * A point-in-time snapshot of a sandbox's service set, object-ified. The
+ * authoritative set lives in the control plane — providers keep
+ * no listable per-sandbox route state (Daytona has none at all) — so the
+ * caller loads the set it already holds and the objects derive everything
+ * else. Lookup keys on the CONTAINER PORT: a service name may repeat across
+ * ports, while a given port hosts exactly one service (the uniqueness key)
+ * and the port is what the provider route layer addresses.
+ */
+export interface LoadedServices {
+  list(): Service[];
+  /** The service on `containerPort`, or null. First match on a legacy set
+   * that carries duplicates (load order decides). */
+  get(containerPort: number): Service | null;
+  /**
+   * Reconcile routes to the loaded set (exposing late-added ports, tearing
+   * down stale ones), then (re)mint the set's preview URLs.
+   */
+  refresh(): Promise<RefreshUrlsResult>;
+}
+
+/** A sandbox's service sub-namespace. `null` on providers without services. */
+export interface SandboxServiceNamespace {
+  /**
+   * (Re)generate signed preview URLs for all of the sandbox's services — the
+   * no-object fast path for read/re-mint flows that must not touch routes.
+   */
+  refreshAll(services: SandboxService[]): Promise<RefreshUrlsResult>;
+  /** Load a point-in-time service set and get {@link Service} objects over it. */
+  load(services: SandboxService[]): LoadedServices;
+}
+
+/** A captured snapshot paired with what the pre-capture scrub removed. */
+export interface ScrubbedSnapshot extends ScrubResult {
+  snapshot: Snapshot;
+}
+
+/**
+ * A sandbox's snapshot sub-namespace: capture a snapshot *from this sandbox*.
+ * (Account-level snapshot lookup/management lives on the top-level
+ * {@link SandboxProvider} snapshot namespace.) `null` on providers without
+ * snapshots.
+ */
+export interface SandboxSnapshotNamespace {
+  /** Capture a snapshot of the running sandbox as-is (secrets included). */
+  create(snapshotName: string): Promise<Snapshot>;
+  /** Remove the given targets, then capture a clean snapshot. */
+  scrubAndCreate(
+    snapshotName: string,
+    targets: ScrubTargets,
+  ): Promise<ScrubbedSnapshot>;
+  /** Whether the sandbox was created with secrets kept out of container env. */
+  isEnvScrubbable(): Promise<boolean>;
+}
+
+/**
+ * A sandbox's git sub-namespace: an OPTIONAL provider override for how repos
+ * are cloned. Present (non-null) only when a provider's SDK has a first-class
+ * clone primitive worth using over shell `git` — Daytona exposes it via the
+ * SDK's native `git.clone`. It is `null` on providers with no native primitive
+ * (Freestyle, Vercel); the provisioning layer clones those by running `git`
+ * over the {@link SandboxAdapter} exec port instead. Cloning is Amika
+ * provisioning orchestration, not a core sandbox capability, so there is no
+ * always-present clone method on {@link Sandbox} — callers presence-check
+ * `sandbox.git` and fall back to their own exec-based clone.
+ */
+export interface SandboxGitNamespace {
+  /** Clone one git repo into the sandbox via the provider's native primitive. */
+  clone(input: CloneRepoInput): Promise<void>;
+}
+
+/**
+ * The inputs a provider persists so it can relaunch a sandbox's services after a
+ * resume — see {@link Sandbox.persistServiceRestartContext}. The relaunch re-runs
+ * the start-phase lifecycle hooks, which need the OpenCode server password and
+ * the agent working directory they run in.
+ */
+export interface ServiceRestartContext {
+  openCodePassword: string;
+  amikaOpenCodeWeb?: string | null;
+  /** The agent working directory (`AMIKA_AGENT_CWD`) the relaunch hooks run in. */
+  repoDir: string;
+}
+
+/**
+ * A provisioned sandbox. Methods that map to a nullable capability
+ * (start/stop/state → the sandbox run-state ops, exec/streamExec → exec, readFile/writeFile → files)
+ * throw {@link SandboxProviderUnsupportedError} when the provider doesn't back
+ * them; the sub-namespaces (`git`, `ssh`, `services`, `snapshots`) are `null`
+ * in that case so callers can presence-check instead.
+ */
+export interface Sandbox {
+  /** The provider's handle for this sandbox (`providerSandboxId`). */
+  readonly id: string;
+  readonly provider: SandboxProviderName;
+  /** The creation result, present only on a `Sandbox` returned from `create`. */
+  readonly created?: CreatedProviderSandbox;
+  start(autoStopInterval?: number | null): Promise<void>;
+  stop(): Promise<void>;
+  delete(): Promise<void>;
+  /** The raw provider run-state string. */
+  getState(): Promise<string>;
+  /** Map a raw provider state to the canonical vocabulary. */
+  mapState(rawState: string): SandboxStatus;
+  /** The raw state mapped to the canonical vocabulary (getState + mapState). */
+  getRuntimeState(): Promise<SandboxStatus>;
+  exec(command: string, opts?: ExecCommandOptions): Promise<SandboxExecResult>;
+  streamExec(command: string, handlers: StreamCommandHandlers): Promise<void>;
+  readFile(filePath: string): Promise<string | null>;
+  writeFile(filePath: string, content: Buffer | string): Promise<void>;
+  /** Optional provider-native clone override; `null` → clone via adapter exec. */
+  readonly git: SandboxGitNamespace | null;
+  /**
+   * Persist the context needed to relaunch this sandbox's services after a
+   * resume — or `null` when the provider doesn't need it.
+   *
+   * Present (non-null) ONLY on providers whose suspended sandboxes come back
+   * with their running processes gone: Vercel's microVMs restore the filesystem
+   * but not the processes the lifecycle hooks started, so on the next exec Vercel
+   * re-runs the start hooks and reads this persisted context for the inputs. On
+   * providers whose processes survive a stop/restart (Daytona, Freestyle) there
+   * is nothing to relaunch, so this is `null` and the provisioning flow skips it.
+   * The flow calls it on create and restart, when the inputs are known — a
+   * provider that never resets services on resume simply omits it, so this stays
+   * out of the shared capability descriptor every provider fills.
+   */
+  readonly persistServiceRestartContext:
+    | ((context: ServiceRestartContext) => Promise<void>)
+    | null;
+  readonly ssh: SandboxSshNamespace | null;
+  readonly services: SandboxServiceNamespace | null;
+  readonly snapshots: SandboxSnapshotNamespace | null;
+}
+
+/** Top-level namespace for resolving and creating {@link Sandbox} objects. */
+export interface SandboxNamespace {
+  /** Provision a new sandbox; the returned `Sandbox` carries the create result. */
+  create(ctx: SandboxCtx, input: CreateSandboxProviderInput): Promise<Sandbox>;
+  /** A lightweight reference to an existing sandbox by handle — no I/O. */
+  get(providerSandboxId: string): Sandbox;
+  /** Enumerate account-wide sandboxes with sizing (spend metering). */
+  list(): Promise<ProviderSandboxListing[]>;
+}
+
+/**
+ * An account-level snapshot, with its metadata (from {@link ProviderSnapshot})
+ * plus the methods to wait on and delete it.
+ *
+ * The bound methods pass the snapshot's `providerSnapshotId` (when present)
+ * through to the capability, so a freshly captured snapshot on an id-only
+ * provider (Vercel) is operable before the name↔id mapping the
+ * {@link SnapshotIdResolver} reads has been persisted.
+ */
+export interface Snapshot extends ProviderSnapshot {
+  /** Resolve once the snapshot reaches the active state. */
+  waitForActive(): Promise<Snapshot>;
+  /** Delete the snapshot (idempotent — a missing snapshot is a no-op). */
+  delete(): Promise<void>;
+}
+
+/**
+ * Account-level snapshot lookup/management — the shape of
+ * `provider.snapshots`. `get`/`find`/`createImage` are nullable: a missing or
+ * still-registering snapshot (or a `createImage` that hit an existing name)
+ * resolves to `null`, preserving the `getSnapshot`/`findSnapshot`/
+ * `createImageSnapshot` contract consumers fall back on. Deleting or waiting
+ * goes through the returned {@link Snapshot}'s bound methods.
+ *
+ * Snapshots are addressed by their org-scoped *name*, which the caller builds
+ * via its own naming helpers — naming is Amika policy, not part of the provider
+ * surface.
+ */
+export interface SnapshotNamespace {
+  /** Look up a snapshot by org-scoped name; `null` when missing. */
+  get(name: string): Promise<Snapshot | null>;
+  /**
+   * Like `get`, but tolerates a snapshot that is still registering (list-scan
+   * fallback). Use when "does any snapshot still occupy this name?" must
+   * account for in-flight captures. `null` when genuinely absent.
+   */
+  find(name: string): Promise<Snapshot | null>;
+  /** Create an image-derived snapshot; `null` when the name already exists. */
+  createImage(input: CreateImageSnapshotInput): Promise<Snapshot | null>;
+}
+
+/** A docker registry, with its metadata plus the method to delete it. */
+export interface DockerRegistry extends ProviderDockerRegistry {
+  delete(): Promise<void>;
+}
+
+/** Namespace for creating/listing/resolving {@link DockerRegistry} objects. */
+export interface DockerRegistryNamespace {
+  create(input: CreateDockerRegistryInput): Promise<DockerRegistry>;
+  list(): Promise<DockerRegistry[]>;
+  get(registryId: string): Promise<DockerRegistry>;
+}
+
+/** Top-level docker namespace (`provider.docker.registries.*`). */
+export interface DockerNamespace {
+  readonly registries: DockerRegistryNamespace;
+}
+
+/**
+ * The sandbox-provisioner contract every consumer codes against. Provider-
+ * agnostic and free of control-plane concerns. Resolve one through the registry
+ * (`./registry`); the only place a concrete provider is named is there.
+ *
+ * The consumer surface is the resource-object API: resolve a
+ * {@link Sandbox} via `sandboxes.get(id)`/`create(...)` and call methods on it;
+ * account-level snapshots and docker registries hang off `snapshots` and
+ * `docker.registries`. Provider *authoring* is capability-namespace-based — a
+ * provider declares its low-level primitives via `defineProvider`'s
+ * {@link ProviderDefinition} — but those namespaces are not exposed here;
+ * `buildProvider` synthesizes the objects over them. Gating: consumers check
+ * the SDK-free `capabilities` descriptor (or a nullable namespace's presence);
+ * an unsupported op throws {@link SandboxProviderUnsupportedError}.
+ *
+ * The Amika-specific provisioning flows live in `@amika/sandbox-provisioning`;
+ * they drive the sandbox through these objects (`sandbox.git?.clone`,
+ * `sandbox.services.refreshAll`) plus the per-provider adapter opened via
+ * `getSandboxAdapter`.
+ */
+export interface SandboxProvider {
+  readonly name: SandboxProviderName;
+  readonly capabilities: SandboxProviderCapabilities;
+  /** TTL of signed preview URLs this provider mints, in seconds. */
+  readonly signedUrlTtlSeconds: number;
+  /**
+   * The user's home directory inside every sandbox this provider boots (e.g.
+   * `/home/amika`, `/vercel/sandbox`) — a per-provider constant, so callers
+   * read it here instead of querying a running sandbox.
+   */
+  readonly userHomeDir: string;
+
+  /** Resolve/create {@link Sandbox} objects. Always present. */
+  readonly sandboxes: SandboxNamespace;
+  /** Account-level snapshot lookup/mgmt, or null when unsupported (`capabilities.snapshots`). */
+  readonly snapshots: SnapshotNamespace | null;
+  /** Docker registry objects, or null when unsupported. */
+  readonly docker: DockerNamespace | null;
+}

--- a/js/sandbox/src/providers/provider.ts
+++ b/js/sandbox/src/providers/provider.ts
@@ -424,6 +424,22 @@ export interface CloneRepoInput {
   repoName?: string | null;
   githubToken?: string | null;
   branch?: string;
+  /**
+   * Whether to check out the repo's git submodules as well. Defaults to `true`
+   * when omitted: a repo that declares submodules is not usable without them,
+   * and silently landing an empty submodule directory fails later, further
+   * away, and far more confusingly than a slow clone does.
+   *
+   * Set this `false` only when the caller knows the extra fetch is wasted (no
+   * submodules) or unauthorized (private submodules the sandbox's credential
+   * cannot reach).
+   *
+   * Note that no provider SDK exposes a submodule option on its native clone
+   * primitive, so honoring `true` means cloning over the exec port instead of
+   * through {@link SandboxGitNamespace.clone}. See `resolveCloneRepo` in
+   * amika-mono's `@amika/sandbox-provisioning`, which makes that choice.
+   */
+  recurseSubmodules?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/js/sandbox/src/providers/registry.test.ts
+++ b/js/sandbox/src/providers/registry.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSandboxProvider,
+  isSandboxProviderName,
+  type SandboxProviderDeps,
+} from "./registry";
+import { SandboxProviderUnsupportedError } from "./provider";
+import type { SandboxProviderName } from "../types";
+
+/**
+ * Construction smoke test: every real provider must build without tripping
+ * `defineProvider`'s capability-reconciliation assertion (which runs at
+ * construction, not typecheck). Factories are lazy — no SDK network calls — so
+ * this only exercises the assembly + assertion.
+ */
+const DEPS: SandboxProviderDeps = {
+  daytona: { apiKey: "k", apiUrl: "https://app.daytona.io/api" },
+  freestyle: { apiKey: "k" },
+  vercel: { apiKey: "k", teamId: "t", projectId: "p" },
+  resolveSnapshotId: async () => null,
+};
+
+describe("createSandboxProvider construction", () => {
+  const names: SandboxProviderName[] = ["daytona", "freestyle", "vercel"];
+
+  it.each(names)("constructs %s with a coherent object surface", (name) => {
+    const p = createSandboxProvider(name, DEPS);
+    // The object surface is always present; a Sandbox ref resolves without I/O
+    // and its richer sub-namespaces are null-or-object.
+    const sbox = p.sandboxes.get("sb_1");
+    expect(sbox.id).toBe("sb_1");
+    for (const ns of [sbox.ssh, sbox.services, sbox.snapshots] as const) {
+      expect(ns === null || typeof ns === "object").toBe(true);
+    }
+  });
+
+  it("gives the three real providers the full capability set", () => {
+    for (const name of ["daytona", "freestyle", "vercel"] as const) {
+      const p = createSandboxProvider(name, DEPS);
+      expect(p.capabilities.lifecycle, name).toBe(true);
+      expect(p.capabilities.exec, name).toBe(true);
+      expect(p.capabilities.listSandboxes, name).toBe(true);
+      const sbox = p.sandboxes.get("sb_1");
+      expect(sbox.services, name).not.toBeNull();
+      // Vercel uses no-relay SSH (services-based) and exposes no legacy `ssh`
+      // namespace; Daytona and Freestyle keep the short-lived SSH capability.
+      if (name === "vercel") {
+        expect(sbox.ssh, name).toBeNull();
+      } else {
+        expect(sbox.ssh, name).not.toBeNull();
+      }
+    }
+  });
+
+  it("rejects a retired provider name (local-docker) as unsupported", () => {
+    // `local-docker` was removed from the provider-name union entirely;
+    // persisted rows that still carry it resolve as unsupported, same as any
+    // unknown name.
+    expect(isSandboxProviderName("local-docker")).toBe(false);
+    expect(() => createSandboxProvider("local-docker", DEPS)).toThrow(
+      SandboxProviderUnsupportedError,
+    );
+  });
+
+  it("rejects Object.prototype keys as provider names", () => {
+    // The registry table is a plain object literal; the name guard must check
+    // OWN keys only, or "constructor" would resolve `Object` off the prototype
+    // chain and `createSandboxProvider` would return garbage instead of
+    // throwing.
+    for (const name of ["toString", "constructor", "valueOf", "__proto__"]) {
+      expect(isSandboxProviderName(name), name).toBe(false);
+      expect(() => createSandboxProvider(name, DEPS), name).toThrow(
+        SandboxProviderUnsupportedError,
+      );
+    }
+  });
+});

--- a/js/sandbox/src/providers/registry.ts
+++ b/js/sandbox/src/providers/registry.ts
@@ -1,0 +1,148 @@
+/**
+ * Sandbox provider registry.
+ *
+ * The single place that maps a provider name to its implementation. Each entry
+ * says how to build the provider from the caller-supplied deps and how to open
+ * its {@link SandboxAdapter}; everything else about a provider lives in its own
+ * folder. Adding a provider = adding one entry to {@link PROVIDERS} (see
+ * `./README.md` for the full recipe).
+ *
+ * Provider construction takes an explicit {@link SandboxProviderDeps} (the
+ * per-provider config slices plus the injected {@link SnapshotIdResolver}); the
+ * caller supplies these, so this package carries no dependency on the caller's
+ * data store. The config *slices* may be built from a documented env-var contract
+ * via the opt-in `sandboxProviderConfigsFromEnv` (the one place this package
+ * reads env-var names — see `../config-from-env`); provider construction itself
+ * stays env-agnostic and takes the resolved slices.
+ */
+import type { DaytonaConfig } from "./daytona/config";
+import type { FreestyleConfig } from "./freestyle/config";
+import type { VercelConfig } from "./vercel/config";
+import type { SandboxProvider, SnapshotIdResolver } from "./provider";
+import { SandboxProviderUnsupportedError } from "./provider";
+import type { SandboxProviderName } from "../types";
+import type { SandboxAdapter } from "./shared/adapter";
+import daytonaProvider from "./daytona/provider";
+import vercelProvider from "./vercel/provider";
+import freestyleProvider from "./freestyle/provider";
+import { openDaytonaAdapter } from "./daytona/provider";
+import { openFreestyleAdapter } from "./freestyle/provider";
+import { openVercelAdapter } from "./vercel/provider";
+
+/**
+ * Everything the registry needs to build any provider: the config slices (null
+ * when a provider isn't configured in this environment) and the snapshot
+ * name↔id resolver the Vercel snapshot capability uses.
+ */
+export interface SandboxProviderDeps {
+  daytona: DaytonaConfig;
+  freestyle: FreestyleConfig | null;
+  vercel: VercelConfig | null;
+  /** Resolves an org-scoped snapshot name to its bootable provider id (Vercel). */
+  resolveSnapshotId: SnapshotIdResolver;
+}
+
+/** How the registry builds one provider and opens its adapter. */
+interface ProviderEntry {
+  create(deps: SandboxProviderDeps): SandboxProvider;
+  openAdapter(
+    deps: SandboxProviderDeps,
+    providerSandboxId: string,
+  ): Promise<SandboxAdapter>;
+}
+
+/** Throw a config-hint error when a provider's config slice is absent. */
+function requireConfig<T>(config: T | null, hint: string): T {
+  if (!config) throw new Error(hint);
+  return config;
+}
+
+const FREESTYLE_HINT =
+  "Freestyle provider is not configured (set FREESTYLE_ENABLED=true and FREESTYLE_API_KEY)";
+const VERCEL_HINT =
+  "Vercel provider is not configured (set VERCEL_ENABLED=true and VERCEL_TOKEN/VERCEL_TEAM_ID/VERCEL_PROJECT_ID)";
+
+/**
+ * The provider table — the one registration point. A `null` entry keeps a
+ * name in the {@link SandboxProviderName} union while resolving as
+ * unsupported (none today). The `satisfies` keeps the table exhaustive:
+ * adding a name to the union without an entry here fails to compile.
+ */
+const PROVIDERS = {
+  daytona: {
+    create: (deps) => daytonaProvider(deps.daytona),
+    openAdapter: (deps, id) => openDaytonaAdapter(deps.daytona, id),
+  },
+  freestyle: {
+    create: (deps) =>
+      freestyleProvider(requireConfig(deps.freestyle, FREESTYLE_HINT)),
+    openAdapter: (deps, id) =>
+      Promise.resolve(
+        openFreestyleAdapter(requireConfig(deps.freestyle, FREESTYLE_HINT), id),
+      ),
+  },
+  vercel: {
+    // The Vercel snapshot capability resolves the org-scoped snapshot
+    // name↔`snap_…` id mapping through the injected resolver (Vercel snapshots
+    // are id-only) — without this package owning that mapping.
+    // Daytona/Freestyle have their own by-name provider access and ignore it.
+    create: (deps) =>
+      vercelProvider({
+        config: requireConfig(deps.vercel, VERCEL_HINT),
+        resolveSnapshotId: deps.resolveSnapshotId,
+      }),
+    openAdapter: (deps, id) =>
+      openVercelAdapter(requireConfig(deps.vercel, VERCEL_HINT), id),
+  },
+} satisfies Record<SandboxProviderName, ProviderEntry | null>;
+
+export function isSandboxProviderName(
+  name: string | null | undefined,
+): name is SandboxProviderName {
+  // `Object.hasOwn`, NOT `in`: `in` walks the prototype chain, so a garbage
+  // name like "toString" or "constructor" would pass the guard and resolve an
+  // inherited Object.prototype member instead of a provider entry.
+  return name != null && Object.hasOwn(PROVIDERS, name);
+}
+
+/** The table entry for `name`, or null for unknown/unbacked names. */
+function providerEntry(name: string | null): ProviderEntry | null {
+  return isSandboxProviderName(name) ? PROVIDERS[name] : null;
+}
+
+/**
+ * Build the provider for `name`. Throws {@link SandboxProviderUnsupportedError}
+ * for an unknown/absent name and a plain error when the named provider is not
+ * configured in this environment (e.g. freestyle/vercel without their
+ * credentials).
+ */
+export function createSandboxProvider(
+  name: string | null,
+  deps: SandboxProviderDeps,
+): SandboxProvider {
+  const entry = providerEntry(name);
+  if (!entry) {
+    throw new SandboxProviderUnsupportedError(name ?? "unknown", "resolve");
+  }
+  return entry.create(deps);
+}
+
+/**
+ * Open a fetched-once {@link SandboxAdapter} for a running sandbox.
+ *
+ * A provisioning run drives dozens of adapter ops against one running sandbox;
+ * the `exec`/`files` capabilities re-fetch the provider handle per call (right
+ * for a one-off op), so the caller opens the adapter once here and reuses it.
+ * Dispatches like {@link createSandboxProvider}.
+ */
+export function getSandboxAdapter(
+  name: string | null,
+  deps: SandboxProviderDeps,
+  providerSandboxId: string,
+): Promise<SandboxAdapter> {
+  const entry = providerEntry(name);
+  if (!entry) {
+    throw new SandboxProviderUnsupportedError(name ?? "unknown", "openAdapter");
+  }
+  return entry.openAdapter(deps, providerSandboxId);
+}

--- a/js/sandbox/src/providers/shared/adapter-helpers.test.ts
+++ b/js/sandbox/src/providers/shared/adapter-helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getRepoDir, getWorkspaceDir } from "./adapter-helpers";
+
+describe("getWorkspaceDir", () => {
+  it("appends /workspace to the home directory", () => {
+    expect(getWorkspaceDir("/home/amika")).toBe("/home/amika/workspace");
+  });
+
+  it("works for a root home directory", () => {
+    expect(getWorkspaceDir("/root")).toBe("/root/workspace");
+  });
+});
+
+describe("getRepoDir", () => {
+  it("nests the repo name under the workspace directory", () => {
+    expect(getRepoDir("/home/amika", "amika")).toBe(
+      "/home/amika/workspace/amika",
+    );
+  });
+
+  it("returns the workspace directory when no repo name is given", () => {
+    expect(getRepoDir("/home/amika")).toBe("/home/amika/workspace");
+  });
+
+  it("returns the workspace directory when the repo name is null", () => {
+    expect(getRepoDir("/home/amika", null)).toBe("/home/amika/workspace");
+  });
+
+  it("returns the workspace directory when the repo name is empty", () => {
+    expect(getRepoDir("/home/amika", "")).toBe("/home/amika/workspace");
+  });
+});

--- a/js/sandbox/src/providers/shared/adapter-helpers.ts
+++ b/js/sandbox/src/providers/shared/adapter-helpers.ts
@@ -1,0 +1,16 @@
+/**
+ * Pure, provider-agnostic workspace-path helpers.
+ *
+ * Generic sandbox mechanics (where a repo lives on disk), used by the core
+ * provider code (`cloneRepo`, the adapter configuration) and shared across
+ * providers.
+ */
+
+export function getWorkspaceDir(homeDir: string): string {
+  return `${homeDir}/workspace`;
+}
+
+export function getRepoDir(homeDir: string, repoName?: string | null): string {
+  const workspaceDir = getWorkspaceDir(homeDir);
+  return repoName ? `${workspaceDir}/${repoName}` : workspaceDir;
+}

--- a/js/sandbox/src/providers/shared/adapter.test.ts
+++ b/js/sandbox/src/providers/shared/adapter.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  execChecked,
+  type ExecOptions,
+  type ExecResult,
+  type SandboxAdapter,
+} from "./adapter";
+
+/** Adapter whose `exec` returns a fixed result and records the call. */
+function stubAdapter(result: ExecResult): {
+  adapter: SandboxAdapter;
+  calls: { command: string; opts?: ExecOptions }[];
+} {
+  const calls: { command: string; opts?: ExecOptions }[] = [];
+  const adapter: SandboxAdapter = {
+    async exec(command, opts) {
+      calls.push({ command, opts });
+      return result;
+    },
+    async uploadFile() {},
+    async downloadFile() {
+      return null;
+    },
+  };
+  return { adapter, calls };
+}
+
+describe("execChecked", () => {
+  it("resolves without throwing when the command exits 0", async () => {
+    const { adapter } = stubAdapter({ exitCode: 0, stdout: "ok", stderr: "" });
+    await expect(execChecked(adapter, "true")).resolves.toBeUndefined();
+  });
+
+  it("forwards the command and options to the adapter", async () => {
+    const { adapter, calls } = stubAdapter({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+    const opts: ExecOptions = { cwd: "/work", sudo: true, env: { A: "1" } };
+    await execChecked(adapter, "ls", opts);
+    expect(calls).toEqual([{ command: "ls", opts }]);
+  });
+
+  it("throws with the command output on a non-zero exit", async () => {
+    const { adapter } = stubAdapter({
+      exitCode: 1,
+      stdout: "boom",
+      stderr: "",
+    });
+    await expect(execChecked(adapter, "false")).rejects.toThrow("boom");
+  });
+
+  it("falls back to a descriptive message when output is empty", async () => {
+    const { adapter } = stubAdapter({ exitCode: 127, stdout: "", stderr: "" });
+    await expect(execChecked(adapter, "nope")).rejects.toThrow(
+      "Command failed: nope",
+    );
+  });
+});

--- a/js/sandbox/src/providers/shared/adapter.ts
+++ b/js/sandbox/src/providers/shared/adapter.ts
@@ -1,0 +1,82 @@
+/**
+ * Provider-agnostic "sandbox adapter" port.
+ *
+ * The adapter provisioning logic (clone, credential injection, lifecycle
+ * scripts, MCP wiring, `/etc/environment` management) needs only a handful of
+ * primitives against a *running* sandbox: run a command, write a file, read a
+ * file, and learn the user's home directory. {@link SandboxAdapter} captures
+ * exactly that surface so the orchestration in `./configure-adapter` can run
+ * against any provider. Each provider supplies an adapter — Daytona via
+ * `daytona/adapter`, Freestyle via `freestyle/adapter` — and never leaks its
+ * SDK's sandbox object into the shared code.
+ */
+
+export interface ExecOptions {
+  /** Working directory the command runs in. */
+  cwd?: string;
+  /** Extra environment variables to expose to the command. */
+  env?: Record<string, string>;
+  /**
+   * Run the command with root privileges. Providers whose default user is
+   * unprivileged (Daytona's `amika` user) translate this to `sudo`; providers
+   * that already run as root (Freestyle VMs) treat it as a no-op.
+   */
+  sudo?: boolean;
+}
+
+/**
+ * The adapter-level echo of {@link SandboxExecResult}: the streams stay
+ * separate so value parsers can read {@link stdout} without incidental
+ * stderr (a `sudo` hostname warning, a deprecation notice) corrupting it.
+ */
+export interface ExecResult {
+  exitCode: number;
+  /** Standard output only; never carries stderr text. */
+  stdout: string;
+  /** Standard error only; empty when the command wrote nothing to it. */
+  stderr: string;
+}
+
+/**
+ * The most diagnosable text a finished command produced: stderr when it
+ * wrote any, else stdout. Every "command failed" message should route
+ * through this so splitting the streams does not cost failure
+ * debuggability, which is the reason stderr used to be merged at all.
+ */
+export function execFailureText(
+  result: Pick<ExecResult, "stdout" | "stderr">,
+): string {
+  const stderr = result.stderr.trim();
+  return stderr !== "" ? stderr : result.stdout.trim();
+}
+
+/**
+ * The minimal adapter surface the shared provisioning logic codes against.
+ * `downloadFile` returns `null` for a missing/unreadable file (rather than
+ * throwing) so callers can treat "no existing config" uniformly across
+ * providers.
+ */
+export interface SandboxAdapter {
+  /** Run a one-shot command and capture its two streams + exit code. */
+  exec(command: string, opts?: ExecOptions): Promise<ExecResult>;
+  /** Write a file, creating parent directories as needed. */
+  uploadFile(content: Buffer | string, path: string): Promise<void>;
+  /** Read a file as UTF-8 text; `null` when it does not exist / can't be read. */
+  downloadFile(path: string): Promise<string | null>;
+}
+
+/**
+ * Run a command and throw when it exits non-zero. The adapter analogue of
+ * Daytona's `executeCheckedCommand`; the thrown message carries the command's
+ * stderr (falling back to stdout) so the failure is diagnosable.
+ */
+export async function execChecked(
+  adapter: SandboxAdapter,
+  command: string,
+  opts?: ExecOptions,
+): Promise<void> {
+  const result = await adapter.exec(command, opts);
+  if (result.exitCode !== 0) {
+    throw new Error(execFailureText(result) || `Command failed: ${command}`);
+  }
+}

--- a/js/sandbox/src/providers/shared/define-provider.test.ts
+++ b/js/sandbox/src/providers/shared/define-provider.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from "vitest";
+import { defineProvider, type ProviderDefinition } from "./define-provider";
+import {
+  SandboxProviderUnsupportedError,
+  type SandboxProviderCapabilities,
+} from "../provider";
+
+const ALL_OFF: SandboxProviderCapabilities = {
+  lifecycle: false,
+  ssh: false,
+  services: false,
+  exec: false,
+  listSandboxes: false,
+  streaming: false,
+  snapshots: false,
+  scrubCapture: false,
+  fullSnapshotCapture: false,
+  dockerRegistries: false,
+  skipStartScript: false,
+  snapshotIdsAreOpaque: false,
+  supportsAutoDelete: false,
+};
+
+/** The always-required `sandbox` namespace, with fake create/delete. */
+const SANDBOX_NAMESPACE: ProviderDefinition["sandbox"] = {
+  create: async () => ({
+    provider: "daytona",
+    providerSandboxId: "sb_1",
+    providerUrl: null,
+    services: [],
+  }),
+  delete: async () => {},
+};
+
+/**
+ * Definition overrides for the test helpers. `sandbox` is a *partial* here (so a
+ * test can supply just the run-state ops without repeating create/delete) and is
+ * merged onto {@link SANDBOX_NAMESPACE}; every other namespace replaces wholesale.
+ */
+type DefOverrides = Partial<Omit<ProviderDefinition, "sandbox">> & {
+  sandbox?: Partial<ProviderDefinition["sandbox"]>;
+};
+
+/** A minimal grouped definition: only the always-required `sandbox` namespace. */
+function minimalDef(overrides: DefOverrides = {}): ProviderDefinition {
+  const { sandbox, ...rest } = overrides;
+  return {
+    name: "daytona",
+    signedUrlTtlSeconds: 0,
+    userHomeDir: "/home/amika",
+    sandbox: { ...SANDBOX_NAMESPACE, ...sandbox },
+    ...rest,
+  };
+}
+
+/** Build a provider from explicit flags + definition overrides. */
+function build(
+  capabilities: SandboxProviderCapabilities,
+  overrides: DefOverrides = {},
+) {
+  return defineProvider(capabilities, () => minimalDef(overrides))({});
+}
+
+/** A coherent lifecycle bundle: run-state + services + cloneRepo, together. */
+const LIFECYCLE_MEMBERS: DefOverrides = {
+  cloneRepo: async () => {},
+  sandbox: {
+    start: async () => {},
+    stop: async () => {},
+    getState: async () => "running",
+  },
+  services: {
+    refreshUrls: async () => ({ providerUrl: null, services: [] }),
+    syncRoutes: async () => {},
+  },
+};
+
+describe("defineProvider metadata + defaults", () => {
+  it("passes through the metadata and required sandbox namespace", async () => {
+    const provider = build(ALL_OFF);
+    expect(provider.name).toBe("daytona");
+    expect(provider.capabilities).toBe(ALL_OFF);
+    expect(provider.signedUrlTtlSeconds).toBe(0);
+    await expect(
+      provider.sandboxes.get("sb_1").delete(),
+    ).resolves.toBeUndefined();
+  });
+
+  it("gates every omitted namespace behind unsupported/null on the objects", async () => {
+    const provider = build(ALL_OFF);
+    const sbox = provider.sandboxes.get("sb_1");
+    // Object methods over omitted capabilities reject with unsupported...
+    await expect(sbox.start()).rejects.toBeInstanceOf(
+      SandboxProviderUnsupportedError,
+    );
+    await expect(sbox.exec("ls")).rejects.toBeInstanceOf(
+      SandboxProviderUnsupportedError,
+    );
+    await expect(sbox.readFile("/f")).rejects.toBeInstanceOf(
+      SandboxProviderUnsupportedError,
+    );
+    await expect(provider.sandboxes.list()).rejects.toBeInstanceOf(
+      SandboxProviderUnsupportedError,
+    );
+    // ...and the richer sub-namespaces / top-level namespaces are null.
+    expect(sbox.ssh).toBeNull();
+    expect(sbox.services).toBeNull();
+    expect(sbox.snapshots).toBeNull();
+    expect(provider.snapshots).toBeNull();
+    expect(provider.docker).toBeNull();
+  });
+
+  it("leaves Sandbox.git null when the clone primitive is omitted", () => {
+    const provider = build(ALL_OFF);
+    // No `cloneRepo` override → no `git` namespace; the provisioning layer
+    // clones over the adapter exec port instead.
+    expect(provider.sandboxes.get("sb_1").git).toBeNull();
+  });
+
+  it("passes the config through the closure to the definition", async () => {
+    const factory = defineProvider(ALL_OFF, (config: { token: string }) =>
+      minimalDef({
+        sandbox: {
+          create: async () => ({
+            provider: "daytona",
+            providerSandboxId: config.token,
+            providerUrl: null,
+            services: [],
+          }),
+          delete: async () => {},
+        },
+      }),
+    );
+    const created = await factory({ token: "sb_from_config" }).sandboxes.create(
+      // ctx/input are unused by this fake
+      {} as never,
+      {} as never,
+    );
+    expect(created.id).toBe("sb_from_config");
+  });
+});
+
+describe("defineProvider capability reconciliation", () => {
+  it("throws when a flag is declared with no backing namespace", () => {
+    expect(() => build({ ...ALL_OFF, snapshots: true })).toThrow(
+      /capability "snapshots"=true but the definition omits it/,
+    );
+  });
+
+  it("throws when a namespace is provided while its flag is false", () => {
+    // A snapshot object present under `snapshots: false` — the API would gate on
+    // the non-null object while the UI reports the capability as unsupported.
+    expect(() => build(ALL_OFF, { snapshots: {} as never })).toThrow(
+      /capability "snapshots"=false but the definition provides it/,
+    );
+    expect(() =>
+      build(ALL_OFF, { exec: { run: async () => ({}) as never } }),
+    ).toThrow(/capability "exec"=false but the definition provides it/);
+  });
+
+  it("throws when streaming is declared but exec has no stream", () => {
+    expect(() =>
+      build(
+        { ...ALL_OFF, exec: true, streaming: true },
+        {
+          exec: { run: async () => ({ exitCode: 0, stdout: "", stderr: "" }) },
+        },
+      ),
+    ).toThrow(/capability "streaming"=true but the definition omits it/);
+  });
+
+  it("throws when the lifecycle members aren't enabled together", () => {
+    // run-state ops present but the rest of the lifecycle bundle (services,
+    // cloneRepo) missing — callers reach all three under the `lifecycle` gate.
+    expect(() =>
+      build(
+        { ...ALL_OFF, lifecycle: true },
+        {
+          sandbox: {
+            start: async () => {},
+            stop: async () => {},
+            getState: async () => "running",
+          },
+        },
+      ),
+    ).toThrow(/lifecycle members must be enabled together/);
+  });
+
+  it("throws when the sandbox run-state ops aren't all present", () => {
+    // `start` alone — start/stop/getState are a unit, so a partial set is a
+    // definition bug the flattened `sandbox` type no longer catches.
+    expect(() =>
+      build(
+        { ...ALL_OFF, lifecycle: true },
+        { sandbox: { start: async () => {} } },
+      ),
+    ).toThrow(/run-state ops \(start\/stop\/getState\) must be all present/);
+  });
+
+  it("throws when lifecycle members are present but the flag is false", () => {
+    expect(() => build(ALL_OFF, LIFECYCLE_MEMBERS)).toThrow(
+      /capability "lifecycle"=false but the definition provides it/,
+    );
+  });
+
+  it("accepts a coherent lifecycle provider", () => {
+    expect(() =>
+      build({ ...ALL_OFF, lifecycle: true, services: true }, LIFECYCLE_MEMBERS),
+    ).not.toThrow();
+  });
+});
+
+describe("defineProvider object assembly", () => {
+  it("create() returns a Sandbox carrying the create result", async () => {
+    const created = {
+      provider: "daytona",
+      providerSandboxId: "sb_1",
+      providerUrl: null,
+      services: [],
+    };
+    const provider = build(ALL_OFF, {
+      sandbox: { create: async () => created, delete: async () => {} },
+    });
+    const sbox = await provider.sandboxes.create({} as never, {} as never);
+    expect(sbox.id).toBe("sb_1");
+    expect(sbox.created).toBe(created);
+    await expect(sbox.delete()).resolves.toBeUndefined();
+  });
+
+  it('defaults an omitted sandbox.mapState to () => "unknown"', async () => {
+    const provider = build(
+      { ...ALL_OFF, lifecycle: true, services: true },
+      LIFECYCLE_MEMBERS,
+    );
+    const sbox = provider.sandboxes.get("sb_1");
+    await expect(sbox.getState()).resolves.toBe("running");
+    // mapState falls back to the safe default when the def omits it.
+    expect(sbox.mapState("x")).toBe("unknown");
+  });
+
+  it("derives streaming support from whether `stream` is provided", async () => {
+    // exec without streaming: streamExec rejects as unsupported.
+    const noStream = build(
+      { ...ALL_OFF, exec: true },
+      {
+        exec: { run: async () => ({ exitCode: 0, stdout: "ok", stderr: "" }) },
+      },
+    );
+    await expect(noStream.sandboxes.get("sb_1").exec("ls")).resolves.toEqual({
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+    });
+    await expect(
+      noStream.sandboxes.get("sb_1").streamExec("ls", { onStdout: () => {} }),
+    ).rejects.toBeInstanceOf(SandboxProviderUnsupportedError);
+
+    // exec with streaming: streamExec delegates.
+    const streamedChunks: string[] = [];
+    const streamed = build(
+      { ...ALL_OFF, exec: true, streaming: true },
+      {
+        exec: {
+          run: async () => ({ exitCode: 0, stdout: "ok", stderr: "" }),
+          stream: async (_id, _cmd, handlers) => {
+            handlers.onStdout("chunk");
+          },
+        },
+      },
+    );
+    await streamed.sandboxes.get("sb_1").streamExec("ls", {
+      onStdout: (chunk) => streamedChunks.push(chunk),
+    });
+    expect(streamedChunks).toEqual(["chunk"]);
+  });
+
+  it("assembles file reads and SSH minting from their method pairs", async () => {
+    const provider = build(
+      { ...ALL_OFF, ssh: true },
+      {
+        files: { read: async () => "contents", write: async () => {} },
+        ssh: {
+          mint: async () => ({
+            token: "t",
+            sshDestination: "u@h",
+            expiresAt: new Date(0),
+          }),
+          revoke: async () => {},
+        },
+      },
+    );
+    const sbox = provider.sandboxes.get("sb_1");
+    await expect(sbox.readFile("/f")).resolves.toBe("contents");
+    expect(sbox.ssh).not.toBeNull();
+    await expect(sbox.ssh?.mint(60)).resolves.toMatchObject({ token: "t" });
+  });
+
+  it("routes git.clone to an author-provided clone primitive", async () => {
+    const cloned: unknown[] = [];
+    const provider = build(
+      { ...ALL_OFF, lifecycle: true, services: true },
+      {
+        ...LIFECYCLE_MEMBERS,
+        cloneRepo: async (id, input) => {
+          cloned.push({ id, input });
+        },
+      },
+    );
+    const git = provider.sandboxes.get("sb_1").git;
+    expect(git).not.toBeNull();
+    await git!.clone({
+      homeDir: "/home/amika",
+      githubUrl: "https://github.com/x/y",
+    });
+    expect(cloned).toEqual([
+      {
+        id: "sb_1",
+        input: { homeDir: "/home/amika", githubUrl: "https://github.com/x/y" },
+      },
+    ]);
+  });
+});

--- a/js/sandbox/src/providers/shared/define-provider.ts
+++ b/js/sandbox/src/providers/shared/define-provider.ts
@@ -1,0 +1,359 @@
+/**
+ * `defineProvider` — the functional way to define a sandbox provider.
+ *
+ * A provider is a `(config) => SandboxProvider` factory. Rather than write a
+ * class that implements every method of {@link SandboxProvider} (and hand-stub
+ * the ops it doesn't support), a provider declares its capability namespaces
+ * directly — the same shape the contract exposes — and omits the ones it can't
+ * back:
+ *
+ *   export default defineProvider(fooCapabilities, (config: FooConfig) => ({
+ *     name: "foo",
+ *     signedUrlTtlSeconds: FOO_URL_TTL_S,
+ *     sandbox: {
+ *       create,
+ *       delete,                 // create/delete always required
+ *       start, stop, getState,  // run-state control; omit → lifecycle false
+ *     },
+ *     exec: { run },            // omit → capabilities.exec false
+ *     // ...only the namespaces foo backs
+ *   }));
+ *
+ * The built provider exposes only the resource-object surface —
+ * `sandboxes`/`snapshots`/`docker` — synthesized over the declared namespaces;
+ * the flat capability members are not on the public contract.
+ *
+ * The definition mirrors the output, so `defineProvider` is almost a pass-through.
+ * It fills only the gaps the contract requires but the author can omit:
+ *   - `sandbox.mapState` → the safe `() => "unknown"` default (no lifecycle ⇒ no
+ *     raw state worth mapping)
+ *   - `exec.streaming` → derived from whether `exec.stream` is present
+ *   - `cloneRepo`      → `null` when omitted, so `Sandbox.git` is `null` and the
+ *     provisioning layer clones over the adapter exec port instead
+ *   - `snapshots.createImageSnapshot` / `findSnapshot` /
+ *     `removeInjectedSecrets` → see {@link SnapshotDefinition}
+ *   - every omitted namespace → `null`
+ *
+ * Two invariants are structural in the types below rather than enforced at
+ * runtime: a `files`/`services` namespace requires *both* its methods, and
+ * `stream` lives *inside* `exec` (so it can't exist without it). The
+ * `sandbox` run-state ops (start/stop/getState) are a unit too, but since they
+ * sit flat on `sandbox` the types can't enforce it, so {@link
+ * assertCapabilitiesMatch} checks that at runtime alongside reconciling the
+ * SDK-free `capabilities` flags against what the definition actually backs.
+ */
+import type {
+  CloneRepoInput,
+  DockerRegistryCapability,
+  ExecCapability,
+  FileCapability,
+  ListingCapability,
+  SandboxCapability,
+  SandboxProvider,
+  SandboxProviderCapabilities,
+  ServiceCapability,
+  ServiceRestartContext,
+  SnapshotCapability,
+  SshCapability,
+} from "../provider";
+import { SandboxProviderUnsupportedError } from "../provider";
+import {
+  makeDockerNamespace,
+  makeSandboxNamespace,
+  makeSnapshotNamespace,
+  type ResourceBackend,
+} from "./resources";
+
+/**
+ * `exec` as authored: `run` plus an optional `stream`. The `streaming` flag on
+ * the built {@link ExecCapability} is derived from whether `stream` is present,
+ * so the author never writes it (and can't let the two disagree). Keeping
+ * `stream` a field of this object is what makes "streaming requires exec"
+ * structural rather than a runtime assertion.
+ */
+type ExecDefinition = Omit<ExecCapability, "streaming" | "stream"> &
+  Partial<Pick<ExecCapability, "stream">>;
+
+/**
+ * `snapshots` as authored: the provider writes only the primitives it genuinely
+ * backs; {@link buildProvider} fills the common defaults so every provider
+ * doesn't repeat the same stubs:
+ *   - `createImageSnapshot`   → throws unsupported (registry-backed image
+ *     snapshots are a Daytona-only concern)
+ *   - `findSnapshot`          → falls back to `getSnapshot` (right for providers
+ *     whose by-name lookup already tolerates an in-flight capture)
+ *   - `removeInjectedSecrets` → no-op (most providers inject no secrets of
+ *     their own; Vercel overrides it to remove its resume-context file)
+ */
+export type SnapshotDefinition = Omit<
+  SnapshotCapability,
+  "createImageSnapshot" | "findSnapshot" | "removeInjectedSecrets"
+> &
+  Partial<
+    Pick<
+      SnapshotCapability,
+      "createImageSnapshot" | "findSnapshot" | "removeInjectedSecrets"
+    >
+  >;
+
+/**
+ * What a provider author writes: the metadata plus the capability namespaces,
+ * matching {@link SandboxProvider} one-for-one. `sandbox` (create/delete) is
+ * required; every other namespace is optional and defaults to `null`. The
+ * client-safe `capabilities` flags are passed separately to {@link defineProvider}
+ * (the client bundle reads them without importing a provider SDK), not embedded
+ * here.
+ */
+export interface ProviderDefinition {
+  name: SandboxProvider["name"];
+  signedUrlTtlSeconds: number;
+
+  /**
+   * The user's home directory inside every sandbox this provider boots — a
+   * per-provider constant (Amika controls the images), so the provisioning
+   * layer reads it off the provider rather than querying a running sandbox.
+   */
+  userHomeDir: string;
+
+  /**
+   * Sandbox existence and run-state control. create/delete is the one
+   * always-required surface; the run-state ops (start/stop/getState, and the
+   * optional mapState whose default buildProvider fills) are present as a unit
+   * on a lifecycle provider and all omitted on a create/delete-only one. See
+   * {@link SandboxCapability}.
+   */
+  sandbox: SandboxCapability;
+
+  /**
+   * OPTIONAL provider-native git-clone override, surfaced as `Sandbox.git`.
+   * Author it only when the provider's SDK has a first-class clone primitive
+   * worth using over shell `git` (Daytona's native `git.clone`). Omit it on any
+   * provider without one (Freestyle, Vercel) → `Sandbox.git` is `null` and the
+   * provisioning layer clones by running `git` over the adapter exec port.
+   * Decoupled from `capabilities.lifecycle`: a lifecycle provider need not
+   * define it.
+   */
+  cloneRepo?: (
+    providerSandboxId: string,
+    input: CloneRepoInput,
+  ) => Promise<void>;
+
+  /**
+   * OPTIONAL: persist what's needed to relaunch the sandbox's services after a
+   * resume, surfaced as the nullable `Sandbox.persistServiceRestartContext`.
+   * Author it ONLY on a provider whose suspended sandboxes come back with their
+   * running processes gone (Vercel); every other provider omits it (→ `null`)
+   * and never has to know the concept exists. See
+   * {@link Sandbox.persistServiceRestartContext}.
+   */
+  persistServiceRestartContext?: (
+    providerSandboxId: string,
+    context: ServiceRestartContext,
+  ) => Promise<void>;
+
+  // Optional capability namespaces — omit (or pass null) when unsupported.
+  exec?: ExecDefinition | null;
+  files?: FileCapability | null;
+  ssh?: SshCapability | null;
+  services?: ServiceCapability | null;
+  listing?: ListingCapability | null;
+  snapshots?: SnapshotDefinition | null;
+  dockerRegistries?: DockerRegistryCapability | null;
+}
+
+/**
+ * Reconcile the SDK-free `capabilities` flags with what the definition actually
+ * backs. The flags are authored in a separate, SDK-free module so the client
+ * bundle can read them without instantiating a provider, which means they
+ * *could* drift from the implementation — this is the single check that keeps
+ * them honest, in both directions (a flag set with no namespace, or a namespace
+ * with the flag unset, both throw).
+ *
+ * The namespace-internal invariants (files/services are method pairs, `stream`
+ * requires `exec`) are gone from here — they're enforced by the definition's
+ * types. `fullSnapshotCapture`/`skipStartScript` are behavioral sub-flags with
+ * no namespace of their own, so they're carried through unchecked (the author
+ * owns them).
+ */
+function assertCapabilitiesMatch(
+  capabilities: SandboxProviderCapabilities,
+  def: ProviderDefinition,
+): void {
+  // The sandbox run-state ops (start/stop/getState) are a unit — useless apart
+  // — so they must be all present or all absent. Once flat on `sandbox` the
+  // types no longer enforce this, so check it here.
+  const runStateOps = [
+    def.sandbox.start,
+    def.sandbox.stop,
+    def.sandbox.getState,
+  ];
+  const runStatePresent = runStateOps.filter((op) => op != null).length;
+  if (runStatePresent !== 0 && runStatePresent !== runStateOps.length) {
+    throw new Error(
+      `Provider "${def.name}": sandbox run-state ops ` +
+        `(start/stop/getState) must be all present or all absent`,
+    );
+  }
+
+  // `lifecycle` gates the two things a provisioning run drives together — the
+  // sandbox run-state ops and services (refreshUrls/syncRoutes) — so they must
+  // be present as a unit or absent as a unit. (Cloning is no longer part of
+  // this: `cloneRepo` is an optional provider-native override, surfaced as the
+  // nullable `Sandbox.git`, and providers without it clone over adapter exec.)
+  const lifecycleParts = {
+    runState: def.sandbox.start != null,
+    services: def.services != null,
+  };
+  const lifecycle = lifecycleParts.runState;
+  if (Object.values(lifecycleParts).some((present) => present !== lifecycle)) {
+    throw new Error(
+      `Provider "${def.name}": lifecycle members must be enabled together, ` +
+        `got ${JSON.stringify(lifecycleParts)}`,
+    );
+  }
+
+  // Each flag derived from namespace presence; the behavioral sub-flags are
+  // mirrored so they compare equal (the author owns them, nothing to derive).
+  const derived: SandboxProviderCapabilities = {
+    lifecycle,
+    exec: def.exec != null,
+    streaming: def.exec?.stream != null,
+    ssh: def.ssh != null,
+    services: def.services != null,
+    listSandboxes: def.listing != null,
+    snapshots: def.snapshots != null,
+    // The scrub is core-synthesized over the exec primitive, so the flag is
+    // the conjunction — a snapshots-without-exec provider offers only the raw
+    // captures.
+    scrubCapture: def.snapshots != null && def.exec != null,
+    dockerRegistries: def.dockerRegistries != null,
+    fullSnapshotCapture: capabilities.fullSnapshotCapture,
+    skipStartScript: capabilities.skipStartScript,
+    // Behavioral facts with no namespace to derive from — the author owns them.
+    snapshotIdsAreOpaque: capabilities.snapshotIdsAreOpaque,
+    supportsAutoDelete: capabilities.supportsAutoDelete,
+  };
+
+  for (const flag of Object.keys(derived) as Array<
+    keyof SandboxProviderCapabilities
+  >) {
+    if (capabilities[flag] !== derived[flag]) {
+      throw new Error(
+        `Provider "${def.name}": declared capability "${flag}"=` +
+          `${capabilities[flag]} but the definition ` +
+          `${derived[flag] ? "provides" : "omits"} it`,
+      );
+    }
+  }
+}
+
+/**
+ * Assemble the full {@link SandboxProvider} from the definition, filling only
+ * the contract-required gaps (the mapState/streaming defaults and the cloneRepo
+ * stub). Every namespace the author omits becomes `null`.
+ */
+function buildProvider(
+  capabilities: SandboxProviderCapabilities,
+  def: ProviderDefinition,
+): SandboxProvider {
+  const { name } = def;
+
+  // Optional provider-native clone override, surfaced as the nullable
+  // `Sandbox.git`. `null` when omitted — the provisioning layer then clones
+  // over the adapter exec port. No stub needed: cloning is not a core sandbox
+  // capability, so there is no always-present clone method to satisfy.
+  const cloneRepo = def.cloneRepo ?? null;
+  // Optional resume-recovery seam, `null` unless the provider resets services
+  // on resume (Vercel). Surfaced as `Sandbox.persistServiceRestartContext`.
+  const persistServiceRestartContext = def.persistServiceRestartContext ?? null;
+  // `mapState` has a safe default, so a lifecycle provider may omit it; fill it
+  // in when the provider backs run-state control (i.e. authored `start`).
+  const sandbox: SandboxCapability = def.sandbox.start
+    ? { ...def.sandbox, mapState: def.sandbox.mapState ?? (() => "unknown") }
+    : def.sandbox;
+  // `streaming` is derived from `stream`'s presence, never authored.
+  const exec: ExecCapability | null = def.exec
+    ? {
+        run: def.exec.run,
+        stdin: def.exec.stdin,
+        streaming: def.exec.stream != null,
+        ...(def.exec.stream ? { stream: def.exec.stream } : {}),
+      }
+    : null;
+  const files = def.files ?? null;
+  const ssh = def.ssh ?? null;
+  const services = def.services ?? null;
+  const listing = def.listing ?? null;
+  // Snapshot defaults (see {@link SnapshotDefinition}): unsupported image
+  // snapshots, `find` falling back to `get`, and a no-op provider-secret
+  // removal — authored only by the providers that genuinely differ.
+  // NOTE: the spread copies OWN enumerable members only — author the snapshot
+  // definition as an object literal (as every provider does), not a class
+  // instance, whose prototype methods a spread would silently drop.
+  const snapshots: SnapshotCapability | null = def.snapshots
+    ? {
+        ...def.snapshots,
+        createImageSnapshot:
+          def.snapshots.createImageSnapshot ??
+          (() => {
+            throw new SandboxProviderUnsupportedError(
+              name,
+              "createImageSnapshot",
+            );
+          }),
+        findSnapshot:
+          def.snapshots.findSnapshot ??
+          def.snapshots.getSnapshot.bind(def.snapshots),
+        removeInjectedSecrets:
+          def.snapshots.removeInjectedSecrets ?? (() => Promise.resolve()),
+      }
+    : null;
+  const dockerRegistries = def.dockerRegistries ?? null;
+
+  // The resource-object surface is synthesized over the low-level
+  // members above and closes over them, so it survives their later removal.
+  const backend: ResourceBackend = {
+    name,
+    sandbox,
+    exec,
+    files,
+    ssh,
+    services,
+    listing,
+    snapshots,
+    dockerRegistries,
+    cloneRepo,
+    persistServiceRestartContext,
+  };
+
+  return {
+    name,
+    capabilities,
+    signedUrlTtlSeconds: def.signedUrlTtlSeconds,
+    userHomeDir: def.userHomeDir,
+
+    // Resource-object surface — the only consumer API. The authored
+    // capability namespaces stay provider-side, reachable through the backend.
+    sandboxes: makeSandboxNamespace(backend),
+    snapshots: snapshots ? makeSnapshotNamespace(snapshots) : null,
+    docker: dockerRegistries ? makeDockerNamespace(dockerRegistries) : null,
+  };
+}
+
+/**
+ * Define a sandbox provider. Takes the provider's client-safe capability flags
+ * and a `define` callback, and returns a `(config) => SandboxProvider` factory
+ * the registry invokes with the provider's config slice. `define` runs per
+ * resolution, so config is captured by closure rather than stored on an
+ * instance; the flags are reconciled against the definition on every build.
+ */
+export function defineProvider<Cfg>(
+  capabilities: SandboxProviderCapabilities,
+  define: (config: Cfg) => ProviderDefinition,
+): (config: Cfg) => SandboxProvider {
+  return (config: Cfg) => {
+    const def = define(config);
+    assertCapabilitiesMatch(capabilities, def);
+    return buildProvider(capabilities, def);
+  };
+}

--- a/js/sandbox/src/providers/shared/exec-input.test.ts
+++ b/js/sandbox/src/providers/shared/exec-input.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SandboxAdapter } from "./adapter";
+import { EXEC_INPUT_STAGING_ROOT, execWithStagedInput } from "./exec-input";
+
+describe("execWithStagedInput", () => {
+  it("keeps input out of commands and removes the staging directory", async () => {
+    const commands: string[] = [];
+    const uploadFile = vi.fn(
+      async (_content: Buffer | string, _path: string) => {},
+    );
+    const adapter: SandboxAdapter = {
+      async exec(command) {
+        commands.push(command);
+        return {
+          exitCode: 0,
+          stdout: command.startsWith("(") ? "ok" : "",
+          stderr: "",
+        };
+      },
+      uploadFile,
+      downloadFile: async () => null,
+    };
+
+    await expect(
+      execWithStagedInput(adapter, "amikad connect-token set", "secret-token", {
+        sudo: true,
+      }),
+    ).resolves.toEqual({ exitCode: 0, stdout: "ok", stderr: "" });
+    expect(commands.join("\n")).not.toContain("secret-token");
+    expect(uploadFile).toHaveBeenCalledWith(
+      "secret-token",
+      expect.stringMatching(
+        new RegExp(`^${EXEC_INPUT_STAGING_ROOT}/[^/]+/stdin$`, "u"),
+      ),
+    );
+    expect(commands.at(-1)).toMatch(/^rm -rf -- /u);
+  });
+});

--- a/js/sandbox/src/providers/shared/exec-input.ts
+++ b/js/sandbox/src/providers/shared/exec-input.ts
@@ -1,0 +1,47 @@
+/** Securely emulate stdin for providers whose SDK exposes only exec + files. */
+import { randomUUID } from "node:crypto";
+import { shellQuote } from "../../util/shell";
+import type { ExecOptions, ExecResult, SandboxAdapter } from "./adapter";
+
+const MAX_INPUT_BYTES = 1024 * 1024;
+export const EXEC_INPUT_STAGING_ROOT = "/tmp/.amika-exec-inputs";
+
+/**
+ * Stage input in a private, unpredictable directory, redirect it to the
+ * command, and remove it in a finally block. The bytes never enter argv,
+ * environment variables, provider logs, or an Amika-specific provider API.
+ */
+export async function execWithStagedInput(
+  adapter: SandboxAdapter,
+  command: string,
+  input: string,
+  opts?: ExecOptions,
+): Promise<ExecResult> {
+  if (Buffer.byteLength(input, "utf8") > MAX_INPUT_BYTES) {
+    throw new Error("Command input exceeds the 1 MiB limit");
+  }
+  const directory = `${EXEC_INPUT_STAGING_ROOT}/${randomUUID()}`;
+  const inputPath = `${directory}/stdin`;
+  const prepared = await adapter.exec(
+    `install -d -m 0700 ${shellQuote(EXEC_INPUT_STAGING_ROOT)} ${shellQuote(directory)}`,
+  );
+  if (prepared.exitCode !== 0) {
+    throw new Error("Failed to prepare command input");
+  }
+  try {
+    await adapter.uploadFile(input, inputPath);
+    const protectedInput = await adapter.exec(
+      `chmod 0600 ${shellQuote(inputPath)}`,
+    );
+    if (protectedInput.exitCode !== 0) {
+      throw new Error("Failed to protect command input");
+    }
+    return await adapter.exec(`(${command}) < ${shellQuote(inputPath)}`, opts);
+  } finally {
+    await adapter
+      .exec(
+        `rm -rf -- ${shellQuote(directory)} && rmdir ${shellQuote(EXEC_INPUT_STAGING_ROOT)} 2>/dev/null || true`,
+      )
+      .catch(() => undefined);
+  }
+}

--- a/js/sandbox/src/providers/shared/lifecycle-commands.test.ts
+++ b/js/sandbox/src/providers/shared/lifecycle-commands.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildLifecycleCommands } from "./lifecycle-commands";
+import {
+  POST_SETUP_SCRIPT,
+  PRE_SETUP_SCRIPT,
+  RUN_HOOK_SCRIPT,
+  SANDBOX_SETUP_SCRIPT,
+  SANDBOX_START_SCRIPT,
+} from "../../constants";
+
+describe("buildLifecycleCommands", () => {
+  it("wraps each lifecycle hook in the run-hook wrapper", () => {
+    expect(buildLifecycleCommands()).toEqual({
+      preSetup: `${RUN_HOOK_SCRIPT} ${PRE_SETUP_SCRIPT}`,
+      setup: `${RUN_HOOK_SCRIPT} ${SANDBOX_SETUP_SCRIPT}`,
+      postSetup: `${RUN_HOOK_SCRIPT} ${POST_SETUP_SCRIPT}`,
+      start: `${RUN_HOOK_SCRIPT} ${SANDBOX_START_SCRIPT}`,
+    });
+  });
+
+  it("routes every hook through the same run-hook script", () => {
+    const commands = buildLifecycleCommands();
+    for (const command of Object.values(commands)) {
+      expect(command.startsWith(`${RUN_HOOK_SCRIPT} `)).toBe(true);
+    }
+  });
+});

--- a/js/sandbox/src/providers/shared/lifecycle-commands.ts
+++ b/js/sandbox/src/providers/shared/lifecycle-commands.ts
@@ -1,0 +1,39 @@
+/**
+ * The wrapped hook command sequence a lifecycle run executes.
+ *
+ * Installing the user lifecycle scripts (`setup.sh`/`start.sh`) and resetting
+ * them before a snapshot are Amika-specific concerns handled in
+ * `@amika/sandbox-provisioning`. This module is the provider-agnostic hook
+ * command builder, which the Vercel resume path in core
+ * (`vercel/operations.ts`'s `restartVercelServicesOnResume`) also depends on —
+ * so it lives in core, where the provisioning package can import it without a
+ * circular import.
+ */
+import {
+  POST_SETUP_SCRIPT,
+  PRE_SETUP_SCRIPT,
+  RUN_HOOK_SCRIPT,
+  SANDBOX_SETUP_SCRIPT,
+  SANDBOX_START_SCRIPT,
+} from "../../constants";
+
+/**
+ * The wrapped hook command sequence a lifecycle run executes (pre-setup →
+ * setup/start → post-setup). Each is `run-hook.sh <hook>` so the on-box wrapper
+ * captures per-hook logs. Provider-agnostic; consumed by the provisioning
+ * package's `runLifecycleScripts` and by the Vercel resume path in
+ * `@amika/sandbox` (which re-runs the start-phase hooks).
+ */
+export function buildLifecycleCommands(): {
+  preSetup: string;
+  setup: string;
+  postSetup: string;
+  start: string;
+} {
+  return {
+    preSetup: `${RUN_HOOK_SCRIPT} ${PRE_SETUP_SCRIPT}`,
+    setup: `${RUN_HOOK_SCRIPT} ${SANDBOX_SETUP_SCRIPT}`,
+    postSetup: `${RUN_HOOK_SCRIPT} ${POST_SETUP_SCRIPT}`,
+    start: `${RUN_HOOK_SCRIPT} ${SANDBOX_START_SCRIPT}`,
+  };
+}

--- a/js/sandbox/src/providers/shared/resources.test.ts
+++ b/js/sandbox/src/providers/shared/resources.test.ts
@@ -1,0 +1,594 @@
+import { describe, expect, it, vi } from "vitest";
+import { defineProvider, type ProviderDefinition } from "./define-provider";
+import {
+  SandboxProviderUnsupportedError,
+  type ExecCommandOptions,
+  type ProviderSnapshot,
+  type SandboxProvider,
+  type SandboxProviderCapabilities,
+} from "../provider";
+
+const ALL_OFF: SandboxProviderCapabilities = {
+  lifecycle: false,
+  ssh: false,
+  services: false,
+  exec: false,
+  listSandboxes: false,
+  streaming: false,
+  snapshots: false,
+  scrubCapture: false,
+  fullSnapshotCapture: false,
+  dockerRegistries: false,
+  skipStartScript: false,
+  snapshotIdsAreOpaque: false,
+  supportsAutoDelete: false,
+};
+
+const ALL_ON: SandboxProviderCapabilities = {
+  lifecycle: true,
+  ssh: true,
+  services: true,
+  exec: true,
+  listSandboxes: true,
+  streaming: true,
+  snapshots: true,
+  scrubCapture: true,
+  fullSnapshotCapture: true,
+  dockerRegistries: true,
+  skipStartScript: false,
+  snapshotIdsAreOpaque: false,
+  supportsAutoDelete: false,
+};
+
+/** A fully-capable definition whose every method is a spy we can assert on. */
+function fullDef() {
+  const spies = {
+    create: vi.fn(async () => ({
+      provider: "daytona" as const,
+      providerSandboxId: "sb_new",
+      providerUrl: "https://sb_new",
+      services: [],
+    })),
+    delete: vi.fn(async () => {}),
+    start: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    getState: vi.fn(async () => "started"),
+    mapState: vi.fn(() => "running" as const),
+    run: vi.fn(
+      async (_id: string, _cmd: string, _opts?: ExecCommandOptions) => ({
+        exitCode: 0,
+        stdout: "ok",
+        stderr: "",
+      }),
+    ),
+    stream: vi.fn(async () => {}),
+    read: vi.fn(async () => "contents"),
+    write: vi.fn(async () => {}),
+    mint: vi.fn(async () => ({
+      token: "tok",
+      sshDestination: "u@h",
+      expiresAt: new Date(0),
+    })),
+    revoke: vi.fn(async () => {}),
+    refreshUrls: vi.fn(async () => ({
+      providerUrl: "https://x",
+      services: [],
+    })),
+    syncRoutes: vi.fn(async () => {}),
+    list: vi.fn(async () => [
+      {
+        providerSandboxId: "sb_a",
+        orgId: "o",
+        state: "running",
+        sizing: { vcpus: 1, memoryGib: 2, diskGib: 32 },
+      },
+    ]),
+    cloneRepo: vi.fn(async () => {}),
+    capture: vi.fn(
+      async (
+        _id: string,
+        _name: string,
+        opts: { keepSourceRunning: boolean },
+      ) =>
+        opts.keepSourceRunning
+          ? { providerSnapshotId: "snap_id" }
+          : { providerSnapshotId: "snap_scrub" },
+    ),
+    removeInjectedSecrets: vi.fn(async () => {}),
+    isEnvScrubbable: vi.fn(async () => true),
+    waitForSnapshotActive: vi.fn(async (name: string) => ({
+      name,
+      state: "active",
+    })),
+    deleteSnapshot: vi.fn(async () => {}),
+    getSnapshot: vi.fn(async (): Promise<ProviderSnapshot | null> => null),
+    findSnapshot: vi.fn(async (): Promise<ProviderSnapshot | null> => null),
+    createImageSnapshot: vi.fn(
+      async (): Promise<ProviderSnapshot | null> => null,
+    ),
+    createRegistry: vi.fn(async () => registryDto("reg_1")),
+    listRegistries: vi.fn(async () => [
+      registryDto("reg_1"),
+      registryDto("reg_2"),
+    ]),
+    getRegistry: vi.fn(async (id: string) => registryDto(id)),
+    deleteRegistry: vi.fn(async () => {}),
+  };
+
+  const def: ProviderDefinition = {
+    name: "daytona",
+    signedUrlTtlSeconds: 60,
+    userHomeDir: "/home/amika",
+    sandbox: {
+      create: spies.create,
+      delete: spies.delete,
+      start: spies.start,
+      stop: spies.stop,
+      getState: spies.getState,
+      mapState: spies.mapState,
+    },
+    cloneRepo: spies.cloneRepo,
+    exec: { run: spies.run, stream: spies.stream },
+    files: { read: spies.read, write: spies.write },
+    ssh: { mint: spies.mint, revoke: spies.revoke },
+    services: {
+      refreshUrls: spies.refreshUrls,
+      syncRoutes: spies.syncRoutes,
+    },
+    listing: { list: spies.list },
+    snapshots: {
+      createImageSnapshot: spies.createImageSnapshot,
+      getSnapshot: spies.getSnapshot,
+      findSnapshot: spies.findSnapshot,
+      deleteSnapshot: spies.deleteSnapshot,
+      waitForSnapshotActive: spies.waitForSnapshotActive,
+      capture: spies.capture,
+      removeInjectedSecrets: spies.removeInjectedSecrets,
+      isEnvScrubbable: spies.isEnvScrubbable,
+    },
+    dockerRegistries: {
+      createRegistry: spies.createRegistry,
+      listRegistries: spies.listRegistries,
+      getRegistry: spies.getRegistry,
+      deleteRegistry: spies.deleteRegistry,
+    },
+  };
+  return { def, spies };
+}
+
+function svc(name: string, containerPort: number) {
+  return {
+    name,
+    url: "",
+    hostPort: 0,
+    containerPort,
+    protocol: "tcp" as const,
+  };
+}
+
+function registryDto(id: string) {
+  return {
+    id,
+    name: `name-${id}`,
+    url: "https://reg",
+    username: "u",
+    registryType: "harbor",
+    createdAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+  };
+}
+
+function fullProvider(): {
+  provider: SandboxProvider;
+  spies: ReturnType<typeof fullDef>["spies"];
+} {
+  const { def, spies } = fullDef();
+  return { provider: defineProvider(ALL_ON, () => def)({}), spies };
+}
+
+/** A create/delete-only provider: every richer capability is absent. */
+function minimalProvider(): SandboxProvider {
+  const def: ProviderDefinition = {
+    name: "daytona",
+    signedUrlTtlSeconds: 0,
+    userHomeDir: "/home/amika",
+    sandbox: {
+      create: async () => ({
+        provider: "daytona",
+        providerSandboxId: "sb_1",
+        providerUrl: null,
+        services: [],
+      }),
+      delete: async () => {},
+    },
+  };
+  return defineProvider(ALL_OFF, () => def)({});
+}
+
+describe("sandboxes namespace", () => {
+  it("get() returns a lightweight ref without I/O", () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_x");
+    expect(sandbox.id).toBe("sb_x");
+    expect(sandbox.provider).toBe("daytona");
+    expect(sandbox.created).toBeUndefined();
+    // No capability was touched just resolving the ref.
+    expect(spies.getState).not.toHaveBeenCalled();
+  });
+
+  it("create() returns a Sandbox carrying the create result", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = await provider.sandboxes.create({} as never, {} as never);
+    expect(spies.create).toHaveBeenCalledOnce();
+    expect(sandbox.id).toBe("sb_new");
+    expect(sandbox.created).toEqual({
+      provider: "daytona",
+      providerSandboxId: "sb_new",
+      providerUrl: "https://sb_new",
+      services: [],
+    });
+  });
+
+  it("list() delegates to the listing capability", async () => {
+    const { provider, spies } = fullProvider();
+    const listed = await provider.sandboxes.list();
+    expect(spies.list).toHaveBeenCalledOnce();
+    expect(listed[0]?.providerSandboxId).toBe("sb_a");
+  });
+});
+
+describe("Sandbox methods delegate to capabilities", () => {
+  it("start/stop/delete/getState/mapState/getRuntimeState", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    await sandbox.start(30);
+    expect(spies.start).toHaveBeenCalledWith("sb_1", 30);
+    await sandbox.stop();
+    expect(spies.stop).toHaveBeenCalledWith("sb_1");
+    await sandbox.delete();
+    expect(spies.delete).toHaveBeenCalledWith("sb_1");
+    await expect(sandbox.getState()).resolves.toBe("started");
+    expect(sandbox.mapState("started")).toBe("running");
+    expect(spies.mapState).toHaveBeenCalledWith("started");
+    await expect(sandbox.getRuntimeState()).resolves.toBe("running");
+  });
+
+  it("exec/streamExec/readFile/writeFile/git.clone", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    await expect(sandbox.exec("ls", { cwd: "/w" })).resolves.toEqual({
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+    });
+    expect(spies.run).toHaveBeenCalledWith("sb_1", "ls", { cwd: "/w" });
+    const handlers = { onStdout: () => {} };
+    await sandbox.streamExec("tail", handlers);
+    expect(spies.stream).toHaveBeenCalledWith("sb_1", "tail", handlers);
+    await expect(sandbox.readFile("/f")).resolves.toBe("contents");
+    expect(spies.read).toHaveBeenCalledWith("sb_1", "/f");
+    await sandbox.writeFile("/f", "data");
+    expect(spies.write).toHaveBeenCalledWith("sb_1", "/f", "data");
+    await sandbox.git!.clone({ homeDir: "/h", githubUrl: "https://g/r" });
+    expect(spies.cloneRepo).toHaveBeenCalledWith("sb_1", {
+      homeDir: "/h",
+      githubUrl: "https://g/r",
+    });
+  });
+});
+
+describe("Sandbox sub-namespaces", () => {
+  it("ssh.mint() returns a handle whose revoke() is bound to the token", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    const access = await sandbox.ssh!.mint(60, []);
+    expect(spies.mint).toHaveBeenCalledWith("sb_1", 60, []);
+    expect(access.token).toBe("tok");
+    await access.revoke();
+    expect(spies.revoke).toHaveBeenCalledWith("sb_1", "tok");
+  });
+
+  it("ssh.revoke(token) revokes a persisted token directly", async () => {
+    const { provider, spies } = fullProvider();
+    await provider.sandboxes.get("sb_1").ssh!.revoke("stored-token");
+    expect(spies.revoke).toHaveBeenCalledWith("sb_1", "stored-token");
+  });
+
+  it("services.refreshAll() delegates without touching routes", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    await sandbox.services!.refreshAll([]);
+    expect(spies.refreshUrls).toHaveBeenCalledWith("sb_1", []);
+    expect(spies.syncRoutes).not.toHaveBeenCalled();
+  });
+
+  it("services.load(): get by port, revoke = set minus me, update = replaced set", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    const web = svc("web", 3000);
+    const agent = svc("Coding Agent", 60998);
+    const loaded = sandbox.services!.load([agent, web]);
+
+    expect(loaded.list().map((s) => s.name)).toEqual(["Coding Agent", "web"]);
+    expect(loaded.get(4000)).toBeNull();
+
+    // revoke: routes reconcile to the loaded set minus the revoked service.
+    await loaded.get(3000)!.revoke();
+    expect(spies.syncRoutes).toHaveBeenCalledWith("sb_1", [agent]);
+
+    // update: routes reconcile to the set with the replacement in place, then
+    // URLs re-mint over that same set.
+    const next = svc("web-v2", 3001);
+    await loaded.get(3000)!.update(next);
+    expect(spies.syncRoutes).toHaveBeenLastCalledWith("sb_1", [agent, next]);
+    expect(spies.refreshUrls).toHaveBeenCalledWith("sb_1", [agent, next]);
+  });
+
+  it("services.load().refresh() reconciles routes then re-mints", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    const set = [svc("Coding Agent", 60998), svc("late", 4000)];
+    await sandbox.services!.load(set).refresh();
+    expect(spies.syncRoutes).toHaveBeenCalledWith("sb_1", set);
+    expect(spies.refreshUrls).toHaveBeenCalledWith("sb_1", set);
+    // Ordering: routes must exist before URLs are minted against them.
+    expect(spies.syncRoutes.mock.invocationCallOrder[0]!).toBeLessThan(
+      spies.refreshUrls.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("services.load() revoke keeps a shared port claimed by another entry", async () => {
+    // Legacy sets can carry two services on one port; identity is positional,
+    // so revoking one leaves the other (and thus the port) in the desired set.
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    const first = svc("web", 3000);
+    const twin = svc("web-twin", 3000);
+    const loaded = sandbox.services!.load([first, twin]);
+    // get() returns the first match on the duplicated port...
+    expect(loaded.get(3000)!.name).toBe("web");
+    await loaded.get(3000)!.revoke();
+    // ...and the twin keeps the port desired.
+    expect(spies.syncRoutes).toHaveBeenCalledWith("sb_1", [twin]);
+  });
+
+  it("snapshots.create() captures and returns a Snapshot with waitForActive/delete", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    const snap = await sandbox.snapshots!.create("org/snap");
+    expect(spies.capture).toHaveBeenCalledWith("sb_1", "org/snap", {
+      keepSourceRunning: true,
+    });
+    expect(snap.name).toBe("org/snap");
+    expect(snap.providerSnapshotId).toBe("snap_id");
+    // The bound ops pass the captured bootable handle alongside the name, so
+    // an id-only provider (Vercel) can act before the control plane records
+    // the name↔id mapping.
+    const active = await snap.waitForActive();
+    expect(spies.waitForSnapshotActive).toHaveBeenCalledWith(
+      "org/snap",
+      "snap_id",
+    );
+    expect(active.state).toBe("active");
+    await snap.delete();
+    expect(spies.deleteSnapshot).toHaveBeenCalledWith("org/snap", "snap_id");
+  });
+
+  it("snapshots.scrubAndCreate() scrubs via exec, runs the provider hook, captures with delete-intent", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    // Removal commands succeed; the `ls -1d` verification finds nothing left.
+    spies.run.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const targets = {
+      files: ["/home/amika/.claude"],
+      sudoFiles: ["/etc/environment"],
+      sudoFileRestores: [],
+      envVarNames: ["E"],
+    };
+    const result = await sandbox.snapshots!.scrubAndCreate("org/snap", targets);
+    // The scrub ran through the exec primitive (rm + rm + verify)...
+    expect(spies.run).toHaveBeenCalledTimes(3);
+    expect(spies.run.mock.calls[0]?.[1]).toContain(".claude");
+    // ...every scrub command resumes bare so a stopped Vercel sandbox can't
+    // relaunch services with the secret being scrubbed...
+    for (const call of spies.run.mock.calls) {
+      expect(call[2]).toMatchObject({ resumeMode: "bare" });
+    }
+    // ...then the provider removed its own injected secrets and captured with
+    // delete-intent.
+    expect(spies.removeInjectedSecrets).toHaveBeenCalledWith("sb_1");
+    expect(spies.capture).toHaveBeenCalledWith("sb_1", "org/snap", {
+      keepSourceRunning: false,
+    });
+    // Security-critical ordering: every scrub command AND the provider's
+    // injected-secret removal MUST run before the capture freezes the
+    // filesystem, or the snapshot retains the very secrets being removed
+    // (e.g. Vercel's resume-context password file).
+    const lastScrubCmd = Math.max(...spies.run.mock.invocationCallOrder);
+    const hookOrder = spies.removeInjectedSecrets.mock.invocationCallOrder[0]!;
+    const captureOrder = spies.capture.mock.invocationCallOrder[0]!;
+    expect(lastScrubCmd).toBeLessThan(hookOrder);
+    expect(hookOrder).toBeLessThan(captureOrder);
+    expect(result.removedFiles).toEqual(["/home/amika/.claude"]);
+    expect(result.removedEnvVars).toEqual(["E"]);
+    expect(result.snapshot.name).toBe("org/snap");
+    expect(result.snapshot.providerSnapshotId).toBe("snap_scrub");
+    await result.snapshot.delete();
+    expect(spies.deleteSnapshot).toHaveBeenCalledWith("org/snap", "snap_scrub");
+  });
+
+  it("snapshots.scrubAndCreate() fails closed when scrubbed paths persist", async () => {
+    const { provider, spies } = fullProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    // rm succeeds but the verification still lists the path — abort before any
+    // capture so no secret-bearing snapshot is produced.
+    spies.run.mockResolvedValue({
+      exitCode: 0,
+      stdout: "/home/amika/.claude",
+      stderr: "",
+    });
+    await expect(
+      sandbox.snapshots!.scrubAndCreate("org/snap", {
+        files: ["/home/amika/.claude"],
+        sudoFiles: [],
+        sudoFileRestores: [],
+        envVarNames: [],
+      }),
+    ).rejects.toThrow(/Scrub verification failed/);
+    expect(spies.capture).not.toHaveBeenCalled();
+    expect(spies.removeInjectedSecrets).not.toHaveBeenCalled();
+  });
+
+  it("snapshots.scrubAndCreate() throws unsupported without exec", async () => {
+    // `snapshots` and `exec` are independently declarable; the synthesized
+    // scrub runs through exec, so a snapshots-without-exec provider offers
+    // only the raw captures (mirrored by `capabilities.scrubCapture`).
+    const { def, spies } = fullDef();
+    const provider = defineProvider(
+      { ...ALL_ON, exec: false, streaming: false, scrubCapture: false },
+      () => ({ ...def, exec: null }),
+    )({});
+    await expect(
+      provider.sandboxes.get("sb_1").snapshots!.scrubAndCreate("org/snap", {
+        files: [],
+        sudoFiles: [],
+        sudoFileRestores: [],
+        envVarNames: [],
+      }),
+    ).rejects.toThrow(/does not support operation "scrubAndCreate"/);
+    expect(spies.capture).not.toHaveBeenCalled();
+    // The raw keep-source capture still works without exec.
+    await provider.sandboxes.get("sb_1").snapshots!.create("org/snap");
+    expect(spies.capture).toHaveBeenCalledWith("sb_1", "org/snap", {
+      keepSourceRunning: true,
+    });
+  });
+
+  it("snapshots.isEnvScrubbable() delegates", async () => {
+    const { provider, spies } = fullProvider();
+    await expect(
+      provider.sandboxes.get("sb_1").snapshots!.isEnvScrubbable(),
+    ).resolves.toBe(true);
+    expect(spies.isEnvScrubbable).toHaveBeenCalledWith("sb_1");
+  });
+});
+
+describe("snapshots namespace (provider.snapshots)", () => {
+  it("get()/find() wrap a hit in a Snapshot and preserve the null contract", async () => {
+    const { provider, spies } = fullProvider();
+    spies.getSnapshot.mockResolvedValueOnce({
+      name: "org/snap",
+      providerSnapshotId: "snap_1",
+      state: "active",
+    });
+    const snap = await provider.snapshots!.get("org/snap");
+    expect(snap?.state).toBe("active");
+    // Bound delete forwards the captured provider handle alongside the name.
+    await snap!.delete();
+    expect(spies.deleteSnapshot).toHaveBeenCalledWith("org/snap", "snap_1");
+    await expect(provider.snapshots!.get("missing")).resolves.toBeNull();
+
+    spies.findSnapshot.mockResolvedValueOnce({ name: "org/snap2" });
+    const found = await provider.snapshots!.find("org/snap2");
+    expect(found?.name).toBe("org/snap2");
+    await expect(provider.snapshots!.find("missing")).resolves.toBeNull();
+  });
+
+  it("createImage() preserves the already-exists null contract", async () => {
+    const { provider, spies } = fullProvider();
+    await expect(
+      provider.snapshots!.createImage({ name: "org/img:tag", image: "i:t" }),
+    ).resolves.toBeNull();
+
+    spies.createImageSnapshot.mockResolvedValueOnce({
+      name: "org/img:tag",
+      state: "building",
+    });
+    const created = await provider.snapshots!.createImage({
+      name: "org/img:tag",
+      image: "i:t",
+    });
+    expect(created?.name).toBe("org/img:tag");
+    const active = await created!.waitForActive();
+    expect(spies.waitForSnapshotActive).toHaveBeenCalledWith(
+      "org/img:tag",
+      undefined,
+    );
+    expect(active.state).toBe("active");
+  });
+
+  it("is null on a provider without the capability", () => {
+    expect(minimalProvider().snapshots).toBeNull();
+  });
+});
+
+describe("docker namespace", () => {
+  it("registries.create/list/get return DockerRegistry objects with delete()", async () => {
+    const { provider, spies } = fullProvider();
+    const created = await provider.docker!.registries.create({
+      name: "n",
+      url: "https://reg",
+      username: "u",
+      password: "p",
+    });
+    expect(spies.createRegistry).toHaveBeenCalledOnce();
+    expect(created.id).toBe("reg_1");
+    await created.delete();
+    expect(spies.deleteRegistry).toHaveBeenCalledWith("reg_1");
+
+    const all = await provider.docker!.registries.list();
+    expect(all.map((r) => r.id)).toEqual(["reg_1", "reg_2"]);
+
+    const got = await provider.docker!.registries.get("reg_9");
+    expect(spies.getRegistry).toHaveBeenCalledWith("reg_9");
+    expect(got.id).toBe("reg_9");
+  });
+});
+
+describe("unsupported operations on a minimal provider", () => {
+  it("null sub-namespaces and throwing run-state/exec/files ops", async () => {
+    const provider = minimalProvider();
+    const sandbox = provider.sandboxes.get("sb_1");
+    expect(sandbox.git).toBeNull();
+    expect(sandbox.ssh).toBeNull();
+    expect(sandbox.services).toBeNull();
+    expect(sandbox.snapshots).toBeNull();
+    expect(provider.docker).toBeNull();
+    await expect(sandbox.start()).rejects.toBeInstanceOf(
+      SandboxProviderUnsupportedError,
+    );
+    await expect(sandbox.exec("ls")).rejects.toBeInstanceOf(
+      SandboxProviderUnsupportedError,
+    );
+    await expect(sandbox.readFile("/f")).rejects.toBeInstanceOf(
+      SandboxProviderUnsupportedError,
+    );
+    // delete stays available — it's the always-present capability.
+    await expect(sandbox.delete()).resolves.toBeUndefined();
+    await expect(provider.sandboxes.list()).rejects.toBeInstanceOf(
+      SandboxProviderUnsupportedError,
+    );
+  });
+
+  it("streamExec throws when exec has no stream", async () => {
+    const def: ProviderDefinition = {
+      name: "daytona",
+      signedUrlTtlSeconds: 0,
+      userHomeDir: "/home/amika",
+      sandbox: {
+        create: async () => ({
+          provider: "daytona",
+          providerSandboxId: "sb_1",
+          providerUrl: null,
+          services: [],
+        }),
+        delete: async () => {},
+      },
+      exec: { run: async () => ({ exitCode: 0, stdout: "", stderr: "" }) },
+    };
+    const provider = defineProvider({ ...ALL_OFF, exec: true }, () => def)({});
+    await expect(
+      provider.sandboxes.get("sb_1").streamExec("x", { onStdout: () => {} }),
+    ).rejects.toBeInstanceOf(SandboxProviderUnsupportedError);
+  });
+});

--- a/js/sandbox/src/providers/shared/resources.ts
+++ b/js/sandbox/src/providers/shared/resources.ts
@@ -1,0 +1,379 @@
+/**
+ * Resource-object factories.
+ *
+ * Synthesizes the consumer-facing {@link Sandbox} / {@link Snapshot} /
+ * {@link DockerRegistry} objects over a provider's low-level capability
+ * namespaces. The factories close over the *authored* capability objects (the
+ * {@link ResourceBackend} passed by {@link buildProvider}), not over public
+ * provider keys, so later removing a flat member from the contract never disturbs
+ * the object wiring.
+ *
+ * Providers write no code here: a provider declares its primitives via
+ * `defineProvider` and gains the resource surface for free. Gating mirrors the flat
+ * surface — an operation whose backing capability is absent throws {@link
+ * SandboxProviderUnsupportedError}, and the `ssh`/`services`/`snapshots`
+ * sub-namespaces are `null` when the provider doesn't back them.
+ */
+import { SandboxProviderUnsupportedError } from "../provider";
+import { scrubTargetsViaExec } from "./scrub-exec";
+import type {
+  CloneRepoInput,
+  DockerNamespace,
+  DockerRegistry,
+  DockerRegistryCapability,
+  ExecCapability,
+  FileCapability,
+  ListingCapability,
+  ProviderDockerRegistry,
+  ProviderSnapshot,
+  Sandbox,
+  SandboxCapability,
+  SandboxGitNamespace,
+  SandboxNamespace,
+  ServiceRestartContext,
+  LoadedServices,
+  SandboxServiceNamespace,
+  SandboxSnapshotNamespace,
+  SandboxSshNamespace,
+  Service,
+  ServiceCapability,
+  Snapshot,
+  SnapshotCapability,
+  SnapshotNamespace,
+  SshCapability,
+} from "../provider";
+import type { SandboxProviderName, SandboxService } from "../../types";
+
+/**
+ * The authored low-level capabilities the resource layer delegates to — the
+ * subset of a built provider the resource objects need. Assembled by
+ * {@link buildProvider} from the provider definition.
+ */
+export interface ResourceBackend {
+  name: SandboxProviderName;
+  sandbox: SandboxCapability;
+  exec: ExecCapability | null;
+  files: FileCapability | null;
+  ssh: SshCapability | null;
+  services: ServiceCapability | null;
+  listing: ListingCapability | null;
+  snapshots: SnapshotCapability | null;
+  dockerRegistries: DockerRegistryCapability | null;
+  /**
+   * Optional provider-native clone primitive. `null` when the provider has no
+   * first-class clone (Freestyle, Vercel) — the provisioning layer clones those
+   * over the adapter exec port instead, so `Sandbox.git` is `null` for them.
+   */
+  cloneRepo:
+    | ((providerSandboxId: string, input: CloneRepoInput) => Promise<void>)
+    | null;
+  /**
+   * Optional per-provider "persist what's needed to relaunch services on resume"
+   * primitive. `null` unless the provider's suspended sandboxes lose their
+   * running processes (Vercel); surfaced as the nullable
+   * `Sandbox.persistServiceRestartContext`.
+   */
+  persistServiceRestartContext:
+    | ((
+        providerSandboxId: string,
+        context: ServiceRestartContext,
+      ) => Promise<void>)
+    | null;
+}
+
+/** Build the top-level `sandboxes` namespace from a backend. */
+export function makeSandboxNamespace(
+  backend: ResourceBackend,
+): SandboxNamespace {
+  const get = (providerSandboxId: string): Sandbox =>
+    makeSandbox(backend, providerSandboxId);
+  return {
+    async create(ctx, input) {
+      const created = await backend.sandbox.create(ctx, input);
+      return makeSandbox(backend, created.providerSandboxId, created);
+    },
+    get,
+    async list() {
+      if (!backend.listing) {
+        throw new SandboxProviderUnsupportedError(backend.name, "list");
+      }
+      return backend.listing.list();
+    },
+  };
+}
+
+/**
+ * Build the top-level `snapshots` namespace over the authored capability.
+ * `get`/`find`/`createImage` preserve the capability's null contract (missing /
+ * still-registering / name-already-exists → `null`) and wrap a hit in a
+ * {@link Snapshot} whose bound ops carry the provider handle. Names are built
+ * by the caller's own naming helpers — naming is Amika policy, not provider
+ * mechanics.
+ */
+export function makeSnapshotNamespace(
+  snapshots: SnapshotCapability,
+): SnapshotNamespace {
+  const wrap = (data: ProviderSnapshot | null): Snapshot | null =>
+    data ? makeSnapshot(snapshots, data) : null;
+  return {
+    async get(name) {
+      return wrap(await snapshots.getSnapshot(name));
+    },
+    async find(name) {
+      return wrap(await snapshots.findSnapshot(name));
+    },
+    async createImage(input) {
+      return wrap(await snapshots.createImageSnapshot(input));
+    },
+  };
+}
+
+/** Build the top-level `docker` namespace, or return null when unsupported. */
+export function makeDockerNamespace(
+  registries: DockerRegistryCapability,
+): DockerNamespace {
+  return {
+    registries: {
+      async create(input) {
+        return makeDockerRegistry(
+          registries,
+          await registries.createRegistry(input),
+        );
+      },
+      async list() {
+        const all = await registries.listRegistries();
+        return all.map((r) => makeDockerRegistry(registries, r));
+      },
+      async get(registryId) {
+        return makeDockerRegistry(
+          registries,
+          await registries.getRegistry(registryId),
+        );
+      },
+    },
+  };
+}
+
+/** The sandbox run-state ops, narrowed to non-optional (present as a unit). */
+type SandboxRunState = Required<
+  Pick<SandboxCapability, "start" | "stop" | "getState" | "mapState">
+>;
+
+function makeSandbox(
+  backend: ResourceBackend,
+  id: string,
+  created?: Sandbox["created"],
+): Sandbox {
+  // The run-state ops live flat on `sandbox` and are present as a unit; narrow
+  // them to a non-optional bundle or throw when the provider omits them.
+  const requireRunState = (op: string): SandboxRunState => {
+    const { start, stop, getState, mapState } = backend.sandbox;
+    if (!start || !stop || !getState || !mapState) {
+      throw new SandboxProviderUnsupportedError(backend.name, op);
+    }
+    return { start, stop, getState, mapState };
+  };
+  const requireExec = (op: string): ExecCapability => {
+    if (!backend.exec) {
+      throw new SandboxProviderUnsupportedError(backend.name, op);
+    }
+    return backend.exec;
+  };
+  const requireFiles = (op: string): FileCapability => {
+    if (!backend.files) {
+      throw new SandboxProviderUnsupportedError(backend.name, op);
+    }
+    return backend.files;
+  };
+
+  // Methods are `async` so an unsupported-capability throw surfaces as a
+  // rejected promise (uniform with the ops that do real I/O), never a
+  // synchronous throw a `.catch()` chain would miss.
+  return {
+    id,
+    provider: backend.name,
+    created,
+    start: async (autoStopInterval) =>
+      requireRunState("start").start(id, autoStopInterval),
+    stop: async () => requireRunState("stop").stop(id),
+    delete: async () => backend.sandbox.delete(id),
+    getState: async () => requireRunState("getState").getState(id),
+    mapState: (rawState) => requireRunState("mapState").mapState(rawState),
+    async getRuntimeState() {
+      const runState = requireRunState("getRuntimeState");
+      return runState.mapState(await runState.getState(id));
+    },
+    exec: async (command, opts) => requireExec("exec").run(id, command, opts),
+    async streamExec(command, handlers) {
+      const exec = requireExec("streamExec");
+      if (!exec.stream) {
+        throw new SandboxProviderUnsupportedError(backend.name, "streamExec");
+      }
+      return exec.stream(id, command, handlers);
+    },
+    readFile: async (filePath) => requireFiles("readFile").read(id, filePath),
+    writeFile: async (filePath, content) =>
+      requireFiles("writeFile").write(id, filePath, content),
+    git: backend.cloneRepo ? makeSandboxGit(backend.cloneRepo, id) : null,
+    persistServiceRestartContext: backend.persistServiceRestartContext
+      ? (context) => backend.persistServiceRestartContext!(id, context)
+      : null,
+    ssh: backend.ssh ? makeSandboxSsh(backend.ssh, id) : null,
+    services: backend.services
+      ? makeSandboxServices(backend.services, id)
+      : null,
+    snapshots: backend.snapshots
+      ? makeSandboxSnapshots(backend, backend.snapshots, id)
+      : null,
+  };
+}
+
+function makeSandboxGit(
+  cloneRepo: (
+    providerSandboxId: string,
+    input: CloneRepoInput,
+  ) => Promise<void>,
+  id: string,
+): SandboxGitNamespace {
+  return { clone: (input) => cloneRepo(id, input) };
+}
+
+function makeSandboxSsh(ssh: SshCapability, id: string): SandboxSshNamespace {
+  return {
+    async mint(expiresInMinutes, services) {
+      const access = await ssh.mint(id, expiresInMinutes, services);
+      return { ...access, revoke: () => ssh.revoke(id, access.token) };
+    },
+    revoke: (token) => ssh.revoke(id, token),
+  };
+}
+
+function makeSandboxServices(
+  services: ServiceCapability,
+  id: string,
+): SandboxServiceNamespace {
+  return {
+    refreshAll: (svcs) => services.refreshUrls(id, svcs),
+    load: (svcs) => makeLoadedServices(services, id, svcs),
+  };
+}
+
+/**
+ * Object-ify a point-in-time service set over the
+ * declarative `syncRoutes` primitive. Each {@link Service}'s mutation derives
+ * the desired set from the loaded snapshot — revoke is "the set minus me",
+ * update is "the set with `next` in my place" — so no caller hand-computes a
+ * removed/remaining split. Identity is positional (not port equality), so a
+ * legacy set carrying two services on one port revokes exactly the loaded
+ * entry, and the shared port survives while the other still claims it.
+ */
+function makeLoadedServices(
+  services: ServiceCapability,
+  providerSandboxId: string,
+  serviceList: SandboxService[],
+): LoadedServices {
+  const loadedServices = [...serviceList];
+  const makeService = (svc: SandboxService, index: number): Service => ({
+    ...svc,
+    revoke: () =>
+      services.syncRoutes(
+        providerSandboxId,
+        loadedServices.filter((_, i) => i !== index),
+      ),
+    async update(next) {
+      const replaced = loadedServices.map((s, i) => (i === index ? next : s));
+      await services.syncRoutes(providerSandboxId, replaced);
+      return services.refreshUrls(providerSandboxId, replaced);
+    },
+  });
+  return {
+    list: () => loadedServices.map(makeService),
+    get(containerPort) {
+      const index = loadedServices.findIndex(
+        (s) => s.containerPort === containerPort,
+      );
+      return index === -1 ? null : makeService(loadedServices[index]!, index);
+    },
+    async refresh() {
+      await services.syncRoutes(providerSandboxId, loadedServices);
+      return services.refreshUrls(providerSandboxId, loadedServices);
+    },
+  };
+}
+
+function makeSandboxSnapshots(
+  backend: ResourceBackend,
+  snapshots: SnapshotCapability,
+  id: string,
+): SandboxSnapshotNamespace {
+  return {
+    async create(snapshotName) {
+      const captured = await snapshots.capture(id, snapshotName, {
+        keepSourceRunning: true,
+      });
+      return makeSnapshot(snapshots, {
+        name: snapshotName,
+        providerSnapshotId: captured.providerSnapshotId,
+      });
+    },
+    // The destructive scrub-and-capture, synthesized here rather than
+    // implemented per provider: scrub the Amika-computed targets
+    // through the exec primitive (fail-closed verification, bare resume so a
+    // stopped Vercel sandbox can't relaunch services with the secret being
+    // scrubbed), have the provider remove its own injected secrets, then
+    // capture with delete-intent. Requires exec — `snapshots` and `exec` are
+    // independently declarable, so the op gates on both (mirrored by the
+    // client-safe `capabilities.scrubCapture` flag).
+    async scrubAndCreate(snapshotName, targets) {
+      if (!backend.exec) {
+        throw new SandboxProviderUnsupportedError(
+          backend.name,
+          "scrubAndCreate",
+        );
+      }
+      await scrubTargetsViaExec(backend.exec, id, targets);
+      await snapshots.removeInjectedSecrets(id);
+      const captured = await snapshots.capture(id, snapshotName, {
+        keepSourceRunning: false,
+      });
+      return {
+        removedFiles: targets.files,
+        removedEnvVars: targets.envVarNames,
+        snapshot: makeSnapshot(snapshots, {
+          name: snapshotName,
+          providerSnapshotId: captured.providerSnapshotId,
+        }),
+      };
+    },
+    isEnvScrubbable: () => snapshots.isEnvScrubbable(id),
+  };
+}
+
+function makeSnapshot(
+  snapshots: SnapshotCapability,
+  data: ProviderSnapshot,
+): Snapshot {
+  // Pass the known bootable handle alongside the name: an id-only provider
+  // (Vercel) uses it directly, so a freshly captured Snapshot is operable
+  // before the name↔id mapping has been recorded.
+  return {
+    ...data,
+    async waitForActive() {
+      return makeSnapshot(
+        snapshots,
+        await snapshots.waitForSnapshotActive(
+          data.name,
+          data.providerSnapshotId,
+        ),
+      );
+    },
+    delete: () => snapshots.deleteSnapshot(data.name, data.providerSnapshotId),
+  };
+}
+
+function makeDockerRegistry(
+  registries: DockerRegistryCapability,
+  data: ProviderDockerRegistry,
+): DockerRegistry {
+  return { ...data, delete: () => registries.deleteRegistry(data.id) };
+}

--- a/js/sandbox/src/providers/shared/scrub-exec.test.ts
+++ b/js/sandbox/src/providers/shared/scrub-exec.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest";
+import { scrubTargetsViaExec } from "./scrub-exec";
+import {
+  ScrubRestoreError,
+  ScrubVerificationError,
+  type ExecCapability,
+  type ExecCommandOptions,
+  type ScrubTargets,
+} from "../provider";
+
+const HOME = "/home/amika";
+const WORKSPACE = `${HOME}/workspace`;
+
+// Sample scrub targets. The mechanism removes exactly what it is handed and has
+// no knowledge of which paths are Amika secrets, so any paths work here.
+const FILES = [`${HOME}/.git-credentials`, `${HOME}/.claude`, `${HOME}/.codex`];
+const SUDO_FILES = [
+  "/etc/environment",
+  "/usr/local/etc/amikad/service-env-vars.json",
+];
+
+function targets(overrides: Partial<ScrubTargets> = {}): ScrubTargets {
+  return {
+    files: FILES,
+    sudoFiles: SUDO_FILES,
+    sudoFileRestores: [],
+    envVarNames: ["OPENAI_API_KEY"],
+    gitTokenWorkspaceRoot: WORKSPACE,
+    ...overrides,
+  };
+}
+
+interface FakeExecOptions {
+  /** Paths that currently exist (drive the `ls -1d` existence probe). */
+  existing?: string[];
+  /** Paths that survive `rm` (simulate a process recreating a scrubbed path). */
+  sticky?: string[];
+  /**
+   * `.git/config` paths the git-remote verify (`grep -l 'x-access-token:'`)
+   * still reports as tokenized — simulates a remote the sanitize missed.
+   */
+  gitRemoteLeftover?: string[];
+  /** Make the baseline restore (`install`) fail, as a read-only fs would. */
+  failRestore?: boolean;
+  /** Make the post-restore SHA-256 verification fail. */
+  restoreMismatch?: boolean;
+  /** Exit code for a failed verification (default 1, a real difference). */
+  restoreVerificationExitCode?: number;
+}
+
+/**
+ * Minimal {@link ExecCapability} stand-in. `ls -1d` echoes the still-present
+ * subset of the queried paths; `rm` drops matching paths from the present set
+ * unless they are `sticky`. Everything else returns success.
+ */
+function fakeExec(opts: FakeExecOptions = {}): {
+  exec: ExecCapability;
+  calls: Array<{ command: string; opts?: ExecCommandOptions }>;
+} {
+  const present = new Set(opts.existing ?? []);
+  const sticky = new Set(opts.sticky ?? []);
+  const calls: Array<{ command: string; opts?: ExecCommandOptions }> = [];
+
+  const exec: ExecCapability = {
+    streaming: false,
+    run: (_id, command, execOpts) => {
+      calls.push({ command, opts: execOpts });
+      if (command.startsWith("install ") && opts.failRestore) {
+        return Promise.resolve({
+          exitCode: 1,
+          stdout: "",
+          stderr: "install: cannot create regular file",
+        });
+      }
+      if (command.startsWith("source_hash=$(sha256sum")) {
+        return Promise.resolve({
+          exitCode: opts.restoreMismatch
+            ? (opts.restoreVerificationExitCode ?? 1)
+            : 0,
+          stdout: "",
+          stderr: "",
+        });
+      }
+      if (command.startsWith("ls -1d")) {
+        const found = [...present].filter((p) => command.includes(p));
+        return Promise.resolve({
+          exitCode: found.length ? 0 : 1,
+          stdout: found.join("\n"),
+          stderr: "",
+        });
+      }
+      if (command.startsWith("rm ")) {
+        for (const p of [...present]) {
+          if (command.includes(p) && !sticky.has(p)) present.delete(p);
+        }
+        return Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+      }
+      // The git-remote scrub: the sanitize (`sed`) succeeds silently; the verify
+      // (`grep -l 'x-access-token:'`) reports any `.git/config` still tokenized.
+      if (command.includes("x-access-token")) {
+        return Promise.resolve({
+          exitCode: 0,
+          stdout: command.includes("grep -l")
+            ? (opts.gitRemoteLeftover ?? []).join("\n")
+            : "",
+          stderr: "",
+        });
+      }
+      return Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+    },
+  };
+
+  return { exec, calls };
+}
+
+describe("scrubTargetsViaExec", () => {
+  it("restores declared system baselines before removing other targets", async () => {
+    const { exec, calls } = fakeExec({ existing: [...FILES, ...SUDO_FILES] });
+
+    await scrubTargetsViaExec(
+      exec,
+      "sb_1",
+      targets({
+        sudoFileRestores: [
+          {
+            sourcePath: "/usr/local/etc/amikad/environment.base",
+            destinationPath: "/etc/environment",
+          },
+        ],
+      }),
+    );
+
+    expect(calls[0]?.command).toContain("environment.base");
+    expect(calls[0]?.command).toContain("install -m 0644");
+    expect(calls.at(-1)?.command).toContain("sha256sum");
+  });
+
+  it("verifies restored baselines even when no paths are removed", async () => {
+    const { exec, calls } = fakeExec();
+
+    await scrubTargetsViaExec(
+      exec,
+      "sb_1",
+      targets({
+        files: [],
+        sudoFiles: [],
+        sudoFileRestores: [
+          {
+            sourcePath: "/usr/local/etc/amikad/environment.base",
+            destinationPath: "/etc/environment",
+          },
+        ],
+      }),
+    );
+
+    expect(
+      calls.some((call) => call.command.startsWith("source_hash=$(sha256sum")),
+    ).toBe(true);
+  });
+
+  it("throws when the baseline restore itself fails", async () => {
+    // The restore runs first, so a failure here means later commands would
+    // scrub a sandbox whose `/etc/environment` was never put back.
+    const { exec } = fakeExec({ failRestore: true });
+
+    await expect(
+      scrubTargetsViaExec(
+        exec,
+        "sb_1",
+        targets({
+          sudoFileRestores: [
+            {
+              sourcePath: "/usr/local/etc/amikad/environment.base",
+              destinationPath: "/etc/environment",
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow(ScrubRestoreError);
+  });
+
+  it("fails closed when the restored baseline does not match its source", async () => {
+    // The hash check is the only thing standing between a bad restore and a
+    // captured snapshot, so a mismatch must abort rather than warn. It must not raise
+    // ScrubVerificationError: that one means a path survived removal, which
+    // the control plane blames on a live agent recreating files, and no agent
+    // activity explains a restore that did not land.
+    const { exec } = fakeExec({
+      existing: [...FILES, ...SUDO_FILES],
+      restoreMismatch: true,
+    });
+
+    const call = scrubTargetsViaExec(
+      exec,
+      "sb_1",
+      targets({
+        sudoFileRestores: [
+          {
+            sourcePath: "/usr/local/etc/amikad/environment.base",
+            destinationPath: "/etc/environment",
+          },
+        ],
+      }),
+    );
+
+    await expect(call).rejects.toThrow(ScrubRestoreError);
+    await expect(call).rejects.not.toThrow(ScrubVerificationError);
+  });
+
+  it("fails closed when the hash verification cannot run", async () => {
+    const { exec } = fakeExec({
+      restoreMismatch: true,
+      restoreVerificationExitCode: 127,
+    });
+
+    await expect(
+      scrubTargetsViaExec(
+        exec,
+        "sb_1",
+        targets({
+          files: [],
+          sudoFiles: [],
+          sudoFileRestores: [
+            {
+              sourcePath: "/usr/local/etc/amikad/environment.base",
+              destinationPath: "/etc/environment",
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow(/verification failed \(exit 127\)/u);
+  });
+
+  it("removes every passed credential + env file, then verifies", async () => {
+    const { exec, calls } = fakeExec({ existing: [...FILES, ...SUDO_FILES] });
+
+    await scrubTargetsViaExec(exec, "sb_1", targets());
+
+    // Every credential path and managed env file was targeted by an rm.
+    for (const path of [...FILES, ...SUDO_FILES]) {
+      expect(
+        calls.some(
+          (c) => c.command.startsWith("rm ") && c.command.includes(path),
+        ),
+      ).toBe(true);
+    }
+    // Managed env files are removed with sudo; credential files as the user.
+    for (const c of calls) {
+      if (c.command.startsWith("rm -f ")) {
+        expect(c.opts?.sudo).toBe(true);
+      }
+    }
+  });
+
+  it("resumes bare on every command — never restart-services", async () => {
+    // On Vercel a generic exec against a stopped sandbox fires the
+    // service-restart resume callback, which reloads the very secret being
+    // scrubbed into a live session right before capture.
+    const { exec, calls } = fakeExec({ existing: [...FILES, ...SUDO_FILES] });
+    await scrubTargetsViaExec(exec, "sb_1", targets());
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.opts?.resumeMode).toBe("bare");
+    }
+  });
+
+  it("throws ScrubVerificationError when a path survives the scrub", async () => {
+    const survivor = FILES[0];
+    const { exec } = fakeExec({
+      existing: [...FILES, ...SUDO_FILES],
+      sticky: [survivor],
+    });
+
+    await expect(
+      scrubTargetsViaExec(exec, "sb_1", targets()),
+    ).rejects.toBeInstanceOf(ScrubVerificationError);
+  });
+
+  it("sanitizes tokenized git remotes under the declared workspace root", async () => {
+    const { exec, calls } = fakeExec({ existing: [...FILES, ...SUDO_FILES] });
+
+    await scrubTargetsViaExec(exec, "sb_1", targets());
+
+    // A `.git/config` sed rewrite that strips the `x-access-token:<token>@`
+    // userinfo, scoped to config files under the declared workspace root.
+    expect(
+      calls.some(
+        (c) =>
+          c.command.includes(WORKSPACE) &&
+          c.command.includes(".git/config") &&
+          c.command.includes("x-access-token") &&
+          c.command.includes("sed"),
+      ),
+    ).toBe(true);
+  });
+
+  it("skips the git-remote pass when no workspace root is declared", async () => {
+    const { exec, calls } = fakeExec({ existing: [...FILES, ...SUDO_FILES] });
+    await scrubTargetsViaExec(
+      exec,
+      "sb_1",
+      targets({ gitTokenWorkspaceRoot: undefined }),
+    );
+    expect(calls.some((c) => c.command.includes("x-access-token"))).toBe(false);
+  });
+
+  it("throws ScrubVerificationError when a tokenized git remote survives", async () => {
+    const { exec } = fakeExec({
+      existing: [...FILES, ...SUDO_FILES],
+      gitRemoteLeftover: [`${WORKSPACE}/repo/.git/config`],
+    });
+
+    await expect(
+      scrubTargetsViaExec(exec, "sb_1", targets()),
+    ).rejects.toBeInstanceOf(ScrubVerificationError);
+  });
+});

--- a/js/sandbox/src/providers/shared/scrub-exec.ts
+++ b/js/sandbox/src/providers/shared/scrub-exec.ts
@@ -1,0 +1,202 @@
+/**
+ * Core-synthesized pre-snapshot secret scrub, expressed against the id-keyed
+ * {@link ExecCapability} primitive.
+ *
+ * Snapshots capture the whole filesystem opaquely, so injected secrets are
+ * removed from the running sandbox immediately before capture. Providers do
+ * not implement this: `makeSandboxSnapshots` runs it above the provider's
+ * `capture()`/`removeInjectedSecrets()` primitives for every provider that
+ * declares exec.
+ *
+ * The mechanism is generic — it removes exactly the paths it is handed and
+ * never decides what is a secret (the target list, including the workspace root
+ * for the git-remote pass, is computed by the caller and arrives as
+ * {@link ScrubTargets}).
+ *
+ * Every command runs with `resumeMode: "bare"`: on Vercel a generic exec
+ * against a stopped sandbox would otherwise fire the service-restart resume
+ * callback, which reads the resume-context file and relaunches OpenCode with
+ * the source password — reloading the very secret being scrubbed into a live
+ * session right before capture. Providers without resume callbacks ignore it.
+ *
+ * Used only on the destructive "snapshot and delete" path — the source is
+ * deleted afterward (or, on failure, kept with the scrub already applied), so
+ * the scrub is not reversed.
+ */
+import { shellQuote } from "../../util/shell";
+import {
+  ScrubRestoreError,
+  ScrubVerificationError,
+  type ScrubTargets,
+} from "../provider";
+import type { ExecCapability, ExecCommandOptions } from "../provider";
+import { execFailureText } from "./adapter";
+
+const SCRUB_EXEC_OPTS: ExecCommandOptions = { resumeMode: "bare" };
+
+/**
+ * Rewrite tokenized Git remotes to their plain `https://` form in every cloned
+ * repo under `workspaceRoot`. Clones performed with
+ * `https://x-access-token:<token>@github.com/...` persist that exact URL in
+ * each repo's `.git/config`; the credential-file/env scrub never touches it,
+ * so without this a "scrubbed" snapshot would still carry a live GitHub token
+ * for any cloned private repo. Verifies none survive (fail closed, like the
+ * file scrub). A no-op when the workspace or repos are absent.
+ */
+async function scrubGitRemoteTokens(
+  exec: ExecCapability,
+  providerSandboxId: string,
+  workspaceRoot: string,
+): Promise<void> {
+  // Only `.git/config` files under the workspace; the userinfo is `[^@/]+` so we
+  // strip exactly the `x-access-token:<token>@` prefix and keep the host/path.
+  const findConfigs = `find ${shellQuote(workspaceRoot)} -type f -path '*/.git/config'`;
+  const sanitizeCmd =
+    `if [ -d ${shellQuote(workspaceRoot)} ]; then ` +
+    `${findConfigs} -exec sed -i -E 's#https://x-access-token:[^@/]+@#https://#g' {} +; fi`;
+  const sanitizeResult = await exec.run(
+    providerSandboxId,
+    sanitizeCmd,
+    SCRUB_EXEC_OPTS,
+  );
+  if (sanitizeResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to scrub tokenized git remotes: ${execFailureText(sanitizeResult)}`,
+    );
+  }
+
+  // Verify no `.git/config` still contains a tokenized remote before the caller
+  // snapshots. `grep -l` prints only the paths that still match; any output is a
+  // leftover token, so fail closed exactly as the file scrub does.
+  const verifyCmd =
+    `if [ -d ${shellQuote(workspaceRoot)} ]; then ` +
+    `${findConfigs} -exec grep -l 'x-access-token:' {} + 2>/dev/null; fi`;
+  const { stdout } = await exec.run(
+    providerSandboxId,
+    verifyCmd,
+    SCRUB_EXEC_OPTS,
+  );
+  const leftover = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (leftover.length > 0) {
+    throw new ScrubVerificationError(leftover);
+  }
+}
+
+/**
+ * Remove the given credential files and managed env files from a running
+ * sandbox, then verify the removal took. Credential files (`targets.files`)
+ * are removed as the unprivileged user; the managed env files
+ * (`targets.sudoFiles`) are system paths removed with sudo. `rm -rf`/`rm -f`
+ * are no-ops on missing paths, so this stays idempotent; the exit-code check
+ * still surfaces a genuine filesystem error. All target paths arrive
+ * absolute, so no home-directory resolution is needed.
+ *
+ * A silent no-op (e.g. a misrouted exec) would produce a snapshot that still
+ * contains secrets — exactly what this guards against — so every removed path
+ * is verified gone afterward, failing closed with
+ * {@link ScrubVerificationError}.
+ */
+export async function scrubTargetsViaExec(
+  exec: ExecCapability,
+  providerSandboxId: string,
+  targets: ScrubTargets,
+): Promise<void> {
+  // Restore system baselines first, before anything else runs. This is what
+  // clears the injected secrets out of `/etc/environment` (the file is
+  // overwritten with its clean baseline rather than removed), so doing it
+  // first keeps the window in which a live process could still read them as
+  // short as possible.
+  for (const restore of targets.sudoFileRestores) {
+    const result = await exec.run(
+      providerSandboxId,
+      `install -m 0644 ${shellQuote(restore.sourcePath)} ${shellQuote(restore.destinationPath)}`,
+      { ...SCRUB_EXEC_OPTS, sudo: true },
+    );
+    if (result.exitCode !== 0) {
+      throw new ScrubRestoreError(
+        restore.sourcePath,
+        restore.destinationPath,
+        `install failed (exit ${result.exitCode}) ${execFailureText(result)}`.trim(),
+      );
+    }
+  }
+
+  for (const file of targets.files) {
+    const result = await exec.run(
+      providerSandboxId,
+      `rm -rf ${shellQuote(file)}`,
+      SCRUB_EXEC_OPTS,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to remove credential path ${file}: ${execFailureText(result)}`,
+      );
+    }
+  }
+
+  for (const filePath of targets.sudoFiles) {
+    const result = await exec.run(
+      providerSandboxId,
+      `rm -f ${shellQuote(filePath)}`,
+      { ...SCRUB_EXEC_OPTS, sudo: true },
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to remove environment file ${filePath}: ${execFailureText(result)}`,
+      );
+    }
+  }
+
+  // Rewrite tokenized Git remotes the credential/env removal doesn't cover
+  // (each cloned repo's `.git/config` still holds the clone-URL token) when
+  // the caller declared a workspace root. Verifies internally, fails closed.
+  if (targets.gitTokenWorkspaceRoot) {
+    await scrubGitRemoteTokens(
+      exec,
+      providerSandboxId,
+      targets.gitTokenWorkspaceRoot,
+    );
+  }
+
+  // Verify the scrub actually took before the caller captures. `ls -1d`
+  // prints existing paths to stdout and routes "no such file" to stderr, so a
+  // single sudo command yields exactly the still-present files; its exit code
+  // is ignored (non-zero whenever any candidate is absent — the good case).
+  const removedPaths = [...targets.files, ...targets.sudoFiles];
+  if (removedPaths.length > 0) {
+    const { stdout } = await exec.run(
+      providerSandboxId,
+      `ls -1d ${removedPaths.map(shellQuote).join(" ")} 2>/dev/null`,
+      { ...SCRUB_EXEC_OPTS, sudo: true },
+    );
+    const present = new Set(
+      stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean),
+    );
+    const leftover = removedPaths.filter((file) => present.has(file));
+    if (leftover.length > 0) {
+      throw new ScrubVerificationError(leftover);
+    }
+  }
+
+  for (const restore of targets.sudoFileRestores) {
+    const result = await exec.run(
+      providerSandboxId,
+      `source_hash=$(sha256sum ${shellQuote(restore.sourcePath)}) && ` +
+        `destination_hash=$(sha256sum ${shellQuote(restore.destinationPath)}) && ` +
+        `[ "\${source_hash%% *}" = "\${destination_hash%% *}" ]`,
+      { ...SCRUB_EXEC_OPTS, sudo: true },
+    );
+    if (result.exitCode === 0) continue;
+    throw new ScrubRestoreError(
+      restore.sourcePath,
+      restore.destinationPath,
+      `verification failed (exit ${result.exitCode}) ${execFailureText(result)}`.trim(),
+    );
+  }
+}

--- a/js/sandbox/src/providers/vercel/capabilities.ts
+++ b/js/sandbox/src/providers/vercel/capabilities.ts
@@ -1,0 +1,37 @@
+/**
+ * Vercel capability flags. Colocated with the provider but kept SDK-free so the
+ * client-safe capabilities table (`../capabilities`) can aggregate it without
+ * pulling in the Vercel SDK.
+ *
+ * Per-sandbox lifecycle + exec + log streaming + snapshots, backed by
+ * Vercel's `@vercel/sandbox` SDK (Firecracker microVMs). Streaming is real (the
+ * SDK's incremental `command.logs()` async generator), unlike Freestyle. SSH
+ * uses the provider-generic `amikad` no-relay service rather than the removed
+ * provider-specific private-key bridge. Snapshots are captured from a
+ * running sandbox via `sandbox.snapshot()`; only the destructive
+ * scrub-and-delete capture is supported (a kept-alive source's
+ * `keepLastSnapshots` retention would evict a full capture), so
+ * `fullSnapshotCapture` is false. Docker registries and image-derived snapshots
+ * stay Daytona-only — a control-plane concern Vercel does not back. Vercel
+ * honors `skipStartScript` in its start-phase lifecycle rerun.
+ */
+import type { SandboxProviderCapabilities } from "../provider";
+
+export const vercelCapabilities: SandboxProviderCapabilities = {
+  lifecycle: true,
+  ssh: false,
+  services: true,
+  exec: true,
+  listSandboxes: true,
+  streaming: true,
+  snapshots: true,
+  scrubCapture: true,
+  fullSnapshotCapture: false,
+  dockerRegistries: false,
+  skipStartScript: true,
+  // Vercel snapshots are id-only (`snap_…`), resolved from the org-scoped name
+  // through the injected resolver.
+  snapshotIdsAreOpaque: true,
+  // Persistent microVMs suspend/resume on idle rather than being auto-deleted.
+  supportsAutoDelete: false,
+};

--- a/js/sandbox/src/providers/vercel/config.ts
+++ b/js/sandbox/src/providers/vercel/config.ts
@@ -1,0 +1,21 @@
+import type { SandboxConfigBase } from "../../config";
+
+// Vercel Sandbox (Firecracker microVM) credentials. Access-token auth is used
+// because amika runs off-Vercel (the recommended OIDC-token path only applies to
+// code deployed on Vercel): the team-scoped access token is `apiKey`, plus the
+// team and project the sandboxes are created under. New sandboxes always boot
+// from a prepared snapshot; there is no runtime fallback, because a plain Vercel
+// runtime lacks the baked-in amikad hooks and agent tooling an Amika sandbox
+// needs.
+export interface VercelConfig extends SandboxConfigBase {
+  apiKey: string;
+  teamId: string;
+  projectId: string;
+}
+
+/**
+ * The home / default working directory inside every Vercel sandbox — they run
+ * as the `vercel-sandbox` user rooted at `/vercel/sandbox`. A per-provider
+ * constant surfaced as `provider.userHomeDir` and used by the SSH mint path.
+ */
+export const VERCEL_HOME_DIR = "/vercel/sandbox";

--- a/js/sandbox/src/providers/vercel/internal/adapter.test.ts
+++ b/js/sandbox/src/providers/vercel/internal/adapter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildVercelCommand, redactCommandForLabel } from "./adapter";
+
+describe("buildVercelCommand", () => {
+  it("sources the managed env before the command", () => {
+    const script = buildVercelCommand("echo hi");
+    const lines = script.split("\n");
+    expect(lines[0]).toContain("/etc/environment");
+    expect(lines.at(-1)).toBe("echo hi");
+  });
+
+  it("exports explicit env vars (quoted) before changing directory and running", () => {
+    const script = buildVercelCommand("npm install", {
+      env: { FOO: "bar baz" },
+      cwd: "/home/sandbox/workspace/app",
+    });
+    const lines = script.split("\n");
+    expect(lines).toEqual([
+      expect.stringContaining("/etc/environment"),
+      `export FOO='bar baz'`,
+      `cd '/home/sandbox/workspace/app' || exit 1`,
+      "npm install",
+    ]);
+  });
+
+  it("omits the export/cd segments when no env or cwd is given", () => {
+    const script = buildVercelCommand("ls");
+    expect(script.split("\n")).toHaveLength(2);
+  });
+});
+
+describe("redactCommandForLabel", () => {
+  it("masks a GitHub token embedded in a clone URL", () => {
+    const command =
+      "git clone 'https://x-access-token:ghs_secretTokenValue@github.com/org/repo.git' '/home/repo'";
+    const redacted = redactCommandForLabel(command);
+    expect(redacted).not.toContain("ghs_secretTokenValue");
+    expect(redacted).toContain("https://***@github.com/org/repo.git");
+  });
+
+  it("masks credentials in any http(s) userinfo, not just clone", () => {
+    expect(redactCommandForLabel("git ls-remote https://user:pw@host/x")).toBe(
+      "git ls-remote https://***@host/x",
+    );
+  });
+
+  it("leaves credential-free commands unchanged", () => {
+    expect(redactCommandForLabel("npm install")).toBe("npm install");
+    expect(redactCommandForLabel("git clone https://github.com/org/repo")).toBe(
+      "git clone https://github.com/org/repo",
+    );
+  });
+});

--- a/js/sandbox/src/providers/vercel/internal/adapter.ts
+++ b/js/sandbox/src/providers/vercel/internal/adapter.ts
@@ -1,0 +1,172 @@
+/**
+ * Vercel adapter for the provider-agnostic {@link SandboxAdapter} port.
+ *
+ * Wraps a `@vercel/sandbox` `Sandbox` instance and maps the four adapter
+ * primitives onto the SDK. Two impedance mismatches with the Daytona model are
+ * handled here, mirroring {@link FreestyleAdapter}:
+ *
+ *  - `sandbox.runCommand` runs a single `cmd` + `args` (no implicit shell), so
+ *    `cwd`/`env`/the managed-env source are folded into a `bash -c` script.
+ *  - Vercel's default exec runs as the unprivileged `vercel-sandbox` user (which
+ *    has passwordless `sudo`), so ordinary adapter work runs as that user and
+ *    `sudo: true` steps go through the SDK's `sudo` flag — the same
+ *    unprivileged-by-default / sudo-for-system-steps contract Daytona expects.
+ */
+import type { Sandbox } from "@vercel/sandbox";
+import { shellQuote } from "../../../util/shell";
+import type {
+  ExecOptions,
+  ExecResult,
+  SandboxAdapter,
+} from "../../shared/adapter";
+
+/**
+ * Load the Amika-managed environment that provisioning persists to
+ * `/etc/environment` (`HOME`, `AMIKA_AGENT_CWD`, `OPENCODE_*`, injected vars)
+ * before running the command. Vercel's `runCommand` starts a fresh shell with
+ * only the sandbox's default `env`, so — like Freestyle's `vm.exec` — it
+ * wouldn't otherwise see the managed env. Guarded with `[ -f ... ]` so it's a
+ * harmless no-op before the file exists (early in init).
+ */
+const SOURCE_MANAGED_ENV =
+  "[ -f /etc/environment ] && { set -a; . /etc/environment; set +a; }";
+
+/**
+ * Strip URL-embedded credentials from a command before it is used as a
+ * diagnostic timing label. The provisioning layer's exec-based clone builds
+ * `git clone 'https://x-access-token:<token>@github.com/...'`, so the raw
+ * command text carries a GitHub token; without this the token would reach
+ * server logs via {@link VercelAdapter.roundTripStats}'s `slowestLabel`.
+ * Rewrites the `user:secret@` userinfo of any `http(s)://` URL to `***@`,
+ * defending every token-bearing exec (clone, `ls-remote`, …), not just today's.
+ */
+export function redactCommandForLabel(command: string): string {
+  return command.replace(/(\bhttps?:\/\/)[^/@\s]+@/gi, "$1***@");
+}
+
+/**
+ * Fold the adapter {@link ExecOptions} into a single shell script for
+ * `bash -c`. The managed env is sourced first, then any explicit env vars are
+ * exported (so they win), then the working directory is changed before the
+ * command runs. The `sudo` flag is not reflected in the script —
+ * {@link VercelAdapter.exec} passes it to `runCommand` instead. Exported for
+ * unit testing.
+ */
+export function buildVercelCommand(
+  command: string,
+  opts?: ExecOptions,
+): string {
+  const segments: string[] = [SOURCE_MANAGED_ENV];
+  if (opts?.env) {
+    for (const [name, value] of Object.entries(opts.env)) {
+      segments.push(`export ${name}=${shellQuote(value)}`);
+    }
+  }
+  if (opts?.cwd) {
+    // Fail fast if the working directory is missing/inaccessible, so the
+    // command can't silently run in the sandbox's previous cwd and let a
+    // successful command mask the failed `cd`.
+    segments.push(`cd ${shellQuote(opts.cwd)} || exit 1`);
+  }
+  segments.push(command);
+  return segments.join("\n");
+}
+
+export class VercelAdapter implements SandboxAdapter {
+  // Round-trip accounting for diagnosing slow provisions. Every adapter op is a
+  // separate HTTPS call to the Vercel API; on a chatty path (a new sandbox makes
+  // dozens) the sum dominates boot time. Tracked here so the orchestrators can
+  // log a per-provision breakdown via {@link roundTripStats}, mirroring
+  // `FreestyleAdapter`.
+  private roundTripCount = 0;
+  private roundTripMs = 0;
+  private slowestMs = 0;
+  private slowestLabel = "";
+
+  constructor(private readonly sandbox: Sandbox) {}
+
+  private async timed<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    const start = performance.now();
+    try {
+      return await fn();
+    } finally {
+      const ms = performance.now() - start;
+      this.roundTripCount += 1;
+      this.roundTripMs += ms;
+      if (ms > this.slowestMs) {
+        this.slowestMs = ms;
+        this.slowestLabel = label;
+      }
+    }
+  }
+
+  get roundTripStats(): {
+    count: number;
+    totalMs: number;
+    slowestMs: number;
+    slowestLabel: string;
+  } {
+    return {
+      count: this.roundTripCount,
+      totalMs: Math.round(this.roundTripMs),
+      slowestMs: Math.round(this.slowestMs),
+      slowestLabel: this.slowestLabel,
+    };
+  }
+
+  async exec(command: string, opts?: ExecOptions): Promise<ExecResult> {
+    // `sudo: true` elevates via the SDK's flag (system-level setup); everything
+    // else runs as the default `vercel-sandbox` user so repos, dotfiles, and
+    // agent processes are owned by the lifecycle user rather than root.
+    const commandHandle = await this.timed(
+      redactCommandForLabel(command).slice(0, 80),
+      () =>
+        this.sandbox.runCommand({
+          cmd: "bash",
+          args: ["-c", buildVercelCommand(command, opts)],
+          sudo: opts?.sudo ?? false,
+        }),
+    );
+    const stdout = await commandHandle.stdout();
+    const stderr = await commandHandle.stderr();
+    return { exitCode: commandHandle.exitCode, stdout, stderr };
+  }
+
+  async uploadFile(content: Buffer | string, path: string): Promise<void> {
+    await this.ensureParentDir(path);
+    const buffer =
+      typeof content === "string" ? Buffer.from(content, "utf8") : content;
+    // `writeFiles` runs as `vercel-sandbox` (the sandbox's default user), so the
+    // file lands owned by the lifecycle user — no root-ownership repair is
+    // needed, unlike Freestyle whose `fs` writes run as root.
+    await this.timed(`write ${path}`, () =>
+      this.sandbox.writeFiles([{ path, content: buffer }]),
+    );
+  }
+
+  async downloadFile(path: string): Promise<string | null> {
+    try {
+      const buffer = await this.timed(`read ${path}`, () =>
+        this.sandbox.readFileToBuffer({ path }),
+      );
+      return buffer ? buffer.toString("utf8") : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async ensureParentDir(path: string): Promise<void> {
+    const idx = path.lastIndexOf("/");
+    if (idx <= 0) return;
+    const dir = path.slice(0, idx);
+    // `mkdir -p` (rather than `sandbox.mkDir`) so intermediate dirs are created.
+    // Best-effort: a real failure surfaces on the subsequent write.
+    try {
+      await this.timed(`mkdir ${dir}`, () =>
+        this.sandbox.runCommand({ cmd: "mkdir", args: ["-p", dir] }),
+      );
+    } catch {
+      // ignore — the subsequent write surfaces a real failure.
+    }
+  }
+}

--- a/js/sandbox/src/providers/vercel/internal/client.ts
+++ b/js/sandbox/src/providers/vercel/internal/client.ts
@@ -1,0 +1,55 @@
+/**
+ * Vercel Sandbox SDK access.
+ *
+ * `@vercel/sandbox` is a static SDK — there is no client object to construct;
+ * `Sandbox.create`/`Sandbox.get` take the credentials inline. Amika runs
+ * off-Vercel, so we use access-token auth (a team-scoped token plus the team
+ * and project ids) rather than the OIDC token the SDK auto-resolves from the
+ * environment when code is deployed on Vercel. Centralizing the credential
+ * mapping here keeps every operation authenticating identically; nothing else
+ * in the provider references the raw {@link VercelConfig} fields.
+ */
+import { Sandbox } from "@vercel/sandbox";
+import type { VercelConfig } from "../config";
+
+/** The credential fields spread into every `Sandbox.create`/`get` call. */
+export function vercelCredentials(config: VercelConfig): {
+  token: string;
+  teamId: string;
+  projectId: string;
+} {
+  return {
+    token: config.apiKey,
+    teamId: config.teamId,
+    projectId: config.projectId,
+  };
+}
+
+/**
+ * Reconnect to an existing sandbox by its provider id — the Vercel sandbox
+ * `name`, generated at create time and stored as `provider_sandbox_id`.
+ *
+ * `resume` defaults to `false` so read-only / teardown operations (state, stop,
+ * delete) don't spin a stopped VM back up just to inspect or remove it. Pass
+ * `true` on paths that need a live VM (exec, file read, lifecycle restart):
+ * Vercel sandboxes are persistent, so a stopped one resumes from its last
+ * snapshot.
+ *
+ * `onResume` is the SDK hook the platform invokes when a `resume: true` call
+ * actually wakes a stopped session from its snapshot (it does NOT fire for a
+ * sandbox that is already running). Persistence restores only the filesystem,
+ * not the processes the lifecycle hooks started, so exec/stream paths pass a
+ * callback here to relaunch OpenCode and the user services on a cold resume.
+ */
+export function getVercelSandbox(
+  config: VercelConfig,
+  providerSandboxId: string,
+  opts?: { resume?: boolean; onResume?: (sandbox: Sandbox) => Promise<void> },
+): Promise<Sandbox> {
+  return Sandbox.get({
+    ...vercelCredentials(config),
+    name: providerSandboxId,
+    resume: opts?.resume ?? false,
+    ...(opts?.onResume ? { onResume: opts.onResume } : {}),
+  });
+}

--- a/js/sandbox/src/providers/vercel/internal/operations.test.ts
+++ b/js/sandbox/src/providers/vercel/internal/operations.test.ts
@@ -1,0 +1,468 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import pino from "pino";
+import type { SandboxCtx } from "../../../logger";
+import type { VercelConfig } from "../config";
+import type {
+  CreateSandboxProviderInput,
+  SandboxService,
+} from "../../provider";
+import {
+  createVercelSandbox,
+  executeVercelCommand,
+  listVercelSandboxes,
+  resolveVercelSnapshotId,
+  resolveVercelPorts,
+  portsForDesiredServices,
+  vercelTimeoutMs,
+  mapVercelSandboxState,
+  writeVercelFile,
+  writeVercelResumeContext,
+  VERCEL_RESUME_CONTEXT_PATH,
+} from "./operations";
+import { AMIKAD_ETC_DIR, SANDBOX_ORG_ID_LABEL } from "../../../constants";
+import type {
+  ExecOptions,
+  ExecResult,
+  SandboxAdapter,
+} from "../../shared/adapter";
+
+/**
+ * In-memory {@link SandboxAdapter} recorder: captures uploads into `files` and
+ * every exec (with its sudo flag) into `commands`, so tests can assert what was
+ * written and run without a provider.
+ */
+class FakeAdapter implements SandboxAdapter {
+  readonly files = new Map<string, string>();
+  readonly commands: { command: string; sudo: boolean }[] = [];
+
+  async exec(command: string, opts?: ExecOptions): Promise<ExecResult> {
+    this.commands.push({ command, sudo: opts?.sudo ?? false });
+    return { exitCode: 0, stdout: "", stderr: "" };
+  }
+
+  async uploadFile(content: Buffer | string, filePath: string): Promise<void> {
+    this.files.set(
+      filePath,
+      typeof content === "string" ? content : content.toString("utf8"),
+    );
+  }
+
+  async downloadFile(filePath: string): Promise<string | null> {
+    return this.files.get(filePath) ?? null;
+  }
+}
+
+const sandboxCreate = vi.fn();
+const sandboxGet = vi.fn();
+const sandboxList = vi.fn();
+vi.mock("@vercel/sandbox", () => ({
+  Sandbox: {
+    create: (...args: unknown[]) => sandboxCreate(...args),
+    get: (...args: unknown[]) => sandboxGet(...args),
+    list: (...args: unknown[]) => sandboxList(...args),
+  },
+}));
+
+const VERCEL_CONFIG: VercelConfig = {
+  apiKey: "tok",
+  teamId: "team_1",
+  projectId: "prj_1",
+};
+
+/** A mock sandbox whose `runCommand` returns fixed output. */
+function mockSandbox(update = vi.fn(async () => {})) {
+  return {
+    update,
+    runCommand: vi.fn(async () => ({
+      exitCode: 0,
+      stdout: async () => "out",
+      stderr: async () => "",
+    })),
+  };
+}
+
+function service(name: string, containerPort: number): SandboxService {
+  return {
+    name,
+    url: "",
+    hostPort: containerPort,
+    containerPort,
+    protocol: "tcp",
+  };
+}
+
+describe("resolveVercelSnapshotId", () => {
+  it("returns the snapshot id when the value looks like one", () => {
+    expect(resolveVercelSnapshotId("snap_abc123")).toBe("snap_abc123");
+  });
+
+  it("throws when no snapshot is configured (empty / undefined)", () => {
+    expect(() => resolveVercelSnapshotId("")).toThrow(
+      /require a prepared snapshot/,
+    );
+    expect(() => resolveVercelSnapshotId(undefined)).toThrow(
+      /require a prepared snapshot/,
+    );
+  });
+
+  it("throws for a runtime name rather than booting a plain runtime", () => {
+    // A plain runtime lacks the baked-in amikad hooks + agent tooling, so it
+    // cannot boot an Amika sandbox — reject rather than degrade.
+    expect(() => resolveVercelSnapshotId("python3.13")).toThrow(
+      /require a prepared snapshot/,
+    );
+  });
+
+  it("throws for a foreign snapshot value (e.g. a Daytona image tag)", () => {
+    // A Daytona-style image tag sent after switching providers is not a Vercel
+    // snapshot id.
+    expect(() => resolveVercelSnapshotId("amika/daytona-coder-m:abc")).toThrow(
+      /require a prepared snapshot/,
+    );
+  });
+});
+
+describe("resolveVercelPorts", () => {
+  it("keeps the Coding Agent port first and dedupes", () => {
+    const ports = resolveVercelPorts([
+      service("web", 3000),
+      service("Coding Agent", 60998),
+      service("web", 3000),
+    ]);
+    expect(ports).toEqual([60998, 3000]);
+  });
+
+  it("caps the exposed ports at the Vercel limit (15), dropping extras after the agent", () => {
+    // 1 agent + 16 services = 17 requested, two over the platform limit of 15.
+    const extras = Array.from({ length: 16 }, (_, i) =>
+      service(`svc-${i}`, 3001 + i),
+    );
+    const ports = resolveVercelPorts([
+      service("Coding Agent", 60998),
+      ...extras,
+    ]);
+    expect(ports).toHaveLength(15);
+    expect(ports[0]).toBe(60998);
+    // The last two requested ports are the ones dropped.
+    expect(ports).not.toContain(3015);
+    expect(ports).not.toContain(3016);
+  });
+});
+
+describe("portsForDesiredServices", () => {
+  it("drops a removed service's port and the legacy SSH bridge route", () => {
+    // Live routes on an older sandbox still carry the legacy `websocat` SSH
+    // bridge (2222); the desired set no longer contains port 3000, so the
+    // reconciled list drops both the removed service and the defunct bridge.
+    expect(
+      portsForDesiredServices(
+        [60998, 3000, 2222],
+        [service("Coding Agent", 60998)],
+      ),
+    ).toEqual([60998]);
+  });
+
+  it("strips the legacy SSH bridge route while keeping surviving services", () => {
+    // Migration case: an older sandbox exposes a live service port (3000)
+    // alongside the legacy bridge (2222). Reconciling to the still-desired
+    // services keeps 3000 and tears down 2222.
+    expect(
+      portsForDesiredServices(
+        [60998, 3000, 2222],
+        [service("Coding Agent", 60998), service("web", 3000)],
+      ),
+    ).toEqual([60998, 3000]);
+  });
+
+  it("is a no-op when a surviving service still uses the port", () => {
+    expect(
+      portsForDesiredServices(
+        [60998, 3000],
+        [service("Coding Agent", 60998), service("other", 3000)],
+      ),
+    ).toBeNull();
+  });
+
+  it("exposes a late-added service port (KAPRO-616)", () => {
+    // A service added after create is not exposed by the base port logic; the
+    // declarative reconcile adds it.
+    expect(
+      portsForDesiredServices(
+        [60998],
+        [service("Coding Agent", 60998), service("late", 4000)],
+      ),
+    ).toEqual([60998, 4000]);
+  });
+
+  it("is a no-op when the port set already matches (order-insensitive)", () => {
+    expect(
+      portsForDesiredServices(
+        [3000, 60998],
+        [service("Coding Agent", 60998), service("web", 3000)],
+      ),
+    ).toBeNull();
+  });
+
+  it("drops the legacy SSH bridge route even when the desired set fills all 15", () => {
+    // 15 desired service ports fill the cap; the live 2222 bridge route is not
+    // part of the desired set, so it is torn down (as it always is now).
+    const desired = Array.from({ length: 15 }, (_, i) =>
+      service(`svc-${i}`, 3000 + i),
+    );
+    const next = portsForDesiredServices([60998, 2222], desired);
+    expect(next).toHaveLength(15);
+    expect(next).not.toContain(2222);
+  });
+});
+
+describe("vercelTimeoutMs", () => {
+  it("maps a positive interval (minutes) to milliseconds", () => {
+    expect(vercelTimeoutMs(10)).toBe(10 * 60_000);
+  });
+
+  it("clamps an over-ceiling interval", () => {
+    expect(vercelTimeoutMs(600)).toBe(45 * 60_000);
+  });
+
+  it("uses the default window for never (0) and absent", () => {
+    expect(vercelTimeoutMs(0)).toBe(45 * 60_000);
+    expect(vercelTimeoutMs(null)).toBe(45 * 60_000);
+    expect(vercelTimeoutMs(undefined)).toBe(45 * 60_000);
+  });
+});
+
+describe("createVercelSandbox", () => {
+  const config: VercelConfig = {
+    apiKey: "tok",
+    teamId: "team_1",
+    projectId: "prj_1",
+  };
+
+  function ctx(): SandboxCtx {
+    return { logger: pino({ enabled: false }), childCtx: () => ctx() };
+  }
+
+  function createInput(
+    overrides?: Partial<CreateSandboxProviderInput>,
+  ): CreateSandboxProviderInput {
+    return {
+      name: "sbx",
+      snapshot: "snap_test",
+      services: [],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => sandboxCreate.mockReset());
+
+  it("boots a persistent sandbox with a flat, non-expiring snapshot retention policy", async () => {
+    sandboxCreate.mockResolvedValue({ name: "vercel-generated" });
+
+    const result = await createVercelSandbox(ctx(), config, createInput());
+
+    expect(sandboxCreate).toHaveBeenCalledTimes(1);
+    // Persistence auto-snapshots on stop; without a retention policy the
+    // snapshots accumulate and inherit Vercel's default 30-day expiry (a
+    // dormant sandbox would lose its resumable state).
+    expect(sandboxCreate.mock.calls[0][0]).toMatchObject({
+      persistent: true,
+      keepLastSnapshots: { count: 1 },
+      snapshotExpiration: 0,
+      source: { type: "snapshot", snapshotId: "snap_test" },
+    });
+    expect(result.provider).toBe("vercel");
+    expect(result.providerSandboxId).toBe("vercel-generated");
+  });
+});
+
+describe("mapVercelSandboxState", () => {
+  it("maps every raw Vercel status onto the canonical vocabulary", () => {
+    const cases: Record<string, string> = {
+      pending: "starting",
+      running: "running",
+      snapshotting: "snapshotting",
+      stopping: "stopping",
+      stopped: "suspended",
+      failed: "failed",
+      aborted: "failed",
+    };
+    for (const [raw, expected] of Object.entries(cases)) {
+      expect(mapVercelSandboxState(raw), raw).toBe(expected);
+    }
+  });
+
+  it("maps the synthesized missing-sandbox sentinel and junk to unknown", () => {
+    expect(mapVercelSandboxState("unknown")).toBe("unknown");
+    expect(mapVercelSandboxState("")).toBe("unknown");
+  });
+});
+
+describe("executeVercelCommand", () => {
+  beforeEach(() => sandboxGet.mockReset());
+
+  it("resumes and restarts lifecycle services by default", async () => {
+    sandboxGet.mockResolvedValue(mockSandbox());
+
+    const result = await executeVercelCommand(
+      VERCEL_CONFIG,
+      "sandbox-name",
+      "echo hi",
+    );
+
+    // Default cold-resume behavior wires an `onResume` hook (service restart)
+    // and resumes the sandbox by its provider id.
+    expect(sandboxGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "sandbox-name",
+        resume: true,
+        onResume: expect.any(Function),
+      }),
+    );
+    expect(result).toEqual({ exitCode: 0, stdout: "out", stderr: "" });
+  });
+
+  it('skips the service restart when resumeMode is "bare"', async () => {
+    sandboxGet.mockResolvedValue(mockSandbox());
+
+    await executeVercelCommand(VERCEL_CONFIG, "sandbox-name", "echo hi", {
+      resumeMode: "bare",
+    });
+
+    // `bare` resumes only the filesystem — no `onResume` hook, so a plain
+    // command (agent launch / exit probe) doesn't pay the relaunch latency.
+    const arg = sandboxGet.mock.calls[0][0] as { onResume?: unknown };
+    expect(arg.onResume).toBeUndefined();
+  });
+
+  it("reapplies the session timeout before running when requested", async () => {
+    const calls: string[] = [];
+    const update = vi.fn(async () => {
+      calls.push("update");
+    });
+    const sandbox = mockSandbox(update);
+    sandbox.runCommand = vi.fn(async () => {
+      calls.push("runCommand");
+      return { exitCode: 0, stdout: async () => "out", stderr: async () => "" };
+    });
+    sandboxGet.mockResolvedValue(sandbox);
+
+    await executeVercelCommand(VERCEL_CONFIG, "sandbox-name", "echo hi", {
+      sessionTimeoutMs: 45 * 60 * 1000,
+    });
+
+    // The timeout must be reapplied *before* the command runs so a resumed
+    // sandbox isn't suspended mid-run.
+    expect(update).toHaveBeenCalledWith({ timeout: 45 * 60 * 1000 });
+    expect(calls).toEqual(["update", "runCommand"]);
+  });
+
+  it("does not touch the timeout when sessionTimeoutMs is omitted", async () => {
+    const sandbox = mockSandbox();
+    sandboxGet.mockResolvedValue(sandbox);
+
+    await executeVercelCommand(VERCEL_CONFIG, "sandbox-name", "echo hi");
+
+    expect(sandbox.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("listVercelSandboxes", () => {
+  beforeEach(() => sandboxList.mockReset());
+
+  function mockList(items: unknown[]): void {
+    sandboxList.mockResolvedValue({ toArray: async () => items });
+  }
+
+  it("maps each sandbox to its org (from tags), status, and derived sizing", async () => {
+    mockList([
+      {
+        name: "sbx-1",
+        tags: { [SANDBOX_ORG_ID_LABEL]: "org_abc" },
+        vcpus: 4,
+        status: "running",
+      },
+    ]);
+
+    const listings = await listVercelSandboxes(VERCEL_CONFIG);
+
+    expect(listings).toEqual([
+      {
+        providerSandboxId: "sbx-1",
+        orgId: "org_abc",
+        state: "running",
+        // Vercel couples 2 GB/vCPU and a fixed 32 GB ephemeral disk.
+        sizing: { vcpus: 4, memoryGib: 8, diskGib: 32 },
+      },
+    ]);
+  });
+
+  it("reports a null org for a sandbox with no org tag", async () => {
+    mockList([{ name: "sbx-1", tags: {}, vcpus: 2, status: "running" }]);
+
+    expect((await listVercelSandboxes(VERCEL_CONFIG))[0]?.orgId).toBeNull();
+  });
+
+  it("skips sandboxes with no reported vCPU count", async () => {
+    mockList([
+      { name: "sbx-sized", tags: {}, vcpus: 2, status: "running" },
+      { name: "sbx-unsized", tags: {}, vcpus: null, status: "running" },
+    ]);
+
+    const ids = (await listVercelSandboxes(VERCEL_CONFIG)).map(
+      (l) => l.providerSandboxId,
+    );
+    expect(ids).toEqual(["sbx-sized"]);
+  });
+});
+
+describe("writeVercelFile", () => {
+  beforeEach(() => sandboxGet.mockReset());
+
+  it("writes content to the path via the sandbox (args not swapped)", async () => {
+    const writeFiles = vi.fn(async () => {});
+    sandboxGet.mockResolvedValue({
+      // ensureParentDir runs a best-effort `mkdir -p` before the write.
+      runCommand: vi.fn(async () => ({})),
+      writeFiles,
+    });
+
+    await writeVercelFile(VERCEL_CONFIG, "sbx", "/home/amika/f.txt", "hello");
+
+    expect(writeFiles).toHaveBeenCalledWith([
+      { path: "/home/amika/f.txt", content: Buffer.from("hello", "utf8") },
+    ]);
+  });
+});
+
+describe("writeVercelResumeContext", () => {
+  const context = {
+    openCodePassword: "pw",
+    amikaOpenCodeWeb: "http://box:60998",
+    repoDir: "/home/amika/workspace/amika",
+  };
+
+  it("uploads the context as JSON to a temp file", async () => {
+    const adapter = new FakeAdapter();
+    await writeVercelResumeContext(adapter, context);
+
+    expect(adapter.files.size).toBe(1);
+    const [tempPath, content] = [...adapter.files.entries()][0];
+    expect(tempPath).toMatch(/^\/tmp\/amika-vercel-resume-.*\.json$/);
+    expect(JSON.parse(content)).toEqual(context);
+  });
+
+  it("installs the file to the resume-context path and cleans up, all as root", async () => {
+    const adapter = new FakeAdapter();
+    await writeVercelResumeContext(adapter, context);
+
+    const [tempPath] = [...adapter.files.keys()];
+    expect(adapter.commands).toEqual([
+      { command: `mkdir -p '${AMIKAD_ETC_DIR}'`, sudo: true },
+      {
+        command: `install -m 0600 '${tempPath}' '${VERCEL_RESUME_CONTEXT_PATH}'`,
+        sudo: true,
+      },
+      { command: `rm -f '${tempPath}'`, sudo: true },
+    ]);
+  });
+});

--- a/js/sandbox/src/providers/vercel/internal/operations.ts
+++ b/js/sandbox/src/providers/vercel/internal/operations.ts
@@ -1,0 +1,610 @@
+/**
+ * Sandbox-level operations against the Vercel Sandbox API: create (from a
+ * prepared snapshot), start/stop/delete, preview-URL resolution, exec, log
+ * streaming, and file reads, plus the cold-resume service restart. The
+ * provisioning lifecycle lives in `@amika/sandbox-provisioning`; this module
+ * keeps the generic provider mechanics, including {@link openVercelAdapter} and
+ * {@link writeVercelResumeContext} (the provisioning seam the package drives).
+ * Vercel has no native clone primitive, so the provisioning layer clones over
+ * the adapter's exec port rather than through this module.
+ */
+import { Sandbox } from "@vercel/sandbox";
+import { shellQuote } from "../../../util/shell";
+import { AMIKAD_ETC_DIR, SANDBOX_ORG_ID_LABEL } from "../../../constants";
+import { withStepContext } from "../../../util/errorutils";
+import type { SandboxCtx } from "../../../logger";
+import type { VercelConfig } from "../config";
+import {
+  type CreateSandboxProviderInput,
+  type CreatedProviderSandbox,
+  type ExecCommandOptions,
+  type ProviderSandboxListing,
+  type RefreshUrlsResult,
+  type SandboxExecResult,
+  type SandboxService,
+  type StreamCommandHandlers,
+} from "../../provider";
+import type { SandboxStatus } from "../../../sandbox-status";
+import { execChecked, type SandboxAdapter } from "../../shared/adapter";
+import { execWithStagedInput } from "../../shared/exec-input";
+import { buildLifecycleCommands } from "../../shared/lifecycle-commands";
+import { buildVercelCommand, VercelAdapter } from "./adapter";
+import { getVercelSandbox, vercelCredentials } from "./client";
+import { vercelSizingForVcpus, vercelVcpusForSize } from "../sizing";
+
+/**
+ * Vercel preview URLs are backed by per-port subdomains that are stable for the
+ * sandbox's lifetime (`sandbox.domain(port)`), so — like Freestyle's domain
+ * mappings, and unlike Daytona's signed URLs — they don't expire. Use a long
+ * TTL so a sandbox's `urls_expire_at` stays far in the future and the refresh
+ * path rarely churns.
+ */
+export const VERCEL_URL_TTL_S = 365 * 24 * 60 * 60;
+
+/**
+ * Default session timeout for a sandbox. Vercel's own default is 5 minutes,
+ * which is far too short for an interactive agent session, so a freshly created
+ * sandbox is given this window. Vercel sandboxes are persistent (auto-snapshot
+ * on stop, resume on the next call), so the timeout behaves like an idle-suspend
+ * interval rather than a hard delete — work can always resume afterwards.
+ */
+const VERCEL_DEFAULT_TIMEOUT_MS = 45 * 60 * 1000;
+
+/**
+ * Ceiling applied to a user-requested auto-stop interval. Per-plan session
+ * limits cap how long a single session may run; clamping here keeps `create`
+ * from being rejected for an over-limit timeout. A longer-lived sandbox simply
+ * suspends at the ceiling and resumes on the next use (persistence).
+ */
+const VERCEL_MAX_TIMEOUT_MS = 45 * 60 * 1000;
+
+/**
+ * Vercel caps the number of ports a sandbox may expose. The platform limit is
+ * 15 across all plans (Hobby/Pro/Enterprise; see Vercel's Sandbox pricing &
+ * limits docs) — the `@vercel/sandbox` type comment that says "up to 4" is
+ * stale. We cap the service port list here (the Coding Agent port is always
+ * kept first) rather than letting `create` reject an over-limit request.
+ */
+export const VERCEL_MAX_EXPOSED_PORTS = 15;
+
+/**
+ * Translate the persisted `auto_stop_interval` (minutes) into Vercel's session
+ * `timeout` (ms): `>0` → that many minutes (clamped to the plan ceiling); `0`
+ * ("never") and absent both fall back to the default window, since Vercel has
+ * no unbounded session — persistence (resume-on-next-use) provides the
+ * "effectively never stops" behavior instead.
+ */
+export function vercelTimeoutMs(autoStopInterval?: number | null): number {
+  if (autoStopInterval != null && autoStopInterval > 0) {
+    return Math.min(autoStopInterval * 60_000, VERCEL_MAX_TIMEOUT_MS);
+  }
+  return VERCEL_DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * Resolve the snapshot a new sandbox boots from. Vercel sandboxes MUST boot from
+ * a prepared snapshot (`snap_...`) that has the amikad lifecycle hook bundle
+ * (`/usr/lib/amikad/*`) and agent tooling (OpenCode, the agent CLIs) baked in —
+ * the same prepared-image dependency Daytona and Freestyle have. A plain Vercel
+ * runtime (`node24`, `python3.13`, …) has none of that, so the Vercel
+ * provisioning flow would fail at the very first lifecycle step
+ * (`run-hook.sh … pre-setup.sh`) before the user's setup script could run.
+ *
+ * So rather than silently booting a runtime that cannot initialize, require a
+ * configured snapshot and fail loudly at create when one is missing (set the
+ * `VERCEL_SNAPSHOT_*` env vars for the preset/size). Mirrors the sizing guard,
+ * which likewise rejects an unsupported request at create instead of degrading.
+ */
+export function resolveVercelSnapshotId(snapshot: string | undefined): string {
+  if (snapshot && snapshot.startsWith("snap_")) {
+    return snapshot;
+  }
+  throw new Error(
+    "Vercel sandboxes require a prepared snapshot with the amikad hook bundle " +
+      "and agent tooling baked in, but none is configured for this preset/size " +
+      `(got ${snapshot ? `"${snapshot}"` : "no snapshot"}). Set the ` +
+      "VERCEL_SNAPSHOT_* env vars to a snap_… id; a plain Vercel runtime cannot " +
+      "boot an Amika sandbox.",
+  );
+}
+
+/**
+ * The (deduped, capped) set of container ports to expose for a sandbox's
+ * services. The Coding Agent port is kept first so it is never the one dropped
+ * when more than {@link VERCEL_MAX_EXPOSED_PORTS} services are requested.
+ */
+export function resolveVercelPorts(services: SandboxService[]): number[] {
+  const ordered = [
+    ...services.filter((s) => s.name === "Coding Agent"),
+    ...services.filter((s) => s.name !== "Coding Agent"),
+  ];
+  const unique: number[] = [];
+  for (const service of ordered) {
+    if (!unique.includes(service.containerPort)) {
+      unique.push(service.containerPort);
+    }
+  }
+  return unique.slice(0, VERCEL_MAX_EXPOSED_PORTS);
+}
+
+/** Up to 5 key-value tags (the Vercel limit) to stamp on the sandbox. */
+function vercelTags(
+  labels?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!labels) return undefined;
+  const entries = Object.entries(labels).slice(0, 5);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+export async function createVercelSandbox(
+  ctx: SandboxCtx,
+  config: VercelConfig,
+  input: CreateSandboxProviderInput,
+): Promise<CreatedProviderSandbox> {
+  const services = input.services;
+  const ports = resolveVercelPorts(services);
+  const snapshotId = resolveVercelSnapshotId(input.snapshot);
+  const timeoutMs = vercelTimeoutMs(input.autoStopInterval);
+  // Map the requested size to Vercel's `resources` (vCPU count, memory derived
+  // at 2 GB/vCPU). Daytona/Freestyle bake size into the image/snapshot; Vercel
+  // takes it at create time, so without this every size would boot at Vercel's
+  // default 2 vCPUs. Omitted when no size is requested (keeps Vercel's default).
+  const resources = input.size
+    ? { vcpus: vercelVcpusForSize(input.size) }
+    : undefined;
+
+  ctx.logger.info(
+    { snapshotId, ports, timeoutMs, resources },
+    "Creating Vercel sandbox",
+  );
+
+  // Org/user attribution rides on tags (the Vercel analogue of Daytona's
+  // labels); the name is left for Vercel to generate, since the generated name
+  // is the stable handle we reconnect by. The repo is cloned inside the sandbox
+  // during initialization (like Freestyle), not via Vercel's git `source`, so
+  // create only needs the snapshot, ports, timeout, resources, and tags.
+  const sandbox = await withStepContext("vercel create: create sandbox", () =>
+    Sandbox.create({
+      ...vercelCredentials(config),
+      ports,
+      timeout: timeoutMs,
+      persistent: true as const,
+      // Persistence auto-snapshots the filesystem on every stop / idle-timeout.
+      // Keep only the latest snapshot so storage stays flat across resume cycles
+      // (older auto-snapshots are evicted), and disable expiration (`0`) so a
+      // dormant sandbox never loses its resumable state to Vercel's default
+      // 30-day snapshot expiry — Amika owns the sandbox lifetime via
+      // `auto_delete_interval` / an explicit delete, which drops the snapshot too.
+      keepLastSnapshots: { count: 1 },
+      snapshotExpiration: 0,
+      tags: vercelTags(input.labels),
+      ...(resources ? { resources } : {}),
+      source: { type: "snapshot", snapshotId },
+    }),
+  );
+
+  return {
+    provider: "vercel",
+    providerSandboxId: sandbox.name,
+    providerUrl: null,
+    services,
+    envVars: {},
+  };
+}
+
+/**
+ * Resolve each service's public preview URL from its exposed port. Vercel routes
+ * are fixed at create (plus later `syncVercelRoutes` reconciles), so this is a
+ * pure lookup (no mapping to create, unlike Freestyle). A port with no route
+ * (one dropped by the {@link VERCEL_MAX_EXPOSED_PORTS} cap, or an authored
+ * `sandbox_services` port that was added after create and so never exposed)
+ * keeps an empty URL rather than throwing, so a single such service can't fail
+ * the whole refresh (which the lifecycle re-run does not catch). Gate on the
+ * sandbox's ACTUAL `routes`, not the desired service set, so an unexposed port
+ * is skipped.
+ */
+export async function refreshVercelUrls(
+  config: VercelConfig,
+  providerSandboxId: string,
+  services: SandboxService[],
+): Promise<RefreshUrlsResult> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: false,
+  });
+  const routedPorts = new Set(sandbox.routes.map((r) => r.port));
+  const refreshed: SandboxService[] = [];
+  let providerUrl: string | null = null;
+
+  for (const service of services) {
+    let url = "";
+    if (routedPorts.has(service.containerPort)) {
+      url = sandbox.domain(service.containerPort);
+    }
+    // TODO(KAPRO-616): an authored service port added after create is never
+    // exposed on Vercel (routes are fixed at create), so it stays url-less
+    // here. Expose it via `sandbox.update({ ports })` before minting instead of
+    // skipping it.
+    refreshed.push({ ...service, url });
+    if (service.name === "Coding Agent" && url) {
+      providerUrl = url;
+    }
+  }
+
+  return { providerUrl, services: refreshed };
+}
+
+/**
+ * The exposed-port list that realizes `desired`, or `null` when the live set
+ * already matches. Pure so it is unit-testable: service ports (deduped,
+ * "Coding Agent" prioritized, capped at {@link VERCEL_MAX_EXPOSED_PORTS}).
+ * Order-insensitive comparison, since `update({ ports })` needs a change only
+ * when the *set* differs.
+ *
+ * A live route the desired set no longer contains is dropped. New sandboxes
+ * never expose the legacy `websocat` SSH bridge port (2222), since the code
+ * that added it on demand is gone, but an older sandbox may still carry it;
+ * reconciling here tears it down, since it is no longer part of any desired
+ * service set.
+ */
+export function portsForDesiredServices(
+  currentPorts: number[],
+  desired: SandboxService[],
+): number[] | null {
+  const ports = resolveVercelPorts(desired);
+  const current = new Set(currentPorts);
+  if (ports.length === current.size && ports.every((p) => current.has(p))) {
+    return null;
+  }
+  return ports;
+}
+
+/**
+ * Reconcile the sandbox's exposed ports to exactly the desired service set.
+ * Vercel routes are fixed at create, so this both tears down a deleted
+ * service's route (its subdomain would otherwise
+ * keep routing until the sandbox dies) and finally exposes a service port
+ * added after create (TODO(KAPRO-616): `refreshVercelUrls` skipped those). A
+ * legacy `websocat` SSH bridge route (port 2222) lingering on an older sandbox
+ * is torn down here too, since it is no longer part of any desired service set.
+ */
+export async function syncVercelRoutes(
+  config: VercelConfig,
+  providerSandboxId: string,
+  desired: SandboxService[],
+): Promise<void> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: false,
+  });
+  const nextPorts = portsForDesiredServices(
+    sandbox.routes.map((r) => r.port),
+    desired,
+  );
+  if (nextPorts === null) return;
+  // TODO(KAPRO-616, remaining half): this read-modify-write of the full
+  // `ports` list is not serialized per sandbox. Two concurrent syncs each start
+  // from an earlier `sandbox.routes` snapshot, so the last `update({ ports })`
+  // can resurrect another deleted service's route or drop a just-added one. The
+  // declarative shape narrows the window to a single write but does not
+  // serialize it; coordinate per-sandbox (or re-read and reconcile on conflict)
+  // before relying on this for real Vercel usage.
+  await sandbox.update({ ports: nextPorts });
+}
+
+export async function getVercelSandboxState(
+  config: VercelConfig,
+  providerSandboxId: string,
+): Promise<string> {
+  try {
+    const sandbox = await getVercelSandbox(config, providerSandboxId, {
+      resume: false,
+    });
+    return sandbox.status;
+  } catch {
+    // A missing/deleted sandbox can't be fetched; report it as absent rather
+    // than throwing, mirroring Freestyle's `unknown` for a VM not in the list.
+    return "unknown";
+  }
+}
+
+/**
+ * Enumerate every sandbox in the Vercel account with its org stamp (a tag),
+ * status, and provisioned sizing. `Sandbox.list().toArray()` auto-paginates and
+ * flattens to the individual sandboxes. Vercel exposes only the vCPU count on a
+ * listed sandbox; memory and disk are recovered from its fixed 2 GB-per-vCPU /
+ * 32 GB-disk coupling (see {@link vercelSizingForVcpus}). Sandboxes with no
+ * reported vCPU count are excluded — they can't be sized or priced.
+ */
+export async function listVercelSandboxes(
+  config: VercelConfig,
+): Promise<ProviderSandboxListing[]> {
+  const list = await Sandbox.list(vercelCredentials(config));
+  const sandboxes = await list.toArray();
+  const listings: ProviderSandboxListing[] = [];
+  for (const sandbox of sandboxes) {
+    if (sandbox.vcpus == null) continue;
+    const sizing = vercelSizingForVcpus(sandbox.vcpus);
+    listings.push({
+      providerSandboxId: sandbox.name,
+      orgId: sandbox.tags?.[SANDBOX_ORG_ID_LABEL] ?? null,
+      state: sandbox.status,
+      sizing: {
+        vcpus: sizing.vcpus,
+        memoryGib: sizing.memoryGb,
+        diskGib: sizing.diskGb,
+      },
+    });
+  }
+  return listings;
+}
+
+/**
+ * Map a raw Vercel sandbox status into the canonical lifecycle vocabulary.
+ * Raw values are the `@vercel/sandbox` status union plus the synthesized
+ * `"unknown"` for a missing/deleted sandbox. `stopped` reads as `suspended`
+ * (persistent sandboxes resume from their last snapshot); `aborted` is
+ * terminal like `failed`.
+ */
+export function mapVercelSandboxState(rawState: string): SandboxStatus {
+  switch (rawState) {
+    case "pending":
+      return "starting";
+    case "running":
+      return "running";
+    case "snapshotting":
+      return "snapshotting";
+    case "stopping":
+      return "stopping";
+    case "stopped":
+      return "suspended";
+    case "failed":
+    case "aborted":
+      return "failed";
+    default:
+      return "unknown";
+  }
+}
+
+export async function startVercelSandbox(
+  config: VercelConfig,
+  providerSandboxId: string,
+  autoStopInterval?: number | null,
+): Promise<void> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: true,
+  });
+  // `Sandbox.get({ resume: true })` resumes a stopped (persistent) sandbox from
+  // its last snapshot, but the resume completes on the first real call; run a
+  // no-op so the VM is live before the lifecycle restart proceeds.
+  await sandbox.runCommand({ cmd: "true" });
+  // Re-apply the persisted auto-stop choice as the session timeout (Vercel does
+  // not carry a per-sandbox idle policy across sessions), mirroring how
+  // Freestyle re-applies its idle timeout on every start.
+  await sandbox.update({ timeout: vercelTimeoutMs(autoStopInterval) });
+}
+
+export async function stopVercelSandbox(
+  config: VercelConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: false,
+  });
+  // Persistent sandboxes snapshot their filesystem on stop and resume from it on
+  // the next `start`. `stop()` is safe to call on an already-stopped sandbox.
+  await sandbox.stop();
+}
+
+export async function deleteVercelSandbox(
+  config: VercelConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: false,
+  });
+  await sandbox.delete();
+}
+
+/**
+ * Root-only file (0600, written via sudo) holding just enough to relaunch a
+ * sandbox's services after a cold resume without any external lookup: the
+ * OpenCode server password, the OpenCode-web mode, and the repo working dir.
+ * Kept out of `/etc/environment` (which every shell auto-sources, and which a
+ * cloned repo's setup script could read) so the password isn't exposed to user
+ * code — the rest of the start-phase env is already persisted there and gets
+ * sourced by `buildVercelCommand` on the restart execs.
+ */
+export const VERCEL_RESUME_CONTEXT_PATH = `${AMIKAD_ETC_DIR}/vercel-resume.json`;
+
+interface VercelResumeContext {
+  openCodePassword: string;
+  amikaOpenCodeWeb?: string | null;
+  /** Repo working directory (`AMIKA_AGENT_CWD`); the lifecycle hooks' cwd. */
+  repoDir: string;
+}
+
+/**
+ * Persist the {@link VercelResumeContext} so {@link restartVercelServicesOnResume}
+ * can restart services after an idle-timeout resume. Written during create and
+ * restart, when the password and repo dir are known.
+ */
+export async function writeVercelResumeContext(
+  adapter: SandboxAdapter,
+  context: VercelResumeContext,
+): Promise<void> {
+  const tempPath = `/tmp/amika-vercel-resume-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2)}.json`;
+  await adapter.uploadFile(JSON.stringify(context) + "\n", tempPath);
+  await execChecked(adapter, `mkdir -p ${shellQuote(AMIKAD_ETC_DIR)}`, {
+    sudo: true,
+  });
+  await execChecked(
+    adapter,
+    `install -m 0600 ${shellQuote(tempPath)} ${shellQuote(VERCEL_RESUME_CONTEXT_PATH)}`,
+    { sudo: true },
+  );
+  await execChecked(adapter, `rm -f ${shellQuote(tempPath)}`, { sudo: true });
+}
+
+/** Read back the persisted resume context, or null when it isn't present yet. */
+async function readVercelResumeContext(
+  adapter: SandboxAdapter,
+): Promise<VercelResumeContext | null> {
+  const result = await adapter.exec(
+    `cat ${shellQuote(VERCEL_RESUME_CONTEXT_PATH)}`,
+    { sudo: true },
+  );
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(result.stdout) as VercelResumeContext;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * SDK `onResume` callback for the exec/stream paths: when Vercel wakes a stopped
+ * session it restores the filesystem but not the processes the lifecycle hooks
+ * started, leaving OpenCode and the user services dead. Re-run the start-phase
+ * hooks (pre-setup → post-setup → start) to bring them back, mirroring how
+ * `runLifecycleScripts({ phase: "start" })` restarts them on an explicit start.
+ * The base/service/injected env is sourced from `/etc/environment` (persisted by
+ * `configureManagedEnvironment`); the password/web/cwd come from the persisted
+ * resume context. Best-effort: a sandbox resumed mid-initialization has no
+ * context yet (skip), and a restart failure is swallowed rather than failing the
+ * triggering exec — the next interaction retries and direct execs (e.g. agent
+ * launches) don't need OpenCode to be up.
+ */
+async function restartVercelServicesOnResume(sandbox: Sandbox): Promise<void> {
+  try {
+    const adapter = new VercelAdapter(sandbox);
+    const context = await readVercelResumeContext(adapter);
+    if (!context) {
+      return;
+    }
+    const hookEnv: Record<string, string> = {
+      AMIKA_AGENT_CWD: context.repoDir,
+      OPENCODE_SERVER_PASSWORD: context.openCodePassword,
+    };
+    if (context.amikaOpenCodeWeb != null) {
+      hookEnv.AMIKA_OPENCODE_WEB = context.amikaOpenCodeWeb;
+    }
+    const commands = buildLifecycleCommands();
+    await execChecked(adapter, commands.preSetup, {
+      cwd: context.repoDir,
+      env: hookEnv,
+      sudo: true,
+    });
+    await execChecked(adapter, commands.postSetup, {
+      cwd: context.repoDir,
+      sudo: true,
+    });
+    await execChecked(adapter, commands.start, {
+      cwd: context.repoDir,
+      env: hookEnv,
+    });
+  } catch {
+    // Swallow — see the doc comment: this is a best-effort recovery, and the
+    // direct-exec paths that trigger it don't depend on the restarted services.
+  }
+}
+
+export async function readVercelFile(
+  config: VercelConfig,
+  providerSandboxId: string,
+  filePath: string,
+): Promise<string | null> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: true,
+  });
+  const adapter = new VercelAdapter(sandbox);
+  return adapter.downloadFile(filePath);
+}
+
+export async function writeVercelFile(
+  config: VercelConfig,
+  providerSandboxId: string,
+  filePath: string,
+  content: Buffer | string,
+): Promise<void> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: true,
+  });
+  await new VercelAdapter(sandbox).uploadFile(content, filePath);
+}
+
+export async function executeVercelCommand(
+  config: VercelConfig,
+  providerSandboxId: string,
+  command: string,
+  opts?: ExecCommandOptions,
+): Promise<SandboxExecResult> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: true,
+    // Default relaunches the lifecycle services on a cold resume so an
+    // interactive session is fully live; `"bare"` skips that (e.g. the chat
+    // worker's agent launch / exit probe, which don't need OpenCode up).
+    onResume:
+      opts?.resumeMode === "bare" ? undefined : restartVercelServicesOnResume,
+  });
+  // A resumed sandbox reverts to Vercel's short default timeout; reapply the
+  // caller's window before running so a long command isn't suspended mid-run.
+  if (opts?.sessionTimeoutMs != null) {
+    await sandbox.update({ timeout: opts.sessionTimeoutMs });
+  }
+  const adapter = new VercelAdapter(sandbox);
+  if (opts?.input !== undefined) {
+    return execWithStagedInput(adapter, command, opts.input, opts);
+  }
+  return adapter.exec(command, opts);
+}
+
+/**
+ * Run `command` and stream its output through `handlers`. Vercel exposes
+ * incremental logs via the `command.logs()` async generator, so — unlike
+ * Freestyle, whose `vm.exec` buffers until exit — Vercel can back the SSE
+ * agent-stream endpoint. The command is run detached and we resolve once it
+ * finishes.
+ */
+export async function streamVercelCommandLogs(
+  config: VercelConfig,
+  providerSandboxId: string,
+  command: string,
+  handlers: StreamCommandHandlers,
+): Promise<void> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: true,
+    onResume: restartVercelServicesOnResume,
+  });
+  const cmd = await sandbox.runCommand({
+    cmd: "bash",
+    args: ["-c", buildVercelCommand(command)],
+    detached: true,
+  });
+  for await (const log of cmd.logs()) {
+    if (log.stream === "stdout") {
+      handlers.onStdout(log.data);
+    } else {
+      handlers.onStderr?.(log.data);
+    }
+  }
+  await cmd.wait();
+}
+
+/**
+ * Open a Vercel adapter handle (the core provisioning seam). Resumes the
+ * sandbox (`resume: true`) exactly as the provisioning flows do, since
+ * provisioning always operates on a live sandbox; the fetched handle is reused
+ * across the package's many adapter ops rather than re-resumed per op.
+ */
+export async function openVercelAdapter(
+  config: VercelConfig,
+  providerSandboxId: string,
+): Promise<SandboxAdapter> {
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: true,
+  });
+  return new VercelAdapter(sandbox);
+}

--- a/js/sandbox/src/providers/vercel/internal/snapshot-capture.test.ts
+++ b/js/sandbox/src/providers/vercel/internal/snapshot-capture.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { VercelConfig } from "../config";
+import {
+  captureVercelSnapshot,
+  removeVercelInjectedSecrets,
+} from "./snapshot-capture";
+
+// --- SDK mocks --------------------------------------------------------------
+const sandboxSnapshot = vi.fn(); // sandbox.snapshot({ expiration })
+const getVercelSandbox = vi.fn(); // ./client getVercelSandbox
+
+vi.mock("./client", () => ({
+  getVercelSandbox: (...args: unknown[]) => getVercelSandbox(...args),
+}));
+
+// Fake `VercelAdapter` so the Vercel-specific resume-context removal
+// (`execChecked` → `adapter.exec`) is observable without a live sandbox.
+const adapterExec = vi.fn();
+vi.mock("./adapter", () => ({
+  VercelAdapter: class {
+    exec = (...args: unknown[]) => adapterExec(...args);
+    downloadFile = () => Promise.resolve(null);
+    uploadFile = () => Promise.resolve();
+  },
+}));
+
+const config: VercelConfig = {
+  apiKey: "test-token",
+  teamId: "team_test",
+  projectId: "prj_test",
+};
+
+/** A fake `@vercel/sandbox` `Snapshot` with just the getters we read. */
+function fakeSnapshot(overrides: {
+  snapshotId?: string;
+  status?: string;
+  sizeBytes?: number;
+}) {
+  return {
+    snapshotId: overrides.snapshotId ?? "snap_default",
+    status: overrides.status ?? "created",
+    sizeBytes: overrides.sizeBytes ?? 1024,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+  };
+}
+
+beforeEach(() => {
+  sandboxSnapshot.mockReset();
+  getVercelSandbox.mockReset();
+  adapterExec.mockReset();
+  adapterExec.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+});
+
+describe("removeVercelInjectedSecrets", () => {
+  it("removes the resume context with sudo over a bare resume", async () => {
+    getVercelSandbox.mockResolvedValue({});
+
+    await removeVercelInjectedSecrets(config, "sbx_2");
+
+    // The Vercel-only resume context (holds the OpenCode server password) is
+    // removed with sudo; the Amika scrub above in core doesn't cover it.
+    expect(adapterExec).toHaveBeenCalledWith(
+      expect.stringContaining("vercel-resume.json"),
+      { sudo: true },
+    );
+    expect(adapterExec).toHaveBeenCalledWith(expect.stringContaining("rm -f"), {
+      sudo: true,
+    });
+    // Bare resume: `resume: true` with NO onResume callback — the
+    // service-restart callback reads the very file being removed and would
+    // relaunch OpenCode with the password mid-scrub.
+    expect(getVercelSandbox).toHaveBeenCalledWith(config, "sbx_2", {
+      resume: true,
+    });
+  });
+});
+
+describe("captureVercelSnapshot", () => {
+  it("snapshots over a bare resume and returns the bootable id", async () => {
+    sandboxSnapshot.mockResolvedValue(
+      fakeSnapshot({ snapshotId: "snap_captured" }),
+    );
+    getVercelSandbox.mockResolvedValue({ snapshot: sandboxSnapshot });
+
+    const result = await captureVercelSnapshot(config, "sbx_2");
+
+    expect(sandboxSnapshot).toHaveBeenCalledWith({ expiration: 0 });
+    expect(getVercelSandbox).toHaveBeenCalledWith(config, "sbx_2", {
+      resume: true,
+    });
+    expect(result.providerSnapshotId).toBe("snap_captured");
+  });
+});

--- a/js/sandbox/src/providers/vercel/internal/snapshot-capture.ts
+++ b/js/sandbox/src/providers/vercel/internal/snapshot-capture.ts
@@ -1,0 +1,85 @@
+/**
+ * Snapshot capture (the write path) against the Vercel Sandbox API.
+ *
+ * Vercel captures a snapshot from a running sandbox with `sandbox.snapshot()`,
+ * which returns a `Snapshot` carrying an opaque `snapshotId` (`snap_…`). Unlike
+ * Freestyle's `vm.snapshot({ name })`, a Vercel snapshot has NO name or label —
+ * it is addressable only by that id. The capture therefore returns the bootable
+ * id for the caller to persist; the by-name lookup/delete path (which bridges
+ * Amika's name-keyed snapshot model to Vercel's id-only API) lives alongside in
+ * `./snapshot-lookup`.
+ *
+ * Only the DESTRUCTIVE delete-intent capture is supported for Vercel: it
+ * captures the sandbox and the caller deletes the source right after. A
+ * non-destructive keep-source capture is NOT offered — the sandbox is created
+ * with `keepLastSnapshots: { count: 1 }` (flat storage), so the source's next
+ * stop/idle auto-snapshot would evict the captured snapshot, and the SDK
+ * exposes no way to pin an individual snapshot. The provider throws
+ * `SandboxProviderUnsupportedError` for `keepSourceRunning: true`.
+ * `sandbox.snapshot()` stops the source as part of the capture — harmless
+ * here, since the source is discarded immediately after.
+ *
+ * The Amika secret scrub itself is core-synthesized and runs before these
+ * primitives through the exec capability with a bare resume;
+ * this module contributes only the provider-owned pieces.
+ *
+ * SECURITY CAVEAT: like Freestyle, the disk scrub removes the injected
+ * credential files and managed env, but `sandbox.snapshot()` captures a live
+ * session — secrets that were already loaded into memory (the OpenCode
+ * server's API keys, an agent's process env) may survive in the captured state
+ * and come back when the snapshot is booted. Acceptable for the current
+ * dev-gated, org-scoped Vercel usage (a snapshot only boots within its owning
+ * org).
+ */
+import { shellQuote } from "../../../util/shell";
+import { getVercelSandbox } from "./client";
+import { VercelAdapter } from "./adapter";
+import { VERCEL_RESUME_CONTEXT_PATH } from "./operations";
+import { execChecked } from "../../shared/adapter";
+import type { CapturedSnapshot } from "../../provider";
+import type { VercelConfig } from "../config";
+
+/**
+ * Remove the secrets Vercel itself injected into the sandbox: the resume
+ * context ({@link VERCEL_RESUME_CONTEXT_PATH}), which holds the source
+ * sandbox's OpenCode server password and would otherwise land on disk in a
+ * capture even after the Amika scrub removed `OPENCODE_SERVER_PASSWORD` from
+ * `/etc/environment`. Root owned (installed 0600), so removed with sudo;
+ * idempotent (`rm -f`). Resumes bare (no `onResume` callback) — the
+ * service-restart callback reads this very file, and relaunching OpenCode with
+ * the password mid-scrub would defeat the removal.
+ */
+export async function removeVercelInjectedSecrets(
+  config: VercelConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  // `resume: true` with no `onResume` is a bare resume.
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: true,
+  });
+  const adapter = new VercelAdapter(sandbox);
+  await execChecked(
+    adapter,
+    `rm -f ${shellQuote(VERCEL_RESUME_CONTEXT_PATH)}`,
+    { sudo: true },
+  );
+}
+
+/**
+ * Capture the sandbox as it stands. `snapshot()` stops the source, but the
+ * caller deletes it right after on this destructive path, so the stop is
+ * harmless. Resumes bare (no `onResume`) for the same reason as the secret
+ * removal above — a service relaunch would reload scrubbed credentials into
+ * the session the capture freezes.
+ */
+export async function captureVercelSnapshot(
+  config: VercelConfig,
+  providerSandboxId: string,
+): Promise<CapturedSnapshot> {
+  // `resume: true` with no `onResume` is a bare resume.
+  const sandbox = await getVercelSandbox(config, providerSandboxId, {
+    resume: true,
+  });
+  const snapshot = await sandbox.snapshot({ expiration: 0 });
+  return { providerSnapshotId: snapshot.snapshotId };
+}

--- a/js/sandbox/src/providers/vercel/internal/snapshot-lookup.test.ts
+++ b/js/sandbox/src/providers/vercel/internal/snapshot-lookup.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { VercelConfig } from "../config";
+import type { SnapshotIdResolver } from "../../provider";
+import {
+  deleteVercelSnapshotByName,
+  getVercelSnapshotByName,
+  mapVercelSnapshotStatus,
+  waitForVercelSnapshotActive,
+} from "./snapshot-lookup";
+
+// --- SDK mocks --------------------------------------------------------------
+const snapshotGet = vi.fn(); // Snapshot.get({ snapshotId })
+const snapshotDelete = vi.fn(); // Snapshot.delete()
+
+/**
+ * Stand-in for the SDK's `APIError` (extends `Error`, carries `response`). The
+ * lookup only treats a 404 as "absent"; everything else must propagate, so
+ * tests raise this with a specific status to exercise both paths. Must be the
+ * class the module imports, so it is the `@vercel/sandbox` mock's `APIError`.
+ * Defined via `vi.hoisted` so it exists when the hoisted mock factory runs.
+ */
+const { FakeAPIError } = vi.hoisted(() => {
+  class FakeAPIError extends Error {
+    response: { status: number };
+    constructor(status: number) {
+      super(`api error ${status}`);
+      this.response = { status };
+    }
+  }
+  return { FakeAPIError };
+});
+
+vi.mock("@vercel/sandbox", () => ({
+  Snapshot: { get: (...args: unknown[]) => snapshotGet(...args) },
+  APIError: FakeAPIError,
+}));
+
+vi.mock("./client", () => ({
+  vercelCredentials: (config: VercelConfig) => ({
+    token: config.apiKey,
+    teamId: config.teamId,
+    projectId: config.projectId,
+  }),
+}));
+
+// The name→id resolution is a control-plane concern injected as a port; the
+// lookup module itself is store-free, so the tests drive a plain stub resolver
+// rather than mocking a snapshot store. (The resolver's own logic —
+// org-scoping the name, reading `provider_snapshot_id` — is tested in
+// `@/lib/sandbox-snapshots/snapshot-id-resolver.test.ts`.)
+const resolveSnapshotId = vi.fn<SnapshotIdResolver>();
+
+const config: VercelConfig = {
+  apiKey: "test-token",
+  teamId: "team_test",
+  projectId: "prj_test",
+};
+const ORG = "org_abc123";
+const NAME = `${ORG}/sandbox/my-snap`;
+
+/** A fake `@vercel/sandbox` `Snapshot` with just the getters we read. */
+function fakeSnapshot(overrides: {
+  snapshotId?: string;
+  status?: string;
+  sizeBytes?: number;
+}) {
+  return {
+    snapshotId: overrides.snapshotId ?? "snap_default",
+    status: overrides.status ?? "created",
+    sizeBytes: overrides.sizeBytes ?? 1024,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    delete: snapshotDelete,
+  };
+}
+
+beforeEach(() => {
+  snapshotGet.mockReset();
+  snapshotDelete.mockReset();
+  resolveSnapshotId.mockReset();
+});
+
+describe("mapVercelSnapshotStatus", () => {
+  it.each([
+    ["created", "active"],
+    ["failed", "build_failed"],
+    ["deleted", "error"],
+  ])("maps Vercel status %s to %s", (status, expected) => {
+    expect(mapVercelSnapshotStatus(status)).toBe(expected);
+  });
+
+  it("passes an unknown status through unchanged", () => {
+    expect(mapVercelSnapshotStatus("weird")).toBe("weird");
+    expect(mapVercelSnapshotStatus(undefined)).toBeUndefined();
+  });
+});
+
+describe("getVercelSnapshotByName", () => {
+  it("returns null and skips the SDK when the resolver yields no id", async () => {
+    resolveSnapshotId.mockResolvedValue(null);
+    expect(
+      await getVercelSnapshotByName(resolveSnapshotId, config, NAME),
+    ).toBeNull();
+    expect(snapshotGet).not.toHaveBeenCalled();
+  });
+
+  it("resolves the name→id via the resolver then gets by id", async () => {
+    resolveSnapshotId.mockResolvedValue("snap_xyz");
+    snapshotGet.mockResolvedValue(
+      fakeSnapshot({ snapshotId: "snap_xyz", status: "created" }),
+    );
+
+    const result = await getVercelSnapshotByName(
+      resolveSnapshotId,
+      config,
+      NAME,
+    );
+
+    expect(resolveSnapshotId).toHaveBeenCalledWith(NAME);
+    expect(snapshotGet).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshotId: "snap_xyz" }),
+    );
+    expect(result).toMatchObject({
+      name: NAME,
+      providerSnapshotId: "snap_xyz",
+      state: "active",
+    });
+  });
+
+  it("returns null when the provider no longer has the snapshot (404)", async () => {
+    resolveSnapshotId.mockResolvedValue("snap_row");
+    snapshotGet.mockRejectedValue(new FakeAPIError(404));
+    expect(
+      await getVercelSnapshotByName(resolveSnapshotId, config, NAME),
+    ).toBeNull();
+  });
+
+  it("propagates a transient (non-404) provider error, not treating it as absent", async () => {
+    resolveSnapshotId.mockResolvedValue("snap_row");
+    snapshotGet.mockRejectedValue(new FakeAPIError(500));
+    // A 5xx must NOT read as "snapshot gone" — that would 404 an active
+    // snapshot; the error propagates so the caller can retry.
+    await expect(
+      getVercelSnapshotByName(resolveSnapshotId, config, NAME),
+    ).rejects.toBeInstanceOf(FakeAPIError);
+  });
+});
+
+describe("deleteVercelSnapshotByName", () => {
+  it("is a no-op when the resolver yields no id for the name", async () => {
+    resolveSnapshotId.mockResolvedValue(null);
+    await deleteVercelSnapshotByName(resolveSnapshotId, config, NAME);
+    expect(snapshotGet).not.toHaveBeenCalled();
+    expect(snapshotDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes the resolved snapshot via the id-keyed SDK", async () => {
+    resolveSnapshotId.mockResolvedValue("snap_del");
+    snapshotGet.mockResolvedValue(
+      fakeSnapshot({ snapshotId: "snap_del", status: "created" }),
+    );
+    await deleteVercelSnapshotByName(resolveSnapshotId, config, NAME);
+    expect(snapshotDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a snapshot already gone from the provider (404)", async () => {
+    resolveSnapshotId.mockResolvedValue("snap_row");
+    snapshotGet.mockRejectedValue(new FakeAPIError(404));
+    await expect(
+      deleteVercelSnapshotByName(resolveSnapshotId, config, NAME),
+    ).resolves.toBeUndefined();
+    expect(snapshotDelete).not.toHaveBeenCalled();
+  });
+
+  it("propagates a transient (non-404) error instead of orphaning the snapshot", async () => {
+    resolveSnapshotId.mockResolvedValue("snap_row");
+    snapshotGet.mockRejectedValue(new FakeAPIError(503));
+    // If a 5xx read as "gone", the service would drop the DB row while the
+    // provider snapshot lived on (orphan). The error must propagate instead.
+    await expect(
+      deleteVercelSnapshotByName(resolveSnapshotId, config, NAME),
+    ).rejects.toBeInstanceOf(FakeAPIError);
+    expect(snapshotDelete).not.toHaveBeenCalled();
+  });
+
+  it("uses a known snapshot id without consulting the resolver", async () => {
+    // A fresh capture's bound delete() runs before the control plane records
+    // the name↔id mapping, so the resolver would say "nothing to delete".
+    resolveSnapshotId.mockResolvedValue(null);
+    snapshotGet.mockResolvedValue(
+      fakeSnapshot({ snapshotId: "snap_known", status: "created" }),
+    );
+    await deleteVercelSnapshotByName(
+      resolveSnapshotId,
+      config,
+      NAME,
+      "snap_known",
+    );
+    expect(resolveSnapshotId).not.toHaveBeenCalled();
+    expect(snapshotDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("waitForVercelSnapshotActive", () => {
+  it("returns once the snapshot reads back as created", async () => {
+    resolveSnapshotId.mockResolvedValue("snap_row");
+    snapshotGet.mockResolvedValue(
+      fakeSnapshot({ snapshotId: "snap_row", status: "created" }),
+    );
+    const result = await waitForVercelSnapshotActive(
+      resolveSnapshotId,
+      config,
+      NAME,
+    );
+    expect(result.state).toBe("active");
+    expect(result.providerSnapshotId).toBe("snap_row");
+  });
+
+  it("throws when the snapshot enters a terminal status", async () => {
+    resolveSnapshotId.mockResolvedValue("snap_row");
+    snapshotGet.mockResolvedValue(
+      fakeSnapshot({ snapshotId: "snap_row", status: "failed" }),
+    );
+    await expect(
+      waitForVercelSnapshotActive(resolveSnapshotId, config, NAME),
+    ).rejects.toThrow(/terminal status "failed"/);
+  });
+
+  it("throws on timeout when no bootable id is ever recorded", async () => {
+    resolveSnapshotId.mockResolvedValue(null);
+    // Zero timeout: the first pass past the deadline throws.
+    await expect(
+      waitForVercelSnapshotActive(resolveSnapshotId, config, NAME, null, 0),
+    ).rejects.toThrow(/did not become ready/);
+    expect(snapshotGet).not.toHaveBeenCalled();
+  });
+
+  it("uses a known snapshot id without consulting the resolver", async () => {
+    // A fresh capture's bound waitForActive() runs before the control plane
+    // records the name↔id mapping; the known id must short-circuit the
+    // resolver or the wait would poll to timeout.
+    resolveSnapshotId.mockResolvedValue(null);
+    snapshotGet.mockResolvedValue(
+      fakeSnapshot({ snapshotId: "snap_known", status: "created" }),
+    );
+    const result = await waitForVercelSnapshotActive(
+      resolveSnapshotId,
+      config,
+      NAME,
+      "snap_known",
+    );
+    expect(resolveSnapshotId).not.toHaveBeenCalled();
+    expect(result.providerSnapshotId).toBe("snap_known");
+    expect(result.state).toBe("active");
+  });
+});

--- a/js/sandbox/src/providers/vercel/internal/snapshot-lookup.ts
+++ b/js/sandbox/src/providers/vercel/internal/snapshot-lookup.ts
@@ -1,0 +1,190 @@
+/**
+ * Snapshot lookup (the query path) against the Vercel Sandbox API.
+ *
+ * Vercel snapshots are addressable only by an opaque `snapshotId` (`snap_…`) —
+ * they carry NO name or label. Amika's snapshot model, however, is name-keyed:
+ * every consumer (`getSnapshot`/`deleteSnapshot`/`waitForSnapshotActive`)
+ * addresses a snapshot by its org-scoped name (`{orgId}/sandbox/{slug}`).
+ *
+ * We bridge the two through an injected {@link SnapshotIdResolver}: the caller
+ * owns the name↔id mapping (recorded when a capture completes), so a by-name
+ * lookup resolves the name to its id via the resolver and then hits the id-keyed
+ * SDK (`Snapshot.get` / `snapshot.delete`). This keeps the shared
+ * `SnapshotCapability` interface unchanged (Daytona/Freestyle keep their own
+ * by-name provider access) while accommodating Vercel's id-only API — and keeps
+ * this module free of any storage coupling. The write/capture side lives
+ * alongside in `./snapshot-capture`; the resolver is injected by the caller.
+ */
+import { APIError, Snapshot } from "@vercel/sandbox";
+import { vercelCredentials } from "./client";
+import type { ProviderSnapshot, SnapshotIdResolver } from "../../provider";
+import type { VercelConfig } from "../config";
+
+/**
+ * How long to wait for a freshly captured Vercel snapshot to reach `created`,
+ * in seconds. `sandbox.snapshot()` resolves once the snapshot exists, so this is
+ * usually satisfied on the first poll; the window exists only to tolerate a
+ * snapshot that briefly reads back as not-yet-`created`. Mirrors the
+ * Freestyle/Daytona activation windows so the background-capture lifecycle
+ * behaves the same across providers.
+ */
+const VERCEL_SNAPSHOT_ACTIVE_TIMEOUT_S = 10 * 60;
+
+/** Poll cadence for {@link waitForVercelSnapshotActive}. */
+const VERCEL_SNAPSHOT_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Normalize a Vercel snapshot status onto the provider-agnostic vocabulary
+ * consumers reconcile against (`active` / terminal). Vercel: `created`
+ * is durable and bootable; `failed` is terminal; `deleted` is treated as absent
+ * by callers (this maps it to `error` for the rare case a lookup surfaces a
+ * `deleted` record). Vercel has no in-flight "building" status — `snapshot()`
+ * returns a `created` snapshot synchronously — so there is no `building` mapping.
+ */
+export function mapVercelSnapshotStatus(
+  status: string | undefined,
+): string | undefined {
+  switch (status) {
+    case "created":
+      return "active";
+    case "failed":
+      return "build_failed";
+    case "deleted":
+      return "error";
+    default:
+      return status;
+  }
+}
+
+function toProviderSnapshot(name: string, snap: Snapshot): ProviderSnapshot {
+  return {
+    name,
+    // The bootable handle (`snap_…`), so a live lookup can backfill a row whose
+    // capture never recorded `provider_snapshot_id`
+    // (`Sandbox.create({ source: { type: "snapshot", snapshotId } })`).
+    providerSnapshotId: snap.snapshotId,
+    state: mapVercelSnapshotStatus(snap.status),
+    createdAt: snap.createdAt,
+    updatedAt: snap.updatedAt,
+    size: snap.sizeBytes,
+  };
+}
+
+/**
+ * Fetch the live snapshot for a `snap_…` id, or `null` when it is genuinely
+ * absent (a 404 — deleted / never existed), which we translate to `null` so
+ * callers don't couple to provider-specific not-found errors (matching the
+ * `SnapshotCapability.getSnapshot` contract).
+ *
+ * ONLY a 404 becomes `null`. A transient 5xx / auth / network failure is
+ * rethrown: callers read `null` as "the snapshot is gone" — `getSnapshot`
+ * reports it absent and `deleteSnapshot` removes the caller's record WITHOUT
+ * deleting the provider snapshot — so swallowing a transient error would orphan
+ * the user's Vercel snapshot. Failing loud lets the caller retry instead.
+ */
+async function getVercelSnapshotById(
+  config: VercelConfig,
+  snapshotId: string,
+): Promise<Snapshot | null> {
+  try {
+    return await Snapshot.get({ ...vercelCredentials(config), snapshotId });
+  } catch (err) {
+    if (err instanceof APIError && err.response.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Look up a snapshot by its org-scoped name, mapped onto the provider-agnostic
+ * shape. Returns `null` when the name has no recorded id, or when the provider no
+ * longer has the snapshot. Vercel has no by-name provider access, so this resolves
+ * the name→id via the injected {@link SnapshotIdResolver} first, then does an
+ * id-keyed get.
+ */
+export async function getVercelSnapshotByName(
+  resolveSnapshotId: SnapshotIdResolver,
+  config: VercelConfig,
+  name: string,
+): Promise<ProviderSnapshot | null> {
+  const snapshotId = await resolveSnapshotId(name);
+  if (!snapshotId) {
+    return null;
+  }
+  const snap = await getVercelSnapshotById(config, snapshotId);
+  return snap ? toProviderSnapshot(name, snap) : null;
+}
+
+/**
+ * Delete the snapshot carrying `name`. Idempotent: a name with no recorded id is
+ * a no-op (nothing to delete), and a snapshot already gone from the provider is
+ * tolerated (`Snapshot.get` returns `null`, so there is nothing to `delete`). The
+ * caller's own record is removed elsewhere, not here.
+ *
+ * `providerSnapshotId` short-circuits the resolver: a caller holding the handle
+ * from a fresh capture (a bound `Snapshot.delete()`) can delete before the
+ * name↔id mapping has been recorded.
+ */
+export async function deleteVercelSnapshotByName(
+  resolveSnapshotId: SnapshotIdResolver,
+  config: VercelConfig,
+  name: string,
+  providerSnapshotId?: string | null,
+): Promise<void> {
+  const snapshotId = providerSnapshotId ?? (await resolveSnapshotId(name));
+  if (!snapshotId) {
+    return;
+  }
+  const snap = await getVercelSnapshotById(config, snapshotId);
+  if (!snap) {
+    return;
+  }
+  await snap.delete();
+}
+
+/**
+ * Block until the snapshot named `name` reaches `created`. Throws on a terminal
+ * status (`failed`/`deleted`) or when the timeout elapses without it becoming
+ * durable. Tolerates the row briefly lacking a recorded id right after capture
+ * (the background capture records `provider_snapshot_id` around the same time it
+ * transitions the row), retrying until the id resolves or the deadline passes.
+ *
+ * `providerSnapshotId` short-circuits the resolver: a caller holding the handle
+ * from a fresh capture (a bound `Snapshot.waitForActive()`) can wait before the
+ * name↔id mapping has been recorded.
+ */
+export async function waitForVercelSnapshotActive(
+  resolveSnapshotId: SnapshotIdResolver,
+  config: VercelConfig,
+  name: string,
+  providerSnapshotId?: string | null,
+  timeoutS: number = VERCEL_SNAPSHOT_ACTIVE_TIMEOUT_S,
+): Promise<ProviderSnapshot> {
+  const deadline = Date.now() + timeoutS * 1000;
+  for (;;) {
+    const snapshotId = providerSnapshotId ?? (await resolveSnapshotId(name));
+    const snap = snapshotId
+      ? await getVercelSnapshotById(config, snapshotId)
+      : null;
+    if (snap?.status === "created") {
+      return toProviderSnapshot(name, snap);
+    }
+    if (snap && (snap.status === "failed" || snap.status === "deleted")) {
+      throw new Error(
+        `Snapshot "${name}" entered terminal status "${snap.status}"`,
+      );
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Snapshot "${name}" did not become ready within ${timeoutS}s ` +
+          (snap
+            ? `(last status: "${snap.status}")`
+            : "(no bootable snapshot id was recorded)"),
+      );
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, VERCEL_SNAPSHOT_POLL_INTERVAL_MS),
+    );
+  }
+}

--- a/js/sandbox/src/providers/vercel/provider.test.ts
+++ b/js/sandbox/src/providers/vercel/provider.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { VercelConfig } from "./config";
+import {
+  getProviderLabel,
+  SANDBOX_PROVIDER_CAPABILITIES,
+} from "../capabilities";
+import {
+  createSandboxProvider,
+  isSandboxProviderName,
+  type SandboxProviderDeps,
+} from "../registry";
+
+const VERCEL_CONFIG: VercelConfig = {
+  apiKey: "test-token",
+  teamId: "team_test",
+  projectId: "prj_test",
+};
+
+function vercelDeps(vercel: VercelConfig | null): SandboxProviderDeps {
+  return {
+    daytona: {
+      apiKey: "",
+      apiUrl: "",
+      target: undefined,
+      organizationId: undefined,
+      useVm: false,
+    },
+    freestyle: null,
+    vercel,
+    resolveSnapshotId: async () => null,
+  };
+}
+
+describe("vercel provider wiring", () => {
+  it("is a recognized provider name", () => {
+    expect(isSandboxProviderName("vercel")).toBe(true);
+    expect(isSandboxProviderName("nope")).toBe(false);
+  });
+
+  it("advertises generic no-relay prerequisites without legacy SSH", () => {
+    expect(SANDBOX_PROVIDER_CAPABILITIES.vercel).toEqual({
+      lifecycle: true,
+      ssh: false,
+      services: true,
+      exec: true,
+      listSandboxes: true,
+      streaming: true,
+      snapshots: true,
+      scrubCapture: true,
+      // Only scrub-and-delete capture is supported; full mode is rejected.
+      fullSnapshotCapture: false,
+      dockerRegistries: false,
+      // Vercel honors skipStartScript on start.
+      skipStartScript: true,
+      // Snapshots are id-only; persistent microVMs aren't auto-deleted.
+      snapshotIdsAreOpaque: true,
+      supportsAutoDelete: false,
+    });
+  });
+
+  it("has a display label", () => {
+    expect(getProviderLabel("vercel")).toBe("Vercel");
+  });
+
+  it("resolves to a Vercel provider when configured", () => {
+    const provider = createSandboxProvider("vercel", vercelDeps(VERCEL_CONFIG));
+    expect(provider.name).toBe("vercel");
+    // Snapshots (per-sandbox capture) are supported; docker registries and
+    // image-derived snapshots (control-plane) are intentionally absent.
+    expect(provider.snapshots).not.toBeNull();
+    expect(provider.docker).toBeNull();
+  });
+
+  it("throws a clear error when Vercel is not configured", () => {
+    expect(() => createSandboxProvider("vercel", vercelDeps(null))).toThrow(
+      /not configured/,
+    );
+  });
+
+  it("uses generic no-relay SSH instead of the legacy private-key bridge", () => {
+    const provider = createSandboxProvider("vercel", vercelDeps(VERCEL_CONFIG));
+    // No-relay SSH replaces the legacy private-key bridge: the provider no
+    // longer exposes an `ssh` capability. Instead it advertises `services` (so
+    // amikad's port can be published on demand) plus stdin-capable exec.
+    const sbox = provider.sandboxes.get("sbx");
+    expect(sbox.ssh).toBeNull();
+    expect(sbox.services).not.toBeNull();
+    expect(provider.capabilities.ssh).toBe(false);
+    expect(provider.capabilities.services).toBe(true);
+  });
+
+  it("throws on non-destructive full capture — only scrub-and-delete is supported", async () => {
+    const provider = createSandboxProvider("vercel", vercelDeps(VERCEL_CONFIG));
+    const sandboxSnapshots = provider.sandboxes.get("sbx").snapshots;
+    expect(sandboxSnapshots).not.toBeNull();
+    // A Vercel sandbox is created with `keepLastSnapshots: { count: 1 }`, so a
+    // full capture that keeps the source alive would be evicted by its next
+    // auto-snapshot; the provider offers only scrub-and-delete and throws here.
+    await expect(
+      sandboxSnapshots?.create("org_x/sandbox/snap"),
+    ).rejects.toThrow(/does not support operation "capture"/);
+  });
+});

--- a/js/sandbox/src/providers/vercel/provider.ts
+++ b/js/sandbox/src/providers/vercel/provider.ts
@@ -1,0 +1,176 @@
+/**
+ * Vercel provider definition: binds a {@link VercelConfig} (plus the injected
+ * {@link SnapshotIdResolver}) and plugs the operation helpers in this directory
+ * into the capability namespaces.
+ *
+ * ⚠️ EXPERIMENTAL — not production-ready. Daytona (VM) is the primary,
+ * supported provider; Vercel is a work in progress and may not fully work
+ * (provisioning, snapshots, and the resume/service behavior are all subject to
+ * change and are not exercised as thoroughly as
+ * Daytona). Prefer Daytona for anything that must work reliably.
+ *
+ * Capability shape (see `./capabilities`): per-sandbox lifecycle + exec + log
+ * streaming + snapshots. Streaming is real (the SDK's incremental
+ * `command.logs()`), unlike Freestyle. SSH is supplied by the generic
+ * provider-exposed `amikad` service and therefore does not occupy this
+ * provider-specific capability. Snapshots are captured from a
+ * running sandbox via `sandbox.snapshot()` and addressed by their org-scoped
+ * name through the injected name↔id resolver (Vercel snapshots are id-only;
+ * see `./internal/snapshot-lookup`). Docker registries and image-derived snapshots stay
+ * Daytona-only, so `dockerRegistries` and `snapshots.createImageSnapshot` are
+ * omitted → unsupported.
+ */
+import type { VercelConfig } from "./config";
+import { VERCEL_HOME_DIR } from "./config";
+import type { SnapshotIdResolver } from "../provider";
+import { SandboxProviderUnsupportedError } from "../provider";
+import { defineProvider } from "../shared/define-provider";
+import { vercelCapabilities } from "./capabilities";
+import {
+  createVercelSandbox,
+  deleteVercelSandbox,
+  executeVercelCommand,
+  getVercelSandboxState,
+  listVercelSandboxes,
+  mapVercelSandboxState,
+  openVercelAdapter,
+  readVercelFile,
+  writeVercelFile,
+  writeVercelResumeContext,
+  refreshVercelUrls,
+  syncVercelRoutes,
+  startVercelSandbox,
+  stopVercelSandbox,
+  streamVercelCommandLogs,
+  VERCEL_URL_TTL_S,
+} from "./internal/operations";
+import {
+  captureVercelSnapshot,
+  removeVercelInjectedSecrets,
+} from "./internal/snapshot-capture";
+import {
+  deleteVercelSnapshotByName,
+  getVercelSnapshotByName,
+  waitForVercelSnapshotActive,
+} from "./internal/snapshot-lookup";
+
+// Provider-root re-exports of the server-side surface consumers wire up. The
+// implementations live in `internal/`; routing them through `provider.ts`
+// keeps the folder root as the provider's only public entry.
+export { openVercelAdapter } from "./internal/operations";
+
+/**
+ * What the Vercel factory binds: the {@link VercelConfig} plus the
+ * {@link SnapshotIdResolver} the snapshot capability uses to resolve the
+ * org-scoped name↔`snap_…` id mapping (Vercel snapshots are id-only). The
+ * registry supplies both from its {@link SandboxProviderDeps}.
+ */
+export interface VercelProviderConfig {
+  config: VercelConfig;
+  resolveSnapshotId: SnapshotIdResolver;
+}
+
+export default defineProvider(
+  vercelCapabilities,
+  ({ config, resolveSnapshotId }: VercelProviderConfig) => ({
+    name: "vercel",
+    signedUrlTtlSeconds: VERCEL_URL_TTL_S,
+    userHomeDir: VERCEL_HOME_DIR,
+
+    sandbox: {
+      create: (ctx, input) => createVercelSandbox(ctx, config, input),
+      delete: (id) => deleteVercelSandbox(config, id),
+
+      start: (id, autoStopInterval) =>
+        startVercelSandbox(config, id, autoStopInterval),
+      stop: (id) => stopVercelSandbox(config, id),
+      getState: (id) => getVercelSandboxState(config, id),
+      mapState: mapVercelSandboxState,
+    },
+
+    // No `cloneRepo` override: Vercel has no first-class git primitive, so
+    // `Sandbox.git` is `null` and the provisioning layer clones by running
+    // shell `git` over the adapter exec port.
+
+    // A Vercel microVM restores its filesystem but NOT its processes on resume,
+    // so the running services die; persist the context Vercel's `onResume`
+    // (`restartVercelServicesOnResume`) reads to re-run the start hooks. Only
+    // Vercel authors this — Daytona/Freestyle omit it (their processes survive a
+    // stop/restart), so the concept never touches the shared contract.
+    persistServiceRestartContext: async (id, context) => {
+      const adapter = await openVercelAdapter(config, id);
+      await writeVercelResumeContext(adapter, context);
+    },
+
+    // Streaming is real (the SDK's incremental `command.logs()`), so `stream`
+    // is provided and `exec.streaming` derives to true.
+    exec: {
+      stdin: true,
+      run: (id, command, opts) =>
+        executeVercelCommand(config, id, command, opts),
+      stream: (id, command, handlers) =>
+        streamVercelCommandLogs(config, id, command, handlers),
+    },
+
+    files: {
+      read: (id, filePath) => readVercelFile(config, id, filePath),
+      write: (id, filePath, content) =>
+        writeVercelFile(config, id, filePath, content),
+    },
+
+    services: {
+      refreshUrls: (id, services) => refreshVercelUrls(config, id, services),
+      syncRoutes: (id, desired) => syncVercelRoutes(config, id, desired),
+    },
+
+    listing: {
+      list: () => listVercelSandboxes(config),
+    },
+
+    snapshots: {
+      // Vercel snapshots are id-only: the by-name methods resolve the
+      // org-scoped name→id mapping through the injected resolver before
+      // hitting the id-keyed SDK (see `./internal/snapshot-lookup`). The resolver-backed
+      // lookup surfaces a snapshot in any recorded state, so the default
+      // `findSnapshot` → `getSnapshot` fallback resolves identically.
+      getSnapshot: (name) =>
+        getVercelSnapshotByName(resolveSnapshotId, config, name),
+      deleteSnapshot: (name, providerSnapshotId) =>
+        deleteVercelSnapshotByName(
+          resolveSnapshotId,
+          config,
+          name,
+          providerSnapshotId,
+        ),
+      waitForSnapshotActive: (name, providerSnapshotId) =>
+        waitForVercelSnapshotActive(
+          resolveSnapshotId,
+          config,
+          name,
+          providerSnapshotId,
+        ),
+      // Non-destructive (keep-source) capture is unsupported: a sandbox is
+      // created with `keepLastSnapshots: { count: 1 }`, so a kept-alive
+      // source's next stop/idle auto-snapshot would evict a snapshot captured
+      // here, and the SDK exposes no way to pin one. Only the destructive
+      // delete-intent capture is offered (the caller deletes the source right
+      // after, so no auto-snapshot can evict it); see `./internal/snapshot-capture`.
+      capture: (id, _snapshotName, opts) => {
+        if (opts.keepSourceRunning) {
+          throw new SandboxProviderUnsupportedError("vercel", "capture");
+        }
+        return captureVercelSnapshot(config, id);
+      },
+      // The one provider-owned injected secret: the resume-context file,
+      // written by Vercel's own create/resume hooks and carrying the source
+      // sandbox's OpenCode server password. Removed here so the
+      // core-synthesized scrub — which only knows the Amika target list —
+      // can't leave it in a capture.
+      removeInjectedSecrets: (id) => removeVercelInjectedSecrets(config, id),
+      // Vercel never bakes Amika secrets into an un-scrubbable container env
+      // spec — injected env vars live only in `/etc/environment`, which the
+      // scrub removes — so every Vercel sandbox is scrub-safe.
+      isEnvScrubbable: () => Promise.resolve(true),
+    },
+  }),
+);

--- a/js/sandbox/src/providers/vercel/sizing.test.ts
+++ b/js/sandbox/src/providers/vercel/sizing.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { vercelSizingForSize, vercelVcpusForSize } from "./sizing";
+
+describe("vercelVcpusForSize", () => {
+  it("picks the smallest valid vCPU count covering both vCPU and memory", () => {
+    // Memory is the binding constraint at 2 GB/vCPU: m wants 8 GB → 4 vCPUs,
+    // l wants 12 GB → 6 vCPUs, xl wants 16 GB → 8 vCPUs. xs (1 GB) → the
+    // minimum of 1 vCPU.
+    expect(vercelVcpusForSize("xs")).toBe(1);
+    expect(vercelVcpusForSize("m")).toBe(4);
+    expect(vercelVcpusForSize("l")).toBe(6);
+    expect(vercelVcpusForSize("xl")).toBe(8);
+  });
+});
+
+describe("vercelSizingForSize", () => {
+  it("derives memory at 2 GB/vCPU and reports the fixed 32 GB disk", () => {
+    expect(vercelSizingForSize("xs")).toEqual({
+      vcpus: 1,
+      memoryGb: 2,
+      diskGb: 32,
+    });
+    expect(vercelSizingForSize("m")).toEqual({
+      vcpus: 4,
+      memoryGb: 8,
+      diskGb: 32,
+    });
+    expect(vercelSizingForSize("l")).toEqual({
+      vcpus: 6,
+      memoryGb: 12,
+      diskGb: 32,
+    });
+    expect(vercelSizingForSize("xl")).toEqual({
+      vcpus: 8,
+      memoryGb: 16,
+      diskGb: 32,
+    });
+  });
+});

--- a/js/sandbox/src/providers/vercel/sizing.ts
+++ b/js/sandbox/src/providers/vercel/sizing.ts
@@ -1,0 +1,82 @@
+/**
+ * Translate a canonical sandbox size (xs/m/l/xl, see {@link SANDBOX_SIZE_SPECS})
+ * into the Vercel `resources` allocation `Sandbox.create` accepts.
+ *
+ * Unlike Daytona (size baked into the image) and Freestyle (size baked into a
+ * per-size snapshot), Vercel takes the size at create time via `resources`, and
+ * couples memory to vCPU count: every vCPU comes with a fixed 2 GB of memory and
+ * the only knob is the vCPU count, which must be `1` or an even number from 2 to
+ * 32 (the Enterprise ceiling; Hobby caps at 4 and Pro at 8). So we pick the
+ * smallest valid vCPU count that satisfies BOTH the canonical size's vCPU and
+ * its memory request — otherwise a larger size would silently boot with Vercel's
+ * default 2 vCPUs / 4 GB. Mapping memory through the 2 GB-per-vCPU coupling
+ * reproduces the advertised memory (m → 8 GB, l → 12 GB, xl → 16 GB) while the
+ * vCPU count rises to match. An over-plan request (e.g. xl → 8 vCPUs on Hobby)
+ * is rejected loudly by `create` rather than silently downsized.
+ */
+import { SANDBOX_SIZE_SPECS } from "../../constants";
+import type { SandboxSize } from "../../enums";
+
+/** Vercel allocates a fixed 2 GB of memory per vCPU; it is not configurable. */
+const VERCEL_MEMORY_GB_PER_VCPU = 2;
+
+/** Largest vCPU count Vercel offers (Enterprise plan ceiling). */
+const VERCEL_MAX_VCPUS = 32;
+
+/**
+ * Every Vercel sandbox gets a fixed 32 GB of ephemeral NVMe storage regardless
+ * of the chosen vCPU/memory size, so disk does not vary by size.
+ */
+const VERCEL_DISK_GB = 32;
+
+export interface VercelSizing {
+  /** vCPU count (`1` or an even number, 2–32). */
+  vcpus: number;
+  /** Memory in GB (derived: 2 GB per vCPU). */
+  memoryGb: number;
+  /** Ephemeral disk in GB (fixed by the platform). */
+  diskGb: number;
+}
+
+/**
+ * The vCPU count to request for `size`: the smallest valid Vercel value (`1`, or
+ * an even number up to {@link VERCEL_MAX_VCPUS}) that provides at least the
+ * size's vCPUs and — via the 2 GB-per-vCPU coupling — at least its memory.
+ */
+export function vercelVcpusForSize(size: SandboxSize): number {
+  const spec = SANDBOX_SIZE_SPECS[size];
+  const needed = Math.max(
+    spec.vcpus,
+    Math.ceil(spec.memoryGb / VERCEL_MEMORY_GB_PER_VCPU),
+  );
+  if (needed <= 1) {
+    return 1;
+  }
+  const even = needed % 2 === 0 ? needed : needed + 1;
+  return Math.min(even, VERCEL_MAX_VCPUS);
+}
+
+/** Effective Vercel dimensions for `size` (for both create and display). */
+export function vercelSizingForSize(size: SandboxSize): VercelSizing {
+  const vcpus = vercelVcpusForSize(size);
+  return {
+    vcpus,
+    memoryGb: vcpus * VERCEL_MEMORY_GB_PER_VCPU,
+    diskGb: VERCEL_DISK_GB,
+  };
+}
+
+/**
+ * Effective Vercel dimensions for an already-provisioned sandbox that reports
+ * `vcpus`. `Sandbox.list()` exposes only the vCPU count, so memory and disk are
+ * recovered from the same fixed 2 GB-per-vCPU / 32 GB-disk coupling
+ * {@link vercelSizingForSize} applies at create time. Used by the spend meter to
+ * size a running sandbox from its live vCPU count.
+ */
+export function vercelSizingForVcpus(vcpus: number): VercelSizing {
+  return {
+    vcpus,
+    memoryGb: vcpus * VERCEL_MEMORY_GB_PER_VCPU,
+    diskGb: VERCEL_DISK_GB,
+  };
+}

--- a/js/sandbox/src/sandbox-status.test.ts
+++ b/js/sandbox/src/sandbox-status.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveSandboxStatus,
+  isSetupInProgress,
+  parseSandboxSetupStatus,
+} from "./sandbox-status";
+
+describe("parseSandboxSetupStatus", () => {
+  it("accepts every setup-track value", () => {
+    expect(parseSandboxSetupStatus("ok")).toBe("ok");
+    expect(parseSandboxSetupStatus("setup-running")).toBe("setup-running");
+    expect(parseSandboxSetupStatus("git-failed")).toBe("git-failed");
+    expect(parseSandboxSetupStatus("setup-failed")).toBe("setup-failed");
+    expect(parseSandboxSetupStatus("sys-setup-failed")).toBe(
+      "sys-setup-failed",
+    );
+  });
+
+  it("returns null for unknown values and absent columns", () => {
+    expect(parseSandboxSetupStatus(null)).toBeNull();
+    expect(parseSandboxSetupStatus(undefined)).toBeNull();
+    expect(parseSandboxSetupStatus("")).toBeNull();
+    expect(parseSandboxSetupStatus("exploded")).toBeNull();
+  });
+});
+
+describe("isSetupInProgress", () => {
+  it("is true only for the in-progress setup value", () => {
+    expect(isSetupInProgress("setup-running")).toBe(true);
+  });
+
+  it("is false for terminal outcomes and absent columns", () => {
+    expect(isSetupInProgress("ok")).toBe(false);
+    expect(isSetupInProgress("git-failed")).toBe(false);
+    expect(isSetupInProgress("setup-failed")).toBe(false);
+    expect(isSetupInProgress("sys-setup-failed")).toBe(false);
+    expect(isSetupInProgress(null)).toBe(false);
+    expect(isSetupInProgress(undefined)).toBe(false);
+    expect(isSetupInProgress("exploded")).toBe(false);
+  });
+});
+
+describe("deriveSandboxStatus", () => {
+  it("splits initializing into creating vs starting by whether setup ever concluded", () => {
+    // No recorded outcome: the first-ever initialization is still running.
+    expect(
+      deriveSandboxStatus({ state: "initializing", setup_status: null }),
+    ).toBe("creating");
+    // Any recorded outcome means this is a restart.
+    expect(
+      deriveSandboxStatus({ state: "initializing", setup_status: "ok" }),
+    ).toBe("starting");
+    expect(
+      deriveSandboxStatus({
+        state: "initializing",
+        setup_status: "setup-failed",
+      }),
+    ).toBe("starting");
+  });
+
+  it("maps settled row states to the canonical vocabulary", () => {
+    expect(deriveSandboxStatus({ state: "stopping" })).toBe("stopping");
+    expect(deriveSandboxStatus({ state: "stopped" })).toBe("suspended");
+    expect(deriveSandboxStatus({ state: "snapshotting" })).toBe("snapshotting");
+    expect(deriveSandboxStatus({ state: "failed" })).toBe("failed");
+    expect(deriveSandboxStatus({ state: "errored" })).toBe("failed");
+  });
+
+  it("reads an active row as running without a live state", () => {
+    expect(deriveSandboxStatus({ state: "active" })).toBe("running");
+  });
+
+  it("reads an active row that is still setting up as running", () => {
+    // Running-before-setup: the VM is up while the lifecycle runs, so the
+    // in-progress setup track stays under the `running` lifecycle status.
+    expect(
+      deriveSandboxStatus({ state: "active", setup_status: "setup-running" }),
+    ).toBe("running");
+    expect(
+      deriveSandboxStatus(
+        { state: "active", setup_status: "setup-running" },
+        "running",
+      ),
+    ).toBe("running");
+  });
+
+  it("surfaces a provider that cannot find the VM as unknown, not running", () => {
+    // "unknown" is a *successful* provider answer (VM absent from the
+    // listing / unfetchable) — a deleted-behind-our-back VM must not show a
+    // healthy green Running.
+    expect(deriveSandboxStatus({ state: "active" }, "unknown")).toBe("unknown");
+  });
+
+  it("defers to the live provider state for active rows", () => {
+    expect(deriveSandboxStatus({ state: "active" }, "running")).toBe("running");
+    // The provider can suspend an idle VM behind our back.
+    expect(deriveSandboxStatus({ state: "active" }, "suspended")).toBe(
+      "suspended",
+    );
+    expect(deriveSandboxStatus({ state: "active" }, "suspending")).toBe(
+      "suspending",
+    );
+    expect(deriveSandboxStatus({ state: "active" }, "failed")).toBe("failed");
+    // An active row can't be mid-create; a creation-phase live state reads as
+    // coming up.
+    expect(deriveSandboxStatus({ state: "active" }, "creating")).toBe(
+      "starting",
+    );
+  });
+
+  it("lets the row's orchestration state win over the live state during transitions", () => {
+    expect(
+      deriveSandboxStatus(
+        { state: "initializing", setup_status: "ok" },
+        "running",
+      ),
+    ).toBe("starting");
+    expect(deriveSandboxStatus({ state: "snapshotting" }, "running")).toBe(
+      "snapshotting",
+    );
+  });
+});

--- a/js/sandbox/src/sandbox-status.ts
+++ b/js/sandbox/src/sandbox-status.ts
@@ -1,0 +1,161 @@
+/**
+ * Canonical two-track sandbox status model.
+ *
+ * A sandbox's status is split into two independent tracks so a setup problem
+ * can never masquerade as a dead VM:
+ *
+ *   1. Lifecycle ({@link SandboxStatus}) — is the VM alive? Derived from the
+ *      persisted orchestration `state` plus, for settled rows, the live
+ *      provider state mapped into the canonical vocabulary
+ *      ({@link SandboxStatus}, one mapper per provider).
+ *   2. Setup ({@link SandboxSetupStatus}) — did the most recent initialization
+ *      run (create or start) set everything up on the VM? Persisted alongside
+ *      the sandbox record and only meaningful alongside a live VM.
+ *
+ *        .
+ *        ├── creating
+ *        ├── failed
+ *        ├── running
+ *        │   ├── git-failed
+ *        │   ├── ok
+ *        │   ├── setup-failed
+ *        │   ├── setup-running
+ *        │   └── sys-setup-failed
+ *        ├── snapshotting
+ *        ├── starting
+ *        ├── stopping
+ *        ├── suspended
+ *        └── suspending
+ *
+ * `failed` therefore means the VM itself is gone or unusable (provisioning
+ * failed, provider reports an error state). A sandbox whose repo clone, user
+ * setup script, or system setup (credentials, env, API key) failed — but whose
+ * VM is up — is `running` with the failure recorded in the setup track.
+ *
+ * The persisted `state` uses its own vocabulary (`initializing`,
+ * `active`, `stopping`, `stopped`, `snapshotting`, `failed`); this module owns
+ * the translation into the canonical statuses so persisted rows and mid-deploy
+ * version skew all keep working. `snapshotting` is not part of the
+ * create/resume taxonomy above but
+ * is a real row state a sandbox can occupy, so it is exposed as its own
+ * lifecycle status rather than being folded into a neighbor.
+ */
+
+/**
+ * Outer lifecycle track: is the VM alive (or on its way up/down)? `unknown`
+ * means the provider answered but couldn't identify the VM (absent from its
+ * listing, unfetchable) or reported a raw state a provider's mapper doesn't
+ * recognize — the status is genuinely indeterminate, which is different from
+ * both `running` and `failed`.
+ */
+export const SANDBOX_STATUS_VALUES = [
+  "creating",
+  "starting",
+  "running",
+  "stopping",
+  "suspending",
+  "suspended",
+  "snapshotting",
+  "failed",
+  "unknown",
+] as const;
+export type SandboxStatus = (typeof SANDBOX_STATUS_VALUES)[number];
+
+/**
+ * Setup track: state of the most recent initialization run (create or start).
+ * `setup-running` is the in-progress value — the VM is already `running` and
+ * reachable (SSH) while clone/setup/post-setup execute in the background; the
+ * run then resolves to a terminal outcome. "Last run wins": a successful
+ * restart clears an earlier failure, because a restart is the natural retry
+ * action and each run re-does the credential/system setup. The one exception is
+ * `git-failed` — a restart never re-clones the primary repo, so the
+ * missing-workspace status stays sticky across restarts no matter how the rerun
+ * goes (see the start flow).
+ *
+ * `setup-running` is a value under the `running` lifecycle status, not a power
+ * state of its own: `deriveSandboxStatus` still reports `running` for it.
+ */
+export const SANDBOX_SETUP_STATUS_VALUES = [
+  "ok",
+  "setup-running",
+  "git-failed",
+  "setup-failed",
+  "sys-setup-failed",
+] as const;
+export type SandboxSetupStatus = (typeof SANDBOX_SETUP_STATUS_VALUES)[number];
+
+/**
+ * Narrow a persisted `setup_status` value to the typed union. Returns `null`
+ * for anything unexpected and for records that predate the field or haven't
+ * recorded an outcome yet.
+ */
+export function parseSandboxSetupStatus(
+  value: string | null | undefined,
+): SandboxSetupStatus | null {
+  return SANDBOX_SETUP_STATUS_VALUES.includes(value as SandboxSetupStatus)
+    ? (value as SandboxSetupStatus)
+    : null;
+}
+
+/**
+ * Whether the sandbox's setup track is still in progress. True only while a
+ * create/start run has the VM `running` but is still executing the
+ * clone/setup/post-setup lifecycle (`setup-running`). Consumers that need the
+ * repo or agent server (agent commands, Slack dispatch, workflow kickoff) must
+ * treat this as "not ready yet", and `stop`/`snapshot` refuse while it holds
+ * (they would corrupt the in-flight lifecycle). `delete` is intentionally still
+ * allowed — it's the way to abort an unwanted or stuck setup, and the
+ * background lifecycle tolerates the row/VM disappearing.
+ */
+export function isSetupInProgress(
+  setupStatus: string | null | undefined,
+): boolean {
+  return parseSandboxSetupStatus(setupStatus) === "setup-running";
+}
+
+/**
+ * Derive the lifecycle status for a sandbox row, optionally refined by the
+ * live provider state (already mapped to the canonical vocabulary by the
+ * provider's `mapSandboxState`).
+ *
+ * The row's orchestration state wins during transitions (initializing,
+ * stopping, snapshotting) and terminal failure; a settled `active` row defers
+ * to the live VM state, which may disagree with the row (e.g. the provider
+ * auto-suspended an idle VM behind our back). Without a usable live state an
+ * `active` row reads as `running`.
+ *
+ * `creating` vs `starting`: both use the row state `initializing`. A row
+ * whose setup track is still NULL has never completed an initialization run,
+ * so it is mid-create; any later `initializing` (which preserves the previous
+ * run's outcome until the new one concludes) is a restart.
+ */
+export function deriveSandboxStatus(
+  row: { state: string; setup_status?: string | null },
+  liveState?: SandboxStatus,
+): SandboxStatus {
+  switch (row.state) {
+    case "initializing":
+      return row.setup_status == null ? "creating" : "starting";
+    case "stopping":
+      return "stopping";
+    case "stopped":
+      return "suspended";
+    case "snapshotting":
+      return "snapshotting";
+    case "failed":
+    case "errored": // legacy failure value; no longer written
+      return "failed";
+    default:
+      // "active" (and any unrecognized legacy value, which only `active`-like
+      // rows ever carried): defer to the live VM state when we have one —
+      // including `unknown` (the provider can't find the VM), which must not
+      // read as a healthy `running`. No live state at all (no lifecycle, or
+      // the probe itself errored) falls back to the row's word.
+      if (liveState !== undefined) {
+        // An active row can't be mid-create; a provider reporting a
+        // creation-phase state for it is effectively coming up.
+        return liveState === "creating" ? "starting" : liveState;
+      }
+      return "running";
+  }
+}

--- a/js/sandbox/src/types.ts
+++ b/js/sandbox/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Provider-facing shared types owned by the provider layer.
+ */
+
+export type SandboxProviderName = "daytona" | "freestyle" | "vercel";
+
+export type ServiceProtocol = "tcp" | "udp";
+export type ServiceUrlScheme = "http" | "https";
+
+/** A live service exposed by a sandbox (name, signed URL, ports, protocol). */
+export interface SandboxService {
+  name: string;
+  url: string;
+  hostPort: number;
+  containerPort: number;
+  protocol: ServiceProtocol;
+  /**
+   * Authored URL scheme from the repo-config service definition, carried
+   * through so `seedSystemSandboxServices` records the intended scheme rather
+   * than inferring one from the (initially empty) live URL. Absent for services
+   * with no authored scheme (e.g. the built-in coding-agent entry).
+   */
+  urlScheme?: "http" | "https";
+}
+
+/**
+ * Service port/protocol shapes the provider API references. These mirror the
+ * caller's repo-config service-definition types (structurally identical), so
+ * resolved service definitions flow into the provider `create`/`refreshUrls`
+ * calls without conversion; the package keeps its own copy so it carries no
+ * dependency on the caller's repo-config domain.
+ */
+export interface ServicePortDefinition {
+  port: number;
+  protocol: ServiceProtocol;
+  url_scheme: ServiceUrlScheme | null;
+}
+
+export interface ServiceDefinitionData {
+  name: string;
+  ports: ServicePortDefinition[];
+}

--- a/js/sandbox/src/util/errorutils.ts
+++ b/js/sandbox/src/util/errorutils.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared helpers for adding context to errors and inspecting error chains.
+ */
+
+/**
+ * A step label for {@link withStepContext}. A function form is evaluated only on
+ * failure, for context that is expensive or only knowable after the error (e.g.
+ * reading provider state once a call has already thrown).
+ */
+export type StepLabel = string | (() => string | Promise<string>);
+
+/**
+ * The error {@link withStepContext} always throws. Carries any caller `fields`
+ * as a structured property so a handler can hoist them into a log; with no
+ * fields it behaves like an ordinary wrapped `Error` (same message prefixing,
+ * same `cause` chain) to be treated like any unexpected failure.
+ */
+export class StepContextError extends Error {
+  // Assigned via `Object.defineProperty` in the constructor (non-enumerable);
+  // `declare` keeps the type without emitting an enumerable field.
+  declare readonly fields: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    fields: Record<string, unknown>,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "StepContextError";
+    // Non-enumerable so the logger's `redactError` (which copies enumerable own
+    // properties) doesn't duplicate the fields onto the logged error; the error
+    // handler reads `err.fields` directly and hoists them under `stepContext`.
+    Object.defineProperty(this, "fields", {
+      value: fields,
+      enumerable: false,
+      writable: false,
+      configurable: true,
+    });
+  }
+}
+
+/**
+ * Run `run`, and if it throws, rethrow a *new* Error whose message is
+ * `${step}: ${original message}`, preserving the original error as `cause`.
+ *
+ * Providers (notably Freestyle) surface opaque `INTERNAL_ERROR` 500s whose
+ * message is just "Internal server error" plus a provider trace id, with no
+ * indication of which call produced it. When several such calls run in sequence
+ * (mint SSH = create identity -> grant VM -> create token; start = resume ->
+ * rerun lifecycle), the failure log can't say which one failed. Prefixing the
+ * step here makes it explicit.
+ *
+ * Wrapping (rather than mutating the caught error) keeps the original intact:
+ * the logger's `redactError` follows `cause` recursively, so the provider's
+ * class name and `traceId` are still logged under `err.cause`, and the global
+ * error handler walks the `cause` chain so the underlying class still
+ * surfaces at the top level.
+ *
+ * Any `fields` are carried on the thrown {@link StepContextError} so a handler
+ * can log them.
+ */
+export async function withStepContext<T>(
+  step: StepLabel,
+  run: () => Promise<T>,
+  fields?: Record<string, unknown>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (err) {
+    const prefix = typeof step === "function" ? await step() : step;
+    const message = err instanceof Error ? err.message : String(err);
+    throw new StepContextError(`${prefix}: ${message}`, fields ?? {}, {
+      cause: err,
+    });
+  }
+}

--- a/js/sandbox/src/util/git-clone.test.ts
+++ b/js/sandbox/src/util/git-clone.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGitCheckoutNewBranchCmd,
+  buildGitSetPlainRemoteCmd,
+} from "./git-clone";
+
+describe("buildGitCheckoutNewBranchCmd", () => {
+  it("builds a checkout command with the branch shell-quoted and a `--` guard", () => {
+    expect(buildGitCheckoutNewBranchCmd("feature/x")).toBe(
+      "git checkout -b 'feature/x' --",
+    );
+  });
+
+  it("throws for a branch name starting with '-' (argument injection)", () => {
+    expect(() => buildGitCheckoutNewBranchCmd("-b")).toThrow(
+      /argument injection/,
+    );
+  });
+
+  it("throws for a branch name with shell metacharacters", () => {
+    expect(() => buildGitCheckoutNewBranchCmd("main; rm -rf /")).toThrow(
+      /shell metacharacters/,
+    );
+  });
+
+  it("throws for an empty branch name", () => {
+    expect(() => buildGitCheckoutNewBranchCmd("")).toThrow(/empty/);
+  });
+});
+
+describe("buildGitSetPlainRemoteCmd", () => {
+  it("builds a set-url command with the URL shell-quoted", () => {
+    expect(
+      buildGitSetPlainRemoteCmd("https://github.com/gofixpoint/amika.git"),
+    ).toBe(
+      "git remote set-url origin 'https://github.com/gofixpoint/amika.git'",
+    );
+  });
+
+  it("neutralizes single quotes in the URL", () => {
+    expect(buildGitSetPlainRemoteCmd("https://host/x'y")).toBe(
+      `git remote set-url origin 'https://host/x'"'"'y'`,
+    );
+  });
+});

--- a/js/sandbox/src/util/git-clone.test.ts
+++ b/js/sandbox/src/util/git-clone.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildGitCheckoutNewBranchCmd,
   buildGitSetPlainRemoteCmd,
+  buildRefreshClonedRepoScript,
 } from "./git-clone";
 
 describe("buildGitCheckoutNewBranchCmd", () => {
@@ -41,5 +42,39 @@ describe("buildGitSetPlainRemoteCmd", () => {
     expect(buildGitSetPlainRemoteCmd("https://host/x'y")).toBe(
       `git remote set-url origin 'https://host/x'"'"'y'`,
     );
+  });
+});
+
+describe("buildRefreshClonedRepoScript", () => {
+  const url = "https://github.com/gofixpoint/amika.git";
+
+  it("syncs and checks out submodules by default", () => {
+    const lines = buildRefreshClonedRepoScript(url, "main").split("\n");
+
+    expect(lines.at(-2)).toBe("git submodule sync --recursive");
+    expect(lines.at(-1)).toBe("git submodule update --init --recursive");
+  });
+
+  it("syncs submodules after the branch checkout, not before", () => {
+    const script = buildRefreshClonedRepoScript(url, "main");
+
+    // The submodule commits a superproject pins are a property of the checked
+    // out tree, so updating before the checkout would sync against the old one.
+    expect(script.indexOf("git submodule update")).toBeGreaterThan(
+      script.indexOf("git checkout -f -B 'main'"),
+    );
+  });
+
+  it("recurses on the default-branch path too", () => {
+    const script = buildRefreshClonedRepoScript(url);
+
+    expect(script).toContain("git submodule update --init --recursive");
+  });
+
+  it("omits the submodule commands when recursion is disabled", () => {
+    const script = buildRefreshClonedRepoScript(url, "main", false);
+
+    expect(script).not.toContain("git submodule");
+    expect(script).toContain("git checkout -f -B 'main'");
   });
 });

--- a/js/sandbox/src/util/git-clone.ts
+++ b/js/sandbox/src/util/git-clone.ts
@@ -138,10 +138,17 @@ export function buildGitSetPlainRemoteCmd(url: string): string {
  * `origin` at `cloneUrl`, restores the full-history refspec, fetches, then
  * checks out the same end state a fresh clone-with-branch-fallback would
  * produce. `branch` is validated; it and `cloneUrl` are shell-quoted.
+ *
+ * When `recurseSubmodules` is true (the default), the script also syncs and
+ * checks out submodules after the branch checkout. `sync --recursive` is what
+ * picks up a `.gitmodules` URL that changed between the snapshot's baked-in
+ * commit and the one being checked out; `update --init` alone would keep using
+ * the stale URL recorded in `.git/config`.
  */
 export function buildRefreshClonedRepoScript(
   cloneUrl: string,
   branch?: string,
+  recurseSubmodules: boolean = true,
 ): string {
   const quotedUrl = shellQuote(cloneUrl);
   const checkoutDefaultBranch = [
@@ -177,6 +184,12 @@ export function buildRefreshClonedRepoScript(
     "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'",
     "git fetch --prune origin",
     checkout,
+    ...(recurseSubmodules
+      ? [
+          "git submodule sync --recursive",
+          "git submodule update --init --recursive",
+        ]
+      : []),
   ].join("\n");
 }
 

--- a/js/sandbox/src/util/git-clone.ts
+++ b/js/sandbox/src/util/git-clone.ts
@@ -1,0 +1,223 @@
+/**
+ * Git command builders + remote checks used by the provider provisioning flows:
+ * ref validation, clone-URL construction, the checkout/remote command-string
+ * builders, the in-place refresh script, a branch-existence probe, and
+ * branch-not-found classification.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { shellQuote } from "./shell";
+
+const execFileAsync = promisify(execFile);
+
+// Characters dangerous in shell interpolation contexts. Even when we use
+// `execFileAsync` (no shell), we reject these so downstream code that *does*
+// interpolate into a shell string is safe by construction.
+const SHELL_METACHAR_RE = /[;`$(){}|&><!"'#]/;
+
+// Characters forbidden by `git check-ref-format` (rule 3): ASCII control
+// chars, space, ~, ^, :, ?, *, [, ], \.
+// eslint-disable-next-line no-control-regex -- rejecting control chars is the point
+const GIT_REF_FORBIDDEN_CHAR_RE = /[\x00-\x1f\x7f ~^:?*[\]\\]/;
+
+const BRANCH_NOT_FOUND_RE = /fatal: Remote branch (.+) not found in upstream/;
+
+/**
+ * Validate a git branch / ref name. Enforces `git check-ref-format --branch`
+ * rules plus rejects shell metacharacters and a leading `-` (argument
+ * injection). Throws a descriptive error when the name is invalid.
+ */
+export function assertValidGitRef(ref: string): void {
+  if (!ref) {
+    throw new Error("Invalid git ref: name is empty");
+  }
+  if (ref.startsWith("-")) {
+    throw new Error(
+      `Invalid git ref: '${ref}' starts with '-' (argument injection)`,
+    );
+  }
+  if (SHELL_METACHAR_RE.test(ref)) {
+    throw new Error(`Invalid git ref: '${ref}' contains shell metacharacters`);
+  }
+  if (GIT_REF_FORBIDDEN_CHAR_RE.test(ref)) {
+    throw new Error(
+      `Invalid git ref: '${ref}' contains characters forbidden by git`,
+    );
+  }
+  if (ref.includes("..")) {
+    throw new Error(`Invalid git ref: '${ref}' contains '..'`);
+  }
+  if (ref.startsWith("/") || ref.endsWith("/") || ref.includes("//")) {
+    throw new Error(`Invalid git ref: '${ref}' has invalid slash usage`);
+  }
+  if (ref.endsWith(".")) {
+    throw new Error(`Invalid git ref: '${ref}' ends with '.'`);
+  }
+  if (ref.includes("@{")) {
+    throw new Error(`Invalid git ref: '${ref}' contains '@{'`);
+  }
+  if (ref === "@") {
+    throw new Error(`Invalid git ref: '${ref}' is the bare '@' character`);
+  }
+  for (const component of ref.split("/")) {
+    if (!component) {
+      throw new Error(`Invalid git ref: '${ref}' has an empty component`);
+    }
+    if (component.startsWith(".")) {
+      throw new Error(
+        `Invalid git ref: '${ref}' has a component starting with '.'`,
+      );
+    }
+    if (component.endsWith(".lock")) {
+      throw new Error(
+        `Invalid git ref: '${ref}' has a component ending with '.lock'`,
+      );
+    }
+  }
+}
+
+export function assertValidGitRemoteUrl(repoUrl: string): void {
+  if (!repoUrl.trim()) {
+    throw new Error("Invalid git remote URL: URL is empty");
+  }
+  if (repoUrl.startsWith("-")) {
+    throw new Error(
+      `Invalid git remote URL: '${repoUrl}' starts with '-' (argument injection)`,
+    );
+  }
+  // eslint-disable-next-line no-control-regex -- rejecting control chars is the point
+  if (/[\x00-\x1f\x7f]/.test(repoUrl)) {
+    throw new Error(
+      `Invalid git remote URL: '${repoUrl}' contains control characters`,
+    );
+  }
+}
+
+/** Embed a `x-access-token:<token>` credential into an HTTPS clone URL. */
+export function buildCloneUrl(
+  repoUrl: string,
+  githubToken?: string | null,
+): string {
+  if (!githubToken) {
+    return repoUrl;
+  }
+  try {
+    const url = new URL(repoUrl);
+    if (url.protocol !== "https:") {
+      return repoUrl;
+    }
+    url.username = "x-access-token";
+    url.password = githubToken;
+    return url.toString();
+  } catch {
+    return repoUrl;
+  }
+}
+
+/**
+ * Build a `git checkout -b <branch>` command string that is safe for shell
+ * execution. Validates the branch name and uses `--` to prevent injection.
+ */
+export function buildGitCheckoutNewBranchCmd(branch: string): string {
+  assertValidGitRef(branch);
+  return `git checkout -b ${shellQuote(branch)} --`;
+}
+
+/**
+ * Build a `git remote set-url origin <url>` command resetting the remote to a
+ * plain (credential-free) URL. Used after `app_token`-mode clones so later
+ * pushes consult the credential helper instead of an expired embedded token.
+ */
+export function buildGitSetPlainRemoteCmd(url: string): string {
+  return `git remote set-url origin ${shellQuote(url)}`;
+}
+
+/**
+ * Build a shell script that refreshes an already-cloned repository in place
+ * (the fast path where the repo is baked into the booted snapshot). Re-points
+ * `origin` at `cloneUrl`, restores the full-history refspec, fetches, then
+ * checks out the same end state a fresh clone-with-branch-fallback would
+ * produce. `branch` is validated; it and `cloneUrl` are shell-quoted.
+ */
+export function buildRefreshClonedRepoScript(
+  cloneUrl: string,
+  branch?: string,
+): string {
+  const quotedUrl = shellQuote(cloneUrl);
+  const checkoutDefaultBranch = [
+    "git remote set-head origin --auto >/dev/null 2>&1 || true",
+    "def=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)",
+    'def="${def#origin/}"',
+    'if [ -z "$def" ]; then',
+    "  def=$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || true)",
+    '  def="${def#origin/}"',
+    "fi",
+    'if [ -z "$def" ]; then echo "could not resolve origin default branch" >&2; exit 1; fi',
+    'git checkout -f -B "$def" "origin/$def" --',
+  ].join("\n");
+
+  let checkout: string;
+  if (branch) {
+    assertValidGitRef(branch);
+    checkout = [
+      `if git show-ref --verify --quiet ${shellQuote(`refs/remotes/origin/${branch}`)}; then`,
+      `  git checkout -f -B ${shellQuote(branch)} ${shellQuote(`origin/${branch}`)} --`,
+      "else",
+      checkoutDefaultBranch.replace(/^/gm, "  "),
+      `  ${buildGitCheckoutNewBranchCmd(branch)}`,
+      "fi",
+    ].join("\n");
+  } else {
+    checkout = checkoutDefaultBranch;
+  }
+
+  return [
+    "set -e",
+    `git remote set-url origin ${quotedUrl} 2>/dev/null || git remote add origin ${quotedUrl}`,
+    "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'",
+    "git fetch --prune origin",
+    checkout,
+  ].join("\n");
+}
+
+function gitLsRemoteHeadsArgs(
+  repoUrl: string,
+  githubToken: string | null | undefined,
+  branch: string,
+): string[] {
+  assertValidGitRemoteUrl(repoUrl);
+  assertValidGitRef(branch);
+  return [
+    "ls-remote",
+    "--heads",
+    "--",
+    buildCloneUrl(repoUrl, githubToken),
+    `refs/heads/${branch}`,
+  ];
+}
+
+/**
+ * Check whether a branch exists on a remote repository without cloning, via
+ * `git ls-remote --heads`. On a network/auth error, returns `true` so the
+ * caller treats existence as unknown and falls back to rethrowing the original
+ * clone error rather than misreporting the branch as missing.
+ */
+export async function checkBranchExistsOnRemote(
+  repoUrl: string,
+  githubToken: string | null | undefined,
+  branch: string,
+): Promise<boolean> {
+  const args = gitLsRemoteHeadsArgs(repoUrl, githubToken, branch);
+  try {
+    const { stdout } = await execFileAsync("git", args);
+    return stdout.trim().length > 0;
+  } catch {
+    return true;
+  }
+}
+
+/** Whether a git clone error is a "remote branch not found in upstream". */
+export function isBranchNotFoundError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : "";
+  return BRANCH_NOT_FOUND_RE.test(msg);
+}

--- a/js/sandbox/src/util/github.test.ts
+++ b/js/sandbox/src/util/github.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { getRepoNameFromGithubUrl } from "./github";
+
+describe("getRepoNameFromGithubUrl", () => {
+  it("extracts the repo name from an owner/repo URL", () => {
+    expect(
+      getRepoNameFromGithubUrl("https://github.com/gofixpoint/amika"),
+    ).toBe("amika");
+  });
+
+  it("strips a trailing .git suffix", () => {
+    expect(
+      getRepoNameFromGithubUrl("https://github.com/gofixpoint/amika.git"),
+    ).toBe("amika");
+  });
+
+  it("only strips .git at the end, not mid-name", () => {
+    expect(
+      getRepoNameFromGithubUrl("https://github.com/gofixpoint/my.git.repo"),
+    ).toBe("my.git.repo");
+  });
+
+  it("ignores trailing slashes", () => {
+    expect(
+      getRepoNameFromGithubUrl("https://github.com/gofixpoint/amika/"),
+    ).toBe("amika");
+  });
+
+  it("returns the repo even when the path has extra segments", () => {
+    expect(
+      getRepoNameFromGithubUrl(
+        "https://github.com/gofixpoint/amika/tree/main/js",
+      ),
+    ).toBe("amika");
+  });
+
+  it("accepts http as well as https", () => {
+    expect(getRepoNameFromGithubUrl("http://github.com/owner/repo")).toBe(
+      "repo",
+    );
+  });
+
+  it("returns null for a non-github host", () => {
+    expect(
+      getRepoNameFromGithubUrl("https://gitlab.com/owner/repo"),
+    ).toBeNull();
+  });
+
+  it("rejects look-alike hosts (no substring match)", () => {
+    expect(
+      getRepoNameFromGithubUrl("https://github.com.evil.com/owner/repo"),
+    ).toBeNull();
+    expect(
+      getRepoNameFromGithubUrl("https://notgithub.com/owner/repo"),
+    ).toBeNull();
+  });
+
+  it("returns null when the owner or repo segment is missing", () => {
+    expect(getRepoNameFromGithubUrl("https://github.com/owner")).toBeNull();
+    expect(getRepoNameFromGithubUrl("https://github.com/")).toBeNull();
+  });
+
+  it("returns null for a non-URL string", () => {
+    expect(getRepoNameFromGithubUrl("not a url")).toBeNull();
+    expect(getRepoNameFromGithubUrl("")).toBeNull();
+  });
+});

--- a/js/sandbox/src/util/github.ts
+++ b/js/sandbox/src/util/github.ts
@@ -1,0 +1,24 @@
+/**
+ * GitHub URL helpers used by the provider layer.
+ */
+function trimGitSuffix(value: string): string {
+  return value.endsWith(".git") ? value.slice(0, -4) : value;
+}
+
+/** Extract the repo name from a `github.com` URL, or null if it isn't one. */
+export function getRepoNameFromGithubUrl(githubUrl: string): string | null {
+  try {
+    const url = new URL(githubUrl);
+    if (url.hostname !== "github.com") {
+      return null;
+    }
+    const path = url.pathname.replace(/^\/+|\/+$/g, "");
+    const parts = path.split("/").filter(Boolean);
+    if (parts.length < 2) {
+      return null;
+    }
+    return trimGitSuffix(parts[1]);
+  } catch {
+    return null;
+  }
+}

--- a/js/sandbox/src/util/shell.test.ts
+++ b/js/sandbox/src/util/shell.test.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { shellQuote } from "./shell";
+
+describe("shellQuote", () => {
+  it("wraps a plain value in single quotes", () => {
+    expect(shellQuote("hello")).toBe("'hello'");
+  });
+
+  it("quotes an empty string", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+
+  it("leaves spaces and double quotes literal inside the single quotes", () => {
+    expect(shellQuote('a b "c"')).toBe(`'a b "c"'`);
+  });
+
+  it("does not expand shell metacharacters", () => {
+    expect(shellQuote("$(rm -rf /); `whoami` && x")).toBe(
+      "'$(rm -rf /); `whoami` && x'",
+    );
+  });
+
+  it("escapes a single quote using the '\"'\"' idiom", () => {
+    expect(shellQuote("it's")).toBe(`'it'"'"'s'`);
+  });
+
+  it("escapes every single quote in a value", () => {
+    expect(shellQuote("'a'")).toBe(`''"'"'a'"'"''`);
+  });
+
+  it("round-trips verbatim through a real shell (sh -c printf)", () => {
+    const values = [
+      "hello",
+      "it's",
+      "a b c",
+      "$(id)",
+      "`whoami`",
+      '"quoted"',
+      "back\\slash",
+      "a'b'c",
+      "; rm -rf / #",
+    ];
+    for (const value of values) {
+      // The quoted token must reach `printf` as a single argument equal to the
+      // original value — no expansion, splitting, or metacharacter effect.
+      const out = execFileSync("sh", ["-c", `printf %s ${shellQuote(value)}`], {
+        encoding: "utf8",
+      });
+      expect(out).toBe(value);
+    }
+  });
+});

--- a/js/sandbox/src/util/shell.ts
+++ b/js/sandbox/src/util/shell.ts
@@ -1,0 +1,8 @@
+/**
+ * Shell helpers for the provider layer. Prefer argv-style command APIs when
+ * available; use `shellQuote` only when a command must be assembled as a
+ * shell string.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/js/sandbox/tsconfig.json
+++ b/js/sandbox/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "stripInternal": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "amika-workspace",
+  "private": true,
+  "packageManager": "pnpm@10.18.2"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,3895 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  eslint-rules:
+    devDependencies:
+      eslint:
+        specifier: ^9
+        version: 9.39.5
+
+  js/sandbox:
+    dependencies:
+      '@daytona/api-client':
+        specifier: ^0.193.0
+        version: 0.193.0
+      '@daytonaio/sdk':
+        specifier: ^0.193.0
+        version: 0.193.0(ws@8.21.3)
+      '@vercel/sandbox':
+        specifier: ^2.2.1
+        version: 2.9.2
+      freestyle:
+        specifier: ^0.1.63
+        version: 0.1.63
+      p-retry:
+        specifier: ^7.1.1
+        version: 7.1.1
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.2
+        version: 9.39.5
+      '@types/node':
+        specifier: ^22
+        version: 22.20.1
+      eslint:
+        specifier: ^9
+        version: 9.39.5
+      globals:
+        specifier: ^16.4.0
+        version: 16.5.0
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.55.0
+        version: 8.67.0(eslint@9.39.5)(typescript@5.9.3)
+      vite:
+        specifier: 7.3.5
+        version: 7.3.5(@types/node@22.20.1)(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(vite@7.3.5(@types/node@22.20.1)(yaml@2.9.0))
+
+packages:
+
+  '@aws-sdk/checksums@3.1000.27':
+    resolution: {integrity: sha512-insWOqKKNUrbN/dohEG7BJ0U5GkyqhjbMb/NHNaLUtq+7my2M8C4EnZZZoxMmXRqCC+P9dEr+KyJA2JGGzoKLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1109.0':
+    resolution: {integrity: sha512-iPWzBeGkAe5H5+dBBGCOdIT4uMhpu12OK+nFnDzjvOChVnHIws4LeoG7Yl0kJHSRWZnNEkVcF4vQYTJny0e5xA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.7':
+    resolution: {integrity: sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.68':
+    resolution: {integrity: sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.70':
+    resolution: {integrity: sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.13':
+    resolution: {integrity: sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.75':
+    resolution: {integrity: sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.79':
+    resolution: {integrity: sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.68':
+    resolution: {integrity: sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.12':
+    resolution: {integrity: sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.74':
+    resolution: {integrity: sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-storage@3.1109.0':
+    resolution: {integrity: sha512-l05ablXGuiLHmuhQZhisBQcK1ZgwP1CsTeb+7x9X942qP9ba6RAMqSfh8R7QGTkN5c9PowWfDVLNbouQDTrQiw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1109.0
+
+  '@aws-sdk/middleware-sdk-s3@3.972.73':
+    resolution: {integrity: sha512-oy7sRA5HvHcAvkcKX6F8RI240jcOf3c8y/Gqjs9qemIibdKQqGBIi0uwa+47ZRYqGLpdEO28TQU4G73yUzo06Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.42':
+    resolution: {integrity: sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.44':
+    resolution: {integrity: sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1108.0':
+    resolution: {integrity: sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.3':
+    resolution: {integrity: sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.38':
+    resolution: {integrity: sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@daytona/api-client@0.193.0':
+    resolution: {integrity: sha512-mA0A9/Su9XuLZ3M/St58mDzZfP/flMVDpQOr119M6KXROon7QL1JzOEXHcbRr/J/959r8yfF8GAyQWdlZG7vPA==}
+
+  '@daytona/toolbox-api-client@0.193.0':
+    resolution: {integrity: sha512-e7dmam632BFJb/UGpzKQPA35hVfzi44Ra/Qz8YzOCgymxYY75gVCNYFWW1AtQMFQnbqoTUkeIonbSxAGLEG9gg==}
+
+  '@daytonaio/sdk@0.193.0':
+    resolution: {integrity: sha512-lBNHHH1xlIbosPCQ+abE3b50kM2qMvT+8j9x/4wf2EL0uuAsGH2uPzFUPjWtUy9uBttt6+xjfMmE4rWjLL0E9w==}
+    deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.5':
+    resolution: {integrity: sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@opentelemetry/api-logs@0.217.0':
+    resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.217.0':
+    resolution: {integrity: sha512-xCtrYOhBqdy6ZOMfe0Oa73ZKF+2LMhoOv4L5vmwAHVvOXUg+V3fvKuEIr9ZyD0Ow+vxllEjWO6PV1wd0DOtyvw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.217.0':
+    resolution: {integrity: sha512-KfLAdt1uilVE+3FxbgVnp2ZrzqbIawzcesnRoi+Kh9ckB5Ld5D8btUgoBvwTbdmuNx1j6b132Wsh72azq+pPNQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-Se0GG/ZO24mQTlQj7zprR4pNI0nKe4lPDPBsuJmi6508b9TlZEuUd3EfyuHk6oJxzL7fGyDFYAbxNigQvRP2ZQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-0GpJKnCoVaVA1rKBMVPHziznfOQlXgH72S9ktjBAF1AnAVPzX7vVEBGrhwiSxxHDAiefXk+J8znApsMb/K6Z3w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.217.0':
+    resolution: {integrity: sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-nfxt/KxVGFkjkO/M+58y1ugHu/dwPtxG4eYq0KApcQ7xk5CHzhdn+IuLZfDSvNDrJ3Uy5q++Fj/wbK7i8yryfQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.217.0':
+    resolution: {integrity: sha512-U9MCXxJu0sBCh5aEkylYRR4xVIL8D1CW6dGwvYXbfFr0qveSorfD0XJchCAWoW6QfAAIcY/yxjf4Dj8OgkHBPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-fPZs2fw7veLH3pEKu8vSepUa2fQpAE2P7al6qU10aH9GrEJJ8YaPgsd5xON7by5rbcEVS71FOU2aWyK6nzB7VQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.217.0':
+    resolution: {integrity: sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-nPV8gKHUiSuTZpQcnZU3/pBlK7crSyEGpZuh5MtWySB0vv6NNG0QvvfKitQt+Fc2Mc6qfyU54KlZcurwoTbrVg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.7.1':
+    resolution: {integrity: sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-http@0.217.0':
+    resolution: {integrity: sha512-B88Y7k5A9a60pHUboFoeJlgVwXq2T0rsZKj6dTwzSMKSOsNXR4Jz5ovwprVn3kHLAZrkyLEjQtBJ34DYHs1U4Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.217.0':
+    resolution: {integrity: sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.217.0':
+    resolution: {integrity: sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.217.0':
+    resolution: {integrity: sha512-7RTAdZuOsCDnsyqTCG4+bDzrfnsWdzkRs7z0AVi/V3tEQx0oKeyc+OuRWYxnRsmaJXgxcmB8vb/lfxn58Dj6Ag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.217.0':
+    resolution: {integrity: sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.7.1':
+    resolution: {integrity: sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.7.1':
+    resolution: {integrity: sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.217.0':
+    resolution: {integrity: sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.217.0':
+    resolution: {integrity: sha512-K/60pSv42+NQiZKy1pAH18nYDkxltsDV4O3SJ233J0E9raU1ksyL9gsKuS8p30bYBb4AMPCfDuutHQaHYpcv0Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.7.1':
+    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@smithy/core@3.32.0':
+    resolution: {integrity: sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.0':
+    resolution: {integrity: sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.0':
+    resolution: {integrity: sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.10.0':
+    resolution: {integrity: sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.0':
+    resolution: {integrity: sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.0':
+    resolution: {integrity: sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@typescript-eslint/eslint-plugin@8.67.0':
+    resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.67.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.67.0':
+    resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.67.0':
+    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.67.0':
+    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.67.0':
+    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.67.0':
+    resolution: {integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.67.0':
+    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.67.0':
+    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.67.0':
+    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/sandbox@2.9.2':
+    resolution: {integrity: sha512-tnPtCNL6MZKM9eRYvmyL0geA2Nifq+PSxVXBNhk/lQNeCWgMp/EYzCDOotKEWR/VH+c0Yv9HG4qk0w2I65xnLA==}
+
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.5:
+    resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  expand-tilde@2.0.2:
+    resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
+    engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
+  freestyle@0.1.63:
+    resolution: {integrity: sha512-sNmr4UHr9abaEQeNzOra4csLrU72qjwPm4lA1i3IYM9pbmkvQ8aOOH/61yawNSVIhxqIoYO9xBcrMNwjqZaWMw==}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.5.0:
+    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+    engines: {node: '>=18'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  homedir-polyfill@1.0.3:
+    resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
+    engines: {node: '>=0.10.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-passwd@1.0.0:
+    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
+    engines: {node: '>=0.10.0'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  process-warning@5.1.0:
+    resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.67.0:
+    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@aws-sdk/checksums@3.1000.27':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1109.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.27
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/credential-provider-node': 3.972.79
+      '@aws-sdk/middleware-sdk-s3': 3.972.73
+      '@aws-sdk/signature-v4-multi-region': 3.996.44
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.7':
+    dependencies:
+      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/xml-builder': 3.972.38
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.32.0
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.13':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/credential-provider-env': 3.972.68
+      '@aws-sdk/credential-provider-http': 3.972.70
+      '@aws-sdk/credential-provider-login': 3.972.75
+      '@aws-sdk/credential-provider-process': 3.972.68
+      '@aws-sdk/credential-provider-sso': 3.973.12
+      '@aws-sdk/credential-provider-web-identity': 3.972.74
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.79':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.68
+      '@aws-sdk/credential-provider-http': 3.972.70
+      '@aws-sdk/credential-provider-ini': 3.973.13
+      '@aws-sdk/credential-provider-process': 3.972.68
+      '@aws-sdk/credential-provider-sso': 3.973.12
+      '@aws-sdk/credential-provider-web-identity': 3.972.74
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.12':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/token-providers': 3.1108.0
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.74':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-storage@3.1109.0(@aws-sdk/client-s3@3.1109.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1109.0
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.73':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/signature-v4-multi-region': 3.996.44
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.42':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/signature-v4-multi-region': 3.996.44
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.44':
+    dependencies:
+      '@aws-sdk/types': 3.974.3
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1108.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.3':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.38':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
+  '@daytona/api-client@0.193.0':
+    dependencies:
+      axios: 1.19.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@daytona/toolbox-api-client@0.193.0':
+    dependencies:
+      axios: 1.19.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@daytonaio/sdk@0.193.0(ws@8.21.3)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1109.0
+      '@aws-sdk/lib-storage': 3.1109.0(@aws-sdk/client-s3@3.1109.0)
+      '@daytona/api-client': 0.193.0
+      '@daytona/toolbox-api-client': 0.193.0
+      '@iarna/toml': 2.2.5
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      axios: 1.19.0
+      busboy: 1.6.0
+      dotenv: 17.4.2
+      expand-tilde: 2.0.2
+      fast-glob: 3.3.3
+      form-data: 4.0.6
+      isomorphic-ws: 5.0.0(ws@8.21.3)
+      pathe: 2.0.3
+      shell-quote: 1.10.0
+      tar: 7.5.22
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+      - ws
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5)':
+    dependencies:
+      eslint: 9.39.5
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.6':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.3.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.5': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@iarna/toml@2.2.5': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@opentelemetry/api-logs@0.217.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/configuration@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      yaml: 2.9.0
+
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation-http@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
+
+  '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-node@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/configuration': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
+  '@pinojs/redact@0.4.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
+  '@smithy/core@3.32.0':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.0':
+    dependencies:
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.0':
+    dependencies:
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.10.0':
+    dependencies:
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.0':
+    dependencies:
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.67.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/type-utils': 8.67.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      eslint: 9.39.5
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3
+      eslint: 9.39.5
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.67.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.67.0(eslint@9.39.5)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.5)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.5
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.67.0': {}
+
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3
+      minimatch: 10.2.6
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.67.0(eslint@9.39.5)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      eslint: 9.39.5
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      eslint-visitor-keys: 5.0.1
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/sandbox@2.9.2':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.29.0
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.0(vite@7.3.5(@types/node@22.20.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@22.20.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  '@workflow/serde@4.1.0-beta.2': {}
+
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0:
+    optional: true
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3:
+    optional: true
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
+  asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
+
+  axios@1.19.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  b4a@1.8.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
+
+  base64-js@1.5.1: {}
+
+  bowser@2.14.1: {}
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  callsites@3.1.0: {}
+
+  chai@6.2.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chownr@3.0.0: {}
+
+  cjs-module-lexer@2.2.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+    optional: true
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  delayed-stream@1.0.0: {}
+
+  dotenv@17.4.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  emoji-regex@10.6.0:
+    optional: true
+
+  emoji-regex@8.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.1: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.5:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.6
+      '@eslint/js': 9.39.5
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  events@3.3.0: {}
+
+  expand-tilde@2.0.2:
+    dependencies:
+      homedir-polyfill: 1.0.3
+
+  expect-type@1.4.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.4
+      keyv: 4.5.4
+
+  flatted@3.4.4: {}
+
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
+  forwarded-parse@2.1.2: {}
+
+  freestyle@0.1.63:
+    optionalDependencies:
+      dotenv: 17.4.2
+      glob: 13.0.6
+      yargs: 18.1.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0:
+    optional: true
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+    optional: true
+
+  globals@14.0.0: {}
+
+  globals@16.5.0: {}
+
+  gopd@1.2.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  homedir-polyfill@1.0.3:
+    dependencies:
+      parse-passwd: 1.0.0
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  ieee754@1.2.1: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.6: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-in-the-middle@3.3.3:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
+
+  imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-network-error@1.3.2: {}
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  isomorphic-ws@5.0.0(ws@8.21.3):
+    dependencies:
+      ws: 8.21.3
+
+  jose@6.2.3: {}
+
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jsonlines@0.1.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.camelcase@4.3.0: {}
+
+  lodash.merge@4.6.2: {}
+
+  long@5.3.2: {}
+
+  lru-cache@11.5.2:
+    optional: true
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.18
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  module-details-from-path@1.0.4: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.18: {}
+
+  natural-compare@1.4.0: {}
+
+  obug@2.1.4: {}
+
+  on-exit-leak-free@2.1.2: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  os-paths@4.4.0: {}
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.2
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-passwd@1.0.0: {}
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+    optional: true
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.5: {}
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.8.3: {}
+
+  process-warning@5.1.0: {}
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 22.20.1
+      long: 5.3.2
+
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 22.20.1
+      long: 5.3.2
+
+  proxy-from-env@2.1.0: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
+
+  require-directory@2.1.1: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  resolve-from@4.0.0: {}
+
+  retry@0.13.1: {}
+
+  reusify@1.1.0: {}
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  shell-quote@1.10.0: {}
+
+  siginfo@2.0.0: {}
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  streamsearch@1.1.0: {}
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+    optional: true
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+    optional: true
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+    optional: true
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  tslib@2.8.1: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.67.0(eslint@9.39.5)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.5)(typescript@5.9.3)
+      eslint: 9.39.5
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici@7.29.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
+
+  vite@7.3.5(@types/node@22.20.1)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+      yaml: 2.9.0
+
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(vite@7.3.5(@types/node@22.20.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@7.3.5(@types/node@22.20.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 7.3.5(@types/node@22.20.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - msw
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+    optional: true
+
+  ws@8.21.3: {}
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
+  y18n@5.0.8: {}
+
+  yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0:
+    optional: true
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+    optional: true
+
+  yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+packages:
+  - "js/*"
+  - "eslint-rules"
+
+# `sdk/typescript` is deliberately NOT a member. It is a self-contained pnpm
+# workspace with its own pnpm-workspace.yaml, its own pnpm-lock.yaml, and its
+# own `packageManager` pin, and both `sdk-typescript.yml` and the OIDC publish
+# workflow install from that lockfile. Absorbing it here would orphan it.
+
+onlyBuiltDependencies:
+  - esbuild

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -34,3 +34,10 @@ cp "$(cmd_mainpath)/.env.local" "$REPO_ROOT/" 2>/dev/null || true
 git config core.hooksPath "$REPO_ROOT/githooks"
 
 echo "Git hooks path configured to: $REPO_ROOT/githooks"
+
+# Install the JS workspace (js/*, eslint-rules). The pre-commit hook shells out
+# to the workspace's pinned prettier, eslint, and tsc, so the hook is only
+# useful once this has run. `sdk/typescript` is a separate workspace with its
+# own lockfile and is not installed here.
+echo "Installing JS workspace dependencies..."
+pnpm -C "$REPO_ROOT" install


### PR DESCRIPTION
Implements the amika-side half of amika-mono's `specs/020-sandbox-oss-submodule-migration.md`. `@amika/sandbox` — the Amika-agnostic sandbox provider abstraction — moves out of the closed-source `amika-mono` repo and into this one. amika-mono consumes it back as a git submodule mounted at `repos/amika/`, registered as a normal pnpm workspace member, so all four existing consumers keep importing `@amika/sandbox` through `workspace:*` with no import-site changes.

This repo becomes the single source of truth for the package: changes land here and reach amika-mono through a pointer bump.

## What's here

**`Import @amika/sandbox from amika-mono as a JS workspace`**

- A JS workspace at the repo root: `pnpm-workspace.yaml` + `package.json` declaring `js/*` and `eslint-rules` as members, plus a committed `pnpm-lock.yaml`.
- `js/sandbox/`, copied from amika-mono.
- `eslint-rules/`, which came along out of necessity — `js/sandbox/eslint.config.mjs` loads the `no-cross-package-internal` rule from it via a relative path. The spec didn't account for this; without the copy the package cannot lint in *either* repo, since after the move that path would point at `repos/amika/eslint-rules`.
- `js/AGENTS.md`, adapted so its examples and links resolve against this repo.
- A `check-sandbox` job (format check → typecheck → lint → test) and a `check-eslint-rules` job in CI.
- A JS branch in `githooks/pre-commit`, driven by a new `.lintstagedrc.mjs`, gated on staged JS paths so a Go-only commit doesn't pay for a pnpm resolution.
- `setup-repo.sh` now installs the JS workspace.

**`Add a recurseSubmodules option to the clone inputs`**

`CloneRepoInput` gains `recurseSubmodules`, defaulting to `true`, honored in `buildRefreshClonedRepoScript`. amika-mono now carries a submodule, so a sandbox provisioned from it needs recursion or `pnpm install` breaks on a missing workspace member. The amika-mono side (`resolveCloneRepo`) lands separately.

## Two things worth a look

**`sdk/typescript` is deliberately not a workspace member.** The spec called for including it. It is already a self-contained pnpm workspace — own `pnpm-workspace.yaml`, own `pnpm-lock.yaml`, own `packageManager` pin (11.1.3 vs. 10.18.2 here) — and both `sdk-typescript.yml` and the OIDC publish workflow install from that lockfile. Absorbing it would nest a workspace inside a workspace and orphan a published package's release pipeline, for no benefit to this migration.

**`prettier` is pinned to an exact `3.8.3`, not `^3.6.2`.** The two repos resolve lockfiles independently, so a caret range lets them pick different patch versions — and prettier's output changes across minors. This bit during the migration: on byte-identical source, `formatcheck` passed under 3.8.3 and failed under 3.9.6. The exact pin is what keeps both repos and both pre-commit hooks agreeing on formatting. Bump it in all four places together.

## Verification

Run at the repo root against this branch:

| Check | Result |
| ----- | ------ |
| `pnpm install` | 3 workspace projects, `sdk/typescript` correctly excluded |
| `@amika/sandbox` formatcheck | clean |
| `@amika/sandbox` typecheck | clean |
| `@amika/sandbox` lint | clean |
| `@amika/sandbox` test | 321 passed (34 files) |
| `eslint-rules` test | 16 passed |