### PR TITLE
Add E2E coverage for `send` and `sessions`

### DIFF
--- a/go/test/e2e/cases/api-agent-sessions.yaml
+++ b/go/test/e2e/cases/api-agent-sessions.yaml
@@ -1,0 +1,140 @@
+name: agent-session chats via send and sessions (send, continue, stream, list, show)
+# `send` and `sessions` are two halves of one feature: `send` creates the
+# durable chat that `sessions list` / `sessions show` then read back. Splitting
+# them would mean paying for a second sandbox and a second agent turn just to
+# produce a session for the read side, so they share one case.
+#
+# This is distinct from api-sandbox-lifecycle.yaml's `sandbox agent-send` step,
+# which is deliberately kept as its own coverage of the older per-sandbox
+# command. `send` drives the newer agent-sessions API instead: durable session
+# ids, continuation across turns, and an SSE streaming transport.
+#
+# The sandbox is created explicitly up front and passed via `--sandbox`, rather
+# than letting `send` provision one behind the scenes. `send`'s auto-create path
+# is the safer thing to leave uncovered here: the sandbox id comes back only in
+# the command's own output, so a turn that creates a sandbox and then fails
+# before printing (an agent turn can run for minutes) would leave a billable
+# sandbox with nothing for the ledger to delete. Creating it explicitly means
+# the `resource` block below owns cleanup from the first step onward. The cost
+# is that `created_sandbox` is asserted false throughout; the auto-create path
+# is not exercised.
+#
+# Each `send` step is a real, billable agent turn, so the case spends exactly
+# three: a new chat, a buffered continuation, and a streamed continuation. Not
+# covered for that reason: `--stream` combined with `-o json` (which must stay
+# buffered so the emitted object remains valid) — that decision is local flag
+# logic inlined in runSend, reachable only with a live client.
+steps:
+  - name: create the sandbox the chat will run in
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, xs, --yes, -o, json]
+    expect:
+      exit: 0
+      schema: Sandbox
+      stdout_json:
+        name: "@string"
+        id: "@string"
+        provider: "{{sandbox_provider}}"
+    capture:
+      sandbox_name: $.name
+    resource:
+      type: sandbox
+      name: "{{sandbox_name}}"
+      cleanup: [sandbox, delete, "{{sandbox_name}}", --remote, --force, -o, json]
+
+  - name: send the first message and start a durable chat
+    # --agent is pinned rather than left to the org default so `agent` below is
+    # a deterministic assertion. The agent's reply text is deliberately NOT
+    # asserted: model output is nondeterministic, so the case checks the
+    # envelope (a string response, no error) and not the words in it.
+    cmd: [send, "Reply with exactly the word: pong", --sandbox, "{{sandbox_name}}", --agent, claude, -o, json]
+    expect:
+      exit: 0
+      schema: AgentSessionSendResponse
+      stdout_json:
+        session_id: "@string"
+        sandbox_id: "@string"
+        agent: claude
+        response: "@string"
+        is_error: false
+        is_new_session: true
+        created_sandbox: false
+    capture:
+      session_id: $.session_id
+
+  - name: continue the same chat with --session-id
+    # is_new_session flipping to false against the same session_id is the whole
+    # point of the durable-session API: the second turn joins the first chat
+    # instead of silently starting another one.
+    cmd: [send, "Reply with exactly the word: pong", --session-id, "{{session_id}}", --agent, claude, -o, json]
+    expect:
+      exit: 0
+      schema: AgentSessionSendResponse
+      stdout_json:
+        session_id: "{{session_id}}"
+        agent: claude
+        is_error: false
+        is_new_session: false
+        created_sandbox: false
+
+  - name: stream a reply over SSE into the same chat
+    # Text output with --stream forces the SSE transport (the runner's stdout is
+    # a pipe, so streaming would otherwise default off). A parse failure in the
+    # event stream surfaces as a non-zero exit here, which is the transport
+    # coverage this step exists for. In text mode stdout carries only the
+    # agent's reply and identifying metadata goes to stderr, so the session id
+    # is asserted on stderr.
+    cmd: [send, "Reply with exactly the word: pong", --session-id, "{{session_id}}", --agent, claude, --stream]
+    expect:
+      exit: 0
+      stderr_contains: "session_id: {{session_id}}"
+
+  - name: sessions list as json includes the chat
+    cmd: [sessions, list, -o, json]
+    expect:
+      exit: 0
+      schema: ListAgentSessionsResponse
+      stdout_json:
+        sessions: "@array"
+        total: "@number"
+      stdout_contains: "{{session_id}}"
+
+  - name: sessions list honors --limit
+    cmd: [sessions, list, --limit, "1", -o, json]
+    expect:
+      exit: 0
+      schema: ListAgentSessionsResponse
+      stdout_json:
+        sessions: ["@object"]
+
+  - name: sessions list renders a text table
+    cmd: [sessions, list]
+    expect:
+      exit: 0
+      stdout_contains: "SESSION ID"
+
+  - name: sessions show returns the chat and its transcript as json
+    cmd: [sessions, show, "{{session_id}}", -o, json]
+    expect:
+      exit: 0
+      schema: AgentSessionDetail
+      stdout_json:
+        session_id: "{{session_id}}"
+        agent: claude
+        sandbox_name: "{{sandbox_name}}"
+        messages: "@array"
+
+  - name: sessions show renders the chat as text
+    cmd: [sessions, show, "{{session_id}}"]
+    expect:
+      exit: 0
+      stdout_contains: "session:  {{session_id}}"
+
+  - name: sessions show rejects an unknown session id
+    cmd: [sessions, show, "no-such-session-{{run_id}}"]
+    expect:
+      exit: 1
+
+  - name: delete the sandbox
+    cmd: [sandbox, delete, "{{sandbox_name}}", --remote, --force, -o, json]
+    expect:
+      exit: 0

