### PR TITLE
Run ordinary Daytona commands without a process session

### DIFF
--- a/js/sandbox/src/providers/daytona/internal/adapter.ts
+++ b/js/sandbox/src/providers/daytona/internal/adapter.ts
@@ -32,9 +32,10 @@ export class DaytonaAdapter implements SandboxAdapter {
 
   async exec(command: string, opts?: ExecOptions): Promise<ExecResult> {
     // Delegates to the provider's public exec path so both share one command
-    // builder (sudo → root shell + `--preserve-env`) and one stream-separating
-    // session runner. The SDK's `process.executeCommand` is deliberately not
-    // used: it returns a single combined string, with stderr folded in.
+    // builder (sudo → root shell + `--preserve-env`) and one runner. That
+    // runner calls the SDK's `process.executeCommand`, whose single combined
+    // string it splits back into two streams on-box; see `commands.ts` for why
+    // a process session is the wrong transport for an ordinary command.
     return executeCommand(this.sandbox, command, opts);
   }
 

--- a/js/sandbox/src/providers/daytona/internal/commands.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildDaytonaCommand,
   buildDaytonaSessionCommand,
+  buildStreamSplitCommand,
   executeCommand,
 } from "./commands";
 import { fakeDaytonaSandbox } from "./test-support";
