### PR TITLE
launch windows editors from wsl

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -280,6 +280,14 @@ through the same Amika-managed SSH host alias (`amika-<id>`, written to
 
 This command requires a signed-in Amika account and a remote sandbox.
 
+On WSL, `--editor cursor` and `--editor vscode` expect the editor to be a
+Windows application. The command mirrors the managed SSH config, identity,
+and host-key pins to the Windows side (`%USERPROFILE%\.ssh\amika.conf`, added
+via an `Include` line) with a `ProxyCommand` that re-enters your WSL
+distribution through `wsl.exe`, then launches the Windows editor directly
+with `--remote ssh-remote+<alias>`. This needs WSL interop (`cmd.exe`,
+`wslpath`) and `WSL_DISTRO_NAME` set (any interactive WSL shell sets it).
+
 ```bash
 amika sandbox code my-sandbox
 amika sandbox code my-sandbox --editor=cursor
@@ -301,8 +309,8 @@ it when normal `sandbox code` cannot reach the provider SSH route. It works
 with remote sandboxes only and requires a signed-in Amika account.
 
 `codev2` adds a named SSH connection to Amika's managed config so Codex can
-find it, then starts or configures Cursor, Claude Desktop, or Codex as
-`sandbox code` does. The connection routes through Amika's direct transport;
+find it, then starts or configures Cursor, VS Code, Claude Desktop, or Codex
+as `sandbox code` does. The connection routes through Amika's direct transport;
 you do not need to configure that transport yourself.
 
 Before first use, create and upload an SSH key:
@@ -312,8 +320,8 @@ amika secret ssh-keygen
 ```
 
 To use an existing key, pass `--import <public-key-file>` instead. Cursor is
-the default editor; Claude Desktop and Codex are also available without an
-environment-variable feature gate.
+the default editor; VS Code, Claude Desktop, and Codex are also available
+without an environment-variable feature gate.
 
 ```bash
 amika sandbox codev2 my-sandbox
@@ -323,7 +331,8 @@ amika sandbox codev2 my-sandbox --editor=claude
 amika sandbox codev2 my-sandbox --editor=codex
 ```
 
-`--editor` and `--path` have the same values and defaults as `sandbox code`.
+`--editor` and `--path` have the same values and defaults as `sandbox code`,
+and WSL behaves the same way (see `sandbox code` above).
 
 ### `amika sandbox sshv2`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -270,6 +270,7 @@ through the same Amika-managed SSH host alias (`amika-<id>`, written to
 `~/.ssh/amika.conf` and included from `~/.ssh/config`):
 
 - `cursor` launches Cursor connected to the sandbox.
+- `vscode` launches VS Code connected to the sandbox.
 - `claude` registers the sandbox as a Claude Desktop SSH environment (in
   `~/.claude/settings.json`), then opens Claude Desktop; pick `Amika: <name>`
   from the environment dropdown.
@@ -282,13 +283,14 @@ This command requires a signed-in Amika account and a remote sandbox.
 ```bash
 amika sandbox code my-sandbox
 amika sandbox code my-sandbox --editor=cursor
+amika sandbox code my-sandbox --editor=vscode
 amika sandbox code my-sandbox --editor=claude
 amika sandbox code my-sandbox --editor=codex
 ```
 
 | Flag              | Default  | Description                                              |
 | ----------------- | -------- | -------------------------------------------------------- |
-| `--editor <name>` | `cursor` | Editor or agent to open: `cursor`, `claude`, or `codex`  |
+| `--editor <name>` | `cursor` | Editor or agent to open: `cursor`, `vscode`, `claude`, or `codex`  |
 | `--path <path>`   | —        | Override the remote path to open (absolute, or relative to the sandbox workspace root) |
 
 ### `amika sandbox codev2`
@@ -316,6 +318,7 @@ environment-variable feature gate.
 ```bash
 amika sandbox codev2 my-sandbox
 amika sandbox codev2 my-sandbox --editor=cursor
+amika sandbox codev2 my-sandbox --editor=vscode
 amika sandbox codev2 my-sandbox --editor=claude
 amika sandbox codev2 my-sandbox --editor=codex
 ```

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -70,9 +70,9 @@ func New() *cobra.Command {
 	// sshv2 registers no flags of its own: it forwards everything after the
 	// subcommand to ssh, so ssh's own -t (and every other option) passes
 	// through untouched.
-	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor or agent to open: \"cursor\", \"claude\", or \"codex\"")
+	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor or agent to open: \"cursor\", \"vscode\", \"claude\", or \"codex\"")
 	sandboxCodeCmd.Flags().String("path", "", "Override the remote path to open (absolute, or relative to the sandbox workspace root)")