--- a/go/test/e2e/cases/offline-send-sessions.yaml
+++ b/go/test/e2e/cases/offline-send-sessions.yaml
@@ -1,0 +1,114 @@
+# Offline case for the top-level `send` command and the `sessions` command
+# group. Everything here is argument/flag/stdin plumbing that resolves before
+# any network call, so the case needs no Docker, no network, and no
+# credentials.
+#
+# `send` and `sessions` are remote-only (the agent-sessions API provisions
+# sandboxes in the control plane, so there is no --local equivalent). That
+# makes the "not logged in" auth check the natural offline backstop: a step
+# that reaches it has proven everything ahead of it parsed and dispatched
+# correctly, without a request ever leaving the machine.
+#
+# Steps that reach that check pin AMIKA_API_KEY to an empty string, because
+# this repo's own dev sandbox exports a real key into every shell and the
+# runner's base env is the process's own os.Environ() (see the runner README).
+name: send and sessions argument handling works offline
+steps:
+  - name: send with no message and no stdin is rejected
+    # The message check runs before the auth check, so this fails on the
+    # message even with credentials available — no AMIKA_API_KEY override
+    # needed, and the ordering is what the step asserts.
+    cmd: [send]
+    expect:
+      exit: 1
+      stderr_contains: "message is required as an argument or via stdin"
+
+  - name: send reads the message from stdin when no positional message is given
+    # With a message on stdin the command gets past the "message is required"
+    # check and fails later, at the auth check, proving the piped message was
+    # read.
+    cmd: [send]
+    stdin: "hello from stdin"
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: send with empty stdin is still rejected as a missing message
+    # A piped-but-empty stdin must not count as a message; it trims to "" and
+    # fails the same way as no stdin at all rather than sending an empty turn.
+    cmd: [send]
+    stdin: ""
+    expect:
+      exit: 1
+      stderr_contains: "message is required as an argument or via stdin"
+
+  - name: send rejects an invalid --output value before doing any work
+    cmd: [send, hello, --output, bogus]
+    expect:
+      exit: 1
+      stderr_contains: 'invalid --output value "bogus": must be one of text, json, json-pretty'
+
+  - name: send is remote-only and requires credentials
+    cmd: [send, hello]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: send --stream reaches the same auth check as the buffered path
+    # --stream selects the SSE transport, but only after auth. Asserting the
+    # same failure here proves the flag is registered and does not change the
+    # order of the checks ahead of the request.
+    cmd: [send, hello, --stream]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: sessions list requires credentials
+    cmd: [sessions, list]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: the singular "session" alias resolves to the same command group
+    cmd: [session, list]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: sessions show requires exactly one session id
+    cmd: [sessions, show]
+    expect:
+      exit: 1
+      stderr_contains: "accepts 1 arg(s), received 0"
+
+  - name: sessions show with an id requires credentials
+    cmd: [sessions, show, some-session-id]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: sessions list rejects an invalid --output value
+    cmd: [sessions, list, --output, bogus]
+    expect:
+      exit: 1
+      stderr_contains: 'invalid --output value "bogus": must be one of text, json, json-pretty'
+
+  - name: sessions help lists its subcommands without needing credentials
+    cmd: [sessions, --help]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 0
+      stdout_contains: "List the organization's agent-session chats"


### PR DESCRIPTION
The top-level `send` and `sessions` commands had only unit tests; the E2E suite covered `sandbox agent-send`, a different and older command. That left the agent-sessions API surface — durable session ids, continuation across turns, and the SSE streaming transport — untested end to end.

Add two cases following the suite's existing two-tier split:

- offline-send-sessions.yaml: argument, flag, and stdin plumbing, no network or credentials. Both commands are remote-only, so the "not logged in" check serves as the offline backstop — reaching it proves everything ahead of it parsed and dispatched.

- api-agent-sessions.yaml: one real chat driven end to end. `send` creates the session that `sessions list` and `sessions show` read back, so both commands share a case rather than paying for a second sandbox and agent turn to set up the read side.

The API case creates its sandbox explicitly and sends into it with --sandbox instead of exercising `send`'s auto-create path. That path returns the new sandbox id only in the command's own output, so a turn that provisions a sandbox and then fails before printing would leave a billable sandbox the ledger cannot delete. The cost is that `created_sandbox` is false throughout and auto-create goes uncovered.

`--stream` combined with `-o json` is also uncovered: it is a fourth billable agent turn for one boolean, and the decision is local flag logic inlined in runSend, reachable only with a live client.

Agent reply text is never asserted, only the response envelope, matching the existing agent-send step — model output is not deterministic.

`sandbox agent-send` coverage in api-sandbox-lifecycle.yaml is unchanged.