### PR TITLE
Restore E2B image permissions

### DIFF
--- a/js/sandbox/src/providers/e2b/internal/operations.test.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.test.ts
@@ -33,7 +33,6 @@ import {
   e2bRouteSyncCommand,
   getE2bSandboxState,
   listE2bSandboxes,
-  openE2bAdapter,
   refreshE2bUrls,
   startE2bSandbox,
   stopE2bSandbox,
@@ -48,7 +47,8 @@ beforeEach(() => {
 
 describe("E2B lifecycle operations", () => {
   it("creates from the prepared template with pause-on-timeout lifecycle", async () => {
-    sdk.create.mockResolvedValue({ sandboxId: "sbx_1" });
+    const run = vi.fn().mockResolvedValue({});
+    sdk.create.mockResolvedValue({ sandboxId: "sbx_1", commands: { run } });
 
     const result = await createE2bSandbox(
       { logger: { info: vi.fn() } } as never,
@@ -75,6 +75,9 @@ describe("E2B lifecycle operations", () => {
       },
       network: { allowPublicTraffic: true },
     });
+    expect(run).toHaveBeenCalledWith(e2bImagePermissionRestoreCommand(), {
+      user: "root",
+    });
     expect(result).toMatchObject({
       provider: "e2b",
       providerSandboxId: "sbx_1",
@@ -91,14 +94,27 @@ describe("E2B lifecycle operations", () => {
     expect(sdk.create).not.toHaveBeenCalled();
   });
 
-  it("restores image permissions before opening the adapter", async () => {
-    const run = vi.fn().mockResolvedValue({});
-    sdk.connect.mockResolvedValue({ commands: { run } });
+  it("kills a new sandbox when restoring image permissions fails", async () => {
+    const restoreError = new Error("chmod failed");
+    const run = vi.fn().mockRejectedValue(restoreError);
+    sdk.create.mockResolvedValue({ sandboxId: "sbx_1", commands: { run } });
+    sdk.kill.mockResolvedValue(undefined);
 
-    await openE2bAdapter(CONFIG, "sbx_1");
+    await expect(
+      createE2bSandbox(
+        { logger: { info: vi.fn(), error: vi.fn() } } as never,
+        CONFIG,
+        {
+          name: "demo",
+          snapshot: "tpl_coder_xs",
+          labels: {},
+          services: [],
+        } as never,
+      ),
+    ).rejects.toBe(restoreError);
 
-    expect(run).toHaveBeenCalledWith(e2bImagePermissionRestoreCommand(), {
-      user: "root",
+    expect(sdk.kill).toHaveBeenCalledWith("sbx_1", {
+      apiKey: "e2b_test",
     });
   });
 

--- a/js/sandbox/src/providers/e2b/internal/operations.test.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.test.ts
@@ -28,10 +28,12 @@ vi.mock("e2b", () => ({
 import {
   createE2bSandbox,
   deleteE2bSandbox,
+  e2bImagePermissionRestoreCommand,
   e2bRouteRestoreCommand,
   e2bRouteSyncCommand,
   getE2bSandboxState,
   listE2bSandboxes,
+  openE2bAdapter,
   refreshE2bUrls,
   startE2bSandbox,
   stopE2bSandbox,
@@ -87,6 +89,17 @@ describe("E2B lifecycle operations", () => {
       } as never),
     ).rejects.toThrow(/E2B_TEMPLATE/);
     expect(sdk.create).not.toHaveBeenCalled();
+  });
+
+  it("restores image permissions before opening the adapter", async () => {
+    const run = vi.fn().mockResolvedValue({});
+    sdk.connect.mockResolvedValue({ commands: { run } });
+
+    await openE2bAdapter(CONFIG, "sbx_1");
+
+    expect(run).toHaveBeenCalledWith(e2bImagePermissionRestoreCommand(), {
+      user: "root",
+    });
   });
 
   it("resumes, pauses with only filesystem state, and kills the sandbox", async () => {

--- a/js/sandbox/src/providers/e2b/internal/operations.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.ts
@@ -346,7 +346,16 @@ export async function openE2bAdapter(
   config: E2bConfig,
   providerSandboxId: string,
 ): Promise<SandboxAdapter> {
-  return new E2bAdapter(await connectE2bSandbox(config, providerSandboxId));
+  const sandbox = await connectE2bSandbox(config, providerSandboxId);
+  await sandbox.commands.run(e2bImagePermissionRestoreCommand(), {
+    user: "root",
+  });
+  return new E2bAdapter(sandbox);
+}
+
+/** Restore the image contract after E2B's finalizer broadens `/usr/local`. */
+export function e2bImagePermissionRestoreCommand(): string {
+  return "chmod 0755 /usr/local/etc/amika";
 }
 
 function commandOptions(opts?: ExecCommandOptions) {

--- a/js/sandbox/src/providers/e2b/internal/operations.ts
+++ b/js/sandbox/src/providers/e2b/internal/operations.ts
@@ -66,6 +66,21 @@ export async function createE2bSandbox(
     },
     network: { allowPublicTraffic: true },
   });
+  try {
+    await sandbox.commands.run(e2bImagePermissionRestoreCommand(), {
+      user: "root",
+    });
+  } catch (error) {
+    try {
+      await Sandbox.kill(sandbox.sandboxId, e2bApiOptions(config));
+    } catch (cleanupError) {
+      ctx.logger.error(
+        { cleanupError, providerSandboxId: sandbox.sandboxId },
+        "Failed to clean up E2B sandbox after image permission restore",
+      );
+    }
+    throw error;
+  }
   return {
     provider: "e2b",
     providerSandboxId: sandbox.sandboxId,
@@ -73,6 +88,11 @@ export async function createE2bSandbox(
     services: input.services,
     envVars: {},
   };
+}
+
+/** Restore the image contract after E2B's finalizer broadens `/usr/local`. */
+export function e2bImagePermissionRestoreCommand(): string {
+  return "chmod 0755 /usr/local/etc/amika";
 }
 
 export async function startE2bSandbox(
@@ -346,16 +366,7 @@ export async function openE2bAdapter(
   config: E2bConfig,
   providerSandboxId: string,
 ): Promise<SandboxAdapter> {
-  const sandbox = await connectE2bSandbox(config, providerSandboxId);
-  await sandbox.commands.run(e2bImagePermissionRestoreCommand(), {
-    user: "root",
-  });
-  return new E2bAdapter(sandbox);
-}
-
-/** Restore the image contract after E2B's finalizer broadens `/usr/local`. */
-export function e2bImagePermissionRestoreCommand(): string {
-  return "chmod 0755 /usr/local/etc/amika";
+  return new E2bAdapter(await connectE2bSandbox(config, providerSandboxId));
 }
 
 function commandOptions(opts?: ExecCommandOptions) {


### PR DESCRIPTION
## Summary
- restore the E2B sandbox image filesystem contract during creation
- clean up a newly created sandbox if restoration fails
- cover successful restoration and failure cleanup

## Validation
- pnpm --filter @amika/sandbox test
- E2B API CLI E2E suite (supported cases)