### PR TITLE
Install gh to /usr/bin so the shim can wrap it

### DIFF
--- a/go/internal/sandbox/sandbox-image/steps/30-node-gh.sh
+++ b/go/internal/sandbox/sandbox-image/steps/30-node-gh.sh
@@ -26,8 +26,13 @@ curl -fsSL \
   "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${gh_archive}" \
   -o "$temporary_dir/$gh_archive"
 tar -xzf "$temporary_dir/$gh_archive" -C "$temporary_dir"
+# /usr/bin, not /usr/local/bin: the app_token gh shim installs itself at
+# /usr/local/bin/gh and resolves the real binary by scanning PATH for a gh
+# that is not itself. /usr/local/bin precedes /usr/bin in the standard PATH,
+# so the shim shadows this binary and still finds it. Installing here too
+# would leave the shim overwriting the binary it wraps.
 install -m 0755 \
   "$temporary_dir/gh_${GH_VERSION}_linux_${gh_arch}/bin/gh" \
-  /usr/local/bin/gh
+  /usr/bin/gh
 
 rm -rf /root/.cache

--- a/sandbox-image/steps/30-node-gh.sh
+++ b/sandbox-image/steps/30-node-gh.sh
@@ -26,8 +26,13 @@ curl -fsSL \
   "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${gh_archive}" \
   -o "$temporary_dir/$gh_archive"
 tar -xzf "$temporary_dir/$gh_archive" -C "$temporary_dir"
+# /usr/bin, not /usr/local/bin: the app_token gh shim installs itself at
+# /usr/local/bin/gh and resolves the real binary by scanning PATH for a gh
+# that is not itself. /usr/local/bin precedes /usr/bin in the standard PATH,
+# so the shim shadows this binary and still finds it. Installing here too
+# would leave the shim overwriting the binary it wraps.
 install -m 0755 \
   "$temporary_dir/gh_${GH_VERSION}_linux_${gh_arch}/bin/gh" \
-  /usr/local/bin/gh
+  /usr/bin/gh
 
 rm -rf /root/.cache


### PR DESCRIPTION
`gh` is broken in every `app_token` sandbox: each invocation exits 127 with
`gh shim: real gh binary not found on PATH`.

## Cause

The `app_token` gh shim (in `amika-mono`) installs itself at
`/usr/local/bin/gh` and resolves the real binary by scanning `PATH` for a `gh`
that is not itself. That worked because `gh` came from apt at `/usr/bin/gh`:
`/usr/local/bin` precedes `/usr/bin` in the standard PATH, so the shim shadowed
the real binary and the scan found it one directory later.

Extracting the shared image bundle switched `gh` to a pinned tarball installed
at `/usr/local/bin/gh`, collapsing both onto one path. The shim now overwrites
the binary it wraps, so the scan finds nothing and bails.

The two halves live in different repos, so neither change could see the other.

## Fix

Install the tarball to `/usr/bin` instead, restoring the original precedence.
The pinned release stays, so `GH_VERSION` remains enforceable by the
`installed-versions` check; returning to apt would give up that pin.

## Testing

- `sandbox-image/tests/run-tests.sh` passes (embedded mirror regenerated via `generate.py`)
- `shellcheck` clean

Not yet verified against a built image: `binary-target-location` asserts
resolved targets live under `/usr` or `/usr/local`, which `/usr/bin/gh` should
satisfy, but that only runs on a real build.

## Follow-up

The `api-base-snapshot-daytona-*` E2E cases surfaced this as a version
mismatch, but they boot the base snapshot *before* the shim is installed, so
they don't cover shim resolution. A case that creates an `app_token` sandbox
and runs `gh` would close that gap.