### PR TITLE
Allow selecting the E2E sandbox provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-contract: goenv
 
 test-e2e: goenv
 	go -C $(GO_DIR) test ./test/e2e/runner/...
-	AMIKA_RUN_E2E=1 go -C $(GO_DIR) test ./test/e2e -sandbox-provider $(E2E_SANDBOX_PROVIDER)
+	E2E_SANDBOX_PROVIDER=$(E2E_SANDBOX_PROVIDER) AMIKA_RUN_E2E=1 go -C $(GO_DIR) test ./test/e2e
 
 # Runs the offline E2E cases AND the api-*.yaml cases that hit the real
 # remote API (which may create billable resources). Requires credentials
@@ -70,7 +70,7 @@ test-e2e: goenv
 # with `make test-e2e-api E2E_API_TIMEOUT=1h` when adding more cases.
 test-e2e-api: goenv
 	go -C $(GO_DIR) test ./test/e2e/runner/...
-	AMIKA_RUN_E2E=1 AMIKA_RUN_E2E_API=1 go -C $(GO_DIR) test -timeout $(E2E_API_TIMEOUT) ./test/e2e -sandbox-provider $(E2E_SANDBOX_PROVIDER)
+	E2E_SANDBOX_PROVIDER=$(E2E_SANDBOX_PROVIDER) AMIKA_RUN_E2E=1 AMIKA_RUN_E2E_API=1 go -C $(GO_DIR) test -timeout $(E2E_API_TIMEOUT) ./test/e2e
 
 # Reclaims remote resources left behind by an E2E run that was killed before
 # its own cleanup could run (SIGKILL, a dead machine). Deliberately manual:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ test-integration: goenv
 test-contract: goenv
 	go -C $(GO_DIR) test ./test/contract/...
 
+# Set E2E_SANDBOX_PROVIDER=sailbox to select the provider used by
+# provider-generic cases. This target runs offline cases only; use
+# test-e2e-api to run the real provider-backed cases.
 test-e2e: goenv
 	go -C $(GO_DIR) test ./test/e2e/runner/...
 	E2E_SANDBOX_PROVIDER=$(E2E_SANDBOX_PROVIDER) AMIKA_RUN_E2E=1 go -C $(GO_DIR) test ./test/e2e

--- a/go/test/e2e/README.md
+++ b/go/test/e2e/README.md
@@ -16,7 +16,10 @@ make test-e2e
 make test-e2e-api E2E_SANDBOX_PROVIDER=sailbox
 
 # Or directly:
-AMIKA_RUN_E2E=1 go -C go test ./test/e2e -sandbox-provider daytona
+E2E_SANDBOX_PROVIDER=sailbox AMIKA_RUN_E2E=1 go -C go test ./test/e2e
+
+# The flag takes precedence over the environment variable:
+E2E_SANDBOX_PROVIDER=sailbox AMIKA_RUN_E2E=1 go -C go test ./test/e2e -sandbox-provider vercel
 
 # Unit tests for the runner itself (matcher, ledger, JSONPath, templating)
 # need no env var, no CLI build, no network, and no Docker:
@@ -132,8 +135,11 @@ the login user's shell. Write the script directly, as above.
 ### Variable substitution
 
 Two variables are predefined: `{{run_id}}`, a timestamp unique to the whole
-run, and `{{sandbox_provider}}`, the validated `-sandbox-provider` selection
-(`daytona` by default). A case that creates a **named** remote resource should
+run, and `{{sandbox_provider}}`, the validated `E2E_SANDBOX_PROVIDER`
+selection (`daytona` by default). The `-sandbox-provider` flag overrides the
+environment variable for a single invocation. Provider-generic remote creates
+must use `{{sandbox_provider}}`; a provider-specific case may instead name a
+supported literal `--provider`. A case that creates a **named** remote resource should
 build the name from the run ID (`--name e2e-ssh-key-{{run_id}}`). Names are
 frequently upserted rather than rejected, so a fixed name lets a case adopt,
 mutate, and then delete a resource the account already had, and lets two

--- a/go/test/e2e/e2e_test.go
+++ b/go/test/e2e/e2e_test.go
@@ -20,14 +20,21 @@ import (
 
 var sandboxProvider = flag.String(
 	"sandbox-provider",
-	"daytona",
-	"sandbox provider for remote API cases (daytona, freestyle, sailbox, or vercel)",
+	"",
+	"override E2E_SANDBOX_PROVIDER for remote API cases (daytona, freestyle, sailbox, or vercel)",
 )
 
 // runE2EEnv gates this test: it drives a real subprocess CLI and, per
 // case, may reach out over the network, so it does not run under a plain
 // `go test ./...`.
 const runE2EEnv = "AMIKA_RUN_E2E"
+
+// sandboxProviderEnv selects the provider used by provider-generic remote API
+// cases. The -sandbox-provider flag overrides it when a caller needs to
+// select a provider without changing its environment.
+const sandboxProviderEnv = "E2E_SANDBOX_PROVIDER"
+
+const defaultSandboxProvider = "daytona"
 
 // openAPIURLEnv overrides the OpenAPI document that expect.schema names are
 // validated against. It is a URL (or local path); when unset it defaults to
@@ -91,9 +98,11 @@ func TestE2ECaseFilesLoad(t *testing.T) {
 	}
 }
 
