### PR TITLE
Stop verifying image paths that cannot persist

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -83,12 +83,17 @@ See [sandbox-configuration.md](sandbox-configuration.md) for details.
 
 ## Container Directory Layout
 
-Preset images provision parallel `amikad` and `amika` directories inside the container:
+Every container has parallel `amikad` and `amika` directories. Preset images
+provision the persistent ones:
 
 - `/usr/lib/amikad` and `/usr/lib/amika`
 - `/usr/local/etc/amikad` and `/usr/local/etc/amika`
 - `/var/lib/amikad` and `/var/lib/amika`
 - `/var/log/amikad` and `/var/log/amika`
+
+The `/run` and `/tmp` pairs are created at container start instead, because both
+filesystems are wiped on every boot and no image can carry them:
+
 - `/run/amikad` and `/run/amika`
 - `/tmp/amikad` and `/tmp/amika`
 

--- a/go/internal/sandbox/sandbox-image/generated/bundle.json
+++ b/go/internal/sandbox/sandbox-image/generated/bundle.json
@@ -35,12 +35,6 @@
         "group": "amika",
         "mode": "755",
         "owner": "amika",
-        "path": "/run/amika"
-      },
-      {
-        "group": "amika",
-        "mode": "755",
-        "owner": "amika",
         "path": "/usr/local/etc/amika"
       },
       {
@@ -48,12 +42,6 @@
         "mode": "755",
         "owner": "amika",
         "path": "/var/lib/amika"
-      },
-      {
-        "group": "amika",
-        "mode": "755",
-        "owner": "amika",
-        "path": "/tmp/amika"
       }
     ],
     "dotfiles": [

--- a/go/internal/sandbox/sandbox-image/manifest.toml
+++ b/go/internal/sandbox/sandbox-image/manifest.toml
@@ -124,6 +124,10 @@ docker_copies = [
   { source = "verify", destination = "/usr/lib/amika-image/verify" },
 ]
 
+# Only directories that are real image content belong here. The paired
+# /run/amika, /run/amikad, /tmp/amika, and /tmp/amikad are deliberately absent:
+# /run and /tmp are wiped on every boot, so no image can carry them. pre-setup.sh
+# creates all four at boot instead, and pre_setup_test.go asserts that it does.
 [[image.directories]]
 path = "/home/amika/.ssh"
 owner = "amika"
@@ -149,12 +153,6 @@ group = "amika"
 mode = "755"
 
 [[image.directories]]
-path = "/run/amika"
-owner = "amika"
-group = "amika"
-mode = "755"
-
-[[image.directories]]
 path = "/usr/local/etc/amika"
 owner = "amika"
 group = "amika"
@@ -162,12 +160,6 @@ mode = "755"
 
 [[image.directories]]
 path = "/var/lib/amika"
-owner = "amika"
-group = "amika"
-mode = "755"
-
-[[image.directories]]
-path = "/tmp/amika"
 owner = "amika"
 group = "amika"
 mode = "755"

--- a/go/internal/sandbox/sandbox-image/steps/20-static-config.sh
+++ b/go/internal/sandbox/sandbox-image/steps/20-static-config.sh
@@ -10,7 +10,7 @@ fi
 
 tic -x -o /usr/share/terminfo "$1/ghostty.terminfo"
 
-install -d -m 0755 /etc/ssh/sshd_config.d /etc/systemd/system /run/sshd
+install -d -m 0755 /etc/ssh/sshd_config.d /etc/systemd/system
 cat > /etc/ssh/sshd_config.d/00-amika.conf <<'EOF'
 PasswordAuthentication no
 KbdInteractiveAuthentication no

--- a/go/internal/sandbox/sandbox-image/steps/50-runtime-user.sh
+++ b/go/internal/sandbox/sandbox-image/steps/50-runtime-user.sh
@@ -29,21 +29,20 @@ chmod 0440 "/etc/sudoers.d/90-${runtime_user}"
 
 install -d -m 0700 -o "$runtime_user" -g "$runtime_group" \
   "$runtime_home/.ssh"
+# The /run and /tmp counterparts of these directories are not created here.
+# Both filesystems are wiped on every boot, so an image cannot carry them;
+# pre-setup.sh creates them at boot instead.
 install -d -m 0755 -o "$runtime_user" -g "$runtime_group" \
   "$runtime_home/workspace" \
   /var/log/amika \
   /usr/lib/amika \
-  /run/amika \
   /usr/local/etc/amika \
-  /var/lib/amika \
-  /tmp/amika
+  /var/lib/amika
 install -d -m 0755 \
   /var/log/amikad \
   /usr/lib/amikad \
-  /run/amikad \
   /usr/local/etc/amikad/setup \
-  /var/lib/amikad \
-  /tmp/amikad
+  /var/lib/amikad
 
 cat > /usr/local/etc/amikad/setup/setup.sh <<'EOF'
 #!/bin/bash

--- a/go/internal/sandbox/sandbox-image/verify/checks/08-sshd-contract.sh
+++ b/go/internal/sandbox/sandbox-image/verify/checks/08-sshd-contract.sh
@@ -8,9 +8,21 @@ source "$(dirname "$0")/../lib/check.sh" "$@"
 config="/etc/ssh/sshd_config"
 failures=()
 [[ -f "$config" ]] || failures+=("config missing")
-effective="$(sshd -T 2>/dev/null || true)"
-grep -q '^passwordauthentication no$' <<<"$effective" || failures+=("password auth enabled")
-grep -q '^kbdinteractiveauthentication no$' <<<"$effective" || failures+=("keyboard-interactive auth enabled")
+
+# sshd -T refuses to run at all without its privilege separation directory, and
+# /run is wiped on every boot, so no image can supply one. The check creates it
+# rather than asserting against a directory that cannot persist. An unrunnable
+# sshd -T is also reported as itself: reading its empty output as a verdict used
+# to turn a missing directory into a false "auth enabled" failure.
+install -d -m 0755 /run/sshd 2>/dev/null || true
+sshd_errors="$(mktemp)"
+if effective="$(sshd -T 2>"$sshd_errors")"; then
+  grep -q '^passwordauthentication no$' <<<"$effective" || failures+=("password auth enabled")
+  grep -q '^kbdinteractiveauthentication no$' <<<"$effective" || failures+=("keyboard-interactive auth enabled")
+else
+  failures+=("sshd -T failed: $(tr -d '\r' <"$sshd_errors" | tr '\n' ' ')")
+fi
+rm -f "$sshd_errors"
 [[ "$(readlink /etc/systemd/system/ssh.socket 2>/dev/null || true)" == "/dev/null" ]] || failures+=("ssh.socket not masked")
 [[ "$(readlink /etc/systemd/system/ssh.service 2>/dev/null || true)" == "/dev/null" ]] || failures+=("ssh.service not masked")
 

--- a/sandbox-image/generated/bundle.json
+++ b/sandbox-image/generated/bundle.json
@@ -35,12 +35,6 @@
         "group": "amika",
         "mode": "755",
         "owner": "amika",
-        "path": "/run/amika"
-      },
-      {
-        "group": "amika",
-        "mode": "755",
-        "owner": "amika",
         "path": "/usr/local/etc/amika"
       },
       {
@@ -48,12 +42,6 @@
         "mode": "755",
         "owner": "amika",
         "path": "/var/lib/amika"
-      },
-      {
-        "group": "amika",
-        "mode": "755",
-        "owner": "amika",
-        "path": "/tmp/amika"
       }
     ],
     "dotfiles": [

--- a/sandbox-image/manifest.toml
+++ b/sandbox-image/manifest.toml
@@ -124,6 +124,10 @@ docker_copies = [
   { source = "verify", destination = "/usr/lib/amika-image/verify" },
 ]
 
+# Only directories that are real image content belong here. The paired
+# /run/amika, /run/amikad, /tmp/amika, and /tmp/amikad are deliberately absent:
+# /run and /tmp are wiped on every boot, so no image can carry them. pre-setup.sh
+# creates all four at boot instead, and pre_setup_test.go asserts that it does.
 [[image.directories]]
 path = "/home/amika/.ssh"
 owner = "amika"
@@ -149,12 +153,6 @@ group = "amika"
 mode = "755"
 
 [[image.directories]]
-path = "/run/amika"
-owner = "amika"
-group = "amika"
-mode = "755"
-
-[[image.directories]]
 path = "/usr/local/etc/amika"
 owner = "amika"
 group = "amika"
@@ -162,12 +160,6 @@ mode = "755"
 
 [[image.directories]]
 path = "/var/lib/amika"
-owner = "amika"
-group = "amika"
-mode = "755"
-
-[[image.directories]]
-path = "/tmp/amika"
 owner = "amika"
 group = "amika"
 mode = "755"

--- a/sandbox-image/steps/20-static-config.sh
+++ b/sandbox-image/steps/20-static-config.sh
@@ -10,7 +10,7 @@ fi
 
 tic -x -o /usr/share/terminfo "$1/ghostty.terminfo"
 
-install -d -m 0755 /etc/ssh/sshd_config.d /etc/systemd/system /run/sshd
+install -d -m 0755 /etc/ssh/sshd_config.d /etc/systemd/system
 cat > /etc/ssh/sshd_config.d/00-amika.conf <<'EOF'
 PasswordAuthentication no
 KbdInteractiveAuthentication no

--- a/sandbox-image/steps/50-runtime-user.sh
+++ b/sandbox-image/steps/50-runtime-user.sh
@@ -29,21 +29,20 @@ chmod 0440 "/etc/sudoers.d/90-${runtime_user}"
 
 install -d -m 0700 -o "$runtime_user" -g "$runtime_group" \
   "$runtime_home/.ssh"
+# The /run and /tmp counterparts of these directories are not created here.
+# Both filesystems are wiped on every boot, so an image cannot carry them;
+# pre-setup.sh creates them at boot instead.
 install -d -m 0755 -o "$runtime_user" -g "$runtime_group" \
   "$runtime_home/workspace" \
   /var/log/amika \
   /usr/lib/amika \
-  /run/amika \
   /usr/local/etc/amika \
-  /var/lib/amika \
-  /tmp/amika
+  /var/lib/amika
 install -d -m 0755 \
   /var/log/amikad \
   /usr/lib/amikad \
-  /run/amikad \
   /usr/local/etc/amikad/setup \
-  /var/lib/amikad \
-  /tmp/amikad
+  /var/lib/amikad
 
 cat > /usr/local/etc/amikad/setup/setup.sh <<'EOF'
 #!/bin/bash

--- a/sandbox-image/verify/checks/08-sshd-contract.sh
+++ b/sandbox-image/verify/checks/08-sshd-contract.sh
@@ -8,9 +8,21 @@ source "$(dirname "$0")/../lib/check.sh" "$@"
 config="/etc/ssh/sshd_config"
 failures=()
 [[ -f "$config" ]] || failures+=("config missing")
-effective="$(sshd -T 2>/dev/null || true)"
-grep -q '^passwordauthentication no$' <<<"$effective" || failures+=("password auth enabled")
-grep -q '^kbdinteractiveauthentication no$' <<<"$effective" || failures+=("keyboard-interactive auth enabled")
+
+# sshd -T refuses to run at all without its privilege separation directory, and
+# /run is wiped on every boot, so no image can supply one. The check creates it
+# rather than asserting against a directory that cannot persist. An unrunnable
+# sshd -T is also reported as itself: reading its empty output as a verdict used
+# to turn a missing directory into a false "auth enabled" failure.
+install -d -m 0755 /run/sshd 2>/dev/null || true
+sshd_errors="$(mktemp)"
+if effective="$(sshd -T 2>"$sshd_errors")"; then
+  grep -q '^passwordauthentication no$' <<<"$effective" || failures+=("password auth enabled")
+  grep -q '^kbdinteractiveauthentication no$' <<<"$effective" || failures+=("keyboard-interactive auth enabled")
+else
+  failures+=("sshd -T failed: $(tr -d '\r' <"$sshd_errors" | tr '\n' ' ')")
+fi
+rm -f "$sshd_errors"
 [[ "$(readlink /etc/systemd/system/ssh.socket 2>/dev/null || true)" == "/dev/null" ]] || failures+=("ssh.socket not masked")
 [[ "$(readlink /etc/systemd/system/ssh.service 2>/dev/null || true)" == "/dev/null" ]] || failures+=("ssh.service not masked")
 


### PR DESCRIPTION
The E2B build of `coder-dind` fails its build-time verification with two
failures that are both artifacts of the checks themselves, not of the image:

```
{"id":"filesystem-contract","status":"failed","actual":"/run/amika=missing; /tmp/amika=missing"}
{"id":"sshd-contract","status":"failed","actual":"password auth enabled keyboard-interactive auth enabled"}
```

`/run` and `/tmp` are wiped on every boot, so no image can carry content
there. E2B is the first provider whose builder reboots a VM from a cached
layer part-way through a build, which is the only reason the contract had
ever appeared to hold: the Docker providers happen to run the whole chain
in one session.

The image contract now covers only directories that are real image content.
The paired `/run` and `/tmp` directories are created at boot by
`pre-setup.sh`, which is where the guarantee belongs, and which
`pre_setup_test.go` already asserts. A boot-context check was the other
option and is worse: it would assert that a `mkdir -p` from a few lines
earlier in the same hook worked, on every sandbox a customer starts, and
would assert a mode that hook never sets.

The sshd failure was the same wipe wearing a disguise. `sshd -T` refuses to
run without its privilege separation directory, so it exited 255 with empty
stdout and both greps came up empty; the config was correct the whole time.
The check now creates that directory itself and reports an unrunnable
`sshd -T` as itself, rather than letting silence pass for a verdict.
`steps/20`'s `install -d /run/sshd` is gone with it, since the check was its
only consumer: at runtime `amikad` runs its own sshd off
`/var/lib/amikad/sshd_config` and creates the directory itself, and the
distro units are masked to `/dev/null`.

## Verification

Reproduced the E2B condition in a container by running steps 20 and 50,
wiping `/run` and `/tmp` to stand in for the cached-layer reboot, then
running both checks: both pass with those directories empty.

The sshd check still catches what it is for. With the hardening config
removed it reports `password auth enabled`; with host keys removed it
reports `sshd -T failed: sshd: no hostkeys available -- exiting.` instead of
a false auth failure.

`make test-sandbox-image`, `go test ./internal/sandbox/...`, and
`generate.py --check` all pass.