### PR TITLE
Run Daytona session commands in their own shell

### DIFF
--- a/js/sandbox/src/providers/daytona/internal/commands.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.test.ts
@@ -9,9 +9,27 @@ import { fakeDaytonaSandbox } from "./test-support";
 type DaytonaSandbox = Parameters<typeof executeCommand>[0];
 
 describe("buildDaytonaCommand", () => {
-  it("runs a non-sudo command verbatim", () => {
-    expect(buildDaytonaCommand("echo hi")).toBe("echo hi");
-    expect(buildDaytonaCommand("echo hi", { sudo: false })).toBe("echo hi");
+  it("runs a non-sudo command inside its own bash -c", () => {
+    expect(buildDaytonaCommand("echo hi")).toBe("bash -c 'echo hi'");
+    expect(buildDaytonaCommand("echo hi", { sudo: false })).toBe(
+      "bash -c 'echo hi'",
+    );
+  });
+
+  it("confines a command's shell state to a child shell", () => {
+    // A session is a long-lived shell fed commands on stdin, so bare text
+    // would run `set -e` in *that* shell. It then exits before the agent
+    // records an exit status, and the synchronous exec never returns --
+    // `buildRefreshClonedRepoScript` opens with `set -e`, so every
+    // from-snapshot create hung.
+    const cmd = buildDaytonaCommand("set -e\ngit fetch --prune origin");
+    expect(cmd).toBe("bash -c 'set -e\ngit fetch --prune origin'");
+  });
+
+  it("quotes a command containing single quotes", () => {
+    expect(buildDaytonaCommand("git config x 'a b'")).toBe(
+      `bash -c 'git config x '"'"'a b'"'"''`,
+    );
   });
 
   it("wraps a sudo command in a root bash -c so a compound command runs fully elevated", () => {
@@ -48,6 +66,16 @@ describe("buildDaytonaSessionCommand", () => {
     expect(
       cmd.startsWith("cd '/home/amika' && export FOO='bar' && sudo -n"),
     ).toBe(true);
+  });
+
+  it("applies cwd and env ahead of the wrapper on the non-sudo path", () => {
+    // The wrapped child inherits both, so they still reach the command.
+    expect(
+      buildDaytonaSessionCommand("printenv FOO", {
+        cwd: "/home/amika",
+        env: { FOO: "bar" },
+      }),
+    ).toBe("cd '/home/amika' && export FOO='bar' && bash -c 'printenv FOO'");
   });
 
   it("rejects an environment variable name that is not shell-legal", () => {

--- a/js/sandbox/src/providers/daytona/internal/commands.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.ts
@@ -17,16 +17,24 @@ const SUDO_PRESERVE_ENV_BASE = [
 ] as const;
 
 /**
- * Build the on-box command string for Daytona's `process.executeCommand`.
- * Non-sudo commands run verbatim (Daytona execs them through a shell, so
- * compound commands already work). For `sudo: true` we:
+ * Build the on-box command string for a Daytona session exec. Both paths run
+ * the *entire* command as the argument of a `bash -c`, never as bare text.
  *
- *   - run the *entire* command in a root shell (`bash -c '<command>'`) so a
- *     compound command / pipeline / redirection runs fully elevated, not just
- *     its first simple command; and
- *   - extend `--preserve-env` with the caller's explicit `env` keys (on top of
- *     the Amika hook vars) so `sudo`'s environment reset doesn't strip the
- *     variables the public `ExecCommandOptions.env` promises to expose.
+ * A session is a long-lived shell that the agent feeds commands through on
+ * stdin, so bare text executes *in that shell* and any shell state it sets
+ * outlives the command. `set -e` is the case that bites: the session shell
+ * inherits it and then exits before the agent records the command's exit
+ * status, so no `exit_code` is written and the synchronous exec call waits on a
+ * result that never comes. Wrapping confines that state to a child shell, and
+ * a script that fails under its own `set -e` still reports a non-zero exit
+ * normally.
+ *
+ * For `sudo: true` the same wrapper additionally means a compound command,
+ * pipeline, or redirection runs fully elevated rather than just its first
+ * simple command, and `--preserve-env` is extended with the caller's explicit
+ * `env` keys (on top of the Amika hook vars) so `sudo`'s environment reset
+ * doesn't strip the variables the public `ExecCommandOptions.env` promises to
+ * expose.
  *
  * `sudo -n` is non-interactive so it fails fast instead of hanging on a
  * password prompt. Exported for unit testing.
@@ -35,7 +43,7 @@ export function buildDaytonaCommand(
   command: string,
   opts?: { env?: Record<string, string>; sudo?: boolean },
 ): string {
-  if (!opts?.sudo) return command;
+  if (!opts?.sudo) return `bash -c ${shellQuote(command)}`;
   const preserve = [...SUDO_PRESERVE_ENV_BASE, ...Object.keys(opts.env ?? {})];
   return `sudo -n --preserve-env=${preserve.join(",")} bash -c ${shellQuote(command)}`;
 }
@@ -48,9 +56,10 @@ const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u;
  * one-shot `process.executeCommand` used to apply for us.
  *
  * Sessions carry no cwd/env parameters (`SessionExecuteRequest` is just a
- * command string), so both are applied in the outer shell, before `sudo`,
- * so that `--preserve-env` actually has something to preserve. Exported for
- * unit testing.
+ * command string), so both are applied in the session shell, ahead of the
+ * `bash -c` wrapper: the child inherits the working directory and the exported
+ * variables, and on the sudo path `--preserve-env` then has something to
+ * preserve. Exported for unit testing.
  */
 export function buildDaytonaSessionCommand(
   command: string,


### PR DESCRIPTION
A Daytona session is a long-lived shell that the agent feeds commands through on stdin, so a command sent as bare text runs *in that shell* and any shell state it sets outlives the command. `set -e` is the case that bites: the session shell inherits it and exits before the agent records an exit status, so no `exit_code` is written and the synchronous `executeSessionCommand` waits on a result that never arrives. That call carries no timeout, so the wait is unbounded.

`buildRefreshClonedRepoScript` opens with `set -e`, and it runs only on the fast path that refreshes a repo already baked into the booted snapshot. Since `recurseSubmodules` began overriding a provider's native git primitive, Daytona clones over the exec port, so that script started reaching Daytona sandboxes and every from-snapshot create wedged in `initializing`. A fresh sandbox sends a single `git clone` and never trips it.

`buildDaytonaCommand` now wraps the non-sudo path in `bash -c` as well, matching what the sudo path already did for its own reasons. Shell state is confined to a child process, and a script that fails under its own `set -e` still reports a non-zero exit. `buildDaytonaSessionCommand` applies `cwd` and `env` ahead of the wrapper, so the child inherits both.

## Testing

`js/sandbox` unit tests cover the wrapper on the non-sudo path, a `set -e` command, single-quote quoting, and `cwd`/`env` ordering.