### PR TITLE
Poll for sandbox state unless WebSockets are enabled

### DIFF
--- a/js/sandbox/src/config-from-env.test.ts
+++ b/js/sandbox/src/config-from-env.test.ts
@@ -12,6 +12,7 @@ describe("sandboxProviderConfigsFromEnv", () => {
       target: undefined,
       organizationId: undefined,
       useVm: false,
+      useWebSocket: false,
     });
     expect(freestyle).toBeNull();
     expect(vercel).toBeNull();
@@ -35,6 +36,16 @@ describe("sandboxProviderConfigsFromEnv", () => {
       organizationId: "org_1",
       useVm: true,
     });
+  });
+
+  it("leaves the Daytona event stream off unless ENABLE_DAYTONA_WEBSOCKET is set", () => {
+    expect(sandboxProviderConfigsFromEnv(BASE).daytona.useWebSocket).toBe(
+      false,
+    );
+    expect(
+      sandboxProviderConfigsFromEnv({ ...BASE, ENABLE_DAYTONA_WEBSOCKET: "on" })
+        .daytona.useWebSocket,
+    ).toBe(true);
   });
 
   it("gates Freestyle on FREESTYLE_ENABLED=true and toggles snapshotPersistence", () => {

--- a/js/sandbox/src/config-from-env.ts
+++ b/js/sandbox/src/config-from-env.ts
@@ -62,8 +62,9 @@ function required(env: Env, name: string): string {
  *
  * Daytona is always configured (the baseline provider). Freestyle/Vercel are
  * gated on `FREESTYLE_ENABLED` / `VERCEL_ENABLED` being exactly `true` and are
- * `null` otherwise. `ENABLE_DAYTONA_VM` (lenient `1`/`true`/`on`) sets
- * `daytona.useVm`; `FREESTYLE_STAGING_SNAPSHOTS` toggles Freestyle's
+ * `null` otherwise. `ENABLE_DAYTONA_VM` and `ENABLE_DAYTONA_WEBSOCKET` (lenient
+ * `1`/`true`/`on`) set `daytona.useVm` and `daytona.useWebSocket`;
+ * `FREESTYLE_STAGING_SNAPSHOTS` toggles Freestyle's
  * `snapshotPersistence` between `sticky` and `persistent`. Throws if a required
  * credential for an enabled provider is missing.
  */
@@ -77,6 +78,9 @@ export function sandboxProviderConfigsFromEnv(
     organizationId: env.DAYTONA_ORGANIZATION_ID,
     // Opt-in: run Daytona resources as VMs (`linux-vm`) rather than containers.
     useVm: parseBooleanLike(env.ENABLE_DAYTONA_VM),
+    // Opt-in: observe sandbox state over the SDK's event stream (a persistent
+    // WebSocket per client). Unset means polling, so no socket is opened.
+    useWebSocket: parseBooleanLike(env.ENABLE_DAYTONA_WEBSOCKET),
   };
 
   const freestyle: FreestyleConfig | null = isEnabled(env.FREESTYLE_ENABLED)

--- a/js/sandbox/src/providers/daytona/config.ts
+++ b/js/sandbox/src/providers/daytona/config.ts
@@ -15,4 +15,12 @@ export interface DaytonaConfig extends SandboxConfigBase {
    * `./internal/vm`).
    */
   useVm?: boolean;
+  /**
+   * Observe sandbox state over the SDK's event stream, which holds a
+   * persistent WebSocket per client (`ENABLE_DAYTONA_WEBSOCKET`). Off by
+   * default: state waits poll instead, so nothing opens a socket unless a
+   * caller asks for one. Streaming trades a connection for fewer polls —
+   * see `./internal/client`.
+   */
+  useWebSocket?: boolean;
 }

--- a/js/sandbox/src/providers/daytona/internal/client.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/client.test.ts
@@ -67,6 +67,22 @@ describe("getDaytonaClient", () => {
     );
   });
 
+  it("polls by default, so no WebSocket is opened", () => {
+    getDaytonaClient(config());
+
+    expect(Daytona).toHaveBeenCalledWith(
+      expect.objectContaining({ useDeprecatedPolling: true }),
+    );
+  });
+
+  it("uses the event stream only when explicitly opted in", () => {
+    getDaytonaClient({ ...config(), useWebSocket: true });
+
+    expect(Daytona).toHaveBeenCalledWith(
+      expect.objectContaining({ useDeprecatedPolling: false }),
+    );
+  });
+
   it("scopes to the organization when one is configured", () => {
     getDaytonaClient({ ...config(), organizationId: "org-1" });
 

--- a/js/sandbox/src/providers/daytona/internal/client.ts
+++ b/js/sandbox/src/providers/daytona/internal/client.ts
@@ -9,8 +9,8 @@ const clients = new WeakMap<DaytonaConfig, Daytona>();
 /**
  * The Daytona client for `config`, built once and reused.
  *
- * The SDK client is a connection holder — it opens a socket for sandbox state
- * events — so one client per operation means one socket per operation.
+ * The SDK client is a connection holder and is not cheap to build, so it is
+ * made once per config rather than per operation.
  *
  * Keyed on the config object's identity, not its fields: callers hold one
  * config per process and pass that same object to every operation. A config
@@ -29,6 +29,14 @@ export function getDaytonaClient(config: DaytonaConfig): Daytona {
     apiKey: config.apiKey,
     apiUrl: config.apiUrl,
     target: config.target,
+    // Poll for sandbox state unless the caller opts into the event stream
+    // (`ENABLE_DAYTONA_WEBSOCKET`), which holds a persistent WebSocket per
+    // client. State waits poll either way; this only changes the cadence —
+    // 100ms easing to 1s when polling, a flat 1s behind pushed events when
+    // streaming. Passed explicitly rather than left to the SDK's own
+    // `DAYTONA_USE_DEPRECATED_POLLING` lookup, so the decision lives with the
+    // rest of the config and no environment acquires a socket by accident.
+    useDeprecatedPolling: !config.useWebSocket,
     // Scope every operation to the configured Daytona organization when one is
     // set (`DAYTONA_ORGANIZATION_ID`). Without it the SDK targets the account's
     // default org, so a `daytona.get`/`list` for a sandbox created under a


### PR DESCRIPTION
Makes polling the default for sandbox state and puts the WebSocket behind an explicit opt-in.

## Why

SDK 0.203 observes sandbox state over an event stream, and its constructor opens a persistent Socket.IO connection unless told otherwise. 0.193 opened no socket at all — I checked the published package, it has no `EventDispatcher`. So adopting the newer SDK silently added a long-lived, credential-bearing connection to `wss://app.daytona.io/api/socket.io/` in every process that touches Daytona.

That's a new class of outbound connection appearing as a side effect of a version bump, not as a decision. This makes it a decision.

## The switch

`ENABLE_DAYTONA_WEBSOCKET` → `DaytonaConfig.useWebSocket` → the SDK's `useDeprecatedPolling`, following the same shape as the existing `ENABLE_DAYTONA_VM` → `useVm`. Unset means no socket is opened anywhere.

The flag is passed explicitly rather than letting the SDK read its own `DAYTONA_USE_DEPRECATED_POLLING`. Two reasons: the decision sits with the rest of the provider config instead of being invisible unless you know the SDK's env contract, and the SDK resolves config *before* env (`config?.useDeprecatedPolling ?? env…`), so passing it explicitly is the only way to guarantee no environment quietly acquires a socket.

## What actually changes

Both modes poll — only the cadence differs (`Sandbox.js:1221`):

| | polling (default) | event stream (opt-in) |
| --- | --- | --- |
| WebSocket | none | 1 per client |
| Poll cadence | 100ms for 5s, then ×1.1 capped at 1s | flat 1s |
| API calls in a 10s wait | ~60 | ~10 |

So the trade is one connection against roughly 6× the API calls during a state wait. Every lifecycle wait is affected, since they all route through `waitForState`: create, start, stop, delete, pause, resize, fork, and `waitForSnapshotComplete` (the capture path).

Worth knowing: streaming is not strictly faster. Its poll runs at a flat 1s because events are expected to carry the news, so if the socket connects but stops delivering, detection is *slower* than polling mode's 100ms. Polling has no such failure mode.

## Verified live

Against production Daytona, both modes, with a real API call in each:

```
useWebSocket=false  dispatcher=false  socketConnected=-     apiCallOk=true
useWebSocket=true   dispatcher=true   socketConnected=true  apiCallOk=true
```

Default builds no dispatcher at all — not a connected-then-idle socket, none constructed. Opt-in connects as expected. Operations work either way.

328 tests pass (2 new: the default, and the opt-in); typecheck, lint, formatcheck clean.

## Downstream

Nothing required in amika-mono — the default is off, and its cue configs don't set the var. To trial streaming later, add `ENABLE_DAYTONA_WEBSOCKET: "true"` to a service and redeploy; no code change.