-// TestRemoteCreatesSelectTheSuiteProvider prevents a new real-API create step
-// from silently falling back to the deployment's default provider.
-func TestRemoteCreatesSelectTheSuiteProvider(t *testing.T) {
+// TestRemoteCreatesSelectAnExplicitProvider prevents a new real-API create
+// step from silently falling back to the deployment's default provider. Cases
+// may either follow the suite-wide provider selection or intentionally name a
+// supported provider for a provider-specific contract.
+func TestRemoteCreatesSelectAnExplicitProvider(t *testing.T) {
 	moduleRoot := testutil.FindModuleRoot(t)
 	caseFiles, err := runner.DiscoverCases(filepath.Join(moduleRoot, "test", "e2e", "cases"))
 	if err != nil {
@@ -111,8 +120,8 @@ func TestRemoteCreatesSelectTheSuiteProvider(t *testing.T) {
 			if !isRemoteSandboxCreate(step.Cmd) {
 				continue
 			}
-			if !hasArgPair(step.Cmd, "--provider", "{{sandbox_provider}}") {
-				t.Errorf("%s step %q: remote sandbox create must select {{sandbox_provider}}", filepath.Base(caseFile), step.Name)
+			if !selectsSandboxProvider(step.Cmd) {
+				t.Errorf("%s step %q: remote sandbox create must select {{sandbox_provider}} or a supported literal provider", filepath.Base(caseFile), step.Name)
 			}
 		}
 	}
@@ -160,7 +169,8 @@ func TestE2ECases(t *testing.T) {
 	if len(files) == 0 {
 		t.Fatalf("no case files found in %s", casesDir)
 	}
-	if err := runner.ValidateSandboxProvider(*sandboxProvider); err != nil {
+	suiteProvider, err := resolveSandboxProvider(*sandboxProvider, os.Getenv(sandboxProviderEnv))
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -244,7 +254,7 @@ func TestE2ECases(t *testing.T) {
 				// remote resource can make the name unique to this run.
 				RunID: runID,
 				// Every remote create command selects the same provider.
-				SandboxProvider: *sandboxProvider,
+				SandboxProvider: suiteProvider,
 				// Offline cases (not api-*) must never reach the real API,
 				// even on a host that exports AMIKA_API_KEY/AMIKA_API_URL
 				// ambiently (this dev environment does). Scrub those from the
@@ -296,11 +306,38 @@ func hasArg(args []string, want string) bool {
 	return false
 }
 
-func hasArgPair(args []string, first, second string) bool {
-	for i := 0; i+1 < len(args); i++ {
-		if args[i] == first && args[i+1] == second {
-			return true
+func resolveSandboxProvider(flagProvider, environmentProvider string) (string, error) {
+	provider := flagProvider
+	if provider == "" {
+		provider = environmentProvider
+	}
+	if provider == "" {
+		provider = defaultSandboxProvider
+	}
+	if err := runner.ValidateSandboxProvider(provider); err != nil {
+		return "", err
+	}
+	return provider, nil
+}
+
+func selectsSandboxProvider(args []string) bool {
+	provider, ok := lastProviderArgument(args)
+	if !ok {
+		return false
+	}
+	return provider == "{{sandbox_provider}}" || runner.ValidateSandboxProvider(provider) == nil
+}
+
+func lastProviderArgument(args []string) (string, bool) {
+	var provider string
+	found := false
+	for i, arg := range args {
+		switch {
+		case arg == "--provider" && i+1 < len(args):
+			provider, found = args[i+1], true
+		case strings.HasPrefix(arg, "--provider="):
+			provider, found = strings.TrimPrefix(arg, "--provider="), true
 		}
 	}
-	return false
+	return provider, found
 }

--- a/go/test/e2e/provider_selection_test.go
+++ b/go/test/e2e/provider_selection_test.go
@@ -1,0 +1,94 @@
+package e2e_test
+
+import "testing"
+
+func TestResolveSandboxProvider(t *testing.T) {
+	tests := []struct {
+		name         string
+		flagProvider string
+		envProvider  string
+		want         string
+		wantErr      bool
+	}{
+		{name: "defaults to daytona", want: "daytona"},
+		{name: "uses environment", envProvider: "sailbox", want: "sailbox"},
+		{
+			name:         "flag overrides environment",
+			flagProvider: "vercel",
+			envProvider:  "sailbox",
+			want:         "vercel",
+		},
+		{name: "rejects invalid environment", envProvider: "unknown", wantErr: true},
+		{
+			name:         "rejects invalid flag before environment",
+			flagProvider: "unknown",
+			envProvider:  "sailbox",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveSandboxProvider(tt.flagProvider, tt.envProvider)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("resolveSandboxProvider() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveSandboxProvider() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveSandboxProvider() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectsSandboxProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "uses suite provider template",
+			args: []string{"sandbox", "create", "--remote", "--provider", "{{sandbox_provider}}"},
+			want: true,
+		},
+		{
+			name: "uses literal provider",
+			args: []string{"sandbox", "create", "--remote", "--provider", "sailbox"},
+			want: true,
+		},
+		{
+			name: "uses equals form",
+			args: []string{"sandbox", "create", "--remote", "--provider=vercel"},
+			want: true,
+		},
+		{
+			name: "rejects missing provider",
+			args: []string{"sandbox", "create", "--remote"},
+			want: false,
+		},
+		{
+			name: "rejects unsupported provider",
+			args: []string{"sandbox", "create", "--remote", "--provider", "unknown"},
+			want: false,
+		},
+		{
+			name: "uses last provider flag",
+			args: []string{"sandbox", "create", "--remote", "--provider", "unknown", "--provider", "freestyle"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectsSandboxProvider(tt.args); got != tt.want {
+				t.Errorf("selectsSandboxProvider() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Select the provider for generic Go E2E cases with `E2E_SANDBOX_PROVIDER`, defaulting to Daytona.
- Keep provider-specific cases pinned to the provider they exercise and cover the selection behavior.
- Document the Make target configuration, including Sailbox API runs.

## Stack

1. #344 — `dylan/sailbox-provider-sdk`
2. This PR — `dylan/e2e-provider-env`