### PR TITLE
Sweep orphaned stderr captures before a snapshot

### DIFF
--- a/js/sandbox/src/providers/daytona/internal/commands.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  STDERR_CAPTURE_PREFIX,
   buildDaytonaCommand,
   buildDaytonaSessionCommand,
   buildStreamSplitCommand,
@@ -285,6 +286,39 @@ describe.skipIf(process.platform !== "linux")(
       expect(stdout).toBe("out\n");
       expect(stderr).toBe("err\n");
     }, 20_000);
+
+    it("names the capture file so the pre-snapshot sweep can find it", () => {
+      // The sweep globs on this prefix. A killed wrapper runs no trap, so the
+      // file survives with the command's stderr in it — and a snapshot taken
+      // afterwards would bake that in. `mktemp`'s default `tmp.XXXXXXXXXX`
+      // could only be swept by a `tmp.*` glob, which would take unrelated
+      // tools' temp files with it.
+      const dir = mkdtempSync(join(tmpdir(), "amika-prefix-"));
+      try {
+        // `sleep` holds the wrapper open; SIGKILL runs no trap, so whatever it
+        // created is still there to inspect.
+        const script = buildStreamSplitCommand(
+          buildDaytonaCommand("echo SENSITIVE >&2; sleep 30"),
+          "--M--",
+        );
+        const child = spawn("sh", { stdio: ["pipe", "ignore", "ignore"] });
+        child.stdin.end(`TMPDIR=${dir}\n${script}`);
+        // Give the wrapper time to reach its `mktemp` before killing it.
+        const deadline = Date.now() + 5000;
+        let names: string[] = [];
+        while (Date.now() < deadline) {
+          names = readdirSync(dir);
+          if (names.length > 0) break;
+          spawnSync("sleep", ["0.05"]);
+        }
+        child.kill("SIGKILL");
+
+        expect(names).toHaveLength(1);
+        expect(names[0]!.startsWith(STDERR_CAPTURE_PREFIX)).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
 
     it("leaves no capture file behind", () => {
       const dir = mkdtempSync(join(tmpdir(), "amika-split-"));

--- a/js/sandbox/src/providers/daytona/internal/commands.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.ts
@@ -154,6 +154,21 @@ async function executeOneShotCommand(
 }
 
 /**
+ * Filename prefix for the stderr capture files {@link buildStreamSplitCommand}
+ * creates, inside `$TMPDIR` (default `/tmp`).
+ *
+ * Named rather than left to `mktemp`'s generic `tmp.XXXXXXXXXX` so the residue
+ * is identifiable. A wrapper killed by an untrappable signal leaves its capture
+ * file behind, and that file holds the command's stderr — which can carry a
+ * secret, a tokenized clone URL being the obvious one. Removing it before a
+ * snapshot means matching it *without* matching every other tool's temp file,
+ * which a generic prefix makes impossible.
+ *
+ * @see removeStderrCaptureFiles
+ */
+export const STDERR_CAPTURE_PREFIX = "amika-exec-stderr.";
+
+/**
  * Wrap a command so its two streams survive a transport that carries only one.
  *
  * `command`'s stderr is captured to a temp file; once it has exited, the
@@ -178,7 +193,10 @@ export function buildStreamSplitCommand(
     // and hand the caller shell diagnostics that look like command output. A
     // full or read-only /tmp is enough to trigger it. Exiting here leaves no
     // marker, so `splitStreamsAtMarker` reports the failure text as stderr.
-    "__amika_err=$(mktemp) || exit 125",
+    // Templated rather than a bare `mktemp` so the file is identifiable as ours
+    // when a killed wrapper leaves it behind (see {@link STDERR_CAPTURE_PREFIX}).
+    // `$TMPDIR` is still honored, so the failure path below is unchanged.
+    `__amika_err=$(mktemp "\${TMPDIR:-/tmp}/${STDERR_CAPTURE_PREFIX}XXXXXXXXXX") || exit 125`,
     '[ -n "$__amika_err" ] || exit 125',
     // Everything from here writes stderr to the capture file, this script
     // included. Redirecting only the command would leave the wrapper's own

--- a/js/sandbox/src/providers/daytona/internal/stderr-captures.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/stderr-captures.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DaytonaConfig } from "../config";
+import { STDERR_CAPTURE_PREFIX } from "./commands";
+import { removeStderrCaptureFiles } from "./stderr-captures";
+
+const getSandbox = vi.fn();
+const execMock = vi.fn();
+
+vi.mock("./client", () => ({
+  getDaytonaClient: () => ({ get: (id: string) => getSandbox(id) }),
+}));
+
+vi.mock("./commands", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands")>();
+  return {
+    ...actual,
+    executeCommand: (...args: unknown[]) => execMock(...args),
+  };
+});
+
+const config: DaytonaConfig = {
+  apiKey: "key",
+  apiUrl: "https://daytona.example",
+  target: undefined,
+  organizationId: undefined,
+  useVm: false,
+};
+
+describe("removeStderrCaptureFiles", () => {
+  beforeEach(() => {
+    getSandbox.mockReset();
+    execMock.mockReset();
+    getSandbox.mockResolvedValue({ id: "sbx-1" });
+    execMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+  });
+
+  it("sweeps the capture files by their own prefix, not every temp file", async () => {
+    // A bare `mktemp` name would force a `tmp.*` glob here, which would delete
+    // unrelated tools' temp files mid-build. The prefix is what makes the sweep
+    // targetable at all.
+    await removeStderrCaptureFiles(config, "sbx-1");
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+    const command = execMock.mock.calls[0]![1] as string;
+    expect(command).toContain(`'${STDERR_CAPTURE_PREFIX}*'`);
+    expect(command).not.toContain("tmp.*");
+    // Bounded to the temp directory: an unanchored search would walk the
+    // sandbox filesystem before every snapshot.
+    expect(command).toContain('"${TMPDIR:-/tmp}"');
+    expect(command).toContain("-maxdepth 1");
+  });
+
+  it("keeps a diagnostic reachable when the sweep deletes its own capture file", async () => {
+    // The sweep's own stderr is being captured to a file the sweep itself
+    // matches, so `find`'s stderr is folded into stdout — otherwise a failure
+    // would report nothing at all.
+    await removeStderrCaptureFiles(config, "sbx-1");
+
+    expect(execMock.mock.calls[0]![1]).toContain("2>&1");
+  });
+
+  it("runs unprivileged, since the framing shell owns every capture file", async () => {
+    await removeStderrCaptureFiles(config, "sbx-1");
+
+    // `undefined` or no opts at all — either way, not `sudo: true`.
+    const opts = execMock.mock.calls[0]![2] as { sudo?: boolean } | undefined;
+    expect(opts?.sudo).toBeFalsy();
+  });
+
+  it("throws with the folded stdout diagnostic when the sweep fails", async () => {
+    execMock.mockResolvedValue({
+      exitCode: 1,
+      stdout: "find: /tmp: Permission denied\n",
+      stderr: "",
+    });
+
+    await expect(removeStderrCaptureFiles(config, "sbx-1")).rejects.toThrow(
+      /Permission denied/u,
+    );
+  });
+
+  it("resolves when there is nothing to remove", async () => {
+    await expect(
+      removeStderrCaptureFiles(config, "sbx-1"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// The generated command is only a string until a shell runs it. These execute it
+// against a real directory, so a glob or `find` predicate that doesn't do what
+// it reads as fails here.
+describe.skipIf(process.platform !== "linux")(
+  "removeStderrCaptureFiles (executed)",
+  () => {
+    beforeEach(() => {
+      getSandbox.mockReset();
+      execMock.mockReset();
+      getSandbox.mockResolvedValue({ id: "sbx-1" });
+      execMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    });
+
+    it("removes capture files and leaves every other temp file alone", async () => {
+      await removeStderrCaptureFiles(config, "sbx-1");
+      const command = execMock.mock.calls[0]![1] as string;
+
+      const dir = mkdtempSync(join(tmpdir(), "sweep-"));
+      try {
+        // Two of ours, plus the shapes that must survive: another tool's
+        // `mktemp` file, and an ordinary file.
+        writeFileSync(
+          join(dir, `${STDERR_CAPTURE_PREFIX}aaaaaaaaaa`),
+          "secret",
+        );
+        writeFileSync(
+          join(dir, `${STDERR_CAPTURE_PREFIX}bbbbbbbbbb`),
+          "secret",
+        );
+        writeFileSync(join(dir, "tmp.someOtherTool"), "keep me");
+        writeFileSync(join(dir, "important.log"), "keep me");
+
+        const r = spawnSync("bash", ["-c", command], {
+          encoding: "utf8",
+          env: { ...process.env, TMPDIR: dir },
+        });
+
+        expect(r.status).toBe(0);
+        expect(readdirSync(dir).sort()).toEqual([
+          "important.log",
+          "tmp.someOtherTool",
+        ]);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("succeeds when the temp directory holds no capture files", async () => {
+      await removeStderrCaptureFiles(config, "sbx-1");
+      const command = execMock.mock.calls[0]![1] as string;
+
+      const dir = mkdtempSync(join(tmpdir(), "sweep-empty-"));
+      try {
+        const r = spawnSync("bash", ["-c", command], {
+          encoding: "utf8",
+          env: { ...process.env, TMPDIR: dir },
+        });
+        // `-exec … +` runs nothing when nothing matches, so this must not be a
+        // non-zero "no such file" that the caller would report as a failure.
+        expect(r.status).toBe(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/js/sandbox/src/providers/daytona/internal/stderr-captures.ts
+++ b/js/sandbox/src/providers/daytona/internal/stderr-captures.ts
@@ -1,0 +1,66 @@
+/**
+ * Pre-snapshot removal of orphaned stderr capture files.
+ *
+ * Daytona's one-shot exec carries a single combined stream, so
+ * {@link buildStreamSplitCommand} rebuilds the two-stream contract by sending
+ * the command's stderr to a temp file and reading it back after the command
+ * exits. The wrapper removes that file in an `EXIT` trap, and traps `INT`,
+ * `TERM` and `HUP` on top — but a `SIGKILL`, an OOM kill, or the sandbox being
+ * force-stopped mid-command runs no trap at all, and the file stays.
+ *
+ * That file holds the command's stderr, which is not reliably non-sensitive: a
+ * failed `git clone https://x-access-token:<token>@github.com/...` prints the
+ * tokenized URL there, the same class of leak `scrubGitRemoteTokens` exists to
+ * clean out of `.git/config`. Snapshots capture the filesystem opaquely and are
+ * forkable, so residue left in `/tmp` is baked in and travels.
+ *
+ * The core scrub (`scrubTargetsViaExec`) cannot cover this: it removes exactly
+ * the paths the caller declares and never decides what is a secret, whereas this
+ * path pattern is an invariant of *this* provider's wrapper. So it lives here,
+ * wired as the Daytona `removeInjectedSecrets` primitive, which
+ * `snapshots.scrubAndCreate` runs after the core scrub and before `capture`.
+ */
+import { shellQuote } from "../../../util/shell";
+import { getDaytonaClient } from "./client";
+import type { DaytonaConfig } from "../config";
+import { STDERR_CAPTURE_PREFIX, executeCommand } from "./commands";
+
+/**
+ * Remove every stderr capture file left in the sandbox's temp directory.
+ *
+ * Deliberately *not* verified fail-closed, unlike the credential-path scrub.
+ * That scrub removes a known secret at a known path, so a survivor is a genuine
+ * failure. Here the target set is opportunistic residue, and every exec — this
+ * one included — creates a capture file of its own while it runs, so a check
+ * would be racing its own plumbing rather than detecting a leak. The in-flight
+ * file is unlinked by the sweep or by its own trap moments later, and either way
+ * it is gone before `capture` freezes the filesystem.
+ *
+ * `find`'s stderr is folded into stdout so a diagnostic survives the sweep
+ * deleting the very file this command's own stderr is being captured to;
+ * `execFailureText` falls back to stdout, so the exit-code check still reports
+ * something useful. Unprivileged: the capture file is created by the framing
+ * shell before any `sudo`, so one user owns all of them.
+ *
+ * Bounded to `$TMPDIR` as this exec sees it. A capture file written under a
+ * caller-supplied `TMPDIR` is not swept — no caller sets one today, and the
+ * alternative is searching the filesystem before every snapshot.
+ */
+export async function removeStderrCaptureFiles(
+  config: DaytonaConfig,
+  providerSandboxId: string,
+): Promise<void> {
+  const daytona = getDaytonaClient(config);
+  const sandbox = await daytona.get(providerSandboxId);
+  const result = await executeCommand(
+    sandbox,
+    `find "\${TMPDIR:-/tmp}" -maxdepth 1 -type f ` +
+      `-name ${shellQuote(`${STDERR_CAPTURE_PREFIX}*`)} ` +
+      `-exec rm -f -- {} + 2>&1`,
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to remove stderr capture files: ${result.stdout.trim() || result.stderr.trim()}`,
+    );
+  }
+}

--- a/js/sandbox/src/providers/daytona/provider.ts
+++ b/js/sandbox/src/providers/daytona/provider.ts
@@ -42,6 +42,7 @@ import {
   getDaytonaDockerRegistry,
   listDaytonaDockerRegistries,
 } from "./internal/docker-registry";
+import { removeStderrCaptureFiles } from "./internal/stderr-captures";
 
 // Provider-root re-exports of the server-side surface the registry wires up.
 // The implementations live in `internal/`; routing them through `provider.ts`
@@ -122,6 +123,11 @@ export default defineProvider(daytonaCapabilities, (config: DaytonaConfig) => ({
       return { providerSnapshotId: null };
     },
     isEnvScrubbable: (id) => isSandboxEnvScrubbable(config, id),
+    // Runs after the core credential scrub and before `capture`. Daytona's
+    // one-shot exec leaves a stderr capture file behind when its wrapper is
+    // killed untrappably, and that file can hold a secret, so it must not be
+    // frozen into a forkable snapshot.
+    removeInjectedSecrets: (id) => removeStderrCaptureFiles(config, id),
   },
 
   dockerRegistries: {


### PR DESCRIPTION
Follows up the security review of #341, now merged. Fixes the one genuinely new exposure that
change introduces; the framing defects found alongside it are tracked separately
in KAPRO-821.

## The leak

#341 moves ordinary commands onto Daytona's one-shot `process.executeCommand`,
which carries a **single combined** stream. To keep the two-stream contract, the
wrapper sends the command's stderr to a temp file and reads it back once the
command exits.

An `EXIT` trap removes that file, and `INT`/`TERM`/`HUP` are trapped on top. But
`SIGKILL`, an OOM kill, and the sandbox being force-stopped mid-command run **no
trap at all**, and the file stays — with the command's stderr in it. Reproduced
directly:

```
files left in TMPDIR after SIGKILL: [ 'tmp.eBNzYjjt6b' ]
  content: "SECRET_TOKEN_abc123\n"
```

Stderr is not reliably non-sensitive. A failed
`git clone https://x-access-token:<token>@github.com/...` prints the tokenized URL
there — the same class of leak `scrubGitRemoteTokens` already exists to clean out
of `.git/config`. Snapshots capture the filesystem opaquely and are forkable, so
residue under `/tmp` is baked in and travels.

**On the session path #341 replaced, this could not happen**: stderr arrived on
separate log callbacks and never touched the filesystem. #341 introduces
stderr-at-rest, and the core scrub cannot reach it — `ScrubTargets` is a
declarative list of caller-declared credential paths, and nothing sweeps a temp
directory.

## The change

**Name the capture file.** `mktemp` → `mktemp "${TMPDIR:-/tmp}/amika-exec-stderr.XXXXXXXXXX"`.

This is what makes a sweep possible at all. `mktemp`'s default is
`tmp.XXXXXXXXXX`, and the only glob that matches it is `tmp.*` — which would
delete unrelated tools' temp files mid-build. `$TMPDIR` is still honored, so the
existing bail-on-unwritable-temp path and the `cat --` flag guard are unchanged.

**Sweep the leftovers before a capture**, as Daytona's `removeInjectedSecrets` —
the hook `snapshots.scrubAndCreate` runs after the core scrub and immediately
before `capture`. It belongs at the provider layer, not in the shared scrub: that
module removes exactly the paths it is handed and never decides what is a secret,
whereas this path pattern is an invariant of *this* provider's wrapper.

## Why it is not verified fail-closed

The credential scrub verifies removal and fails closed, so the obvious question is
why this doesn't. That scrub removes a known secret at a known path, so a
survivor is a genuine failure. Here every exec — including the verifying one —
creates a capture file of its own while it runs, so a check would be racing its
own plumbing.

That isn't theoretical. Two `ls /tmp` calls through the adapter on a live sandbox,
around the sweep:

```
[before] amika-exec-stderr.0Zpa3c4iZm   <- the listing exec's own capture file
         amika-exec-stderr.orphan01     <- the orphan under test
         important.log
         tmp.someOtherTool

[after]  amika-exec-stderr.SSnC9gLefn   <- a different one, same reason
         important.log
         tmp.someOtherTool
```

A fail-closed check would have thrown on both listings. Each in-flight file is
unlinked by its own trap moments later, so nothing lingers into the capture.

The sweep folds `find`'s stderr into stdout, because the sweep deletes the very
file its own stderr is being captured to; `execFailureText` already prefers stdout
when stderr is empty, so the exit-code check still reports something useful. It
runs unprivileged — the capture file is created by the framing shell before any
`sudo`, so one user owns all of them.

## Verification

`typecheck`, `lint`, `formatcheck`, 359 unit tests.

Unit coverage executes the generated command against a real directory rather than
only asserting the string, and three mutations were confirmed to fail it: globbing
`*` instead of the prefix, dropping the `2>&1` fold, and reverting `mktemp` to
bare. A separate case SIGKILLs a real wrapper and asserts the file it leaves
behind carries the prefix.

Against a live Daytona sandbox (sandbox deleted, 0 leaked):

| Check                                          | Result |
| ---------------------------------------------- | ------ |
| Orphan holding a token removed                 | pass   |
| Unrelated `important.log` survived             | pass   |
| Decoy `tmp.someOtherTool` survived             | pass   |
| Token no longer findable anywhere under `/tmp` | pass   |
| Second sweep on a clean temp dir still succeeds | pass  |

## Known limits

- Bounded to `$TMPDIR` as the sweeping exec sees it. A capture file written under
  a caller-supplied `TMPDIR` is not swept; no caller sets one today, and the
  alternative is searching the filesystem before every snapshot.
- Only the Daytona provider is affected, because only its wrapper writes these
  files. Freestyle and Vercel need nothing.
- Does not address the framing defects from the same review — startup stderr
  landing in stdout, and a background child's stdout landing in stderr. Those
  share a root cause (framing bounded only at the end) and are KAPRO-821.
