### PR TITLE
Give every streamed command its own session id

### DIFF
--- a/js/sandbox/src/providers/daytona/internal/operations.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/operations.test.ts
@@ -5,12 +5,15 @@ import {
   _parseSshDestination,
   listDaytonaSandboxes,
   mapDaytonaSandboxState,
+  streamDaytonaCommandLogs,
 } from "./operations";
 
 const daytonaList = vi.fn();
+const daytonaGet = vi.fn();
 vi.mock("./client", () => ({
   getDaytonaClient: () => ({
     list: (...args: unknown[]) => daytonaList(...args),
+    get: (...args: unknown[]) => daytonaGet(...args),
   }),
 }));
 
@@ -147,5 +150,38 @@ describe("listDaytonaSandboxes", () => {
       (l) => l.providerSandboxId,
     );
     expect(ids).toEqual(["sb_1", "sb_2"]);
+  });
+});
+
+describe("streamDaytonaCommandLogs", () => {
+  it("gives every stream its own session, even within one millisecond", () => {
+    // Session ids are per-sandbox and the stream deletes its session when it
+    // ends, so two concurrent streams sharing an id would mean the first to
+    // finish reaps the other's still-running command. A timestamp-derived id
+    // collides at exactly the concurrency this has to survive.
+    const created: string[] = [];
+    daytonaGet.mockResolvedValue({
+      process: {
+        createSession: (id: string) => {
+          created.push(id);
+          return Promise.resolve();
+        },
+        executeSessionCommand: () => Promise.resolve({ cmdId: "cmd-1" }),
+        getSessionCommandLogs: () => Promise.resolve(),
+        deleteSession: () => Promise.resolve(),
+      },
+    });
+
+    const config = {} as DaytonaConfig;
+    const handlers = { onStdout: () => {}, onStderr: () => {} };
+    // Started in the same tick, so any clock-derived id would be identical.
+    return Promise.all([
+      streamDaytonaCommandLogs(config, "sbx-1", "echo a", handlers),
+      streamDaytonaCommandLogs(config, "sbx-1", "echo b", handlers),
+    ]).then(() => {
+      expect(created).toHaveLength(2);
+      expect(created[0]).not.toBe(created[1]);
+      expect(created[0]!.startsWith("stream-")).toBe(true);
+    });
   });
 });

--- a/js/sandbox/src/providers/daytona/internal/operations.ts
+++ b/js/sandbox/src/providers/daytona/internal/operations.ts
@@ -6,6 +6,7 @@
  * package drives.
  */
 import { Daytona, DaytonaError } from "@daytonaio/sdk";
+import { randomUUID } from "node:crypto";
 import pRetry from "p-retry";
 import {
   SANDBOX_DELETE_INTERVAL_KEEP_ON_STOP,
@@ -448,6 +449,10 @@ export async function executeDaytonaCommand(
  * Stream a command's output over a Daytona process session. The
  * WebSocket-based callback overload resolves when the command finishes and the
  * socket closes; the session is best-effort deleted afterwards.
+ *
+ * A session is needed here for the same reason the stdin path needs one:
+ * subscribing to a running command's logs requires its id, which only an async
+ * run hands back before the command finishes.
  */
 export async function streamDaytonaCommandLogs(
   config: DaytonaConfig,
@@ -457,7 +462,11 @@ export async function streamDaytonaCommandLogs(
 ): Promise<void> {
   const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
-  const sessionId = `agent-stream-${Date.now()}`;
+  // Random, not a timestamp: session ids are per-sandbox, and the teardown
+  // below deletes the session — so two streams against one sandbox in the same
+  // millisecond would share an id and the first to finish would reap the
+  // other's still-running command.
+  const sessionId = `stream-${randomUUID()}`;
   await sandbox.process.createSession(sessionId);
   try {
     const execResult = await sandbox.process.executeSessionCommand(sessionId, {


### PR DESCRIPTION
## Why

`streamDaytonaCommandLogs` named its session by millisecond timestamp:

```ts
const sessionId = `agent-stream-${Date.now()}`;
```

Session ids are per-sandbox, and the stream deletes its session in a `finally`
when it ends. So two streams against the same sandbox starting in the same
millisecond get the same id — and whichever finishes first reaps the other's
still-running command. That's the same ownership-reaping mechanism as #341, just
pointed at a sibling stream.

Not a security issue: predicting the id buys nothing without the Daytona API key,
and with that key you own the sandbox anyway. It's a collision hazard, and the
failure — a stream dying because an unrelated one finished — would be miserable
to debug.

## Change

```diff
- const sessionId = `agent-stream-${Date.now()}`;
+ const sessionId = `stream-${randomUUID()}`;
```

Matching how the stdin path in `commands.ts` names its own throwaway sessions
(`exec-${randomUUID()}`).

**The prefix changes too.** `agent-stream-` was named after
`POST /sandboxes/{id}/agent-stream`, the route this code was extracted from in
June — a route being removed in amika-mono #981. The surviving caller reaches
this through `/agent-sessions/stream`, so the old prefix names something that
won't exist. Naming it after the *operation* rather than any one caller keeps it
accurate as callers change, and pairs with `exec-` next door.

## Test

Two streams started in the same tick must get different session ids — the exact
concurrency a clock-derived id fails at. Verified it fails against the old
implementation before landing the fix.

`typecheck`, `lint`, `formatcheck`, 334 unit tests pass.
