### PR TITLE
Trim `sandbox list` default columns to five

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -165,11 +165,19 @@ List all tracked sandboxes.
 amika sandbox list
 ```
 
-Output columns: `NAME`, `STATE`, `LOCATION`, `PROVIDER`, `IMAGE`, `BRANCH`, `REPO`, `CREATED BY`, `PORTS`, `CREATED`.
+Output columns: `NAME`, `STATE`, `REPO`, `BRANCH`, `CREATOR`.
+
+Pass `-l`/`--long` for the full set, which adds `LOCATION`, `IMAGE`, `PORTS`, and `CREATED`:
+
+```bash
+amika sandbox list --long
+```
+
+Column selection applies only to `--output text`. `-o json` and `-o json-pretty` always emit every field.
 
 The `REPO` column lists the repositories mounted into the sandbox workspace (`/home/amika/workspace/<repo>`). For remote sandboxes it shows the repository name parsed from the sandbox's `repo_url`.
 
-The `CREATED BY` column shows the human who created a remote sandbox (name, falling back to email). It is always `-` for local sandboxes and for remote sandboxes whose creator the server could not resolve (deleted user, API-key principal, or `noop` auth mode).
+The `CREATOR` column shows the human who created a remote sandbox (name, falling back to email). It is always `-` for local sandboxes and for remote sandboxes whose creator the server could not resolve (deleted user, API-key principal, or `noop` auth mode).
 
 ### `amika sandbox connect`
 

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -59,7 +59,7 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().String("branch", "", "Check out this git branch, or create it if it doesn't exist.")
 	sandboxCreateCmd.Flags().String("new-branch", "", "Create a new git branch. With --branch, starts from that branch; otherwise starts from the current checkout.")
 	sandboxCreateCmd.Flags().String("github-auth-mode", "", "GitHub auth mode for the sandbox runtime: pat, app_token, or app-token (remote only; unset uses server default)")
-	sandboxListCmd.Flags().BoolP("long", "l", false, "Show additional columns (IMAGE, PORTS)")
+	sandboxListCmd.Flags().BoolP("long", "l", false, "Show additional columns (LOCATION, IMAGE, PORTS, CREATED)")
 	sandboxDeleteCmd.Flags().Bool("force", false, "Skip confirmation prompt")
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")

--- a/go/cmd/amika/sandbox/sandbox_lifecycle.go
+++ b/go/cmd/amika/sandbox/sandbox_lifecycle.go
@@ -322,14 +322,14 @@ var sandboxListCmd = &cobra.Command{
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
 		if long {
-			fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tIMAGE\tBRANCH\tREPO\tCREATOR\tPORTS\tCREATED")
+			fmt.Fprintln(w, "NAME\tSTATE\tREPO\tBRANCH\tCREATOR\tLOCATION\tIMAGE\tPORTS\tCREATED")
 			for _, sb := range allItems {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Image, sb.Branch, formatRepos(sb.Repos), formatCreatedBy(sb.CreatedBy), formatPortBindings(sb.Ports), sb.CreatedAt)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, formatRepos(sb.Repos), sb.Branch, formatCreatedBy(sb.CreatedBy), sb.Location, sb.Image, formatPortBindings(sb.Ports), sb.CreatedAt)
 			}
 		} else {
-			fmt.Fprintln(w, "NAME\tSTATE\tLOCATION\tBRANCH\tREPO\tCREATOR\tCREATED")
+			fmt.Fprintln(w, "NAME\tSTATE\tREPO\tBRANCH\tCREATOR")
 			for _, sb := range allItems {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, sb.Location, sb.Branch, formatRepos(sb.Repos), formatCreatedBy(sb.CreatedBy), sb.CreatedAt)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", sb.Name, sb.State, formatRepos(sb.Repos), sb.Branch, formatCreatedBy(sb.CreatedBy))
 			}
 		}
 		w.Flush()

--- a/go/cmd/amika/sandbox_commands_test.go
+++ b/go/cmd/amika/sandbox_commands_test.go
@@ -119,11 +119,15 @@ func TestSandboxListCommand_PrintsRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sandbox list failed: %v", err)
 	}
-	if !strings.Contains(out, "NAME") || !strings.Contains(out, "CREATOR") {
-		t.Fatalf("missing header: %s", out)
+	for _, col := range []string{"NAME", "STATE", "REPO", "BRANCH", "CREATOR"} {
+		if !strings.Contains(out, col) {
+			t.Fatalf("missing default column %q: %s", col, out)
+		}
 	}
-	if strings.Contains(out, "PROVIDER") || strings.Contains(out, "PORTS") || strings.Contains(out, "IMAGE") {
-		t.Fatalf("unexpected wide-only column in default output: %s", out)
+	for _, col := range []string{"PROVIDER", "PORTS", "IMAGE", "LOCATION", "CREATED"} {
+		if strings.Contains(out, col) {
+			t.Fatalf("unexpected long-only column %q in default output: %s", col, out)
+		}
 	}
 	if !strings.Contains(out, "sb-a") {
 		t.Fatalf("missing sandbox row: %s", out)


### PR DESCRIPTION
## Summary

`amika sandbox list` printed seven columns by default, enough to wrap on a normal terminal. This narrows the default `--output text` table to the five that matter most and moves the rest behind the existing `-l`/`--long` flag.

**Default:**

```
NAME     STATE    REPO   BRANCH     CREATOR
sb-demo  running  amika  feature/x  Dylan B. Mikus
```

**`--long`** adds `LOCATION`, `IMAGE`, `PORTS`, and `CREATED`. The long header is reordered to lead with the same five columns so the two views line up; it previously put `BRANCH` before `REPO`.

`LOCATION` and `CREATED` are the two columns that leave the default view.

## JSON is unaffected

`-o json` and `-o json-pretty` still emit every field of the `RemoteSandbox` shape, exactly as before. Column selection applies only to `--output text`, and `--long` has no effect on JSON output.

## Docs

`docs/cli-reference.md` listed a stale column set: it advertised a `PROVIDER` column that isn't printed and called the creator column `CREATED BY` (the code has printed `CREATOR` for a while). Corrected, and both views are now documented along with the JSON caveat.

## Testing

- `make fmtcheck vet lint build` pass.
- The `sandbox list` test now asserts the exact default column set and that each long-only column is absent, rather than spot-checking three names. `go test ./cmd/amika/...` passes.
- Rendered both views locally against a fixture state file to confirm header order.
- Not verified locally: `make shellcheck` (not installed) and `internal/materialize` tests (require `rsync`, not installed). Neither is touched by this change; leaving them to CI.