### PR TITLE
Assert the gh shim's install path stays free

### DIFF
--- a/go/internal/sandbox/sandbox-image/verify/checks/16-gh-shim-path-free.sh
+++ b/go/internal/sandbox/sandbox-image/verify/checks/16-gh-shim-path-free.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Verifies the app_token gh shim's install path is free and gh resolves behind it.
+# shellcheck disable=SC1091,SC2034
+CHECK_ID="gh-shim-path-free"
+CHECK_CONTEXTS="build"
+source "$(dirname "$0")/../lib/check.sh" "$@"
+
+# The gh shim (installed by the control plane for github_auth_mode=app_token)
+# lands at /usr/local/bin/gh and resolves the real binary by scanning PATH for a
+# gh that is not itself. It works because /usr/local/bin precedes /usr/bin on
+# the standard PATH: the shim shadows the real binary rather than replacing it.
+#
+# Installing gh at the shim's own path collapses the two, so the shim overwrites
+# what it wraps and every invocation exits 127. That regression shipped once and
+# reached production, so the invariant is asserted here at build time. Build
+# context only: this is a property of the image, and boot checks cost every
+# sandbox start.
+shim_path="/usr/local/bin/gh"
+expected="gh installed outside $shim_path, leaving it free for the shim"
+
+resolved="$(PATH="$(standard_path)" command -v gh 2>/dev/null || true)"
+[[ -n "$resolved" ]] || fail "$expected" "gh not found on the standard PATH"
+[[ ! -e "$shim_path" ]] || fail "$expected" \
+  "gh installed at $shim_path; the app_token shim would overwrite the binary it wraps"
+
+pass "$expected" "gh at $resolved"

--- a/sandbox-image/AGENTS.md
+++ b/sandbox-image/AGENTS.md
@@ -1,0 +1,43 @@
+# Sandbox image — agent guidance
+
+Source of truth for the `coder` and `coder-dind` images. Most of this
+directory is generated, so an edit here is only half the change.
+
+- **Never hand-edit generated files.** `generated/*.Dockerfile`,
+  `generated/bundle.json`, and everything under
+  `go/internal/sandbox/sandbox-image/` are generator output.
+- **Run the generator after any change** to `manifest.toml`, `versions.env`,
+  `steps/`, `assets/`, or `verify/`, then check it:
+
+  ```bash
+  python3 sandbox-image/generate.py
+  make test-sandbox-image
+  ```
+
+- **Commit the source change and every generated file together.** The
+  `go/internal/sandbox/sandbox-image/` mirror duplicates this bundle on
+  purpose, so `go install` needs no code-generation step. That duplication is
+  intentional; do not "clean it up".
+- `python3 sandbox-image/generate.py --check` verifies generated files are
+  current without writing them.
+
+## Verification checks
+
+`verify/checks/` is auto-discovered by `find` (executable `*.sh`, sorted), so a
+new check needs no registration. Each sets `CHECK_CONTEXTS`:
+
+- `build` — image properties, asserted once at build time.
+- `boot` — costs every sandbox start. Only for what cannot be checked earlier.
+
+Prefer `build`. A `build,boot` check pays its cost on every sandbox a customer
+starts.
+
+## Paths shared with the control plane
+
+Some paths in this image are claimed by `amika-mono` at provision time, so a
+change here can break something no diff in this repo shows. `/usr/local/bin/gh`
+is one: the `app_token` gh shim installs there and resolves the real `gh` by
+scanning `PATH` for one that is not itself, which works only while the image
+installs `gh` elsewhere (`16-gh-shim-path-free.sh` guards this).
+
+See `sandbox-image/README.md` for the full change workflow and local builds.

--- a/sandbox-image/CLAUDE.md
+++ b/sandbox-image/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/sandbox-image/verify/checks/16-gh-shim-path-free.sh
+++ b/sandbox-image/verify/checks/16-gh-shim-path-free.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Verifies the app_token gh shim's install path is free and gh resolves behind it.
+# shellcheck disable=SC1091,SC2034
+CHECK_ID="gh-shim-path-free"
+CHECK_CONTEXTS="build"
+source "$(dirname "$0")/../lib/check.sh" "$@"
+
+# The gh shim (installed by the control plane for github_auth_mode=app_token)
+# lands at /usr/local/bin/gh and resolves the real binary by scanning PATH for a
+# gh that is not itself. It works because /usr/local/bin precedes /usr/bin on
+# the standard PATH: the shim shadows the real binary rather than replacing it.
+#
+# Installing gh at the shim's own path collapses the two, so the shim overwrites
+# what it wraps and every invocation exits 127. That regression shipped once and
+# reached production, so the invariant is asserted here at build time. Build
+# context only: this is a property of the image, and boot checks cost every
+# sandbox start.
+shim_path="/usr/local/bin/gh"
+expected="gh installed outside $shim_path, leaving it free for the shim"
+
+resolved="$(PATH="$(standard_path)" command -v gh 2>/dev/null || true)"
+[[ -n "$resolved" ]] || fail "$expected" "gh not found on the standard PATH"
+[[ ! -e "$shim_path" ]] || fail "$expected" \
+  "gh installed at $shim_path; the app_token shim would overwrite the binary it wraps"
+
+pass "$expected" "gh at $resolved"


### PR DESCRIPTION
Follow-up to #346, which fixed the `gh` path collision. This adds the guard so
it cannot come back.

## What broke

The `app_token` gh shim installs at `/usr/local/bin/gh` and resolves the real
binary by scanning `PATH` for a `gh` that is not itself. That works because
`/usr/local/bin` precedes `/usr/bin`: the shim *shadows* the real binary rather
than replacing it.

Installing `gh` at that same path collapses the two. The shim overwrites what
it wraps, the scan finds nothing, and every invocation exits 127.

The two halves live in different repos, so neither diff could show the
collision. It surfaced only downstream, as a version mismatch in the
`api-base-snapshot-daytona-*` E2E cases.

## The check

`16-gh-shim-path-free.sh` asserts `gh` is installed and resolves somewhere
other than `/usr/local/bin/gh`, failing the image build if that path is
occupied.

`CHECK_CONTEXTS="build"` — build only. The invariant is a property of the
image, and boot checks cost every sandbox start.

## Testing

Exercised all three branches against fixture manifests:

| Scenario | Result |
|---|---|
| `gh` present, shim path free | `passed` |
| `gh` absent from PATH | `failed` |
| `gh` installed at the shim path (the regression) | `failed` |

`sandbox-image/tests/run-tests.sh` and `shellcheck` pass; embedded mirror
regenerated via `generate.py`.

## Why not an E2E test

An E2E case covering the shim's *runtime* resolution isn't possible today.
`app_token` requires a user principal, but the suite authenticates with an
API key, which resolves to a userless `api-key:*` identity and degrades to
`pat` (`mode.ts`, `bot-identity.ts` in amika-mono). Such a case would create a
`pat` sandbox with no shim installed, and would have passed green for the
entire window this bug was live.

Closing that gap needs user-principal auth in the E2E suite — worth doing, but
separate from this.