@@ -9,25 +14,26 @@ import { fakeDaytonaSandbox } from "./test-support";
 type DaytonaSandbox = Parameters<typeof executeCommand>[0];
 
 describe("buildDaytonaCommand", () => {
-  it("runs a non-sudo command inside its own bash -c", () => {
+  it("wraps a non-sudo command in its own bash -c", () => {
+    // One quoted word, so the command can never interact with the syntax of
+    // whatever script embeds it, and it runs under bash rather than the zsh
+    // Daytona picks for the outer script.
     expect(buildDaytonaCommand("echo hi")).toBe("bash -c 'echo hi'");
     expect(buildDaytonaCommand("echo hi", { sudo: false })).toBe(
       "bash -c 'echo hi'",
     );
   });
 
-  it("confines a command's shell state to a child shell", () => {
-    // A session is a long-lived shell fed commands on stdin, so bare text
-    // would run `set -e` in *that* shell. It then exits before the agent
-    // records an exit status, and the synchronous exec never returns --
-    // `buildRefreshClonedRepoScript` opens with `set -e`, so every
-    // from-snapshot create hung.
-    const cmd = buildDaytonaCommand("set -e\ngit fetch --prune origin");
-    expect(cmd).toBe("bash -c 'set -e\ngit fetch --prune origin'");
+  it("keeps a command that would break an embedding script inert", () => {
+    // Quoted, these cannot swallow a closing paren or strand it after an `&`.
+    expect(buildDaytonaCommand("echo hi # note")).toBe(
+      "bash -c 'echo hi # note'",
+    );
+    expect(buildDaytonaCommand("sleep 1 &")).toBe("bash -c 'sleep 1 &'");
   });
 
-  it("quotes a command containing single quotes", () => {
-    expect(buildDaytonaCommand("git config x 'a b'")).toBe(
+  it("quotes a sudo command containing single quotes", () => {
+    expect(buildDaytonaCommand("git config x 'a b'", { sudo: true })).toContain(
       `bash -c 'git config x '"'"'a b'"'"''`,
     );
   });
@@ -51,6 +57,18 @@ describe("buildDaytonaCommand", () => {
       "--preserve-env=AMIKA_AGENT_CWD,AMIKA_OPENCODE_WEB,OPENCODE_SERVER_PASSWORD,FOO",
     );
   });
+
+  it("rejects an env name that is not shell-legal", () => {
+    // The name lands unquoted in `--preserve-env=`, so a `;` in it would end
+    // the sudo command and start a new one. Checked here, not only in the
+    // session builder, because the no-stdin path never reaches that one.
+    expect(() =>
+      buildDaytonaCommand("true", {
+        sudo: true,
+        env: { "FOO;touch /tmp/pwned": "x" },
+      }),
+    ).toThrow(/Invalid environment variable name/u);
+  });
 });
 
 describe("buildDaytonaSessionCommand", () => {
@@ -68,8 +86,7 @@ describe("buildDaytonaSessionCommand", () => {
     ).toBe(true);
   });
 
-  it("applies cwd and env ahead of the wrapper on the non-sudo path", () => {
-    // The wrapped child inherits both, so they still reach the command.
+  it("applies cwd and env on the non-sudo path", () => {
     expect(
       buildDaytonaSessionCommand("printenv FOO", {
         cwd: "/home/amika",
@@ -77,6 +94,41 @@ describe("buildDaytonaSessionCommand", () => {
       }),
     ).toBe("cd '/home/amika' && export FOO='bar' && bash -c 'printenv FOO'");
   });
+
+  it("emits no setup prefix when there is nothing to set up", () => {
+    expect(buildDaytonaSessionCommand("printenv FOO")).toBe(
+      "bash -c 'printenv FOO'",
+    );
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "aborts a multi-line command when the setup fails",
+    () => {
+      // `&&` is only safe here because the command is one `bash -c` word. Were
+      // it inlined, the `&&` would bind to its first line and the tail would
+      // run after a failed `cd` — in the wrong directory, reporting success.
+      const cmd = buildDaytonaSessionCommand("echo one\necho two", {
+        cwd: "/nonexistent",
+      });
+      const r = spawnSync("sh", { input: cmd, encoding: "utf8" });
+      expect(r.status).not.toBe(0);
+      expect(r.stdout).not.toContain("one");
+      expect(r.stdout).not.toContain("two");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "applies cwd and env to every line of a multi-line command",
+    () => {
+      const cmd = buildDaytonaSessionCommand(
+        'echo "1 $FOO $(pwd)"\necho "2 $FOO $(pwd)"',
+        { cwd: "/tmp", env: { FOO: "bar" } },
+      );
+      const r = spawnSync("sh", { input: cmd, encoding: "utf8" });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("1 bar /tmp\n2 bar /tmp\n");
+    },
+  );
 
   it("rejects an environment variable name that is not shell-legal", () => {
     // The name is interpolated into an `export`, so it can't be trusted.
@@ -86,10 +138,192 @@ describe("buildDaytonaSessionCommand", () => {
   });
 });
 
+describe("buildStreamSplitCommand", () => {
+  it("routes the wrapper's own stderr into the capture file too", () => {
+    // Capturing only the command's stderr leaves the wrapper's diagnostics — a
+    // `Terminated` on a group kill, an OOM notice — in the response ahead of
+    // the marker, i.e. reported as stdout.
+    const script = buildStreamSplitCommand("bash -c 'true'", "M");
+    expect(script).toContain('exec 2>"$__amika_err"');
+    expect(script.indexOf("exec 2>")).toBeLessThan(
+      script.indexOf("bash -c 'true'"),
+    );
+  });
+
+  it("re-raises the command's own exit status after emitting the streams", () => {
+    // The wrapper must be invisible to the caller: `mktemp`, `printf` and `cat`
+    // all succeed, so without this the exit code would always be 0.
+    const script = buildStreamSplitCommand("false", "M");
+    expect(script).toContain("__amika_rc=$?");
+    expect(script.trimEnd().endsWith('exit "$__amika_rc"')).toBe(true);
+  });
+
+  it("cleans up on a signal by exiting, not by falling through", () => {
+    // A POSIX trap handler resumes where the shell was, so a cleanup-only
+    // handler on INT/TERM/HUP would delete the capture file and then run on to
+    // `cat` it — replacing the command's real stderr with a `No such file`
+    // error and reporting its status for a wrapper that was told to stop.
+    const script = buildStreamSplitCommand("true", "M");
+    // The buggy form was `… EXIT INT TERM HUP`, of which this is a prefix, so
+    // pin that EXIT stands alone.
+    expect(script).toContain("trap 'rm -f -- \"$__amika_err\"' EXIT\n");
+    for (const [signal, code] of [
+      ["INT", 130],
+      ["TERM", 143],
+      ["HUP", 129],
+    ] as const) {
+      expect(script).toContain(`trap '__amika_bail ${code}' ${signal}`);
+    }
+    // Bailing must still emit both streams. Exiting bare would leave no marker,
+    // so the whole of stdout would come back reported as failure text — and it
+    // must emit at most once, or a signal landing mid-emit yields two markers.
+    expect(script).toContain(
+      '__amika_bail() { if [ -z "$__amika_emitted" ]; then __amika_emit; fi;',
+    );
+    expect(script).toContain("__amika_emit() { __amika_emitted=1;");
+  });
+
+  it("guards the capture path against being read as flags", () => {
+    // `mktemp` honors TMPDIR, so a value starting with `-` would otherwise make
+    // `cat` parse the path as an option bundle.
+    expect(buildStreamSplitCommand("true", "M")).toContain(
+      'cat -- "$__amika_err"',
+    );
+  });
+});
+
+// Asserting the generated text only proves it was generated. These run it, so
+// they fail if the shell disagrees with what the string appears to say.
+//
+// Linux-only, not just non-Windows: the script calls bare `mktemp`, which BSD
+// (macOS) `mktemp` rejects without a template, so every case here would take
+// the `exit 125` guard path on a Mac. The sandboxes this runs against are
+// Linux, so the script itself is fine — it is the assertions that don't
+// travel.
+describe.skipIf(process.platform !== "linux")(
+  "buildStreamSplitCommand (executed)",
+  () => {
+    const run = (script: string, env: NodeJS.ProcessEnv = {}) =>
+      spawnSync("sh", {
+        input: script,
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      });
+
+    it("splits the two streams at the marker", () => {
+      const r = run(buildStreamSplitCommand("echo out; echo err >&2", "--M--"));
+      expect(r.status).toBe(0);
+      const [stdout, stderr] = r.stdout.split("--M--");
+      expect(stdout).toBe("out\n");
+      expect(stderr).toBe("err\n");
+    });
+
+    it("does not run the command at all when the capture file can't be made", () => {
+      // The bug the guard exists for: without it the failed `2>""` redirect
+      // skips the subshell while the marker is still printed, so the split
+      // succeeds and shell diagnostics arrive looking like command output.
+      const r = run(buildStreamSplitCommand("echo SHOULD_NOT_RUN", "--M--"), {
+        TMPDIR: "/nonexistent-dir-for-this-test",
+      });
+      // 125 specifically, so a shell dying for an unrelated reason can't pass.
+      expect(r.status).toBe(125);
+      expect(r.stdout).not.toContain("SHOULD_NOT_RUN");
+      // No marker, so `splitStreamsAtMarker` reports it as failure text rather
+      // than handing a parser the diagnostic as a value.
+      expect(r.stdout).not.toContain("--M--");
+    });
+
+    it("re-raises the command's own exit status", () => {
+      const r = run(buildStreamSplitCommand("exit 42", "--M--"));
+      expect(r.status).toBe(42);
+    });
+
+    it("preserves both streams when the wrapper is signalled", async () => {
+      // The gap that let a regression through: nothing exercised the signal
+      // traps at runtime. Bailing without emitting would leave no marker, so
+      // `splitStreamsAtMarker` would report the whole of stdout as failure
+      // text and the real stderr would be lost entirely.
+      //
+      // POSIX defers a trap until the foreground command finishes, so the
+      // sleep bounds the test's runtime — the signal is handled after it, not
+      // during it.
+      const script = buildStreamSplitCommand(
+        "echo out; echo err >&2; sleep 2",
+        "--M--",
+      );
+      const child = spawn("sh", { stdio: ["pipe", "pipe", "ignore"] });
+      let out = "";
+      child.stdout.setEncoding("utf8");
+      const done = new Promise<number | null>((resolve) => {
+        child.on("close", (code) => resolve(code));
+      });
+      // Kill only once the command has actually produced output, so the test
+      // does not race the shell's startup.
+      const sawOutput = new Promise<void>((resolve) => {
+        child.stdout.on("data", (chunk: string) => {
+          out += chunk;
+          if (out.includes("out")) resolve();
+        });
+      });
+      let code: number | null;
+      try {
+        child.stdin.end(script);
+        await sawOutput;
+        child.kill("SIGTERM");
+        code = await done;
+      } finally {
+        // Bounded anyway by the `sleep`, but don't strand a shell if an
+        // assertion or a stalled read gets here first.
+        child.kill("SIGKILL");
+      }
+
+      expect(code).toBe(143);
+      // Exactly one marker: a signal arriving mid-emit must not make the
+      // handler emit a second one on top of the normal path's.
+      expect(out.split("--M--")).toHaveLength(2);
+      const [stdout, stderr] = out.split("--M--");
+      expect(stdout).toBe("out\n");
+      expect(stderr).toBe("err\n");
+    }, 20_000);
+
+    it("leaves no capture file behind", () => {
+      const dir = mkdtempSync(join(tmpdir(), "amika-split-"));
+      try {
+        const r = run(
+          buildStreamSplitCommand("echo hi; echo bye >&2", "--M--"),
+          {
+            TMPDIR: dir,
+          },
+        );
+        expect(r.status).toBe(0);
+        expect(readdirSync(dir)).toEqual([]);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  },
+);
+
 describe("executeCommand", () => {
+  it("opens no session for an ordinary command, so what it backgrounds survives", async () => {
+    // The regression this guards: Daytona owns a session's processes and kills
+    // them when the session is deleted, `nohup`/`setsid` included, so a command
+    // run that way loses the daemon it was meant to leave behind.
+    const { sandbox, openSessions, commands } = fakeDaytonaSandbox();
+
+    await executeCommand(
+      sandbox as DaytonaSandbox,
+      "nohup my-daemon >/var/log/my-daemon.log 2>&1 &",
+    );
+
+    expect(openSessions.size).toBe(0);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]!.command).toContain("nohup my-daemon");
+  });
+
   it("keeps stderr out of stdout on a successful command", async () => {
-    // The regression this guards: `sudo` writes "unable to resolve host …" to
-    // stderr on images whose hostname doesn't resolve. Merging that into the
+    // The regression the split guards: `sudo` writes "unable to resolve host …"
+    // to stderr on images whose hostname doesn't resolve. Merging that into the
     // value stream broke every stdout parser, `amikad host-key show` first.
     const { sandbox } = fakeDaytonaSandbox(() => ({
       exitCode: 0,
@@ -109,6 +343,57 @@ describe("executeCommand", () => {
     expect(result.stderr).toBe("sudo: unable to resolve host sandbox\n");
   });
 
+  it("passes cwd and env to the one-shot API rather than into the command", async () => {
+    // Unlike a session, `executeCommand` takes both as parameters, so `sudo`
+    // inherits the env and `--preserve-env` has something to preserve.
+    const { sandbox, commands } = fakeDaytonaSandbox();
+
+    await executeCommand(sandbox as DaytonaSandbox, "printenv FOO", {
+      cwd: "/home/amika",
+      env: { FOO: "bar" },
+    });
+
+    expect(commands[0]!.cwd).toBe("/home/amika");
+    expect(commands[0]!.env).toEqual({ FOO: "bar" });
+    expect(commands[0]!.command).not.toContain("export FOO");
+  });
+
+  it("refuses a shell-illegal env name instead of running the command", async () => {
+    // The no-stdin path skips the session builder that used to be the only
+    // place this was checked, so assert it at the exec boundary itself: the
+    // command must not reach the sandbox at all.
+    const { sandbox, commands } = fakeDaytonaSandbox();
+
+    await expect(
+      executeCommand(sandbox as DaytonaSandbox, "true", {
+        sudo: true,
+        env: { "FOO;touch /tmp/pwned": "x" },
+      }),
+    ).rejects.toThrow(/Invalid environment variable name/u);
+    expect(commands).toHaveLength(0);
+  });
+
+  it("reports a failure whose output never reached the marker as stderr", async () => {
+    // The shell died before the wrapper's `printf`, so the response is a
+    // diagnostic, not a value — it has to reach `execFailureText`, and must not
+    // be handed to a stdout parser.
+    const sandbox = {
+      process: {
+        executeCommand: () =>
+          Promise.resolve({ exitCode: 127, result: "sh: no such file" }),
+      },
+    };
+
+    const result = await executeCommand(
+      sandbox as unknown as DaytonaSandbox,
+      "nope",
+    );
+
+    expect(result.exitCode).toBe(127);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("sh: no such file");
+  });
+
   it("pipes input to the command and closes stdin at the exact byte count", async () => {
     const { sandbox, commands } = fakeDaytonaSandbox();
 
@@ -125,22 +410,41 @@ describe("executeCommand", () => {
     expect(commands[0]!.input).toBe("ssh-ed25519 AAAA\n");
   });
 
-  it("treats empty input as no stdin wiring", async () => {
+  it("runs a stdin command in a subshell so its shell state can't escape", async () => {
+    // This is the only path left that touches a session, and a session is a
+    // long-lived shell: bare text would run `set -e` in *that* shell, which
+    // exits before the agent records an exit code and hangs the caller on a
+    // result that never comes. The parens are what prevent it.
     const { sandbox, commands } = fakeDaytonaSandbox();
+
+    await executeCommand(sandbox as DaytonaSandbox, "set -e\ngit fetch", {
+      input: "x",
+    });
+
+    expect(commands[0]!.command).toBe(
+      "head -c 1 | (bash -c 'set -e\ngit fetch')",
+    );
+  });
+
+  it("treats empty input as no stdin wiring", async () => {
+    const { sandbox, commands, openSessions } = fakeDaytonaSandbox();
 
     await executeCommand(sandbox as DaytonaSandbox, "true", { input: "" });
 
     expect(commands[0]!.command).not.toContain("head -c");
     expect(commands[0]!.input).toBeUndefined();
+    expect(openSessions.size).toBe(0);
   });
 
-  it("deletes the session even when the command fails", async () => {
+  it("deletes the stdin path's session even when the command fails", async () => {
     const { sandbox, openSessions } = fakeDaytonaSandbox(() => ({
       exitCode: 1,
       stderr: "boom",
     }));
 
-    const result = await executeCommand(sandbox as DaytonaSandbox, "false");
+    const result = await executeCommand(sandbox as DaytonaSandbox, "false", {
+      input: "x",
+    });
 
     expect(result.exitCode).toBe(1);
     expect(openSessions.size).toBe(0);

--- a/js/sandbox/src/providers/daytona/internal/commands.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.ts
@@ -17,63 +17,85 @@ const SUDO_PRESERVE_ENV_BASE = [
 ] as const;
 
 /**
- * Build the on-box command string for a Daytona session exec. Both paths run
- * the *entire* command as the argument of a `bash -c`, never as bare text.
+ * Build the on-box command string for a Daytona exec, one-shot or session.
+ * Both paths run the *entire* command as the single quoted argument of a
+ * `bash -c`, which buys three things:
  *
- * A session is a long-lived shell that the agent feeds commands through on
- * stdin, so bare text executes *in that shell* and any shell state it sets
- * outlives the command. `set -e` is the case that bites: the session shell
- * inherits it and then exits before the agent records the command's exit
- * status, so no `exit_code` is written and the synchronous exec call waits on a
- * result that never comes. Wrapping confines that state to a child shell, and
- * a script that fails under its own `set -e` still reports a non-zero exit
- * normally.
+ *   - **Syntactic isolation.** Every caller embeds this inside a larger script
+ *     — a subshell for the stream split, a pipeline for stdin. As one word the
+ *     command cannot interact with that script's syntax: a trailing comment
+ *     can't swallow the closing paren, a trailing `&` can't strand it, and a
+ *     multi-line command can't escape a preceding `&&`.
+ *   - **A known interpreter.** Daytona runs the outer script under `zsh`
+ *     (verified on a live sandbox), which is close to but not `bash` — word
+ *     splitting differs most notably. Callers write bash, so run bash.
+ *   - **Shell-state containment**, which matters on the session path: a session
+ *     is a long-lived shell, and a script's `set -e` sent as bare text would
+ *     take it down before the agent recorded an exit status.
  *
- * For `sudo: true` the same wrapper additionally means a compound command,
- * pipeline, or redirection runs fully elevated rather than just its first
- * simple command, and `--preserve-env` is extended with the caller's explicit
+ * `sudo: true` additionally elevates the whole command rather than just its
+ * first simple command, and extends `--preserve-env` with the caller's explicit
  * `env` keys (on top of the Amika hook vars) so `sudo`'s environment reset
- * doesn't strip the variables the public `ExecCommandOptions.env` promises to
- * expose.
- *
- * `sudo -n` is non-interactive so it fails fast instead of hanging on a
+ * doesn't strip the variables `ExecCommandOptions.env` promises to expose.
+ * `sudo -n` is non-interactive so it fails fast rather than hanging on a
  * password prompt. Exported for unit testing.
  */
 export function buildDaytonaCommand(
   command: string,
   opts?: { env?: Record<string, string>; sudo?: boolean },
 ): string {
-  if (!opts?.sudo) return `bash -c ${shellQuote(command)}`;
+  assertEnvNames(opts?.env);
+  const inner = `bash -c ${shellQuote(command)}`;
+  if (!opts?.sudo) return inner;
   const preserve = [...SUDO_PRESERVE_ENV_BASE, ...Object.keys(opts.env ?? {})];
-  return `sudo -n --preserve-env=${preserve.join(",")} bash -c ${shellQuote(command)}`;
+  return `sudo -n --preserve-env=${preserve.join(",")} ${inner}`;
 }
 
 /** Shell-legal environment variable name; anything else is rejected. */
 const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 
 /**
- * Wrap {@link buildDaytonaCommand} with the `cwd` and `env` that Daytona's
- * one-shot `process.executeCommand` used to apply for us.
+ * Reject any environment variable name that isn't shell-legal.
  *
- * Sessions carry no cwd/env parameters (`SessionExecuteRequest` is just a
- * command string), so both are applied in the session shell, ahead of the
- * `bash -c` wrapper: the child inherits the working directory and the exported
+ * Both builders interpolate these names into a command string unquoted — into
+ * `sudo --preserve-env=` here, and into an `export` on the session path — so a
+ * name is never safe to take on trust. Checked in {@link buildDaytonaCommand}
+ * rather than only at the call sites because every exec path funnels through
+ * it, which is what makes the guard unbypassable.
+ */
+function assertEnvNames(env?: Record<string, string>): void {
+  for (const name of Object.keys(env ?? {})) {
+    if (!ENV_NAME_RE.test(name)) {
+      throw new Error(`Invalid environment variable name: ${name}`);
+    }
+  }
+}
+
+/**
+ * Wrap {@link buildDaytonaCommand} with the `cwd` and `env` that Daytona's
+ * one-shot `process.executeCommand` takes as parameters.
+ *
+ * Only the stdin path needs this: a `SessionExecuteRequest` is just a command
+ * string, with nowhere to put either. Both are applied in the session shell,
+ * ahead of the command, so it inherits the working directory and the exported
  * variables, and on the sudo path `--preserve-env` then has something to
- * preserve. Exported for unit testing.
+ * preserve.
+ *
+ * A plain `&&` chain is enough because {@link buildDaytonaCommand} hands back a
+ * single `bash -c '…'` word: there is no second line for the `&&` to miss, so a
+ * failed `cd` stops everything. Exported for unit testing.
  */
 export function buildDaytonaSessionCommand(
   command: string,
   opts?: { cwd?: string; env?: Record<string, string>; sudo?: boolean },
 ): string {
-  const prefix: string[] = [];
-  if (opts?.cwd) prefix.push(`cd ${shellQuote(opts.cwd)}`);
+  assertEnvNames(opts?.env);
+  const setup: string[] = [];
+  if (opts?.cwd) setup.push(`cd ${shellQuote(opts.cwd)}`);
   for (const [name, value] of Object.entries(opts?.env ?? {})) {
-    if (!ENV_NAME_RE.test(name)) {
-      throw new Error(`Invalid environment variable name: ${name}`);
-    }
-    prefix.push(`export ${name}=${shellQuote(value)}`);
+    setup.push(`export ${name}=${shellQuote(value)}`);
   }
-  return [...prefix, buildDaytonaCommand(command, opts)].join(" && ");
+  return [...setup, buildDaytonaCommand(command, opts)].join(" && ");
 }
 
 export async function executeCommand(
@@ -90,12 +112,134 @@ export async function executeCommand(
   // stdin wiring already sees, so it takes the same path as the no-input case.
   return opts?.input
     ? executeSessionCommandWithInput(sandbox, command, opts.input, opts)
-    : executeSessionCommand(sandbox, command, opts);
+    : executeOneShotCommand(sandbox, command, opts);
 }
 
 const MAX_COMMAND_INPUT_BYTES = 1024 * 1024;
 
 type DaytonaSandbox = Awaited<ReturnType<Daytona["get"]>>;
+
+/**
+ * Run one command through Daytona's one-shot `process.executeCommand`.
+ *
+ * Deliberately *not* a process session. Daytona owns a session's processes and
+ * kills them when the session is deleted, `nohup` and `setsid` included, so a
+ * command whose point is the daemon it leaves behind loses it the moment the
+ * command returns. The one-shot API has no owning session, so it survives.
+ *
+ * Sessions were reached for because this API reports a single combined
+ * `result`, with stderr folded into the value stream, corrupting any caller
+ * that parses stdout. {@link buildStreamSplitCommand} recovers the two streams
+ * on-box instead, so both properties hold at one round-trip per command.
+ */
+async function executeOneShotCommand(
+  sandbox: DaytonaSandbox,
+  command: string,
+  opts?: { cwd?: string; env?: Record<string, string>; sudo?: boolean },
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const marker = `--amika-stderr-${randomUUID()}--`;
+  const response = await sandbox.process.executeCommand(
+    buildStreamSplitCommand(buildDaytonaCommand(command, opts), marker),
+    opts?.cwd,
+    opts?.env,
+  );
+  // `ExecuteResponse.exitCode` is typed `number` but the wire model has it
+  // optional, so TypeScript cannot catch an omitted value; the stdin path has
+  // carried the same fallback all along.
+  const exitCode = response.exitCode ?? 1;
+  return {
+    exitCode,
+    ...splitStreamsAtMarker(response.result, marker, exitCode),
+  };
+}
+
+/**
+ * Wrap a command so its two streams survive a transport that carries only one.
+ *
+ * `command`'s stderr is captured to a temp file; once it has exited, the
+ * response body is its stdout, then `marker`, then the captured stderr, so
+ * {@link splitStreamsAtMarker} can cut the two apart. The command's own exit
+ * status is re-raised at the end, so the wrapper is invisible to the caller.
+ * `marker` must be unique per command, so that no legitimate output can
+ * contain it and split at the wrong place.
+ *
+ * `command` arrives from {@link buildDaytonaCommand} as a single `bash -c '…'`
+ * word, so nothing in it can interact with this script's syntax. Exported for
+ * unit testing.
+ */
+export function buildStreamSplitCommand(
+  command: string,
+  marker: string,
+): string {
+  return [
+    // Bail if the capture file can't be made. Without this the redirect below
+    // becomes `2>""`, which fails, which means the subshell never runs at all —
+    // and the wrapper would still print its marker, so the split would succeed
+    // and hand the caller shell diagnostics that look like command output. A
+    // full or read-only /tmp is enough to trigger it. Exiting here leaves no
+    // marker, so `splitStreamsAtMarker` reports the failure text as stderr.
+    "__amika_err=$(mktemp) || exit 125",
+    '[ -n "$__amika_err" ] || exit 125',
+    // Everything from here writes stderr to the capture file, this script
+    // included. Redirecting only the command would leave the wrapper's own
+    // diagnostics — a `Terminated` on a group kill, an OOM notice — in the
+    // response *ahead* of the marker, i.e. reported as stdout, which is the
+    // one thing `ExecResult.stdout` promises never to carry.
+    'exec 2>"$__amika_err"',
+    // Covers the normal exit as well as a killed wrapper, which a trailing
+    // `rm` would miss — the file holds captured stderr.
+    "trap 'rm -f -- \"$__amika_err\"' EXIT",
+    // Emit whatever the command produced, then leave with the signal's
+    // conventional status. A POSIX trap handler resumes where the shell was
+    // rather than exiting, so a cleanup-only handler would delete the capture
+    // file and let the script run on to `cat` it — losing the real stderr and
+    // reporting the command's own status for a wrapper told to stop. Exiting
+    // without emitting first is no better: the response would carry no marker,
+    // and the whole of stdout would be reported as failure text. Exiting here
+    // still runs the EXIT trap, so cleanup happens exactly once.
+    // `__amika_emitted` keeps a signal that lands *during* the normal emit
+    // below from emitting a second time: two markers in one response would
+    // leave the split reporting the captured stderr twice with a raw marker
+    // between the copies.
+    // Cleared explicitly: `env` may legally carry a leading-underscore name, so
+    // an inherited `__amika_emitted` would otherwise suppress the bail emit.
+    "__amika_emitted=",
+    `__amika_bail() { if [ -z "$__amika_emitted" ]; then __amika_emit; fi; exit "$1"; }`,
+    `__amika_emit() { __amika_emitted=1; printf '%s' ${shellQuote(marker)}; cat -- "$__amika_err"; }`,
+    "trap '__amika_bail 130' INT",
+    "trap '__amika_bail 143' TERM",
+    "trap '__amika_bail 129' HUP",
+    `( ${command} )`,
+    "__amika_rc=$?",
+    // `--` inside `__amika_emit` so a TMPDIR beginning with `-` can't make the
+    // capture path read as flags.
+    "__amika_emit",
+    `exit "$__amika_rc"`,
+  ].join("\n");
+}
+
+/** Cut a {@link buildStreamSplitCommand} response back into its two streams. */
+function splitStreamsAtMarker(
+  combined: string,
+  marker: string,
+  exitCode: number,
+): { stdout: string; stderr: string } {
+  const at = combined.indexOf(marker);
+  if (at === -1) {
+    // The wrapper never reached its `printf`, so this is not command output at
+    // all — the shell itself failed to start, or the command took the process
+    // down with it. On a failure that text is the only diagnostic there is, so
+    // route it where `execFailureText` will find it rather than leaving it to
+    // be parsed as a value.
+    return exitCode === 0
+      ? { stdout: combined, stderr: "" }
+      : { stdout: "", stderr: combined };
+  }
+  return {
+    stdout: combined.slice(0, at),
+    stderr: combined.slice(at + marker.length),
+  };
+}
 
 /** Run `body` against a throwaway session, always tearing the session down. */
 async function withSession<T>(
@@ -112,37 +256,13 @@ async function withSession<T>(
 }
 
 /**
- * Run one command in a session and read back its two streams.
+ * As {@link executeOneShotCommand}, but with `input` on the command's stdin.
  *
- * Sessions rather than `process.executeCommand`, which returns only a single
- * combined `result` string: stderr folded into the value stream corrupts
- * every caller that parses stdout (host keys, JSON, PIDs). A synchronous
- * session command reports `stdout`, `stderr`, and the exit code directly, so
- * this costs one extra round-trip over the one-shot API, not several.
- */
-async function executeSessionCommand(
-  sandbox: DaytonaSandbox,
-  command: string,
-  opts?: { cwd?: string; env?: Record<string, string>; sudo?: boolean },
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  return withSession(sandbox, async (sessionId) => {
-    const response = await sandbox.process.executeSessionCommand(sessionId, {
-      command: buildDaytonaSessionCommand(command, opts),
-    });
-    return {
-      exitCode: response.exitCode ?? 1,
-      stdout: response.stdout ?? "",
-      stderr: response.stderr ?? "",
-    };
-  });
-}
-
-/**
- * As {@link executeSessionCommand}, but with `input` on the command's stdin.
- *
- * Sending stdin needs the command's id, which only an async run hands back
- * before the command finishes, so this variant runs detached and collects the
- * streams from the log callbacks instead.
+ * Sending stdin needs the command's id, which only a session's async run hands
+ * back before the command finishes, so this variant alone still pays for a
+ * session — and gets the two streams from the log callbacks for free. Deleting
+ * that session reaps whatever the command left running, which is safe here: a
+ * command fed bytes on stdin consumes them and exits rather than daemonizing.
  */
 async function executeSessionCommandWithInput(
   sandbox: DaytonaSandbox,
@@ -157,6 +277,12 @@ async function executeSessionCommandWithInput(
   return withSession(sandbox, async (sessionId) => {
     // Daytona does not expose a close-stdin operation. Bound the reader to the
     // exact byte count so the command sees EOF without putting input in argv.
+    //
+    // The parens are load-bearing beyond grouping the pipe's right-hand side: a
+    // session is a long-lived shell, and bare text would run *in* it, so a
+    // script's `set -e` would take the shell down before the agent recorded an
+    // exit code and this call would wait on a result that never comes. Both the
+    // pipeline and the explicit subshell confine that state to a child.
     const onBox = buildDaytonaSessionCommand(command, opts);
     const response = await sandbox.process.executeSessionCommand(sessionId, {
       command: `head -c ${byteLength} | (${onBox})`,

--- a/js/sandbox/src/providers/daytona/internal/configure.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/configure.test.ts
@@ -58,7 +58,7 @@ describe("startDockerForSnapshot", () => {
     // failure must not surface and mask the capture's success.
     const sandbox = {
       process: {
-        createSession: () => Promise.reject(new Error("exec down")),
+        executeCommand: () => Promise.reject(new Error("exec down")),
       },
     } as unknown as Parameters<typeof startDockerForSnapshot>[0];
 

--- a/js/sandbox/src/providers/daytona/internal/test-support.ts
+++ b/js/sandbox/src/providers/daytona/internal/test-support.ts
@@ -1,21 +1,35 @@
 /**
- * Test-only fake of the Daytona `process` session surface.
+ * Test-only fake of the Daytona `process` surface.
  *
- * Daytona commands run through a throwaway session (see `commands.ts`) so the
- * two output streams stay separate, which means a test can no longer stub a
- * single `process.executeCommand`. This fake records each session command and
- * replays scripted stdout/stderr/exit codes. Deliberately free of any test-
- * framework import so it stays a plain module.
+ * `commands.ts` runs ordinary commands through the one-shot `executeCommand`
+ * and stdin-carrying ones through a session (see there for why), so this fake
+ * models both and records every command in the order it ran.
+ *
+ * The one-shot half reproduces the property the code under test exists to work
+ * around: the real API reports a *single* combined `result` string. So the fake
+ * concatenates the scripted stdout, the stream marker it finds in the script it
+ * was handed, and the scripted stderr — and leaves `commands.ts` to cut them
+ * apart again. A test that gets its two streams back has exercised the split,
+ * not a stub of it.
+ *
+ * Deliberately free of any test-framework import so it stays a plain module.
  */
 
-export interface FakeSessionCommand {
-  /** The full on-box command string the session was asked to run. */
+/** The delimiter `buildStreamSplitCommand` emits between the two streams. */
+const STREAM_MARKER_RE = /--amika-stderr-[0-9a-fA-F-]+--/u;
+
+export interface FakeCommand {
+  /** The full on-box command string the sandbox was asked to run. */
   command: string;
+  /** Working directory, when the caller passed one (one-shot path only). */
+  cwd?: string;
+  /** Environment, when the caller passed one (one-shot path only). */
+  env?: Record<string, string>;
   /** Bytes sent to the command's stdin, when the caller passed input. */
   input?: string;
 }
 
-export interface FakeSessionResponse {
+export interface FakeResponse {
   exitCode?: number;
   stdout?: string;
   stderr?: string;
@@ -24,53 +38,54 @@ export interface FakeSessionResponse {
 export interface FakeDaytonaSandbox {
   /** Pass where a Daytona `Sandbox` is expected. */
   sandbox: unknown;
-  /** Every session command run, in order. */
-  commands: FakeSessionCommand[];
-  /** Sessions created but never deleted; non-empty means a leak. */
+  /** Every command run, in order, across both paths. */
+  commands: FakeCommand[];
+  /**
+   * Sessions currently open. Empty after an ordinary command, which must not
+   * open one at all — a session owns its processes and kills them on delete.
+   */
   openSessions: Set<string>;
 }
 
 /**
- * Build a fake sandbox whose session commands resolve to `respond(command)`,
- * defaulting to a clean zero-exit with empty streams. One command per session,
- * matching how `commands.ts` uses the API.
+ * Build a fake sandbox whose commands resolve to `respond(command)`, defaulting
+ * to a clean zero-exit with empty streams. `command` is the full on-box string,
+ * so a caller can key its response off the command it recognizes.
  */
 export function fakeDaytonaSandbox(
-  respond: (command: string) => FakeSessionResponse = () => ({}),
+  respond: (command: string) => FakeResponse = () => ({}),
 ): FakeDaytonaSandbox {
-  const commands: FakeSessionCommand[] = [];
+  const commands: FakeCommand[] = [];
   const openSessions = new Set<string>();
-  let response: FakeSessionResponse = {};
+  let response: FakeResponse = {};
 
   const process = {
+    executeCommand(
+      command: string,
+      cwd?: string,
+      env?: Record<string, string>,
+    ): Promise<{ exitCode: number; result: string }> {
+      commands.push({ command, cwd, env });
+      response = respond(command);
+      const marker = STREAM_MARKER_RE.exec(command)?.[0] ?? "";
+      return Promise.resolve({
+        exitCode: response.exitCode ?? 0,
+        result: `${response.stdout ?? ""}${marker}${response.stderr ?? ""}`,
+      });
+    },
     createSession(sessionId: string): Promise<void> {
       openSessions.add(sessionId);
       return Promise.resolve();
     },
+    // Only the stdin path reaches a session, and it always runs detached, so a
+    // session command reports just the id and its streams arrive via the logs.
     executeSessionCommand(
       _sessionId: string,
-      request: { command: string; runAsync?: boolean },
-    ): Promise<{
-      cmdId: string;
-      exitCode?: number;
-      stdout?: string;
-      stderr?: string;
-    }> {
+      request: { command: string },
+    ): Promise<{ cmdId: string }> {
       commands.push({ command: request.command });
       response = respond(request.command);
-      const cmdId = `cmd-${commands.length}`;
-      // A detached run reports only the id; a synchronous one carries the
-      // finished command's streams, exactly as the Daytona API does.
-      return Promise.resolve(
-        request.runAsync
-          ? { cmdId }
-          : {
-              cmdId,
-              exitCode: response.exitCode ?? 0,
-              stdout: response.stdout ?? "",
-              stderr: response.stderr ?? "",
-            },
-      );
+      return Promise.resolve({ cmdId: `cmd-${commands.length}` });
     },
     sendSessionCommandInput(
       _sessionId: string,


### PR DESCRIPTION
## Why this has to change

A Daytona session owns every process started inside it, and deleting the session
kills them. Every command ran in a throwaway session that was deleted in a
`finally`:

```
create session → run command → delete session (kills its processes)
```

Harmless for `ls`. Fatal for a command whose *entire point* is the daemon it
leaves behind — the provisioning hook that backgrounds OpenCode, `amikad serve
--bg`, the post-snapshot `dockerd` relaunch. Each died the instant its command
returned.

`nohup`/`setsid` don't save it. Those defend against signals and parent death;
Daytona is reaping by ownership, and you can't detach out of a bookkeeping entry.

The result: nothing listening on the agent port, the Coding Agent URL answering
Daytona's `502 proxy upstream error` — and because OpenCode liveness is
warning-only, **provisioning still reported success**. A silent failure.

## The fix

Run ordinary commands through the one-shot `process.executeCommand`. No owning
session, nothing to delete, nothing to kill.

Same command, same sandbox, both paths:

| Path                     | `nohup sleep 600 &`, then probe |
| ------------------------ | ------------------------------- |
| Session (today's `main`) | **dead**                        |
| One-shot (this PR)       | **alive**                       |

## Why it isn't a plain revert

Sessions were adopted (8b995247, 878a08ca) for a real reason: the one-shot API
returns a *single combined* string with stderr folded into the value stream. That
corrupted every caller parsing stdout — `sudo` prints `unable to resolve host` on
images whose hostname doesn't resolve, which broke `amikad host-key show` and took
SSH provisioning down with a 503.

So the two-stream contract is kept and rebuilt on-box: stderr to a temp file, then
stdout + a per-command random marker + that stderr, split by the adapter. The
command sits alone on its own line inside a subshell, so a trailing `&`, a
trailing comment, or a compound command all keep working, and its exit status is
re-raised so the wrapper is invisible. `cwd`/`env` return to being
`executeCommand` parameters.

Both properties now hold at once, at **one round-trip per command instead of
three**.

Two guards had to be carried across explicitly, since neither existed in the
pre-session one-shot code:

- **Env-name validation** moved into `buildDaytonaCommand`. It previously sat only
  in the session builder, which every command reached while they all used
  sessions. Those names are interpolated *unquoted* into `sudo --preserve-env=`,
  so `FOO;touch /tmp/pwned` would end the sudo command and start another. Putting
  it in the builder both paths funnel through is what makes it unbypassable.
- **Stream splitting** is new code (`buildStreamSplitCommand`); the old one-shot
  path had none.

## #342 stays intact

An earlier revision of this PR (`219a37d`) returned non-sudo commands verbatim, on
the reasoning that #342's `bash -c` only guarded bare text in a long-lived session
shell. That was reverted before this PR settled: `buildDaytonaCommand` wraps
**both** paths in `bash -c` at head, byte-identical in behavior to `main`. Nothing
about #342 changes here.

Keeping it also settles four review comments at once — an empty or comment-only
command stays syntactically valid, `kill -TERM $$` reaches the command's own shell
rather than the wrapper, and callers keep guaranteed bash rather than whatever
shell the transport picks.

The relocated reasoning still stands where it matters: the parens in
`executeSessionCommandWithInput` are load-bearing, with a test pinning that shape.
The trigger that motivated #342, `buildRefreshClonedRepoScript`, sends no stdin
and so can no longer reach a session at all.

## What still uses a session, and why

Sending stdin needs the command id, and only an async session run hands that back
before the command finishes. That's the whole remaining set — two credential
writes, both of which consume their bytes and exit rather than daemonizing, so
session teardown costs them nothing:

- `amikad authorized-keys set`
- `amikad connect-token set`

(The pre-existing `streamDaytonaCommandLogs` path also uses a session, for the
same underlying reason: live log streaming needs a command id. Untouched here.)

## Verification

`typecheck`, `lint`, `formatcheck`, 351 unit tests.

Re-verified against a live Daytona sandbox by driving this branch's actual
`executeCommand` — not a reimplementation — on a box created from
`amika-daytona-vm-xs` (2 sandboxes created across two runs, both deleted, 0
leaked):

| Check                                                       | Result                                                                              |
| ----------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| `nohup sleep 601 &`, then a bracketed `pgrep`               | `ALIVE` — the daemon survives                                                       |
| `sudo` on a host whose name doesn't resolve                 | stdout `"OUT\n"`, stderr `"sudo: unable to resolve host sandbox: …\nERR\n"`          |
| `ps -o args= -p "$PPID"` + a real stdout line               | both streams split correctly                                                        |
| `ps aux` + a real stdout line                               | both streams split correctly                                                        |
| `exit 42`                                                   | `exitCode: 42`                                                                      |
| `cwd: /tmp`, `env: {FOO: bar}`                              | stdout `"bar\n/tmp\n"`                                                              |

Row two is the bug that motivated sessions, reproducing live: the real `sudo:
unable to resolve host` warning appears, lands on stderr, and leaves the value
stream clean. That is exactly what `parseEd25519PublicKey` choked on when the two
were merged, so the split is genuinely preserved without sessions.

Not covered: the full provisioning flow end to end — OpenCode listening on 60998,
the Coding Agent URL returning 401 rather than 502, and surviving a stop/start.
This verifies the exec mechanism the fix turns on, not the whole lifecycle above
it.

## Two review findings that don't reproduce

Both were raised against the one-shot path and both were checked on a live
sandbox rather than argued. Neither needs a code change, so nothing was added for
them.

**"Pass a timeout — `ExecuteRequest` defaults an omitted timeout to 10 seconds."**
The type does document that, and the session API it replaces has no timeout field
at all, so the concern is reasonable on paper. The server does not apply it:

| Call                                       | Wall time | Outcome                    |
| ------------------------------------------ | --------- | -------------------------- |
| timeout **omitted**, `sleep 30; echo DONE` | 30450ms   | exit 0, `DONE`             |
| timeout **omitted**, `sleep 45; echo DONE` | 45274ms   | exit 0, `DONE45`           |
| timeout **5**, `sleep 20`                  | 5287ms    | `command execution timeout` |
| timeout **0**, `sleep 30; echo DONE`       | 30286ms   | exit 0, `DONE`             |

The field is live — an explicit `5` kills at 5s — but the documented 10s default
isn't being applied, so no ordinary command is being capped. Nothing on this path
is at risk today, and adding `timeout: 0` would pin behavior that already holds.
Worth knowing if Daytona ever starts honoring its own default.

**"The marker could collide with a command that reports process arguments."**
`splitStreamsAtMarker` cuts at the first occurrence, and the wrapper spells the
marker out in its own script text — so if that text were reachable from inside the
command, `ps aux` would echo the marker and the split would cut in the wrong
place. It isn't reachable: Daytona feeds the script to `zsh` on **stdin**, not as
an argv. Measured with a sentinel placed in the script, from inside the command:

```
parent chain:   pid=995 argv=[/usr/bin/zsh]   pid=891 argv=[/opt/daytona/daytona]
argv_hits:      [NONE]      # grep across /proc/[0-9]*/cmdline
environ_hits:   [NONE]      # grep across /proc/[0-9]*/environ
file_hits:      [NONE]      # grep -r across /tmp /var/tmp /run
```

The `ps aux` and `ps -o args= -p "$PPID"` rows in the table above confirm the
split holds for such commands in practice.
