### PR TITLE
Move isSandboxProviderName to the client-safe layer

### DIFF
--- a/js/sandbox/src/client.test.ts
+++ b/js/sandbox/src/client.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Guards the `@amika/sandbox/client` invariant documented in `client.ts`: no
+ * provider SDK and no `node:` built-in anywhere in its module graph.
+ *
+ * This is a bundler constraint, so it cannot be observed by importing the entry
+ * (Node resolves `node:fs` happily). Instead we walk the static import graph
+ * from `client.ts` and fail on the first forbidden specifier, reporting the
+ * path that pulled it in.
+ *
+ * Without this, a client-reachable module that reaches a provider SDK only
+ * fails much later, in a consumer's browser build, as an opaque Turbopack
+ * "chunking context does not support external modules" error.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const CLIENT_ENTRY = resolve(import.meta.dirname, "client.ts");
+
+/** Runtime deps that carry a provider SDK (and transitively `node:` built-ins). */
+const FORBIDDEN_PACKAGES = [
+  "@daytona/api-client",
+  "@daytonaio/sdk",
+  "@vercel/sandbox",
+  "e2b",
+  "freestyle",
+];
+
+/** Every `import`/`export ... from "..."` specifier in `source`. */
+function importSpecifiers(source: string): string[] {
+  // Matches the `from "..."` of static import/export declarations plus bare
+  // side-effect imports (`import "..."`). Type-only declarations are included
+  // deliberately: `import type` is erased, but `import { type X }` is not
+  // distinguishable here, so we over-collect rather than miss a value import.
+  const pattern = /(?:from|import)\s*["']([^"']+)["']/g;
+  return [...source.matchAll(pattern)].map((match) => match[1]);
+}
+
+/** Resolve a relative specifier to a concrete `.ts` file on disk. */
+function resolveRelative(fromFile: string, specifier: string): string | null {
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [`${base}.ts`, `${base}/index.ts`]) {
+    try {
+      readFileSync(candidate, "utf8");
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk the import graph from `entry`, returning the first violation found as
+ * the chain of files leading to it.
+ */
+function findForbiddenImport(entry: string): {
+  specifier: string;
+  chain: string[];
+} | null {
+  const visited = new Set<string>();
+  const queue: { file: string; chain: string[] }[] = [
+    { file: entry, chain: [entry] },
+  ];
+
+  while (queue.length > 0) {
+    const { file, chain } = queue.shift()!;
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    for (const specifier of importSpecifiers(readFileSync(file, "utf8"))) {
+      if (specifier.startsWith(".")) {
+        const next = resolveRelative(file, specifier);
+        if (next) queue.push({ file: next, chain: [...chain, next] });
+        continue;
+      }
+      const forbidden =
+        specifier.startsWith("node:") ||
+        FORBIDDEN_PACKAGES.some(
+          (pkg) => specifier === pkg || specifier.startsWith(`${pkg}/`),
+        );
+      if (forbidden) return { specifier, chain };
+    }
+  }
+  return null;
+}
+
+describe("@amika/sandbox/client module graph", () => {
+  it("pulls in no provider SDK and no node: built-in", () => {
+    const violation = findForbiddenImport(CLIENT_ENTRY);
+    const detail = violation
+      ? `"${violation.specifier}" reached via:\n  ${violation.chain.join("\n  ")}`
+      : "";
+    expect(detail).toBe("");
+  });
+
+  it("detects a forbidden import when one exists (guards the walker)", () => {
+    // Sanity-check the walker against a known-bad entry: the root barrel does
+    // pull in the provider SDKs, so a null result here would mean the graph
+    // walk is silently finding nothing.
+    const violation = findForbiddenImport(
+      resolve(import.meta.dirname, "index.ts"),
+    );
+    expect(violation).not.toBeNull();
+  });
+});

--- a/js/sandbox/src/providers/capabilities.ts
+++ b/js/sandbox/src/providers/capabilities.ts
@@ -11,6 +11,7 @@ import type {
   SandboxProviderCapabilities,
   SandboxProviderName,
 } from "./provider";
+import { SANDBOX_PROVIDER_NAMES } from "../types";
 import { daytonaCapabilities } from "./daytona/capabilities";
 import { e2bCapabilities } from "./e2b/capabilities";
 import { freestyleCapabilities } from "./freestyle/capabilities";
@@ -54,14 +55,19 @@ export const SANDBOX_PROVIDER_DISPLAY: Record<
 
 const UNKNOWN_BADGE_CLASS = "bg-gray-200 text-gray-700";
 
-function isKnownProvider(
+/**
+ * Whether `name` is a known provider name.
+ *
+ * Lives here, in the client-safe layer, rather than next to the provider table
+ * in `registry.ts`: client components need this guard, and importing it from
+ * `registry.ts` drags every provider SDK (and the `node:` built-ins they use)
+ * into the browser bundle. `registry.ts` re-imports it from here.
+ */
+export function isSandboxProviderName(
   name: string | null | undefined,
 ): name is SandboxProviderName {
   return (
-    name === "daytona" ||
-    name === "e2b" ||
-    name === "freestyle" ||
-    name === "vercel"
+    name != null && (SANDBOX_PROVIDER_NAMES as readonly string[]).includes(name)
   );
 }
 
@@ -69,12 +75,14 @@ function isKnownProvider(
 export function getProviderCapabilities(
   name: string | null | undefined,
 ): SandboxProviderCapabilities | null {
-  return isKnownProvider(name) ? SANDBOX_PROVIDER_CAPABILITIES[name] : null;
+  return isSandboxProviderName(name)
+    ? SANDBOX_PROVIDER_CAPABILITIES[name]
+    : null;
 }
 
 /** Display label for `name`, falling back to the raw name. */
 export function getProviderLabel(name: string | null | undefined): string {
-  return isKnownProvider(name)
+  return isSandboxProviderName(name)
     ? SANDBOX_PROVIDER_DISPLAY[name].label
     : (name ?? "Unknown");
 }
@@ -83,7 +91,7 @@ export function getProviderLabel(name: string | null | undefined): string {
 export function getProviderBadgeClassName(
   name: string | null | undefined,
 ): string {
-  return isKnownProvider(name)
+  return isSandboxProviderName(name)
     ? SANDBOX_PROVIDER_DISPLAY[name].badgeClassName
     : UNKNOWN_BADGE_CLASS;
 }

--- a/js/sandbox/src/providers/e2b/provider.test.ts
+++ b/js/sandbox/src/providers/e2b/provider.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   getProviderLabel,
+  isSandboxProviderName,
   SANDBOX_PROVIDER_CAPABILITIES,
 } from "../capabilities";
-import {
-  createSandboxProvider,
-  isSandboxProviderName,
-  type SandboxProviderDeps,
-} from "../registry";
+import { createSandboxProvider, type SandboxProviderDeps } from "../registry";
 import {
   E2B_DEFAULT_TIMEOUT_MS,
   E2B_MAX_TIMEOUT_MS,

--- a/js/sandbox/src/providers/freestyle/provider.test.ts
+++ b/js/sandbox/src/providers/freestyle/provider.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   getProviderLabel,
+  isSandboxProviderName,
   SANDBOX_PROVIDER_CAPABILITIES,
 } from "../capabilities";
-import {
-  createSandboxProvider,
-  isSandboxProviderName,
-  type SandboxProviderDeps,
-} from "../registry";
+import { createSandboxProvider, type SandboxProviderDeps } from "../registry";
 
 function deps(overrides: Partial<SandboxProviderDeps>): SandboxProviderDeps {
   return {

--- a/js/sandbox/src/providers/registry.test.ts
+++ b/js/sandbox/src/providers/registry.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
-import {
-  createSandboxProvider,
-  isSandboxProviderName,
-  type SandboxProviderDeps,
-} from "./registry";
+import { createSandboxProvider, type SandboxProviderDeps } from "./registry";
+import { isSandboxProviderName } from "./capabilities";
 import { SandboxProviderUnsupportedError } from "./provider";
 import type { SandboxProviderName } from "../types";
 
@@ -69,10 +66,11 @@ describe("createSandboxProvider construction", () => {
   });
 
   it("rejects Object.prototype keys as provider names", () => {
-    // The registry table is a plain object literal; the name guard must check
-    // OWN keys only, or "constructor" would resolve `Object` off the prototype
-    // chain and `createSandboxProvider` would return garbage instead of
-    // throwing.
+    // The guard matches against the canonical name list, so these are rejected
+    // like any other unknown name. Kept as a regression test because a guard
+    // written against the registry table instead (with `in`, or any lookup that
+    // walks the prototype chain) would resolve "constructor" to `Object` and
+    // make `createSandboxProvider` return garbage instead of throwing.
     for (const name of ["toString", "constructor", "valueOf", "__proto__"]) {
       expect(isSandboxProviderName(name), name).toBe(false);
       expect(() => createSandboxProvider(name, DEPS), name).toThrow(

--- a/js/sandbox/src/providers/registry.ts
+++ b/js/sandbox/src/providers/registry.ts
@@ -22,6 +22,9 @@ import type { VercelConfig } from "./vercel/config";
 import type { SandboxProvider, SnapshotIdResolver } from "./provider";
 import { SandboxProviderUnsupportedError } from "./provider";
 import type { SandboxProviderName } from "../types";
+// Defined in the client-safe capabilities module, not here: importing it from
+// this module would pull the provider SDKs below into client bundles.
+import { isSandboxProviderName } from "./capabilities";
 import type { SandboxAdapter } from "./shared/adapter";
 import daytonaProvider from "./daytona/provider";
 import e2bProvider, { openE2bAdapter } from "./e2b/provider";
@@ -109,15 +112,6 @@ const PROVIDERS = {
       openVercelAdapter(requireConfig(deps.vercel, VERCEL_HINT), id),
   },
 } satisfies Record<SandboxProviderName, ProviderEntry | null>;
-
-export function isSandboxProviderName(
-  name: string | null | undefined,
-): name is SandboxProviderName {
-  // `Object.hasOwn`, NOT `in`: `in` walks the prototype chain, so a garbage
-  // name like "toString" or "constructor" would pass the guard and resolve an
-  // inherited Object.prototype member instead of a provider entry.
-  return name != null && Object.hasOwn(PROVIDERS, name);
-}
 
 /** The table entry for `name`, or null for unknown/unbacked names. */
 function providerEntry(name: string | null): ProviderEntry | null {

--- a/js/sandbox/src/providers/vercel/provider.test.ts
+++ b/js/sandbox/src/providers/vercel/provider.test.ts
@@ -2,13 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { VercelConfig } from "./config";
 import {
   getProviderLabel,
+  isSandboxProviderName,
   SANDBOX_PROVIDER_CAPABILITIES,
 } from "../capabilities";
-import {
-  createSandboxProvider,
-  isSandboxProviderName,
-  type SandboxProviderDeps,
-} from "../registry";
+import { createSandboxProvider, type SandboxProviderDeps } from "../registry";
 
 const VERCEL_CONFIG: VercelConfig = {
   apiKey: "test-token",

--- a/js/sandbox/src/types.ts
+++ b/js/sandbox/src/types.ts
@@ -2,7 +2,20 @@
  * Provider-facing shared types owned by the provider layer.
  */
 
-export type SandboxProviderName = "daytona" | "e2b" | "freestyle" | "vercel";
+/**
+ * Canonical provider-name list. A runtime value (not just a type union) so the
+ * client-safe `isSandboxProviderName` guard can be derived from it rather than
+ * from the provider table in `providers/registry.ts`, which pulls every
+ * provider SDK — and with it `node:` built-ins — into any importing bundle.
+ */
+export const SANDBOX_PROVIDER_NAMES = [
+  "daytona",
+  "e2b",
+  "freestyle",
+  "vercel",
+] as const;
+
+export type SandboxProviderName = (typeof SANDBOX_PROVIDER_NAMES)[number];
 
 export type ServiceProtocol = "tcp" | "udp";
 export type ServiceUrlScheme = "http" | "https";


### PR DESCRIPTION
`isSandboxProviderName` lived in `providers/registry.ts`, next to the `PROVIDERS` table — so importing the guard pulled in every provider SDK and the `node:` built-ins they use. That makes it unusable from a client component, which is what breaks amika-mono's build today.

The guard only checks whether a string is one of four names, so it doesn't need any of that.

**Change:** derive it from a new `SANDBOX_PROVIDER_NAMES` list in `types.ts` (a module with no imports) and define it in `providers/capabilities.ts`, which `client.ts` already re-exports. `registry.ts` imports it back, so the root barrel is unchanged for server consumers.

Also removes a duplicate — `capabilities.ts` had its own private `isKnownProvider` with the names hardcoded as an `||` chain.

**New test:** `client.ts` documents that its module graph has no provider SDK or `node:` built-in, but nothing enforced it. `client.test.ts` now walks the import graph and fails on the first violation, printing the chain that reached it. I checked it fails on a reintroduced violation, and a second case asserts it flags the known-bad root barrel so it can't pass vacuously.

Lint, formatcheck, typecheck, and all 377 tests pass.