### PR TITLE
Install less in the base sandbox image

### DIFF
--- a/go/internal/sandbox/sandbox-image/steps/10-os-packages.sh
+++ b/go/internal/sandbox/sandbox-image/steps/10-os-packages.sh
@@ -18,6 +18,7 @@ apt-get install -y --no-install-recommends \
   gnupg \
   gettext \
   iproute2 \
+  less \
   libcurl4-openssl-dev \
   libexpat1-dev \
   libssl-dev \

--- a/sandbox-image/steps/10-os-packages.sh
+++ b/sandbox-image/steps/10-os-packages.sh
@@ -18,6 +18,7 @@ apt-get install -y --no-install-recommends \
   gnupg \
   gettext \
   iproute2 \
+  less \
   libcurl4-openssl-dev \
   libexpat1-dev \
   libssl-dev \


### PR DESCRIPTION
## Summary

KAPRO-833: the default base snapshots ship without `less`.

`less` is the default pager for `git` and `gh`, and `steps/10-os-packages.sh`
installs with `--no-install-recommends`, so git's recommends entry never pulls
it in and nothing else in the image installs it. Every sandbox started from a
default base snapshot (`coder`, `coder-dind`, on any provider) therefore greets
an interactive `git log`, `git diff`, or `git show` with

```
error: cannot run less: No such file or directory
```

before falling back to unpaged output.

This adds `less` to the `os-packages` step and regenerates the bundle. The
generated mirror under `go/internal/sandbox/sandbox-image/` is committed
alongside the source change, per `sandbox-image/CLAUDE.md`.

## Test plan

```
python3 sandbox-image/generate.py --check   # generated files current
make test-sandbox-image                     # bundle consistency + verify harness + shellcheck
```

Both pass. No new verification check: `less` is an OS package like `vim`,
`nano`, and `tmux`, none of which are declared in `presets.*.binaries` (that
list covers the toolchain and agent CLIs, and is asserted in the `boot` context
on every sandbox start).

## Follow-up

Not in this PR, and blocked on it merging:

1. Publish new base snapshots per `amika-mono`'s
   `devdocs/sandbox-image-releases.md`.
2. Bump the `repos/amika` pointer in `amika-mono` and repoint the pinned
   snapshot names with `bin/update-base-snapshots <short-sha>`.