### PR TITLE
Harden E2B lifecycle, snapshots, and billing

### DIFF
--- a/js/sandbox/src/providers/e2b/internal/client.ts
+++ b/js/sandbox/src/providers/e2b/internal/client.ts
@@ -1,9 +1,32 @@
-import { Sandbox } from "e2b";
+import { ApiClient, ConnectionConfig, Sandbox } from "e2b";
 import type { E2bConfig } from "../config";
 
 /** Options shared by E2B's static sandbox API calls. */
-export function e2bApiOptions(config: E2bConfig): { apiKey: string } {
-  return { apiKey: config.apiKey };
+export function e2bApiOptions(config: E2bConfig): {
+  apiKey: string;
+  apiUrl?: string;
+} {
+  return {
+    apiKey: config.apiKey,
+    ...(config.apiUrl ? { apiUrl: config.apiUrl } : {}),
+  };
+}
+
+/** Read provisioned disk capacity omitted by E2B's public SDK mapper. */
+export async function getE2bSandboxDiskSizeMib(
+  config: E2bConfig,
+  providerSandboxId: string,
+): Promise<number> {
+  const client = new ApiClient(new ConnectionConfig(e2bApiOptions(config)));
+  const response = await client.api.GET("/sandboxes/{sandboxID}", {
+    params: { path: { sandboxID: providerSandboxId } },
+  });
+  if (response.error || !response.data) {
+    throw new Error(
+      `Unable to determine E2B disk capacity for ${providerSandboxId}`,
+    );
+  }
+  return response.data.diskSizeMB;
 }
 
 /** Connect to a sandbox, resuming it when it is paused. */

--- a/js/sandbox/src/providers/e2b/internal/operations.test.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.test.ts
@@ -187,7 +187,7 @@ describe("E2B services and listing", () => {
     expect(sdk.connect).not.toHaveBeenCalled();
   });
 
-  it("paginates listings and omits sandboxes without usable disk metrics", async () => {
+  it("paginates listings without dropping sandboxes missing disk metrics", async () => {
     const pages = [
       [
         {
@@ -222,6 +222,12 @@ describe("E2B services and listing", () => {
         orgId: "org_1",
         state: "running",
         sizing: { vcpus: 2, memoryGib: 8, diskGib: 10 },
+      },
+      {
+        providerSandboxId: "sbx_new",
+        orgId: null,
+        state: "paused",
+        sizing: { vcpus: 1, memoryGib: 1, diskGib: 0 },
       },
     ]);
   });

--- a/js/sandbox/src/providers/e2b/internal/operations.test.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.test.ts
@@ -84,7 +84,7 @@ describe("E2B lifecycle operations", () => {
     expect(sdk.create).not.toHaveBeenCalled();
   });
 
-  it("resumes, pauses with memory, and kills the same sandbox id", async () => {
+  it("resumes, pauses with only filesystem state, and kills the sandbox", async () => {
     const run = vi.fn().mockResolvedValue({});
     sdk.connect.mockResolvedValue({ commands: { run } });
     await startE2bSandbox(CONFIG, "sbx_1", 10);
@@ -100,7 +100,7 @@ describe("E2B lifecycle operations", () => {
     });
     expect(sdk.pause).toHaveBeenCalledWith("sbx_1", {
       apiKey: "e2b_test",
-      keepMemory: true,
+      keepMemory: false,
     });
     expect(sdk.kill).toHaveBeenCalledWith("sbx_1", {
       apiKey: "e2b_test",

--- a/js/sandbox/src/providers/e2b/internal/operations.test.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.test.ts
@@ -8,13 +8,18 @@ const { sdk, FakeSandboxNotFoundError } = vi.hoisted(() => ({
     kill: vi.fn(),
     getInfo: vi.fn(),
     getMetrics: vi.fn(),
+    getSandboxDetail: vi.fn(),
     list: vi.fn(),
   },
   FakeSandboxNotFoundError: class SandboxNotFoundError extends Error {},
 }));
 
 vi.mock("e2b", () => ({
+  ApiClient: class ApiClient {
+    api = { GET: sdk.getSandboxDetail };
+  },
   Sandbox: sdk,
+  ConnectionConfig: class ConnectionConfig {},
   CommandExitError: class CommandExitError extends Error {},
   FileNotFoundError: class FileNotFoundError extends Error {},
   SandboxNotFoundError: FakeSandboxNotFoundError,
@@ -215,6 +220,9 @@ describe("E2B services and listing", () => {
     sdk.getMetrics.mockImplementation(async (id: string) =>
       id === "sbx_1" ? [{ diskTotal: 10 * 1024 ** 3 }] : [],
     );
+    sdk.getSandboxDetail.mockResolvedValue({
+      data: { diskSizeMB: 20 * 1024 },
+    });
 
     await expect(listE2bSandboxes(CONFIG)).resolves.toEqual([
       {
@@ -227,8 +235,12 @@ describe("E2B services and listing", () => {
         providerSandboxId: "sbx_new",
         orgId: null,
         state: "paused",
-        sizing: { vcpus: 1, memoryGib: 1, diskGib: 0 },
+        sizing: { vcpus: 1, memoryGib: 1, diskGib: 20 },
       },
     ]);
+    expect(sdk.getSandboxDetail).toHaveBeenCalledWith(
+      "/sandboxes/{sandboxID}",
+      { params: { path: { sandboxID: "sbx_new" } } },
+    );
   });
 });

--- a/js/sandbox/src/providers/e2b/internal/operations.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.ts
@@ -21,7 +21,11 @@ import type {
 import type { SandboxAdapter } from "../../shared/adapter";
 import type { E2bConfig } from "../config";
 import { E2bAdapter } from "./adapter";
-import { connectE2bSandbox, e2bApiOptions } from "./client";
+import {
+  connectE2bSandbox,
+  e2bApiOptions,
+  getE2bSandboxDiskSizeMib,
+} from "./client";
 
 export const E2B_URL_TTL_S = 24 * 60 * 60;
 export const E2B_MAX_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
@@ -319,6 +323,10 @@ export async function listE2bSandboxes(
         apiOptions,
       ).catch(() => []);
       const latest = metrics.at(-1);
+      const diskGib =
+        latest && latest.diskTotal > 0
+          ? latest.diskTotal / 1024 ** 3
+          : (await getE2bSandboxDiskSizeMib(config, info.sandboxId)) / 1024;
       listings.push({
         providerSandboxId: info.sandboxId,
         orgId: info.metadata[SANDBOX_ORG_ID_LABEL] ?? null,
@@ -326,8 +334,7 @@ export async function listE2bSandboxes(
         sizing: {
           vcpus: info.cpuCount,
           memoryGib: info.memoryMB / 1024,
-          diskGib:
-            latest && latest.diskTotal > 0 ? latest.diskTotal / 1024 ** 3 : 0,
+          diskGib,
         },
       });
     }

--- a/js/sandbox/src/providers/e2b/internal/operations.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.ts
@@ -314,9 +314,11 @@ export async function listE2bSandboxes(
   while (paginator.hasNext) {
     const page = await paginator.nextItems();
     for (const info of page) {
-      const metrics = await Sandbox.getMetrics(info.sandboxId, apiOptions);
+      const metrics = await Sandbox.getMetrics(
+        info.sandboxId,
+        apiOptions,
+      ).catch(() => []);
       const latest = metrics.at(-1);
-      if (!latest || latest.diskTotal <= 0) continue;
       listings.push({
         providerSandboxId: info.sandboxId,
         orgId: info.metadata[SANDBOX_ORG_ID_LABEL] ?? null,
@@ -324,7 +326,8 @@ export async function listE2bSandboxes(
         sizing: {
           vcpus: info.cpuCount,
           memoryGib: info.memoryMB / 1024,
-          diskGib: latest.diskTotal / 1024 ** 3,
+          diskGib:
+            latest && latest.diskTotal > 0 ? latest.diskTotal / 1024 ** 3 : 0,
         },
       });
     }

--- a/js/sandbox/src/providers/e2b/internal/operations.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.ts
@@ -90,7 +90,7 @@ export async function stopE2bSandbox(
 ): Promise<void> {
   await Sandbox.pause(providerSandboxId, {
     ...e2bApiOptions(config),
-    keepMemory: true,
+    keepMemory: false,
   });
 }
 

--- a/js/sandbox/src/providers/e2b/internal/snapshot-operations.test.ts
+++ b/js/sandbox/src/providers/e2b/internal/snapshot-operations.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({
+  createSnapshot: vi.fn(),
+  listSnapshots: vi.fn(),
+}));
+
+vi.mock("e2b", () => ({ Sandbox: sdk }));
+
+import {
+  captureE2bSnapshot,
+  getE2bSnapshotByName,
+} from "./snapshot-operations";
+
+const CONFIG = { apiKey: "e2b_test" };
+const LOGICAL_NAME = "org_123/sandbox/repo.snapshot";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("E2B snapshot names", () => {
+  it("captures canonical Amika names through a deterministic E2B-safe alias", async () => {
+    sdk.createSnapshot.mockResolvedValue({ snapshotId: "snap_1" });
+
+    await expect(
+      captureE2bSnapshot(CONFIG, "sbx_1", LOGICAL_NAME),
+    ).resolves.toEqual({ providerSnapshotId: "snap_1" });
+
+    const opts = sdk.createSnapshot.mock.calls[0]![1];
+    expect(opts).toMatchObject({ apiKey: "e2b_test" });
+    expect(opts.name).toMatch(/^[a-z0-9_-]+$/);
+    expect(opts.name).not.toContain("/");
+    expect(opts.name.length).toBeLessThanOrEqual(63);
+  });
+
+  it("matches the E2B-safe alias inside a team-namespaced response", async () => {
+    sdk.listSnapshots.mockImplementation((opts: { name: string }) => {
+      const pages = [
+        [
+          {
+            snapshotId: "snap_1",
+            names: [`team-slug/${opts.name}:default`],
+          },
+        ],
+      ];
+      return {
+        get hasNext() {
+          return pages.length > 0;
+        },
+        nextItems: async () => pages.shift(),
+      };
+    });
+
+    await expect(getE2bSnapshotByName(CONFIG, LOGICAL_NAME)).resolves.toEqual({
+      name: LOGICAL_NAME,
+      providerSnapshotId: "snap_1",
+      state: "active",
+    });
+    expect(sdk.listSnapshots.mock.calls[0]![0].name).toMatch(/^[a-z0-9_-]+$/);
+  });
+});

--- a/js/sandbox/src/providers/e2b/internal/snapshot-operations.ts
+++ b/js/sandbox/src/providers/e2b/internal/snapshot-operations.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Sandbox, type SnapshotInfo } from "e2b";
 import type {
   CapturedSnapshot,
@@ -11,8 +12,11 @@ export async function getE2bSnapshotByName(
   config: E2bConfig,
   name: string,
 ): Promise<ProviderSnapshot | null> {
-  const snapshots = await listE2bSnapshots(config, name);
-  const snapshot = snapshots.find((item) => snapshotHasName(item, name));
+  const providerName = e2bSnapshotName(name);
+  const snapshots = await listE2bSnapshots(config, providerName);
+  const snapshot = snapshots.find((item) =>
+    snapshotHasName(item, providerName),
+  );
   return snapshot ? toProviderSnapshot(name, snapshot) : null;
 }
 
@@ -50,7 +54,7 @@ export async function captureE2bSnapshot(
 ): Promise<CapturedSnapshot> {
   const snapshot = await Sandbox.createSnapshot(providerSandboxId, {
     ...e2bApiOptions(config),
-    name,
+    name: e2bSnapshotName(name),
   });
   return { providerSnapshotId: snapshot.snapshotId };
 }
@@ -69,9 +73,20 @@ async function listE2bSnapshots(
 }
 
 function snapshotHasName(snapshot: SnapshotInfo, name: string): boolean {
-  return snapshot.names.some(
-    (candidate) => candidate === name || candidate.startsWith(`${name}:`),
-  );
+  return snapshot.names.some((candidate) => {
+    const withoutTag = candidate.split(":", 1)[0]!;
+    return withoutTag === name || withoutTag.endsWith(`/${name}`);
+  });
+}
+
+function e2bSnapshotName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  const hash = createHash("sha256").update(name).digest("hex").slice(0, 12);
+  return `amika-${slug || "snapshot"}-${hash}`;
 }
 
 function toProviderSnapshot(


### PR DESCRIPTION
## Summary

- pause explicitly stopped E2B sandboxes without retaining memory, matching filesystem-only timeout pauses and cold resumes
- map canonical Amika snapshot names to deterministic E2B-safe aliases and recognize team-namespaced aliases returned by E2B
- keep every sandbox in billing listings when metrics are not yet available, recovering provisioned disk capacity from E2B sandbox details instead of reporting zero
- honor configured E2B API URL overrides when fetching sandbox details

## Verification

- sandbox formatcheck and typecheck
- 38 sandbox test files passed: 367 passed, 8 skipped
- GitHub build-and-test, ESLint, and sandbox checks passed