### PR TITLE
Unlink the stderr capture instead of trapping its removal

### DIFF
--- a/js/sandbox/src/providers/daytona/internal/commands.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -159,14 +166,10 @@ describe("buildStreamSplitCommand", () => {
   });
 
   it("cleans up on a signal by exiting, not by falling through", () => {
-    // A POSIX trap handler resumes where the shell was, so a cleanup-only
-    // handler on INT/TERM/HUP would delete the capture file and then run on to
-    // `cat` it — replacing the command's real stderr with a `No such file`
-    // error and reporting its status for a wrapper that was told to stop.
+    // A POSIX trap handler resumes where the shell was, so a handler that fell
+    // through would report the command's own status for a wrapper that was told
+    // to stop.
     const script = buildStreamSplitCommand("true", "M");
-    // The buggy form was `… EXIT INT TERM HUP`, of which this is a prefix, so
-    // pin that EXIT stands alone.
-    expect(script).toContain("trap 'rm -f -- \"$__amika_err\"' EXIT\n");
     for (const [signal, code] of [
       ["INT", 130],
       ["TERM", 143],
@@ -183,11 +186,53 @@ describe("buildStreamSplitCommand", () => {
     expect(script).toContain("__amika_emit() { __amika_emitted=1;");
   });
 
+  it("unlinks the capture before running the command, and fails closed", () => {
+    // The security property: no path resolves to the captured stderr while the
+    // command runs, so an untrappable kill can leave nothing behind.
+    const script = buildStreamSplitCommand("true", "M");
+    expect(script).toContain('rm -f -- "$__amika_err" || exit 125');
+    expect(script.indexOf('rm -f -- "$__amika_err" || exit 125')).toBeLessThan(
+      script.indexOf("( true )"),
+    );
+    // Redirected while the name still resolves, since that is the only moment it
+    // can be opened at all.
+    expect(script.indexOf('exec 2>"$__amika_err"')).toBeLessThan(
+      script.indexOf('rm -f -- "$__amika_err" || exit 125'),
+    );
+    // Bash treats a failed redirection on a bare `exec` as non-fatal, so without
+    // this it would run the command and emit its marker with no usable capture,
+    // reporting a clean success carrying no stderr. Asserted structurally rather
+    // than executed: redirecting fd 2 onto a descriptor that already exists, over
+    // a file `mktemp` just created, has no reachable failure to drive from a test.
+    expect(script).toContain('exec 2>"$__amika_err" || exit 125');
+    // Nothing may read it by path afterwards — that is what the unlink breaks.
+    expect(script).not.toContain('cat -- "$__amika_err"');
+    expect(script).toContain("cat /proc/self/fd/2");
+    // No second descriptor: one would need a free high fd and would be inherited
+    // by every process the command leaves running.
+    expect(script).not.toContain("9<");
+  });
+
+  it("arms cleanup for the window where the capture still has a name", () => {
+    // dash and `sh` treat a redirection error on `exec` as fatal and kill the
+    // script before any `||` branch runs, so the guard alone cannot clean up.
+    // The trap has to be armed before that `exec` to cover it.
+    const script = buildStreamSplitCommand("true", "M");
+    expect(script).toContain(`trap 'rm -f -- "$__amika_err"' EXIT`);
+    expect(script.indexOf("trap 'rm -f")).toBeLessThan(
+      script.indexOf('exec 2>"$__amika_err"'),
+    );
+    // And it is armed only after there is something to remove.
+    expect(script.indexOf("__amika_err=$(mktemp)")).toBeLessThan(
+      script.indexOf("trap 'rm -f"),
+    );
+  });
+
   it("guards the capture path against being read as flags", () => {
     // `mktemp` honors TMPDIR, so a value starting with `-` would otherwise make
-    // `cat` parse the path as an option bundle.
+    // `rm` parse the path as an option bundle.
     expect(buildStreamSplitCommand("true", "M")).toContain(
-      'cat -- "$__amika_err"',
+      'rm -f -- "$__amika_err"',
     );
   });
 });
@@ -285,6 +330,162 @@ describe.skipIf(process.platform !== "linux")(
       expect(stdout).toBe("out\n");
       expect(stderr).toBe("err\n");
     }, 20_000);
+
+    it("leaves nothing on disk even when killed untrappably", async () => {
+      // The regression this guards. Cleanup used to be an `EXIT` trap, which a
+      // `SIGKILL` never runs, so the capture file survived with the command's
+      // stderr in it — and stderr carries secrets (a failed tokenized `git
+      // clone` prints its URL there). A snapshot taken afterwards bakes that in
+      // and is forkable. Unlinking up front means there is no name to leave.
+      const dir = mkdtempSync(join(tmpdir(), "amika-kill-"));
+      try {
+        const script = buildStreamSplitCommand(
+          buildDaytonaCommand("echo SECRET_TOKEN_abc123 >&2; sleep 10"),
+          "--M--",
+        );
+        // TMPDIR must reach `mktemp` as an *environment* variable: it is a child
+        // process, so an unexported shell assignment inside the script would be
+        // invisible to it and this test would watch an empty directory and pass
+        // no matter what the wrapper did.
+        const child = spawn("sh", {
+          stdio: ["pipe", "ignore", "ignore"],
+          env: { ...process.env, TMPDIR: dir },
+        });
+        child.stdin.end(script);
+        const exited = new Promise<void>((resolve) => {
+          child.on("close", () => resolve());
+        });
+        // Let the wrapper get past its `mktemp`/unlink and into the command.
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        // Unlinked while the command is still running, so nothing is visible
+        // even mid-flight — not merely cleaned up afterwards.
+        expect(readdirSync(dir)).toEqual([]);
+        child.kill("SIGKILL");
+        await exited;
+
+        expect(readdirSync(dir)).toEqual([]);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }, 20_000);
+
+    it("does not leak the capture handle to a process the command leaves running", async () => {
+      // This path exists to leave daemons running, so any descriptor the wrapper
+      // holds open is inherited and kept for the daemon's whole life — pinning the
+      // unlinked inode, its bytes unreclaimable. An earlier revision opened a
+      // second handle on fd 9 for reading the capture back, and redirecting was no
+      // defense against it: that replaces fd 1 and 2 and never touches fd 9, so
+      // even this well-behaved daemon held it. Reading via `/proc/self/fd/2`
+      // needs no such handle; this pins that none comes back.
+      const dir = mkdtempSync(join(tmpdir(), "amika-fd-"));
+      // Unique per run, so a concurrent job on the same machine can't be found
+      // instead of this test's own daemon.
+      const tag = `sleep 9${100000 + (process.pid % 100000)}`;
+      try {
+        const script = buildStreamSplitCommand(
+          // Redirects both its own streams, so any deleted-inode handle it holds
+          // came from the wrapper rather than from its own stderr.
+          buildDaytonaCommand(`nohup ${tag} >/dev/null 2>&1 &`),
+          "--M--",
+        );
+        spawnSync("sh", {
+          input: script,
+          encoding: "utf8",
+          env: { ...process.env, TMPDIR: dir },
+        });
+
+        // Find the daemon by its exact argv rather than a pattern match, so the
+        // asking process can't be mistaken for it. Polled rather than read once:
+        // the wrapper exits as soon as it has forked, so a single scan races the
+        // child becoming visible in /proc — which is exactly how this test first
+        // failed in CI while passing locally.
+        const findDaemon = (): string | undefined =>
+          readdirSync("/proc")
+            .filter((name) => /^\d+$/u.test(name))
+            .find((pid) => {
+              try {
+                const argv = readFileSync(`/proc/${pid}/cmdline`, "utf8");
+                return argv.replace(/\0/gu, " ").trim() === tag;
+              } catch {
+                return false;
+              }
+            });
+        let daemon = findDaemon();
+        const deadline = Date.now() + 10_000;
+        while (!daemon && Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          daemon = findDaemon();
+        }
+        expect(daemon).toBeDefined();
+
+        try {
+          const fds = readdirSync(`/proc/${daemon!}/fd`).map((fd) => {
+            try {
+              return readlinkSync(`/proc/${daemon!}/fd/${fd}`);
+            } catch {
+              return "";
+            }
+          });
+          expect(fds.filter((target) => target.includes("(deleted)"))).toEqual(
+            [],
+          );
+        } finally {
+          try {
+            process.kill(Number(daemon), "SIGKILL");
+          } catch {
+            // Already gone; nothing to clean up.
+          }
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }, 20_000);
+
+    it("leaves no capture behind under descriptor exhaustion, on any shell", () => {
+      // The invariant is residue, not a particular exit status: under a tight
+      // `RLIMIT_NOFILE` some shells complete normally, bash bails via the `||`
+      // guard, and dash and `sh` die on the `exec` before any branch can run.
+      // Whichever happens, nothing may be left with a name — that last case is
+      // why the cleanup is a trap and not only a `||` branch.
+      //
+      // Each shell is checked, because the failure is shell-specific and an
+      // earlier version of this test watched only bash. Three runs each, since a
+      // single leak is easy to miss but accumulation is not.
+      const shells = ["bash", "dash", "sh", "zsh"];
+      for (const shell of shells) {
+        if (spawnSync("sh", ["-c", `command -v ${shell}`]).status !== 0)
+          continue;
+        const dir = mkdtempSync(join(tmpdir(), "amika-nofile-"));
+        try {
+          // Script kept outside TMPDIR, so the assertion sees only residue.
+          const scriptPath = join(tmpdir(), `amika-wrapper-${process.pid}.sh`);
+          writeFileSync(
+            scriptPath,
+            buildStreamSplitCommand(
+              buildDaytonaCommand("echo OUT; echo IMPORTANT_STDERR >&2"),
+              "--M--",
+            ),
+          );
+          try {
+            for (let run = 0; run < 3; run += 1) {
+              spawnSync(
+                "sh",
+                ["-c", `ulimit -n 9; exec ${shell} "$1"`, "_", scriptPath],
+                { encoding: "utf8", env: { ...process.env, TMPDIR: dir } },
+              );
+            }
+            expect({ shell, residue: readdirSync(dir) }).toEqual({
+              shell,
+              residue: [],
+            });
+          } finally {
+            rmSync(scriptPath, { force: true });
+          }
+        } finally {
+          rmSync(dir, { recursive: true, force: true });
+        }
+      }
+    });
 
     it("leaves no capture file behind", () => {
       const dir = mkdtempSync(join(tmpdir(), "amika-split-"));

--- a/js/sandbox/src/providers/daytona/internal/commands.ts
+++ b/js/sandbox/src/providers/daytona/internal/commands.ts
@@ -163,6 +163,9 @@ async function executeOneShotCommand(
  * `marker` must be unique per command, so that no legitimate output can
  * contain it and split at the wrong place.
  *
+ * That capture file is unlinked as soon as it exists and is read back through a
+ * surviving descriptor, so stderr is never reachable on disk under any name.
+ *
  * `command` arrives from {@link buildDaytonaCommand} as a single `bash -c '…'`
  * word, so nothing in it can interact with this script's syntax. Exported for
  * unit testing.
@@ -180,23 +183,58 @@ export function buildStreamSplitCommand(
     // marker, so `splitStreamsAtMarker` reports the failure text as stderr.
     "__amika_err=$(mktemp) || exit 125",
     '[ -n "$__amika_err" ] || exit 125',
+    // Cleanup for the one window where the capture has a name: between `mktemp`
+    // and the `rm` two lines below. A redirection error on `exec` — a special
+    // built-in — is fatal to a non-interactive shell in dash and `sh`, which kill
+    // the script before any `||` branch can run, so that branch alone cannot
+    // clean up and this trap is what does. After the `rm` it is a no-op on a path
+    // that no longer exists, which is why an untrappable kill past that point
+    // still leaves nothing: there is no file, not merely no handler.
+    `trap 'rm -f -- "$__amika_err"' EXIT`,
     // Everything from here writes stderr to the capture file, this script
     // included. Redirecting only the command would leave the wrapper's own
     // diagnostics — a `Terminated` on a group kill, an OOM notice — in the
     // response *ahead* of the marker, i.e. reported as stdout, which is the
     // one thing `ExecResult.stdout` promises never to carry.
-    'exec 2>"$__amika_err"',
-    // Covers the normal exit as well as a killed wrapper, which a trailing
-    // `rm` would miss — the file holds captured stderr.
-    "trap 'rm -f -- \"$__amika_err\"' EXIT",
+    //
+    // Guarded because bash, unlike dash, treats a failed redirection on a bare
+    // `exec` as non-fatal and carries on. Unguarded there, it would run the
+    // command and print its marker with no usable capture, reporting a clean
+    // success carrying no stderr at all — the silently-wrong answer this framing
+    // exists to prevent.
+    //
+    // Only fd 2 is redirected, and only onto a descriptor that already exists.
+    // An earlier revision also opened a second descriptor to read the capture
+    // back; that needed a free high fd, so `RLIMIT_NOFILE` below 10 broke it, and
+    // it was inherited by every process the command left running — pinning the
+    // unlinked inode for a daemon's whole life even when the daemon redirected
+    // its own streams, since that replaces fd 1 and 2 and never touches fd 9.
+    // Reading through `/proc/self/fd/2` needs no second descriptor and so has
+    // neither problem.
+    'exec 2>"$__amika_err" || exit 125',
+    // Unlink the name immediately. From here the capture exists only as an open
+    // inode: writes still land through fd 2, and it still reads back through
+    // `/proc/self/fd/2`, but no path resolves to it.
+    //
+    // Cleanup used to be an `EXIT` trap, which a `SIGKILL`, an OOM kill, or a
+    // sandbox force-stopped mid-command never runs — leaving the file on disk
+    // with the command's stderr in it. Stderr is not reliably non-sensitive: a
+    // failed `git clone https://x-access-token:<token>@…` prints the tokenized
+    // URL there. Snapshots capture the filesystem opaquely and are forkable, so
+    // that residue would be baked in and travel. Unlinking up front removes the
+    // window rather than cleaning up after it — there is no name to leak, and
+    // the kernel frees the inode when the process dies however it dies.
+    //
+    // Fails closed: proceeding with a still-named capture file would reinstate
+    // exactly the exposure this prevents. `--` so a `TMPDIR` beginning with `-`
+    // can't make the path read as flags.
+    'rm -f -- "$__amika_err" || exit 125',
     // Emit whatever the command produced, then leave with the signal's
     // conventional status. A POSIX trap handler resumes where the shell was
-    // rather than exiting, so a cleanup-only handler would delete the capture
-    // file and let the script run on to `cat` it — losing the real stderr and
-    // reporting the command's own status for a wrapper told to stop. Exiting
-    // without emitting first is no better: the response would carry no marker,
-    // and the whole of stdout would be reported as failure text. Exiting here
-    // still runs the EXIT trap, so cleanup happens exactly once.
+    // rather than exiting, so a handler that fell through would report the
+    // command's own status for a wrapper that was told to stop. Exiting without
+    // emitting first is no better: the response would carry no marker, and the
+    // whole of stdout would be reported as failure text.
     // `__amika_emitted` keeps a signal that lands *during* the normal emit
     // below from emitting a second time: two markers in one response would
     // leave the split reporting the captured stderr twice with a raw marker
@@ -205,14 +243,17 @@ export function buildStreamSplitCommand(
     // an inherited `__amika_emitted` would otherwise suppress the bail emit.
     "__amika_emitted=",
     `__amika_bail() { if [ -z "$__amika_emitted" ]; then __amika_emit; fi; exit "$1"; }`,
-    `__amika_emit() { __amika_emitted=1; printf '%s' ${shellQuote(marker)}; cat -- "$__amika_err"; }`,
+    // Reads the capture through the kernel's own handle on fd 2 rather than by
+    // path, since the path is already gone. A fresh open, so it starts at offset
+    // 0 regardless of how much stderr has been written. `self` is `cat`, whose
+    // fd 2 it inherited from this shell, so it reopens the same inode; the
+    // command ran in a subshell, so nothing it did to its own copy applies here.
+    `__amika_emit() { __amika_emitted=1; printf '%s' ${shellQuote(marker)}; cat /proc/self/fd/2; }`,
     "trap '__amika_bail 130' INT",
     "trap '__amika_bail 143' TERM",
     "trap '__amika_bail 129' HUP",
     `( ${command} )`,
     "__amika_rc=$?",
-    // `--` inside `__amika_emit` so a TMPDIR beginning with `-` can't make the
-    // capture path read as flags.
     "__amika_emit",
     `exit "$__amika_rc"`,
   ].join("\n");


### PR DESCRIPTION
Replaces #349, which fixed the same leak by sweeping the residue before a
snapshot. This removes the residue instead, so there is nothing to sweep.

Follows up the security review of #341.

## The leak

#341 moved ordinary commands onto Daytona's one-shot `process.executeCommand`,
which carries a **single combined** stream. To keep the two-stream contract, the
wrapper sends the command's stderr to a temp file and reads it back once the
command exits.

Removing that file was an `EXIT` trap. `SIGKILL`, an OOM kill, and a sandbox
force-stopped mid-command run **no trap at all**, so the file stayed — with the
command's stderr in it:

```
files left in TMPDIR after SIGKILL: [ 'tmp.eBNzYjjt6b' ]
  content: "SECRET_TOKEN_abc123\n"
```

Stderr is not reliably non-sensitive. A failed
`git clone https://x-access-token:<token>@github.com/...` prints the tokenized URL
there — the same class of leak `scrubGitRemoteTokens` already exists to clean out
of `.git/config`. Snapshots capture the filesystem opaquely and are forkable, so
residue under `/tmp` is baked in and travels.

On the session path #341 replaced this could not happen: stderr arrived on
separate log callbacks and never touched the filesystem.

## The change

Keep a read handle on the capture, then unlink its name immediately:

```sh
__amika_err=$(mktemp) || exit 125
trap 'rm -f -- "$__amika_err"' EXIT        # covers only the window below
exec 2>"$__amika_err" || exit 125          # writes land here
rm -f -- "$__amika_err" || exit 125        # no path resolves to it from here
( command )
… printf marker; cat /proc/self/fd/2       # read the unlinked inode back
```

From the unlink on, the capture exists only as an open inode. The kernel frees it
when the process dies, however it dies, so there is no window in which an
untrappable kill can leave a named file behind. The `EXIT` trap goes away with it;
`INT`/`TERM`/`HUP` stay, since those emit the streams before exiting rather than
clean up.

Three details worth a look, all three shaped by review:

- **Fails closed** if the unlink doesn't take. Proceeding with the name in place
  would reinstate exactly the exposure this prevents.
- **`--` moves from the `cat` to the `rm`**, still guarding a `TMPDIR` beginning
  with `-` from being read as flags.
- **No second descriptor.** An earlier revision kept the read handle on fd 9. That
  needed a free high fd, so `RLIMIT_NOFILE` below 10 broke it — and worse, it was
  inherited by every process the command left running. Since this path exists to
  leave daemons running, a daemon pinned the unlinked inode for its whole life
  *even after redirecting its own streams*, because that replaces fd 1 and 2 and
  never touches fd 9 (`/proc/<pid>/fd/9` still pointed at the deleted capture).
  `/proc/self/fd/2` reopens the same inode with no handle to leak.
- **A trap covers the naming window, and only that.** Between `mktemp` and the
  `rm` the file briefly has a name. A redirection error on `exec` — a special
  built-in — is fatal to a non-interactive shell in `dash` and `sh`, which die
  before any `||` branch can run, so a guard alone cannot clean up there. After
  the `rm` the trap is a no-op on a path that no longer exists, which is why a
  kill past that point still leaves nothing: there is no file, not merely no
  handler.
- **The redirection fails closed.** Bash treats that same failure as non-fatal and
  carries on, and would otherwise run the command and emit its marker with no
  usable capture — a clean success carrying no stderr. Pinned structurally rather
  than executed: redirecting fd 2 onto a descriptor that already exists, over a
  file `mktemp` just created, leaves no reachable failure to drive from a test.

## Why not scrub it, as #349 did

#349 named the capture file and swept the leftovers in Daytona's
`removeInjectedSecrets`. That worked, but it put a "this is sensitive" decision
inside core, which `snapshot-scrub.ts` reserves for the provisioning layer — core
"removes exactly the paths it is handed and never decides which files/env vars are
Amika secrets."

The properly-layered version of that fix would follow `EXEC_INPUT_STAGING_ROOT`:
core exports the path, `computeSnapshotScrubTargets` declares it. But that route
has a real obstacle — `files` entries are verified fail-closed with `ls -1d`, and
*every* exec creates a stderr capture, including the verifying one, so the check
would trip on its own plumbing and abort every `scrubAndCreate`. Making it work
needs a new `ScrubTargets` field with emptiness-rather-than-absence semantics,
across two repos, for residue that only exists after an untrappable kill.

Unlinking up front makes all of that unnecessary: no path constant to publish, no
provisioning change, no new field, and no policy decision in core.

## Verification

`typecheck`, `lint`, `formatcheck`, 356 unit tests.

New unit cases, each confirmed to fail with its own fix reverted: a real wrapper
SIGKILLed with the temp directory asserted empty both *during* the run and after
the kill; a daemon's `/proc/<pid>/fd` checked for any descriptor pinning a deleted
inode; and the wrapper run three times under `ulimit -n 9` **on each of `bash`,
`dash`, `sh` and `zsh`**, asserting zero residue whatever exit status the shell
chooses. That last one is per-shell because the failure is shell-specific and an
earlier version of the test watched only bash — which hid that `dash` and `sh` die
before any `||` branch can run.

Generated script executed under every shell that could run it:

| Shell  | Happy path                                  | Under `ulimit -n 9` (×3 runs) |
| ------ | ------------------------------------------- | ----------------------------- |
| `sh`   | `exit 7` propagates, split, 0 files left    | 0 files left                  |
| `bash` | `exit 7` propagates, split, 0 files left    | 0 files left                  |
| `dash` | `exit 7` propagates, split, 0 files left    | 0 files left                  |
| `zsh`  | `exit 7` propagates, split, 0 files left    | 0 files left                  |

Against a live Daytona sandbox (deleted, 0 leaked). The platform's own command
timeout supplies a genuine untrappable kill, which is the case that matters:

| Check                                                | Result |
| ---------------------------------------------------- | ------ |
| Streams still split correctly                        | pass   |
| Exit status still propagates (`exit 42`)             | pass   |
| `sudo` resolve-host warning stays out of stdout      | pass   |
| No capture file visible even mid-exec                | pass   |
| Wrapper killed untrappably by the platform at ~5s    | pass   |
| Nothing left in `/tmp` after that kill               | pass   |
| The secret its stderr carried is not findable on disk | pass  |
| Daemon inherits no descriptor pinning the unlinked capture | pass |
| Backgrounded daemon still survives the one-shot path  | pass   |
| `cwd` and `env` reach the command                    | pass   |

## Not addressed

A command's own stderr descriptor (fd 2) is still inherited by a background child
that does not redirect, so such a child writes into the unlinked inode and holds
its space until it exits. That is inherent — fd 2 *is* the capture — and it is unchanged from before this PR. It belongs to the
wider framing issue: output written outside the command's synchronous window is
misattributed, because the framing is bounded only at the end. Tracked separately.

