### PR TITLE
Reuse one Daytona client per config

### DIFF
--- a/js/sandbox/src/providers/daytona/internal/client.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/client.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DaytonaConfig } from "../config";
+import { getDaytonaClient } from "./client";
+
+vi.mock("@daytonaio/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@daytonaio/sdk")>();
+  return { ...actual, Daytona: vi.fn() };
+});
+
+const { Daytona } = await import("@daytonaio/sdk");
+
+// A factory, not a shared object: the cache is keyed on config identity, so a
+// module-level config would let one case's client bleed into the next.
+const config = (): DaytonaConfig => ({
+  apiKey: "key",
+  apiUrl: "https://daytona.example",
+  target: "us-west-2",
+  organizationId: undefined,
+  useVm: false,
+});
+
+describe("getDaytonaClient", () => {
+  beforeEach(() => {
+    vi.mocked(Daytona).mockReset();
+    // Regular function (not an arrow) so it works as a constructor with `new`.
+    vi.mocked(Daytona).mockImplementation(function () {
+      return {} as InstanceType<typeof Daytona>;
+    });
+  });
+
+  it("builds the client once per config and reuses it", () => {
+    // The point of the cache: the SDK constructor opens a Socket.IO connection,
+    // and operations resolve their client per call. Repeated calls with the
+    // config the caller holds for the process must not each open one.
+    const cfg = config();
+
+    const first = getDaytonaClient(cfg);
+    const second = getDaytonaClient(cfg);
+
+    expect(second).toBe(first);
+    expect(Daytona).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds a separate client per config object", () => {
+    // Keyed on identity, not on field values — two configs that happen to be
+    // field-identical are still two callers, and a caller that rebuilds its
+    // config gets a client matching it.
+    const first = getDaytonaClient(config());
+    const second = getDaytonaClient(config());
+
+    expect(second).not.toBe(first);
+    expect(Daytona).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes the configured target through and omits an unset organization", () => {
+    getDaytonaClient(config());
+
+    expect(Daytona).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "key",
+        apiUrl: "https://daytona.example",
+        target: "us-west-2",
+      }),
+    );
+    expect(vi.mocked(Daytona).mock.calls[0]?.[0]).not.toHaveProperty(
+      "organizationId",
+    );
+  });
+
+  it("scopes to the organization when one is configured", () => {
+    getDaytonaClient({ ...config(), organizationId: "org-1" });
+
+    expect(Daytona).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: "org-1" }),
+    );
+  });
+});

--- a/js/sandbox/src/providers/daytona/internal/client.ts
+++ b/js/sandbox/src/providers/daytona/internal/client.ts
@@ -4,8 +4,28 @@
 import { Daytona } from "@daytonaio/sdk";
 import type { DaytonaConfig } from "../config";
 