-	sandboxCodeV2Cmd.Flags().String("editor", "cursor", "Editor or agent to open: \"cursor\", \"claude\", or \"codex\"")
+	sandboxCodeV2Cmd.Flags().String("editor", "cursor", "Editor or agent to open: \"cursor\", \"vscode\", \"claude\", or \"codex\"")
 	sandboxCodeV2Cmd.Flags().String("path", "", "Override the remote path to open (absolute, or relative to the sandbox workspace root)")
 	sandboxAgentSendCmd.Flags().Bool("no-wait", false, "Send the instruction and return immediately without waiting for a response")
 	sandboxAgentSendCmd.Flags().String("workdir", "$AMIKA_AGENT_CWD", "Working directory inside the container (default: $AMIKA_AGENT_CWD)")

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -21,7 +21,7 @@ import (
 // validateEditor checks that the requested editor is supported.
 func validateEditor(editor string) error {
 	switch editor {
-	case "cursor", "claude", "codex":
+	case "cursor", "vscode", "claude", "codex":
 		return nil
 	default:
 		return fmt.Errorf("unsupported editor %q; supported editors are %q", editor, supportedEditors)
@@ -113,7 +113,7 @@ Examples:
 }
 
 // supportedEditors lists the values accepted by `sandbox code --editor`.
-var supportedEditors = []string{"cursor", "claude", "codex"}
+var supportedEditors = []string{"cursor", "vscode", "claude", "codex"}
 
 var sandboxCodeCmd = &cobra.Command{
 	Use:   "code <name>",
@@ -122,6 +122,7 @@ var sandboxCodeCmd = &cobra.Command{
 
 Supported --editor values:
   cursor   launch Cursor connected to the sandbox (default)
+  vscode   launch VS Code connected to the sandbox
   claude   register the sandbox as a Claude Desktop SSH environment
   codex    expose the sandbox to Codex as an SSH connection
 
@@ -131,6 +132,7 @@ appears as a remote environment; select it in the app to start the session.
 Examples:
   amika sandbox code my-sandbox
   amika sandbox code my-sandbox --editor=cursor
+  amika sandbox code my-sandbox --editor=vscode
   amika sandbox code my-sandbox --editor=claude
   amika sandbox code my-sandbox --editor=codex`,
 	Args: cobra.ExactArgs(1),
@@ -231,6 +233,8 @@ func openSandboxInEditor(cmd *cobra.Command, editor string, paths basedir.Paths,
 	switch editor {
 	case "cursor":
 		return openSandboxInCursorTarget(cmd, target, pathOverride)
+	case "vscode":
+		return openSandboxInVSCodeTarget(cmd, target, pathOverride)
 	case "claude":
 		return openSandboxInClaudeTarget(cmd, paths, target, pathOverride)
 	case "codex":
@@ -240,24 +244,38 @@ func openSandboxInEditor(cmd *cobra.Command, editor string, paths basedir.Paths,
 	}
 }
 
-// openSandboxInCursor launches Cursor connected to a prepared SSH target.
+// openSandboxInCursorTarget launches Cursor connected to a prepared SSH target.
 func openSandboxInCursorTarget(cmd *cobra.Command, target sandboxSSHAlias, pathOverride string) error {
-	if _, err := exec.LookPath("cursor"); err != nil {
-		return fmt.Errorf("cursor CLI is not installed or not in PATH; install it from Cursor > Settings > Extensions > cursor-cli")
+	return launchRemoteSSHEditor(cmd, "cursor", "Cursor",
+		"Cursor > Settings > Extensions > cursor-cli", target, pathOverride)
+}
+
+// openSandboxInVSCodeTarget launches VS Code connected to a prepared SSH target.
+func openSandboxInVSCodeTarget(cmd *cobra.Command, target sandboxSSHAlias, pathOverride string) error {
+	return launchRemoteSSHEditor(cmd, "code", "VS Code",
+		"the VS Code Command Palette: \"Shell Command: Install 'code' command in PATH\"", target, pathOverride)
+}
+
+// launchRemoteSSHEditor launches a VS Code-family editor (Cursor, VS Code)
+// against a prepared SSH target. Both share VS Code's Remote-SSH CLI contract:
+// <cli> --remote ssh-remote+<host> <path>.
+func launchRemoteSSHEditor(cmd *cobra.Command, cli, name, installHint string, target sandboxSSHAlias, pathOverride string) error {
+	if _, err := exec.LookPath(cli); err != nil {
+		return fmt.Errorf("%s CLI is not installed or not in PATH; install it from %s", cli, installHint)
 	}
 
 	remotePath := resolveRemoteWorkspacePath(target.repoName, pathOverride)
 
-	cursorCmd := exec.Command("cursor", "--remote", "ssh-remote+"+target.alias, remotePath)
-	cursorCmd.Stdin = os.Stdin
-	cursorCmd.Stdout = os.Stdout
-	cursorCmd.Stderr = os.Stderr
+	editorCmd := exec.Command(cli, "--remote", "ssh-remote+"+target.alias, remotePath)
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Opening sandbox %q in Cursor via SSH (%s)...\n", target.sandboxName, target.alias)
-	fmt.Fprintf(cmd.OutOrStdout(), "Running: cursor --remote ssh-remote+%s %s\n", target.alias, remotePath)
-	fmt.Fprintf(cmd.OutOrStdout(), "Hint: if the file explorer is not visible, press Cmd+Shift+E in Cursor to open it.\n")
-	if err := cursorCmd.Run(); err != nil {
-		return fmt.Errorf("cursor failed: %w\n\nMake sure the \"Remote - SSH\" extension is installed in Cursor", err)
+	fmt.Fprintf(cmd.OutOrStdout(), "Opening sandbox %q in %s via SSH (%s)...\n", target.sandboxName, name, target.alias)
+	fmt.Fprintf(cmd.OutOrStdout(), "Running: %s --remote ssh-remote+%s %s\n", cli, target.alias, remotePath)
+	fmt.Fprintf(cmd.OutOrStdout(), "Hint: if the file explorer is not visible, press Cmd+Shift+E in %s to open it.\n", name)
+	if err := editorCmd.Run(); err != nil {
+		return fmt.Errorf("%s failed: %w\n\nMake sure the \"Remote - SSH\" extension is installed in %s", cli, err, name)
 	}
 	return nil
 }

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/ssh"
+	"github.com/gofixpoint/amika/go/internal/wslbridge"
 	"github.com/spf13/cobra"
 )
 
@@ -232,9 +233,9 @@ func resolveSandboxSSHAlias(client sshInfoClient, paths basedir.Paths, name stri
 func openSandboxInEditor(cmd *cobra.Command, editor string, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
 	switch editor {
 	case "cursor":
-		return openSandboxInCursorTarget(cmd, target, pathOverride)
+		return openSandboxInCursorTarget(cmd, paths, target, pathOverride)
 	case "vscode":
-		return openSandboxInVSCodeTarget(cmd, target, pathOverride)
+		return openSandboxInVSCodeTarget(cmd, paths, target, pathOverride)
 	case "claude":
 		return openSandboxInClaudeTarget(cmd, paths, target, pathOverride)
 	case "codex":
@@ -245,21 +246,34 @@ func openSandboxInEditor(cmd *cobra.Command, editor string, paths basedir.Paths,
 }
 
 // openSandboxInCursorTarget launches Cursor connected to a prepared SSH target.
-func openSandboxInCursorTarget(cmd *cobra.Command, target sandboxSSHAlias, pathOverride string) error {
+func openSandboxInCursorTarget(cmd *cobra.Command, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
 	return launchRemoteSSHEditor(cmd, "cursor", "Cursor",
-		"Cursor > Settings > Extensions > cursor-cli", target, pathOverride)
+		"Cursor > Settings > Extensions > cursor-cli", paths, target, pathOverride)
 }
 
 // openSandboxInVSCodeTarget launches VS Code connected to a prepared SSH target.
-func openSandboxInVSCodeTarget(cmd *cobra.Command, target sandboxSSHAlias, pathOverride string) error {
+func openSandboxInVSCodeTarget(cmd *cobra.Command, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
 	return launchRemoteSSHEditor(cmd, "code", "VS Code",
-		"the VS Code Command Palette: \"Shell Command: Install 'code' command in PATH\"", target, pathOverride)
+		"the VS Code Command Palette: \"Shell Command: Install 'code' command in PATH\"", paths, target, pathOverride)
 }
+
+// The WSL seams isolate the editor launch from the Windows side, so tests
+// can drive the handoff without interop.
+var (
+	wslIsWSL           = wslbridge.IsWSL
+	wslResolveTarget   = wslbridge.ResolveTarget
+	wslEditorExe       = wslbridge.EditorExe
+	wslLaunchWindows   = wslbridge.LaunchDetached
+	mirrorSSHToWindows = ssh.MirrorToWindows
+)
 
 // launchRemoteSSHEditor launches a VS Code-family editor (Cursor, VS Code)
 // against a prepared SSH target. Both share VS Code's Remote-SSH CLI contract:
 // <cli> --remote ssh-remote+<host> <path>.
-func launchRemoteSSHEditor(cmd *cobra.Command, cli, name, installHint string, target sandboxSSHAlias, pathOverride string) error {
+func launchRemoteSSHEditor(cmd *cobra.Command, cli, name, installHint string, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
+	if wslIsWSL() {
+		return launchWindowsEditorFromWSL(cmd, cli, name, paths, target, pathOverride)
+	}
 	if _, err := exec.LookPath(cli); err != nil {
 		return fmt.Errorf("%s CLI is not installed or not in PATH; install it from %s", cli, installHint)
 	}
@@ -276,6 +290,34 @@ func launchRemoteSSHEditor(cmd *cobra.Command, cli, name, installHint string, ta
 	fmt.Fprintf(cmd.OutOrStdout(), "Hint: if the file explorer is not visible, press Cmd+Shift+E in %s to open it.\n", name)
 	if err := editorCmd.Run(); err != nil {
 		return fmt.Errorf("%s failed: %w\n\nMake sure the \"Remote - SSH\" extension is installed in %s", cli, err, name)
+	}
+	return nil
+}
+
+// launchWindowsEditorFromWSL is launchRemoteSSHEditor's counterpart when the
+// editor is a Windows application: it mirrors the SSH config to the Windows
+// user's .ssh directory so the editor's OpenSSH can reach the sandbox, then
+// opens the editor on the Windows desktop.
+func launchWindowsEditorFromWSL(cmd *cobra.Command, cli, name string, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
+	windowsTarget, err := wslResolveTarget()
+	if err != nil {
+		return fmt.Errorf("resolve the Windows side: %w", err)
+	}
+	if err := mirrorSSHToWindows(paths, windowsTarget); err != nil {
+		return fmt.Errorf("mirror SSH config to Windows: %w", err)
+	}
+	exe, err := wslEditorExe(cli)
+	if err != nil {
+		return err
+	}
+
+	remotePath := resolveRemoteWorkspacePath(target.repoName, pathOverride)
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Mirrored SSH config for sandbox %q to %s.\n", target.sandboxName, windowsTarget.SSHDirWindows)
+	fmt.Fprintf(out, "Opening %s (Windows)...\n", name)
+
+	if err := wslLaunchWindows(exe, "--remote", "ssh-remote+"+target.alias, remotePath); err != nil {
+		return fmt.Errorf("launch Windows %s: %w\n\nMake sure the \"Remote - SSH\" extension is installed in %s", name, err, name)
 	}
 	return nil
 }

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -247,14 +247,12 @@ func openSandboxInEditor(cmd *cobra.Command, editor string, paths basedir.Paths,
 
 // openSandboxInCursorTarget launches Cursor connected to a prepared SSH target.
 func openSandboxInCursorTarget(cmd *cobra.Command, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
-	return launchRemoteSSHEditor(cmd, "cursor", "Cursor",
-		"Cursor > Settings > Extensions > cursor-cli", paths, target, pathOverride)
+	return launchRemoteSSHEditor(cmd, "cursor", "Cursor", paths, target, pathOverride)
 }
 
 // openSandboxInVSCodeTarget launches VS Code connected to a prepared SSH target.
 func openSandboxInVSCodeTarget(cmd *cobra.Command, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
-	return launchRemoteSSHEditor(cmd, "code", "VS Code",
-		"the VS Code Command Palette: \"Shell Command: Install 'code' command in PATH\"", paths, target, pathOverride)
+	return launchRemoteSSHEditor(cmd, "code", "VS Code", paths, target, pathOverride)
 }
 
 // The WSL seams isolate the editor launch from the Windows side, so tests
@@ -270,12 +268,12 @@ var (
 // launchRemoteSSHEditor launches a VS Code-family editor (Cursor, VS Code)
 // against a prepared SSH target. Both share VS Code's Remote-SSH CLI contract:
 // <cli> --remote ssh-remote+<host> <path>.
-func launchRemoteSSHEditor(cmd *cobra.Command, cli, name, installHint string, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
+func launchRemoteSSHEditor(cmd *cobra.Command, cli, name string, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
 	if wslIsWSL() {
 		return launchWindowsEditorFromWSL(cmd, cli, name, paths, target, pathOverride)
 	}
 	if _, err := exec.LookPath(cli); err != nil {
-		return fmt.Errorf("%s CLI is not installed or not in PATH; install it from %s", cli, installHint)
+		return fmt.Errorf("%s CLI is not installed or not in PATH: %w", cli, err)
 	}
 
 	remotePath := resolveRemoteWorkspacePath(target.repoName, pathOverride)
@@ -313,8 +311,8 @@ func launchWindowsEditorFromWSL(cmd *cobra.Command, cli, name string, paths base
 
 	remotePath := resolveRemoteWorkspacePath(target.repoName, pathOverride)
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Mirrored SSH config for sandbox %q to %s.\n", target.sandboxName, windowsTarget.SSHDirWindows)
-	fmt.Fprintf(out, "Opening %s (Windows)...\n", name)
+	fmt.Fprintf(out, "Opening sandbox %q in %s (Windows) via SSH (%s)...\n", target.sandboxName, name, target.alias)
+	fmt.Fprintf(out, "Hint: if the file explorer is not visible, press Cmd+Shift+E in %s to open it.\n", name)
 
 	if err := wslLaunchWindows(exe, "--remote", "ssh-remote+"+target.alias, remotePath); err != nil {
 		return fmt.Errorf("launch Windows %s: %w\n\nMake sure the \"Remote - SSH\" extension is installed in %s", name, err, name)

--- a/go/cmd/amika/sandbox/sandbox_ssh_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/ssh"
+	"github.com/gofixpoint/amika/go/internal/wslbridge"
 	"github.com/spf13/cobra"
 )
 
@@ -279,5 +281,101 @@ func TestResolveSandboxV2SSHAliasUsesSharedSessionPreparation(t *testing.T) {
 	}
 	if target.alias != "my-sandbox.sb_abc.app-amika-dev.amika" || target.sandboxName != "my-sandbox" || target.repoName != "biz" {
 		t.Fatalf("target = %#v", target)
+	}
+}
+
+// stubWSLSeams wires the WSL handoff seams to recorders, so the editor
+// launch runs to completion in tests without a Windows side.
+func stubWSLSeams(t *testing.T) (*[]wslbridge.Target, *[][]string) {
+	t.Helper()
+	var mirrored []wslbridge.Target
+	var launched [][]string
+
+	prevIsWSL, prevTarget, prevExe, prevLaunch, prevMirror := wslIsWSL, wslResolveTarget, wslEditorExe, wslLaunchWindows, mirrorSSHToWindows
+	wslIsWSL = func() bool { return true }
+	wslResolveTarget = func() (wslbridge.Target, error) {
+		return wslbridge.Target{
+			SSHDir:        t.TempDir(),
+			SSHDirWindows: `C:\Users\testuser\.ssh`,
+			Distro:        "Ubuntu",
+			User:          "testuser",
+		}, nil
+	}
+	wslEditorExe = func(string) (string, error) {
+		return `C:\Users\testuser\AppData\Local\Programs\Microsoft VS Code\Code.exe`, nil
+	}
+	wslLaunchWindows = func(exe string, args ...string) error {
+		launched = append(launched, append([]string{exe}, args...))
+		return nil
+	}
+	mirrorSSHToWindows = func(_ basedir.Paths, target wslbridge.Target) error {
+		mirrored = append(mirrored, target)
+		return nil
+	}
+	t.Cleanup(func() {
+		wslIsWSL, wslResolveTarget, wslEditorExe, wslLaunchWindows, mirrorSSHToWindows = prevIsWSL, prevTarget, prevExe, prevLaunch, prevMirror
+	})
+	return &mirrored, &launched
+}
+
+func TestOpenSandboxInEditorMirrorsToWindowsUnderWSL(t *testing.T) {
+	mirrored, launched := stubWSLSeams(t)
+	paths, _ := testSSHPaths(t)
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	target := sandboxSSHAlias{alias: "my-sandbox.sb_abc.prod.amika", sandboxName: "my-sandbox", repoName: "biz"}
+	if err := openSandboxInEditor(cmd, "vscode", paths, target, ""); err != nil {
+		t.Fatalf("openSandboxInEditor: %v", err)
+	}
+	if len(*mirrored) != 1 {
+		t.Fatalf("mirror calls = %d, want 1", len(*mirrored))
+	}
+	if (*mirrored)[0].User != "testuser" {
+		t.Fatalf("mirrored target = %+v", (*mirrored)[0])
+	}
+	if len(*launched) != 1 {
+		t.Fatalf("launch calls = %d, want 1", len(*launched))
+	}
+	argv := (*launched)[0]
+	if !strings.HasSuffix(argv[0], "Code.exe") ||
+		argv[1] != "--remote" ||
+		argv[2] != "ssh-remote+my-sandbox.sb_abc.prod.amika" ||
+		argv[3] != "/home/amika/workspace/biz" {
+		t.Fatalf("launch argv = %q", argv)
+	}
+
+	// The same handoff serves Cursor, which shares the launcher.
+	*mirrored, *launched = nil, nil
+	if err := openSandboxInEditor(cmd, "cursor", paths, target, ""); err != nil {
+		t.Fatalf("openSandboxInEditor(cursor): %v", err)
+	}
+	if len(*mirrored) != 1 || len(*launched) != 1 {
+		t.Fatalf("mirror/launch calls = %d/%d, want 1/1", len(*mirrored), len(*launched))
+	}
+}
+
+func TestOpenSandboxInEditorSkipsWindowsWhenNotWSL(t *testing.T) {
+	mirrored, launched := stubWSLSeams(t)
+	wslIsWSL = func() bool { return false }
+	// An empty PATH makes the local editor CLI lookup fail deterministically,
+	// so the test observes the requirement without launching a real editor.
+	t.Setenv("PATH", t.TempDir())
+	paths, _ := testSSHPaths(t)
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	target := sandboxSSHAlias{alias: "amika-sb_abc", sandboxName: "my-sandbox", repoName: "biz"}
+	// Without WSL the launcher requires the editor CLI locally; the error
+	// names the install hint rather than touching the Windows side.
+	err := openSandboxInEditor(cmd, "vscode", paths, target, "")
+	if err == nil {
+		t.Fatal("expected a local editor CLI requirement")
+	}
+	if !strings.Contains(err.Error(), "install") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(*mirrored) != 0 || len(*launched) != 0 {
+		t.Fatalf("mirror/launch calls = %d/%d, want 0/0", len(*mirrored), len(*launched))
 	}
 }

--- a/go/cmd/amika/sandbox/sandbox_ssh_v2.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_v2.go
@@ -144,6 +144,7 @@ hands that alias to the selected editor. It requires an SSH identity from
 Examples:
   amika sandbox codev2 my-sandbox
   amika sandbox codev2 my-sandbox --editor=cursor
+  amika sandbox codev2 my-sandbox --editor=vscode
   amika sandbox codev2 my-sandbox --editor=claude
   amika sandbox codev2 my-sandbox --editor=codex`,
 	Args: cobra.ExactArgs(1),

--- a/go/internal/basedir/basedir.go
+++ b/go/internal/basedir/basedir.go
@@ -369,3 +369,21 @@ func SSHHostsStateFileIn(stateDir string) string {
 func SSHAmikaConfigName() string {
 	return sshAmikaConfigFile
 }
+
+// SSHConfigName returns the bare filename of the user's primary ssh config,
+// as it should appear in an `Include` directive within ~/.ssh/config.
+func SSHConfigName() string {
+	return sshConfigFile
+}
+
+// SSHIdentityName returns the bare filename of the default user-owned Ed25519
+// private key in ~/.ssh.
+func SSHIdentityName() string {
+	return sshIdentityFile
+}
+
+// SSHKnownHostsName returns the bare filename of the dedicated strict host-key
+// pin file in ~/.ssh.
+func SSHKnownHostsName() string {
+	return sshKnownHostsFile
+}

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -237,22 +237,16 @@ func (s *HostsState) UpsertSessionHost(alias string) {
 // so the file stays human-readable even though it is keyed by id.
 func Render(state HostsState) string {
 	var b strings.Builder
+	writeManagedConfig(&b, state, renderSessionBlocks(state))
+	return b.String()
+}
+
+// writeManagedConfig assembles the shared layout of the managed config:
+// provider-native hosts, then the concrete session aliases editors discover
+// connections by, then the wildcard session blocks.
+func writeManagedConfig(b *strings.Builder, state HostsState, blocks []string) {
 	b.WriteString(managedHeader)
-	for _, h := range state.Hosts {
-		b.WriteString("\n")
-		if h.SandboxName != "" {
-			fmt.Fprintf(&b, "# %s\n", h.SandboxName)
-		}
-		fmt.Fprintf(&b, "Host %s\n", Alias(h.SandboxID))
-		fmt.Fprintf(&b, "  HostName %s\n", h.HostName)
-		if h.User != "" {
-			fmt.Fprintf(&b, "  User %s\n", h.User)
-		}
-		if h.Port != 0 {
-			fmt.Fprintf(&b, "  Port %d\n", h.Port)
-		}
-		b.WriteString("  StrictHostKeyChecking accept-new\n")
-	}
+	writeHostBlocks(b, state.Hosts)
 	if hosts := renderSessionHosts(state); len(hosts) > 0 {
 		b.WriteString("\n# Direct WebSocket SSH aliases for editor discovery.\n")
 		for i, host := range hosts {
@@ -262,7 +256,7 @@ func Render(state HostsState) string {
 			b.WriteString(host)
 		}
 	}
-	if blocks := renderSessionBlocks(state); len(blocks) > 0 {
+	if len(blocks) > 0 {
 		b.WriteString("\n# No-relay WebSocket SSH aliases, one block per control plane.\n")
 		for i, block := range blocks {
 			if i > 0 {
@@ -271,7 +265,25 @@ func Render(state HostsState) string {
 			b.WriteString(block)
 		}
 	}
-	return b.String()
+}
+
+// writeHostBlocks renders one block per provider-native host entry.
+func writeHostBlocks(b *strings.Builder, hosts []HostEntry) {
+	for _, h := range hosts {
+		b.WriteString("\n")
+		if h.SandboxName != "" {
+			fmt.Fprintf(b, "# %s\n", h.SandboxName)
+		}
+		fmt.Fprintf(b, "Host %s\n", Alias(h.SandboxID))
+		fmt.Fprintf(b, "  HostName %s\n", h.HostName)
+		if h.User != "" {
+			fmt.Fprintf(b, "  User %s\n", h.User)
+		}
+		if h.Port != 0 {
+			fmt.Fprintf(b, "  Port %d\n", h.Port)
+		}
+		b.WriteString("  StrictHostKeyChecking accept-new\n")
+	}
 }
 
 // renderSessionHosts emits intentionally empty concrete Host stanzas before
@@ -461,6 +473,14 @@ func EnsureInclude(paths basedir.Paths) error {
 	if err != nil {
 		return err
 	}
+	return ensureIncludeIn(configPath)
+}
+
+// ensureIncludeIn prepends the Include line for the managed config to an ssh
+// config file, creating the file when absent and preserving existing content.
+// It is target-agnostic so the Windows mirror can maintain its own config the
+// same way the Linux one is maintained.
+func ensureIncludeIn(configPath string) error {
 	writePath, err := resolveWriteTarget(configPath)
 	if err != nil {
 		return err

--- a/go/internal/ssh/mirror.go
+++ b/go/internal/ssh/mirror.go
@@ -1,0 +1,151 @@
+package ssh
+
+// mirror.go renders and writes the Windows-side copy of the managed SSH
+// config for WSL setups, where amika runs in WSL but the editors that need
+// the connection state run as Windows applications.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/gofixpoint/amika/go/internal/wslbridge"
+)
+
+// safeWindowsConfigPath accepts an absolute Windows path whose characters
+// cannot alter ssh config parsing or OpenSSH %-token expansion.
+var safeWindowsConfigPath = regexp.MustCompile(`^[A-Za-z]:\\[^/*?:"<>|%\r\n\t'` + "`" + `]+$`)
+
+// runIcacls is a seam over the Windows ACL tool, so tests observe the
+// permission hardening without a Windows side.
+var runIcacls = func(path, user string) error {
+	cmd := exec.Command("icacls.exe", path, "/inheritance:r", "/grant:r", user+":F")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("icacls %s: %w: %s", path, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// RenderWindows renders the managed config for a Windows OpenSSH client.
+// Provider-native host blocks pass through unchanged, since their
+// destinations are reachable from Windows directly; session blocks reference
+// the mirrored identity and pin files and dial through wsl.exe into the
+// distribution that owns the session state.
+func RenderWindows(state HostsState, target wslbridge.Target) (string, error) {
+	if !safeWindowsConfigPath.MatchString(target.SSHDirWindows) {
+		return "", fmt.Errorf("unsafe Windows .ssh directory %q", target.SSHDirWindows)
+	}
+	blocks, err := renderWindowsSessionBlocks(state, target)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	writeManagedConfig(&b, state, blocks)
+	return b.String(), nil
+}
+
+// renderWindowsSessionBlocks renders one wildcard block per control plane,
+// rebuilding each ProxyCommand as its wsl.exe equivalent and pointing the key
+// material at the mirrored copies in the Windows .ssh directory.
+func renderWindowsSessionBlocks(state HostsState, target wslbridge.Target) ([]string, error) {
+	if state.SessionConfig == nil {
+		return nil, nil
+	}
+	environments := make([]string, 0, len(state.SessionProxyCommands))
+	for environment := range state.SessionProxyCommands {
+		environments = append(environments, environment)
+	}
+	sort.Strings(environments)
+	blocks := make([]string, 0, len(environments))
+	for _, environment := range environments {
+		binaryPath, err := ParseProxyCommand(state.SessionProxyCommands[environment])
+		if err != nil {
+			return nil, fmt.Errorf("environment %s: %w", environment, err)
+		}
+		proxyCommand, err := BuildWSLProxyCommand(target.Distro, binaryPath)
+		if err != nil {
+			return nil, fmt.Errorf("environment %s: %w", environment, err)
+		}
+		blocks = append(blocks, renderSessionBlock(
+			environment,
+			proxyCommand,
+			quoteWindowsPath(target.SSHDirWindows+"\\"+basedir.SSHIdentityName()),
+			quoteWindowsPath(target.SSHDirWindows+"\\"+basedir.SSHKnownHostsName()),
+		))
+	}
+	return blocks, nil
+}
+
+// quoteWindowsPath wraps a path in the double quotes ssh config accepts, so
+// profiles containing spaces parse as one value.
+func quoteWindowsPath(path string) string {
+	return `"` + path + `"`
+}
+
+// MirrorToWindows publishes the current managed SSH state to the Windows
+// side: it renders the config for a Windows client, writes it as the
+// mirrored amika.conf, adds the Include line to the Windows ssh config, and
+// copies the identity and host-key pins the rendered config references,
+// restricting the identity's Windows ACLs. The Windows copies are
+// regenerated artifacts; the Linux-side state stays the only source of
+// truth.
+func MirrorToWindows(paths basedir.Paths, target wslbridge.Target) error {
+	state, err := LoadState(paths)
+	if err != nil {
+		return err
+	}
+	content, err := RenderWindows(state, target)
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomic(filepath.Join(target.SSHDir, basedir.SSHAmikaConfigName()), []byte(content), 0o600); err != nil {
+		return err
+	}
+	if err := ensureIncludeIn(filepath.Join(target.SSHDir, basedir.SSHConfigName())); err != nil {
+		return fmt.Errorf("ensure Windows ssh config include: %w", err)
+	}
+
+	identityPath, err := paths.SSHIdentityFile()
+	if err != nil {
+		return err
+	}
+	identityCopied, err := mirrorFile(identityPath, filepath.Join(target.SSHDir, basedir.SSHIdentityName()))
+	if err != nil {
+		return err
+	}
+	if identityCopied {
+		if err := runIcacls(target.SSHDirWindows+"\\"+basedir.SSHIdentityName(), target.User); err != nil {
+			return fmt.Errorf("restrict mirrored identity permissions: %w", err)
+		}
+	}
+
+	knownHostsPath, err := paths.SSHKnownHostsFile()
+	if err != nil {
+		return err
+	}
+	_, err = mirrorFile(knownHostsPath, filepath.Join(target.SSHDir, basedir.SSHKnownHostsName()))
+	return err
+}
+
+// mirrorFile copies src to dst when src exists, reporting whether it copied.
+// The copy is a derived artifact, so it is overwritten wholesale rather than
+// merged.
+func mirrorFile(src, dst string) (bool, error) {
+	data, err := os.ReadFile(src)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %q: %w", src, err)
+	}
+	if err := writeFileAtomic(dst, data, 0o600); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/go/internal/ssh/mirror_test.go
+++ b/go/internal/ssh/mirror_test.go
@@ -1,0 +1,240 @@
+package ssh
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gofixpoint/amika/go/internal/basedir"
+	"github.com/gofixpoint/amika/go/internal/wslbridge"
+)
+
+func TestBuildWSLProxyCommand(t *testing.T) {
+	got, err := BuildWSLProxyCommand("Ubuntu-22.04", "/usr/local/bin/amika")
+	if err != nil {
+		t.Fatalf("BuildWSLProxyCommand: %v", err)
+	}
+	want := "wsl.exe -d Ubuntu-22.04 -e /usr/local/bin/amika plumbing ssh-stdio-proxy %h"
+	if got != want {
+		t.Fatalf("BuildWSLProxyCommand = %q, want %q", got, want)
+	}
+
+	tests := []struct {
+		name   string
+		distro string
+		binary string
+	}{
+		{name: "distro with space", distro: "My Distro", binary: "/usr/local/bin/amika"},
+		{name: "distro with metachar", distro: "Ubuntu;rm -rf", binary: "/usr/local/bin/amika"},
+		{name: "binary with space", distro: "Ubuntu", binary: "/opt/amika bin/amika"},
+		{name: "binary with semicolon", distro: "Ubuntu", binary: "/opt/amika;sh"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := BuildWSLProxyCommand(tt.distro, tt.binary); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+// windowsTestTarget points the mirror at a scratch directory while keeping
+// Windows-style path spelling for the rendered config.
+func windowsTestTarget(dir string) wslbridge.Target {
+	return wslbridge.Target{
+		SSHDir:        dir,
+		SSHDirWindows: `C:\Users\testuser\.ssh`,
+		Distro:        "Ubuntu",
+		User:          "testuser",
+	}
+}
+
+// sessionTestState builds a fully valid state: one provider-native host plus
+// a session configured against the caller's paths.
+func sessionTestState(t *testing.T, paths basedir.Paths) HostsState {
+	t.Helper()
+	identity, err := paths.SSHIdentityFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	knownHosts, err := paths.SSHKnownHostsFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy, err := BuildProxyCommand("/usr/local/bin/amika")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return HostsState{
+		Hosts: []HostEntry{{
+			SandboxID:   "sb_1",
+			SandboxName: "my-sandbox",
+			HostName:    "ssh.app.daytona.io",
+			User:        "tok",
+			Port:        2222,
+		}},
+		SessionConfig: &SessionConfig{
+			IdentityFile:   identity,
+			KnownHostsFile: knownHosts,
+		},
+		SessionProxyCommands: map[string]string{"prod": proxy},
+		SessionHosts:         []SessionHostEntry{{Alias: "my-sandbox.sb_1.prod.amika"}},
+	}
+}
+
+func TestRenderWindows(t *testing.T) {
+	state := sessionTestState(t, testPaths(t))
+	content, err := RenderWindows(state, windowsTestTarget(t.TempDir()))
+	if err != nil {
+		t.Fatalf("RenderWindows: %v", err)
+	}
+
+	for _, want := range []string{
+		"Host amika-sb_1\n",
+		"  HostName ssh.app.daytona.io\n",
+		"Host my-sandbox.sb_1.prod.amika\n",
+		`IdentityFile "C:\Users\testuser\.ssh\amika_id_ed25519"` + "\n",
+		`UserKnownHostsFile "C:\Users\testuser\.ssh\amika_known_hosts"` + "\n",
+		"ProxyCommand wsl.exe -d Ubuntu -e /usr/local/bin/amika plumbing ssh-stdio-proxy %h\n",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("rendered config missing %q:\n%s", want, content)
+		}
+	}
+}
+
+func TestRenderWindowsWithoutSession(t *testing.T) {
+	state := sessionTestState(t, testPaths(t))
+	state.SessionConfig = nil
+	state.SessionProxyCommands = nil
+	state.SessionHosts = nil
+
+	content, err := RenderWindows(state, windowsTestTarget(t.TempDir()))
+	if err != nil {
+		t.Fatalf("RenderWindows: %v", err)
+	}
+	if strings.Contains(content, "ProxyCommand") {
+		t.Fatalf("expected no session block without session state:\n%s", content)
+	}
+	if !strings.Contains(content, "Host amika-sb_1\n") {
+		t.Fatalf("provider-native host should pass through:\n%s", content)
+	}
+}
+
+func TestRenderWindowsRejectsUnsafeTarget(t *testing.T) {
+	target := windowsTestTarget(t.TempDir())
+	target.SSHDirWindows = `C:\Users\bad%name\.ssh`
+	if _, err := RenderWindows(sessionTestState(t, testPaths(t)), target); err == nil {
+		t.Fatal("expected error for a directory with an unsafe character")
+	}
+}
+
+func TestMirrorToWindows(t *testing.T) {
+	paths := testPaths(t)
+	if err := SaveState(paths, sessionTestState(t, paths)); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	identity, err := paths.SSHIdentityFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(identity), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(identity, []byte("private key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	knownHosts, err := paths.SSHKnownHostsFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(knownHosts, []byte("my-sandbox.sb_1.prod.amika ssh-ed25519 AAAA\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var icaclsCalls [][2]string
+	prevIcacls := runIcacls
+	runIcacls = func(path, user string) error {
+		icaclsCalls = append(icaclsCalls, [2]string{path, user})
+		return nil
+	}
+	t.Cleanup(func() { runIcacls = prevIcacls })
+
+	winSSH := filepath.Join(t.TempDir(), "winssh")
+	target := windowsTestTarget(winSSH)
+	if err := MirrorToWindows(paths, target); err != nil {
+		t.Fatalf("MirrorToWindows: %v", err)
+	}
+
+	conf, err := os.ReadFile(filepath.Join(winSSH, "amika.conf"))
+	if err != nil {
+		t.Fatalf("read mirrored amika.conf: %v", err)
+	}
+	if !strings.Contains(string(conf), "ProxyCommand wsl.exe -d Ubuntu -e /usr/local/bin/amika") {
+		t.Fatalf("mirrored config missing wsl proxy:\n%s", conf)
+	}
+	assertPerm(t, filepath.Join(winSSH, "amika.conf"), 0o600)
+
+	config, err := os.ReadFile(filepath.Join(winSSH, "config"))
+	if err != nil {
+		t.Fatalf("read mirrored ssh config: %v", err)
+	}
+	if !strings.Contains(string(config), "Include amika.conf") {
+		t.Fatalf("mirrored config missing include:\n%s", config)
+	}
+
+	copiedIdentity, err := os.ReadFile(filepath.Join(winSSH, "amika_id_ed25519"))
+	if err != nil {
+		t.Fatalf("read mirrored identity: %v", err)
+	}
+	if string(copiedIdentity) != "private key" {
+		t.Fatalf("mirrored identity = %q", copiedIdentity)
+	}
+
+	copiedPins, err := os.ReadFile(filepath.Join(winSSH, "amika_known_hosts"))
+	if err != nil {
+		t.Fatalf("read mirrored known hosts: %v", err)
+	}
+	if !strings.Contains(string(copiedPins), "my-sandbox.sb_1.prod.amika") {
+		t.Fatalf("mirrored known hosts missing pin:\n%s", copiedPins)
+	}
+
+	if len(icaclsCalls) != 1 {
+		t.Fatalf("icacls calls = %v, want one", icaclsCalls)
+	}
+	want := [2]string{`C:\Users\testuser\.ssh\amika_id_ed25519`, "testuser"}
+	if icaclsCalls[0] != want {
+		t.Fatalf("icacls = %v, want %v", icaclsCalls[0], want)
+	}
+}
+
+func TestMirrorToWindowsWithoutIdentity(t *testing.T) {
+	paths := testPaths(t)
+	state := sessionTestState(t, paths)
+	state.SessionConfig = nil
+	state.SessionProxyCommands = nil
+	state.SessionHosts = nil
+	if err := SaveState(paths, state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	icaclsCalled := false
+	prevIcacls := runIcacls
+	runIcacls = func(string, string) error {
+		icaclsCalled = true
+		return nil
+	}
+	t.Cleanup(func() { runIcacls = prevIcacls })
+
+	winSSH := filepath.Join(t.TempDir(), "winssh")
+	if err := MirrorToWindows(paths, windowsTestTarget(winSSH)); err != nil {
+		t.Fatalf("MirrorToWindows: %v", err)
+	}
+	if icaclsCalled {
+		t.Fatal("icacls must not run when no identity was mirrored")
+	}
+	if _, err := os.Stat(filepath.Join(winSSH, "amika.conf")); err != nil {
+		t.Fatalf("mirrored config should exist: %v", err)
+	}
+}

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -181,6 +181,22 @@ func ResolveProxyCommand() (string, error) {
 	return BuildProxyCommand(binaryPath)
 }
 
+// BuildWSLProxyCommand renders the ProxyCommand a Windows OpenSSH client uses
+// to reach a session alias: it re-enters the owning WSL distribution and
+// execs the same Linux amika binary the Linux-side proxy would. The
+// distribution name and binary path are held to the alias and proxy path
+// safety rules, so a corrupted mirror source can only ever produce the fixed
+// proxy invocation.
+func BuildWSLProxyCommand(distro, binaryPath string) (string, error) {
+	if !safeAliasPart.MatchString(distro) {
+		return "", fmt.Errorf("unsafe WSL distribution name %q", distro)
+	}
+	if !safeProxyBinaryPath(binaryPath) {
+		return "", ErrUnsafeBinaryPath
+	}
+	return "wsl.exe -d " + distro + " -e " + binaryPath + proxyCommandSuffix, nil
+}
+
 // RenderSessionConfig renders one environment's wildcard block. The pattern is
 // scoped to `*.<environment>.amika` rather than `*.amika` so each control plane
 // gets its own ProxyCommand: a bare `*.amika` would also match every other
@@ -195,6 +211,13 @@ func RenderSessionConfig(environment, proxyCommand string, session SessionConfig
 	if _, err := ParseProxyCommand(proxyCommand); err != nil {
 		return "", err
 	}
+	return renderSessionBlock(environment, proxyCommand, session.IdentityFile, session.KnownHostsFile), nil
+}
+
+// renderSessionBlock formats one environment's wildcard session block. Path
+// and command validation belongs to the callers, which apply different rules
+// per target platform.
+func renderSessionBlock(environment, proxyCommand, identityFile, knownHostsFile string) string {
 	return fmt.Sprintf(`Host *.%s.amika
   User amika
   IdentityFile %s
@@ -204,7 +227,7 @@ func RenderSessionConfig(environment, proxyCommand string, session SessionConfig
   ProxyCommand %s
   ServerAliveInterval 15
   ServerAliveCountMax 3
-`, environment, session.IdentityFile, session.KnownHostsFile, proxyCommand), nil
+`, environment, identityFile, knownHostsFile, proxyCommand)
 }
 
 // KnownHostLine returns one canonical alias-keyed Ed25519 pin.

--- a/go/internal/wslbridge/wslbridge.go
+++ b/go/internal/wslbridge/wslbridge.go
@@ -1,0 +1,211 @@
+// Package wslbridge spans the WSL boundary: amika runs as a Linux binary
+// inside a WSL distribution while the user's editors run as Windows
+// applications. It detects WSL, resolves the Windows user's paths through
+// interop, and locates Windows editor executables, so callers can mirror
+// connection state to the Windows side and launch editors there.
+package wslbridge
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// readProcVersion is a seam over the kernel version file, so tests can decide
+// whether the process looks like it runs under WSL.
+var readProcVersion = func() ([]byte, error) { return os.ReadFile("/proc/version") }
+
+// runInterop is a seam over interop execution: Windows-side helper programs
+// invoked from WSL, whose answers the caller cannot compute on its own. Tests
+// stub it to answer without a Windows side.
+var runInterop = func(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run %s: %w: %s", name, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// userProfileLine matches one drive-anchored Windows path, the shape a valid
+// %USERPROFILE% expansion must have. Matching the whole line keeps leading
+// interop noise from being mistaken for the value.
+var userProfileLine = regexp.MustCompile(`(?m)^[A-Za-z]:\\[^\r\n]*$`)
+
+// IsWSL reports whether this process runs inside the Windows Subsystem for
+// Linux, where the user's editors are Windows applications. Any failure to
+// read the kernel version means not WSL.
+func IsWSL() bool {
+	version, err := readProcVersion()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(version)), "microsoft")
+}
+
+// Distro returns the name of the WSL distribution this process runs in, which
+// a Windows-side proxy command must pin so it re-enters the distribution that
+// owns amika's state.
+func Distro() (string, error) {
+	distro := os.Getenv("WSL_DISTRO_NAME")
+	if distro == "" {
+		return "", fmt.Errorf("WSL_DISTRO_NAME is not set; run amika from an interactive WSL shell")
+	}
+	return distro, nil
+}
+
+// Target names the Windows side an editor launch needs: the user's .ssh
+// directory in both path spellings, the WSL distribution a proxy command must
+// re-enter, and the Windows account name used for ACL grants.
+type Target struct {
+	SSHDir        string
+	SSHDirWindows string
+	Distro        string
+	User          string
+}
+
+// ResolveTarget collects the Windows-side facts the SSH mirror and the editor
+// launch need. It fails rather than guesses when interop cannot answer.
+func ResolveTarget() (Target, error) {
+	distro, err := Distro()
+	if err != nil {
+		return Target{}, err
+	}
+	profile, err := UserProfile()
+	if err != nil {
+		return Target{}, err
+	}
+	sshDirWindows := profile + "\\.ssh"
+	sshDir, err := toWSLPath(sshDirWindows)
+	if err != nil {
+		return Target{}, err
+	}
+	user := profile[strings.LastIndexByte(profile, '\\')+1:]
+	if user == "" {
+		return Target{}, fmt.Errorf("derive Windows account name from profile %q", profile)
+	}
+	return Target{SSHDir: sshDir, SSHDirWindows: sshDirWindows, Distro: distro, User: user}, nil
+}
+
+// UserProfile returns the Windows user profile directory (for example
+// C:\Users\name) by asking cmd.exe to expand %USERPROFILE%.
+func UserProfile() (string, error) {
+	out, err := runInterop("cmd.exe", "/c", "echo", "%USERPROFILE%")
+	if err != nil {
+		return "", fmt.Errorf("expand %%USERPROFILE%% (is WSL interop enabled?): %w", err)
+	}
+	out = strings.ReplaceAll(out, "\r\n", "\n")
+	lines := userProfileLine.FindAllString(out, -1)
+	if len(lines) == 0 {
+		return "", fmt.Errorf("cmd.exe returned %q for %%USERPROFILE%%", strings.TrimSpace(out))
+	}
+	return strings.TrimSpace(lines[len(lines)-1]), nil
+}
+
+// editorInstalls maps a VS Code-family CLI name to its Windows install folder
+// and executable, covering the default per-user locations used when the CLI
+// cannot be found on the Windows PATH.
+var editorInstalls = map[string]struct{ dir, exe string }{
+	"code":   {"Microsoft VS Code", "Code.exe"},
+	"cursor": {"Cursor", "Cursor.exe"},
+}
+
+// EditorExe locates the Windows application executable behind a VS Code-family
+// editor CLI name ("code", "cursor") and returns its Windows path.
+func EditorExe(cli string) (string, error) {
+	install, ok := editorInstalls[cli]
+	if !ok {
+		return "", fmt.Errorf("unsupported Windows editor %q", cli)
+	}
+	var candidates []string
+	if where, err := runInterop("where.exe", cli); err == nil {
+		if line := firstLine(where); line != "" {
+			if idx := strings.LastIndexByte(line, '\\'); idx > 2 {
+				dir := line[:idx]
+				// The CLI launcher sits one bin\ or cmd\ level below the application
+				// executable, so search the install root it belongs to.
+				lower := strings.ToLower(dir)
+				if strings.HasSuffix(lower, "\\bin") || strings.HasSuffix(lower, "\\cmd") {
+					dir = dir[:strings.LastIndexByte(dir, '\\')]
+				}
+				candidates = append(candidates, dir+"\\"+install.exe)
+			}
+		}
+	}
+	if profile, err := UserProfile(); err == nil {
+		candidates = append(candidates,
+			profile+"\\AppData\\Local\\Programs\\"+install.dir+"\\"+install.exe)
+	}
+	for _, candidate := range candidates {
+		wslPath, err := toWSLPath(candidate)
+		if err != nil {
+			continue
+		}
+		if info, err := os.Stat(wslPath); err == nil && info.Mode().IsRegular() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("no Windows %s found; install the editor on Windows, or install its Linux build inside WSL", install.exe)
+}
+
+// execDetached is a seam over the detached spawn, so tests observe the argv
+// without a Windows side.
+var execDetached = func(name string, args ...string) error {
+	// All stdio is /dev/null so the child inherits no pipe, and the process
+	// is reaped in the background: the caller returns once the process is
+	// spawned, not when it exits.
+	null, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer null.Close()
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = null
+	cmd.Stdout = null
+	cmd.Stderr = null
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go cmd.Wait()
+	return nil
+}
+
+// LaunchDetached starts a Windows executable through cmd.exe's start command
+// and returns as soon as it is spawned. The empty title argument keeps start
+// from treating a quoted executable path as the window title.
+func LaunchDetached(windowsExe string, args ...string) error {
+	startArgs := append([]string{"/c", "start", "", windowsExe}, args...)
+	if err := execDetached("cmd.exe", startArgs...); err != nil {
+		return fmt.Errorf("launch %s: %w", windowsExe, err)
+	}
+	return nil
+}
+
+// toWSLPath converts an absolute Windows path to its WSL mount path via
+// wslpath, so file operations can reach it from Linux.
+func toWSLPath(windowsPath string) (string, error) {
+	out, err := runInterop("wslpath", "-u", windowsPath)
+	if err != nil {
+		return "", fmt.Errorf("convert %q to a WSL path: %w", windowsPath, err)
+	}
+	converted := strings.TrimSpace(out)
+	if converted == "" {
+		return "", fmt.Errorf("wslpath returned nothing for %q", windowsPath)
+	}
+	return converted, nil
+}
+
+// firstLine returns the first non-empty line of a command's output.
+func firstLine(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/go/internal/wslbridge/wslbridge.go
+++ b/go/internal/wslbridge/wslbridge.go
@@ -150,7 +150,7 @@ func EditorExe(cli string) (string, error) {
 			return candidate, nil
 		}
 	}
-	return "", fmt.Errorf("no Windows %s found; install the editor on Windows, or install its Linux build inside WSL", install.exe)
+	return "", fmt.Errorf("no Windows %s found; install the editor on Windows", install.exe)
 }
 
 // execDetached is a seam over the detached spawn, so tests observe the argv

--- a/go/internal/wslbridge/wslbridge_test.go
+++ b/go/internal/wslbridge/wslbridge_test.go
@@ -1,0 +1,221 @@
+package wslbridge
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubInterop replaces interop execution with scripted answers keyed by the
+// invoked program, so no test needs a Windows side.
+func stubInterop(t *testing.T, answers map[string]string) *[]string {
+	t.Helper()
+	var calls []string
+	prev := runInterop
+	runInterop = func(name string, args ...string) (string, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		answer, ok := answers[name]
+		if !ok {
+			return "", errors.New("unexpected interop call: " + name)
+		}
+		return answer, nil
+	}
+	t.Cleanup(func() { runInterop = prev })
+	return &calls
+}
+
+func TestIsWSL(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		readErr error
+		want    bool
+	}{
+		{name: "wsl2 kernel", version: "Linux version 5.15.167.4-microsoft-standard-WSL2...", want: true},
+		{name: "case insensitive", version: "Linux version ... Microsoft-WSL", want: true},
+		{name: "plain linux", version: "Linux version 6.8.0-40-generic...", want: false},
+		{name: "unreadable", readErr: errors.New("no such file"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := readProcVersion
+			readProcVersion = func() ([]byte, error) {
+				if tt.readErr != nil {
+					return nil, tt.readErr
+				}
+				return []byte(tt.version), nil
+			}
+			t.Cleanup(func() { readProcVersion = prev })
+
+			if got := IsWSL(); got != tt.want {
+				t.Fatalf("IsWSL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDistro(t *testing.T) {
+	t.Setenv("WSL_DISTRO_NAME", "Ubuntu-22.04")
+	distro, err := Distro()
+	if err != nil {
+		t.Fatalf("Distro: %v", err)
+	}
+	if distro != "Ubuntu-22.04" {
+		t.Fatalf("Distro = %q", distro)
+	}
+
+	t.Setenv("WSL_DISTRO_NAME", "")
+	if _, err := Distro(); err == nil {
+		t.Fatal("expected error when WSL_DISTRO_NAME is unset")
+	}
+}
+
+func TestUserProfileIgnoresLeadingNoise(t *testing.T) {
+	stubInterop(t, map[string]string{
+		"cmd.exe": "'\\\\wsl.localhost\\Ubuntu\\home\\u'\r\nCMD.EXE was started with the above path as the current directory.\r\nC:\\Users\\Test User\r\n",
+	})
+	profile, err := UserProfile()
+	if err != nil {
+		t.Fatalf("UserProfile: %v", err)
+	}
+	if profile != `C:\Users\Test User` {
+		t.Fatalf("UserProfile = %q", profile)
+	}
+}
+
+func TestUserProfileRejectsGarbage(t *testing.T) {
+	stubInterop(t, map[string]string{"cmd.exe": "\r\n"})
+	if _, err := UserProfile(); err == nil {
+		t.Fatal("expected error for output without a drive path")
+	}
+}
+
+func TestResolveTarget(t *testing.T) {
+	t.Setenv("WSL_DISTRO_NAME", "Ubuntu")
+	stubInterop(t, map[string]string{
+		"cmd.exe": "C:\\Users\\hrishikesh\r\n",
+		"wslpath": "/mnt/c/Users/hrishikesh/.ssh\n",
+	})
+	target, err := ResolveTarget()
+	if err != nil {
+		t.Fatalf("ResolveTarget: %v", err)
+	}
+	want := Target{
+		SSHDir:        "/mnt/c/Users/hrishikesh/.ssh",
+		SSHDirWindows: `C:\Users\hrishikesh\.ssh`,
+		Distro:        "Ubuntu",
+		User:          "hrishikesh",
+	}
+	if target != want {
+		t.Fatalf("ResolveTarget = %+v, want %+v", target, want)
+	}
+}
+
+func TestResolveTargetRequiresDistro(t *testing.T) {
+	t.Setenv("WSL_DISTRO_NAME", "")
+	if _, err := ResolveTarget(); err == nil {
+		t.Fatal("expected error when WSL_DISTRO_NAME is unset")
+	}
+}
+
+func TestEditorExeFromWhere(t *testing.T) {
+	install := t.TempDir()
+	fake := filepath.Join(install, "Code.exe")
+	if err := os.WriteFile(fake, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prev := runInterop
+	runInterop = func(name string, args ...string) (string, error) {
+		switch name {
+		case "where.exe":
+			// where reports the CLI launcher one bin/ level below the executable.
+			return "C:\\Users\\u\\AppData\\Local\\Programs\\Microsoft VS Code\\bin\\code.cmd\r\n", nil
+		case "cmd.exe":
+			return "C:\\Users\\u\r\n", nil
+		case "wslpath":
+			if strings.Contains(args[1], "Code.exe") {
+				return fake + "\n", nil
+			}
+			return "", errors.New("unexpected path " + args[1])
+		}
+		return "", errors.New("unexpected call " + name)
+	}
+	t.Cleanup(func() { runInterop = prev })
+
+	exe, err := EditorExe("code")
+	if err != nil {
+		t.Fatalf("EditorExe: %v", err)
+	}
+	want := `C:\Users\u\AppData\Local\Programs\Microsoft VS Code\Code.exe`
+	if exe != want {
+		t.Fatalf("EditorExe = %q, want %q", exe, want)
+	}
+}
+
+// TestExecDetachedReturnsWhileChildRuns encodes the contract the WSL launch
+// depends on: the spawn returns immediately even though the launched process
+// is still running, because WSL interop would otherwise hold the caller until
+// every Windows descendant exits.
+func TestExecDetachedReturnsWhileChildRuns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only check")
+	}
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- execDetached("sleep", "5")
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("execDetached: %v", err)
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Fatalf("execDetached waited %v for a running child", elapsed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("execDetached blocked while the child was still running")
+	}
+}
+
+func TestLaunchDetachedStartsWithEmptyTitle(t *testing.T) {
+	var got []string
+	prev := execDetached
+	execDetached = func(name string, args ...string) error {
+		got = append([]string{name}, args...)
+		return nil
+	}
+	t.Cleanup(func() { execDetached = prev })
+
+	exe := `C:\Program Files\Microsoft VS Code\Code.exe`
+	if err := LaunchDetached(exe, "--remote", "ssh-remote+sb.example.amika", "/home/amika/workspace"); err != nil {
+		t.Fatalf("LaunchDetached: %v", err)
+	}
+	want := []string{"cmd.exe", "/c", "start", "", exe, "--remote", "ssh-remote+sb.example.amika", "/home/amika/workspace"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("argv = %q, want %q", got, want)
+	}
+}
+
+func TestEditorExeNotFound(t *testing.T) {
+	prev := runInterop
+	runInterop = func(string, ...string) (string, error) {
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { runInterop = prev })
+
+	if _, err := EditorExe("code"); err == nil {
+		t.Fatal("expected error when nothing resolves")
+	}
+}
+
+func TestEditorExeUnsupportedCLI(t *testing.T) {
+	if _, err := EditorExe("vim"); err == nil {
+		t.Fatal("expected error for an editor without a Windows install layout")
+	}
+}


### PR DESCRIPTION
## Problem

`amika sandbox code --editor cursor|vscode` does not work when amika runs inside WSL.

The editor is a Windows application, while amika writes the SSH configuration only on the Linux side. The Windows editor reads the Windows SSH configuration and therefore cannot find the sandbox.

Additionally, the `code` command in WSL is a wrapper script that adds its own WSL remote connection (`wsl+`). This conflicts with amika's sandbox remote connection (`ssh-remote+`), causing the editor to open the WSL home directory instead of the sandbox.

## Changes

* Add the `wslbridge` package to detect WSL, resolve the Windows user profile, and locate the editor executable.
* Mirror amika's managed SSH configuration, key, and host-key pins to the Windows user's `.ssh` directory.
* Rewrite each `ProxyCommand` to use `wsl.exe -d <distro> -e <binary>`, allowing Windows SSH to re-enter the WSL distro that owns the session state.
* Restrict permissions on the mirrored SSH key using `icacls`.
* Keep the Linux-side configuration as the single source of truth. Windows files are regenerated copies.
* Add unit tests covering the SSH config mirroring and bridge logic.

## Testing

*  Verified with VS Code on WSL