-export function createDaytonaClient(config: DaytonaConfig): Daytona {
-  return new Daytona({
+const clients = new WeakMap<DaytonaConfig, Daytona>();
+
+/**
+ * The Daytona client for `config`, built once and reused.
+ *
+ * The SDK client is a connection holder — it opens a socket for sandbox state
+ * events — so one client per operation means one socket per operation.
+ *
+ * Keyed on the config object's identity, not its fields: callers hold one
+ * config per process and pass that same object to every operation. A config
+ * built per call still yields a client per call, which is wasteful but
+ * correct. Entries are weak, so there is nothing to tear down.
+ *
+ * Don't dispose a client from here — the SDK's `disconnect()` is permanent,
+ * and the cache would go on handing out the dead client.
+ */
+export function getDaytonaClient(config: DaytonaConfig): Daytona {
+  const cached = clients.get(config);
+  if (cached) {
+    return cached;
+  }
+  const client = new Daytona({
     apiKey: config.apiKey,
     apiUrl: config.apiUrl,
     target: config.target,
@@ -16,4 +36,6 @@ export function createDaytonaClient(config: DaytonaConfig): Daytona {
     // value stays absent rather than forcing the default-org path.
     ...(config.organizationId ? { organizationId: config.organizationId } : {}),
   });
+  clients.set(config, client);
+  return client;
 }

--- a/js/sandbox/src/providers/daytona/internal/operations.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/operations.test.ts
@@ -9,7 +9,7 @@ import {
 
 const daytonaList = vi.fn();
 vi.mock("./client", () => ({
-  createDaytonaClient: () => ({
+  getDaytonaClient: () => ({
     list: (...args: unknown[]) => daytonaList(...args),
   }),
 }));

--- a/js/sandbox/src/providers/daytona/internal/operations.ts
+++ b/js/sandbox/src/providers/daytona/internal/operations.ts
@@ -16,7 +16,7 @@ import {
 import { DEFAULT_HOME_DIR } from "../../../constants";
 import type { DaytonaConfig } from "../config";
 import type { SandboxCtx } from "../../../logger";
-import { createDaytonaClient } from "./client";
+import { getDaytonaClient } from "./client";
 import { createVmSandbox } from "./vm";
 import { ensureDaytonaSnapshotActive } from "./snapshot-operations";
 import { DaytonaAdapter } from "./adapter";
@@ -43,7 +43,7 @@ export async function refreshDaytonaUrls(
   providerSandboxId: string,
   services: SandboxService[],
 ): Promise<{ providerUrl: string | null; services: SandboxService[] }> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   return refreshServiceUrls(sandbox, services);
 }
@@ -77,7 +77,7 @@ export async function getDaytonaSandboxState(
   config: DaytonaConfig,
   providerSandboxId: string,
 ): Promise<string> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   try {
     const sandbox = await daytona.get(providerSandboxId);
     return sandbox.state ?? "unknown";
@@ -142,14 +142,14 @@ const DAYTONA_LIST_PAGE_SIZE = 100;
  * walks every page; `limit` is only the per-page fetch size, not a cap on the
  * total. Errored/deleted sandboxes are excluded by the API default. Daytona
  * reports sizing already in billing units (`cpu`/`memory`/`disk` =
- * vCPUs/GiB/GiB), so no MiB→GiB conversion is needed. `createDaytonaClient`
+ * vCPUs/GiB/GiB), so no MiB→GiB conversion is needed. `getDaytonaClient`
  * scopes to the configured organization, so the listing is account-wide within
  * it.
  */
 export async function listDaytonaSandboxes(
   config: DaytonaConfig,
 ): Promise<ProviderSandboxListing[]> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const listings: ProviderSandboxListing[] = [];
   for await (const sandbox of daytona.list({ limit: DAYTONA_LIST_PAGE_SIZE })) {
     listings.push({
@@ -170,7 +170,7 @@ export async function startDaytonaSandbox(
   config: DaytonaConfig,
   providerSandboxId: string,
 ): Promise<void> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   await sandbox.start();
 }
@@ -179,7 +179,7 @@ export async function stopDaytonaSandbox(
   config: DaytonaConfig,
   providerSandboxId: string,
 ): Promise<void> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   await sandbox.stop();
 }
@@ -188,7 +188,7 @@ export async function deleteDaytonaSandbox(
   config: DaytonaConfig,
   providerSandboxId: string,
 ): Promise<void> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
 
   await pRetry(() => sandbox.delete(), {
@@ -236,7 +236,7 @@ export async function createDaytonaSshAccess(
   sshDestination: string;
   expiresAt: Date;
 }> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   const sshAccess = await sandbox.createSshAccess(expiresInMinutes);
   return {
@@ -262,7 +262,7 @@ export async function revokeDaytonaSshAccess(
   providerSandboxId: string,
   token: string,
 ): Promise<void> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   await sandbox.revokeSshAccess(token);
 }
@@ -289,7 +289,7 @@ export async function createDaytonaSandbox(
   services: SandboxService[];
   envVars: Record<string, string>;
 }> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const cwd = getRepoDir(DEFAULT_HOME_DIR, input.repoName);
 
   // Only NON-SECRET operational vars go into the container env. Anything
@@ -399,7 +399,7 @@ export async function readSandboxFile(
   filePath: string,
 ): Promise<string | null> {
   try {
-    const daytona = createDaytonaClient(config);
+    const daytona = getDaytonaClient(config);
     const sandbox = await daytona.get(providerSandboxId);
     const content = await sandbox.fs.downloadFile(filePath);
     return content.toString("utf8");
@@ -414,7 +414,7 @@ export async function writeSandboxFile(
   filePath: string,
   content: Buffer | string,
 ): Promise<void> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   await new DaytonaAdapter(sandbox, daytona).uploadFile(content, filePath);
 }
@@ -428,7 +428,7 @@ export async function openDaytonaAdapter(
   config: DaytonaConfig,
   providerSandboxId: string,
 ): Promise<SandboxAdapter> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   return new DaytonaAdapter(await daytona.get(providerSandboxId), daytona);
 }
 
@@ -439,7 +439,7 @@ export async function executeDaytonaCommand(
   command: string,
   opts?: ExecCommandOptions,
 ): Promise<SandboxExecResult> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   return executeCommand(sandbox, command, opts);
 }
@@ -455,7 +455,7 @@ export async function streamDaytonaCommandLogs(
   command: string,
   handlers: StreamCommandHandlers,
 ): Promise<void> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   const sessionId = `agent-stream-${Date.now()}`;
   await sandbox.process.createSession(sessionId);
@@ -482,7 +482,7 @@ export async function cloneDaytonaRepo(
   providerSandboxId: string,
   input: CloneRepoInput,
 ): Promise<void> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   await cloneRepository(
     sandbox,

--- a/js/sandbox/src/providers/daytona/internal/sandbox-ops.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/sandbox-ops.test.ts
@@ -37,20 +37,23 @@ function setupMockDaytona(deleteFn: () => Promise<void>) {
   });
 }
 
-const testConfig = {
+// A fresh config object per test: the Daytona client is memoized per config
+// (see `./client`), so sharing one object across tests would hand every test
+// the first test's mocked client and defeat `setupMockDaytona`.
+const testConfig = () => ({
   apiKey: "test-key",
   apiUrl: "https://test.daytona.io",
   target: "test-target",
   organizationId: undefined,
   useVm: false,
-};
+});
 
 describe("deleteDaytonaSandbox", () => {
   it("succeeds on first attempt", async () => {
     const deleteFn = vi.fn().mockResolvedValue(undefined);
     setupMockDaytona(deleteFn);
 
-    await deleteDaytonaSandbox(testConfig, "sandbox-1");
+    await deleteDaytonaSandbox(testConfig(), "sandbox-1");
 
     expect(deleteFn).toHaveBeenCalledTimes(1);
   });
@@ -66,7 +69,7 @@ describe("deleteDaytonaSandbox", () => {
       .mockResolvedValueOnce(undefined);
     setupMockDaytona(deleteFn);
 
-    await deleteDaytonaSandbox(testConfig, "sandbox-1");
+    await deleteDaytonaSandbox(testConfig(), "sandbox-1");
 
     expect(deleteFn).toHaveBeenCalledTimes(2);
   }, 15_000);
@@ -79,9 +82,9 @@ describe("deleteDaytonaSandbox", () => {
     const deleteFn = vi.fn().mockRejectedValue(stateChangeError);
     setupMockDaytona(deleteFn);
 
-    await expect(deleteDaytonaSandbox(testConfig, "sandbox-1")).rejects.toThrow(
-      "state change in progress",
-    );
+    await expect(
+      deleteDaytonaSandbox(testConfig(), "sandbox-1"),
+    ).rejects.toThrow("state change in progress");
 
     // 1 initial + 3 retries = 4
     expect(deleteFn).toHaveBeenCalledTimes(4);
@@ -92,9 +95,9 @@ describe("deleteDaytonaSandbox", () => {
     const deleteFn = vi.fn().mockRejectedValue(otherError);
     setupMockDaytona(deleteFn);
 
-    await expect(deleteDaytonaSandbox(testConfig, "sandbox-1")).rejects.toThrow(
-      "Sandbox not found",
-    );
+    await expect(
+      deleteDaytonaSandbox(testConfig(), "sandbox-1"),
+    ).rejects.toThrow("Sandbox not found");
 
     expect(deleteFn).toHaveBeenCalledTimes(1);
   });
@@ -116,7 +119,7 @@ describe("createDaytonaSandbox", () => {
       typeof createDaytonaSandbox
     >[0];
 
-    await createDaytonaSandbox(ctx, testConfig, {
+    await createDaytonaSandbox(ctx, testConfig(), {
       name: "sb",
       snapshot: "snap",
       services: [],
@@ -166,7 +169,7 @@ describe("createDaytonaSandbox", () => {
       typeof createDaytonaSandbox
     >[0];
 
-    await createDaytonaSandbox(ctx, testConfig, {
+    await createDaytonaSandbox(ctx, testConfig(), {
       name: "sb",
       snapshot: "user-snapshot",
       services: [],
@@ -211,7 +214,7 @@ describe("createDaytonaSandbox", () => {
       typeof createDaytonaSandbox
     >[0];
 
-    await createDaytonaSandbox(ctx, testConfig, {
+    await createDaytonaSandbox(ctx, testConfig(), {
       name: "sb",
       snapshot: "snap",
       services: [],
@@ -257,7 +260,7 @@ describe("createDaytonaSandbox", () => {
 
     const result = await createDaytonaSandbox(
       ctx,
-      { ...testConfig, useVm: true },
+      { ...testConfig(), useVm: true },
       {
         name: "sb",
         snapshot: "snap",

--- a/js/sandbox/src/providers/daytona/internal/snapshot-operations.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/snapshot-operations.test.ts
@@ -19,7 +19,7 @@ const isVmSandboxMock = vi.fn();
 // One client for everything: the capture, the docker quiesce/restore, and
 // the snapshot reads all run against the configured target.
 vi.mock("./client", () => ({
-  createDaytonaClient: () => ({
+  getDaytonaClient: () => ({
     get: (id: string) => getSandbox(id),
     snapshot: {
       get: (name: string) => getSnapshot(name),

--- a/js/sandbox/src/providers/daytona/internal/snapshot-operations.ts
+++ b/js/sandbox/src/providers/daytona/internal/snapshot-operations.ts
@@ -1,8 +1,9 @@
 /**
  * Snapshot management operations wrapping the Daytona SDK's snapshot service.
  *
- * Each function creates a fresh Daytona client, consistent with the
- * per-operation pattern used in operations.ts.
+ * Each function resolves the client through {@link getDaytonaClient}, which
+ * hands back the one instance bound to this config rather than building a new
+ * one per call.
  */
 import { DaytonaError, type Daytona } from "@daytonaio/sdk";
 import {
@@ -10,7 +11,7 @@ import {
   SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
 } from "../../../constants";
 import type { DaytonaConfig } from "../config";
-import { createDaytonaClient } from "./client";
+import { getDaytonaClient } from "./client";
 import { captureVmSandboxSnapshot, isVmSandbox } from "./vm";
 import { startDockerForSnapshot, stopDockerForSnapshot } from "./configure";
 
@@ -29,7 +30,7 @@ export async function createDaytonaSnapshot(
   config: DaytonaConfig,
   input: CreateSnapshotInput,
 ): Promise<DaytonaSnapshot> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   return daytona.snapshot.create({
     name: input.name,
     image: input.image,
@@ -43,7 +44,7 @@ export async function listDaytonaSnapshots(
   page?: number,
   limit?: number,
 ): Promise<PaginatedDaytonaSnapshots> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   return daytona.snapshot.list(page, limit);
 }
 
@@ -51,7 +52,7 @@ export async function getDaytonaSnapshot(
   config: DaytonaConfig,
   snapshotName: string,
 ): Promise<DaytonaSnapshot> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   return daytona.snapshot.get(snapshotName);
 }
 
@@ -66,7 +67,7 @@ export async function findDaytonaSnapshot(
   config: DaytonaConfig,
   snapshotName: string,
 ): Promise<DaytonaSnapshot | null> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   return (await findDaytonaSnapshotByName(daytona, snapshotName)) ?? null;
 }
 
@@ -74,7 +75,7 @@ export async function deleteDaytonaSnapshot(
   config: DaytonaConfig,
   snapshotName: string,
 ): Promise<void> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   // Locate via the list-scan fallback rather than a bare get: a snapshot that
   // is still registering (e.g. a large capture that activated after our wait
   // timed out, leaving the row `failed`) can be absent from the by-name
@@ -91,7 +92,7 @@ export async function activateDaytonaSnapshot(
   config: DaytonaConfig,
   snapshotName: string,
 ): Promise<DaytonaSnapshot> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const snapshot = await daytona.snapshot.get(snapshotName);
   return daytona.snapshot.activate(snapshot);
 }
@@ -158,7 +159,7 @@ export async function captureDaytonaSandboxSnapshot(
     return;
   }
 
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   const capture = () =>
     sandbox.createSnapshot(snapshotName, SANDBOX_SNAPSHOT_TIMEOUT_S);
@@ -261,7 +262,7 @@ export async function waitForDaytonaSnapshotActive(
   snapshotName: string,
   timeoutS: number = SANDBOX_SNAPSHOT_ACTIVE_TIMEOUT_S,
 ): Promise<DaytonaSnapshot> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const deadline = Date.now() + timeoutS * 1000;
   for (;;) {
     const snapshot = await findDaytonaSnapshotByName(daytona, snapshotName);
@@ -315,7 +316,7 @@ export async function ensureDaytonaSnapshotActive(
   config: DaytonaConfig,
   snapshotName: string,
 ): Promise<boolean> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   let snapshot: DaytonaSnapshot;
   try {
     snapshot = await daytona.snapshot.get(snapshotName);
@@ -353,7 +354,7 @@ export async function isSandboxEnvScrubbable(
   config: DaytonaConfig,
   providerSandboxId: string,
 ): Promise<boolean> {
-  const daytona = createDaytonaClient(config);
+  const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
   return (
     sandbox.labels?.[SANDBOX_ENV_SECRETS_EXCLUDED_LABEL] ===

--- a/js/sandbox/src/providers/daytona/internal/vm.ts
+++ b/js/sandbox/src/providers/daytona/internal/vm.ts
@@ -38,20 +38,30 @@ const VM_POLL_REQUEST_TIMEOUT_MS = 30_000;
  */
 const VM_STATE_TRANSITION_TIMEOUT_S = 5 * 60;
 
+const sandboxApis = new WeakMap<DaytonaConfig, SandboxApi>();
+
 /**
- * Build the low-level generated `SandboxApi`, mirroring the SDK's auth: the
- * Daytona API key as a Bearer token in the default request headers. The
+ * The low-level generated `SandboxApi` for `config`, mirroring the SDK's auth:
+ * the Daytona API key as a Bearer token in the default request headers. The
  * region/target is sent per-request in the create body (not on the client), and
  * the snapshot-capture endpoint operates on an existing sandbox by id, so a
  * single client serves both VM calls.
+ *
+ * Memoized per config, like the SDK client in `./client`.
  */
-function createSandboxApi(config: DaytonaConfig): SandboxApi {
-  return new SandboxApi(
+function getSandboxApi(config: DaytonaConfig): SandboxApi {
+  const cached = sandboxApis.get(config);
+  if (cached) {
+    return cached;
+  }
+  const api = new SandboxApi(
     new Configuration({
       basePath: config.apiUrl,
       baseOptions: { headers: { Authorization: `Bearer ${config.apiKey}` } },
     }),
   );
+  sandboxApis.set(config, api);
+  return api;
 }
 
 export interface CreateVmSandboxParams {
@@ -99,7 +109,7 @@ export async function createVmSandbox(
     autoDeleteInterval: params.autoDeleteInterval,
     class: SandboxClass.LINUX_VM,
   };
-  const api = createSandboxApi(config);
+  const api = getSandboxApi(config);
   const response = await api.createSandbox(body, undefined, {
     timeout: params.timeoutSeconds * 1000,
   });
@@ -184,7 +194,7 @@ export async function isVmSandbox(
   providerSandboxId: string,
 ): Promise<boolean> {
   const { data: sandbox } =
-    await createSandboxApi(config).getSandbox(providerSandboxId);
+    await getSandboxApi(config).getSandbox(providerSandboxId);
   return sandbox.sandboxClass === SandboxClass.LINUX_VM;
 }
 
@@ -281,7 +291,7 @@ export async function captureVmSandboxSnapshot(
   timeoutSeconds: number,
   restartAfterCapture: boolean,
 ): Promise<void> {
-  const api = createSandboxApi(config);
+  const api = getSandboxApi(config);
 
   // The stop + snapshot are inside the try so the `finally`'s keep-path restart
   // runs on EVERY failure after we begin stopping — otherwise a failed stop or

--- a/js/sandbox/src/providers/freestyle/internal/client.ts
+++ b/js/sandbox/src/providers/freestyle/internal/client.ts
@@ -1,8 +1,10 @@
 /**
  * Freestyle SDK client construction.
  *
- * A fresh client per operation, mirroring the per-call pattern the Daytona
- * provider uses. The `Freestyle` class reads its API key from the constructor
+ * A fresh client per operation. Unlike Daytona's, whose client holds a
+ * Socket.IO connection and so is memoized per config, a `Freestyle` holds no
+ * connection — building one per call costs nothing worth caching. The
+ * `Freestyle` class reads its API key from the constructor
  * (we pass the configured key explicitly rather than relying on the
  * `FREESTYLE_API_KEY` env-var singleton).
  */


### PR DESCRIPTION
Stacked on #335 — review that one first; this diff is against it.

## The problem

`@amika/sandbox` builds a fresh `Daytona` on every operation, ~29 construction sites across `operations.ts` and `snapshot-operations.ts`. Under 0.193 that was merely wasteful: the client held nothing but an axios instance.

Under 0.203 the constructor also opens a Socket.IO connection for sandbox state events (`esm/Daytona.js:200-204`, unless `useDeprecatedPolling` is set). 0.193 has no `EventDispatcher` at all — I checked the published package. So on the SDK version #335 brings in, a client per operation means an outbound socket to `app.daytona.io` per Daytona call, each idling out 30s after its listeners drop.

Nothing breaks: the sockets are unref'd, connect failures are swallowed, and state waits still fall back to HTTP polling. But it's connection churn for no benefit, and it's the opposite of what a long-lived client is for.

## The fix

Memoize on the config object's identity with a `WeakMap`:

```ts
const clients = new WeakMap<DaytonaConfig, Daytona>();

export function getDaytonaClient(config: DaytonaConfig): Daytona {
  const cached = clients.get(config);
  if (cached) return cached;
  const client = new Daytona({ ... });
  clients.set(config, client);
  return client;
}
```

Identity rather than field values, for two reasons. The caller already builds one config per process and hands that same object to every operation — amika-mono keeps it on its `ServerEnv` singleton — so identity is the natural key. And it keeps an API key out of a map key. Entries are weak, so a discarded config takes its client with it; there is nothing to close and no lifecycle to manage.

`createDaytonaClient` → `getDaytonaClient`, since it no longer constructs on every call and the old name would be a lie at all 29 sites. `vm.ts` gets the same treatment for its generated `SandboxApi` (`createSandboxApi` → `getSandboxApi`); that one holds no socket, so reuse there only avoids re-allocating, but it keeps both Daytona entry points on one rule.

## Tests

`sandbox-ops.test.ts` needed a change, and the reason is worth knowing: it shared a single config object across tests while re-mocking the SDK constructor per test. The cache defeats that — every test after the first would get the first test's client. Its config is now a factory, which is the honest expression of the new contract. This showed up as a real failure, not a guess.

New `client.test.ts` covers the contract directly: same config → one construction, distinct configs → separate clients, plus target passthrough and the organization-scoping branch.

325 tests pass (up from 321); typecheck, lint, formatcheck clean.

## Note on `useDeprecatedPolling`

Not set, deliberately. One long-lived socket per process is the SDK's intended shape, and the flag is marked `@deprecated` with removal planned. If event streaming ever proves troublesome in practice — filtered egress to the socket.io endpoint would show up as `connect_error` noise and up to 10 reconnect attempts per client — it can be set per-environment via `DAYTONA_USE_DEPRECATED_POLLING` without a code change.

## CI will not run on this PR while it is stacked

`.github/workflows/ci.yml` filters `pull_request` to `branches: [main]`, and this PR targets `amika/fix-regions`. So GitHub reports no checks here — not a failure, just no trigger. CI runs as soon as #335 merges and this retargets to `main`.

Verified locally in the meantime, on this branch alone:

| Check | Result |
| ----------- | ---------------- |
| `test` | 325 passed (35 files) |
| `typecheck` | clean |
| `lint` | clean |
| `formatcheck` | clean |

The downstream amika-mono pointer bump (gofixpoint/amika-mono#967) does get full CI, since that repo's `pull_request` trigger has no branch filter, and it passed there.

## Review follow-ups

A Claude review found no bug and confirmed the parts that actually needed confirming, by reading the SDK source rather than trusting the change:

- **Concurrent sharing is safe.** All `Daytona` instance state is connection-holder state, written once in the constructor and never reassigned. Per-call request options are spread into fresh objects, so nothing mutates shared config. `Sandbox` objects carry nothing back into the client — `get`/`create` hand each one a `structuredClone`d config and its own axios instance, which the SDK does deliberately (there is a comment at `Daytona.js:467` about the constructor mutating `basePath`). The two genuinely shared mutable things, the memoized analytics-URL promise and `EventSubscriptionManager`, are both designed for sharing; the latter is keyed per `resourceId`, so sharing is strictly better here than per-call clients were.
- **Identity is a sound key.** Every consumer path passes the config by reference off a cached env object, and no code anywhere in either repo mutates a `DaytonaConfig` field after construction — so no stale client bound to changed settings.
- **No teardown needed.** `EventDispatcher` unrefs the raw socket and its timers, and falls back to an immediate idle disconnect where it can't. Confirmed empirically: a process that constructs a client and does nothing exits in 38ms.

Three items fixed in response:

1. `providers/freestyle/internal/client.ts` documented its per-call construction as "mirroring the per-call pattern the Daytona provider uses" — no longer true, and it would point a future contributor at the wrong consistency. It now says why Freestyle differs: its client holds no connection.
2. `getDaytonaClient`'s docstring now warns against disposing a cached client. `disconnect()` latches the dispatcher closed permanently, so the cache would keep serving a dead client — and the failure would be quiet, since the subscription manager still issues ids and `waitForState` would wait on a stream that never delivers.
3. `client.test.ts` now asserts the two clients are distinct instances, not merely that the constructor ran twice, and carries the same "factory, not a shared object" warning that `sandbox-ops.test.ts` got.

Informational, no change made: coding-agents ends up with **two** clients, not one — it builds a `WorkerEnv` lazily for Linear events, and `chat-core`'s env calls `sandboxProviderConfigsFromEnv()` again, producing a second config object. Bounded and memoized, but worth knowing the count.
