### PR TITLE
Stage build steps outside /tmp

### DIFF
--- a/go/internal/sandbox/sandbox-image/generated/coder-dind.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/coder-dind.Dockerfile
@@ -7,68 +7,68 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG DOCKER_VERSION=28.3.3
 ARG BUILDX_VERSION=0.25.0
-COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/90-dind.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_PRESET=coder-dind /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_PRESET=coder-dind /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/go/internal/sandbox/sandbox-image/generated/coder.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/coder.Dockerfile
@@ -7,63 +7,63 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_PRESET=coder /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_PRESET=coder /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/sandbox-image/generate.py
+++ b/sandbox-image/generate.py
@@ -11,6 +11,16 @@ from pathlib import Path
 
 EMBED_SOURCE_DIRECTORIES = ("assets", "steps", "verify")
 
+# Every step's script and assets are staged here by COPY, then removed by the
+# RUN that consumes them. This deliberately avoids /tmp: E2B's builder reboots
+# the VM between cached layers, and a boot wipes /tmp, so a COPY into /tmp is
+# gone by the time the next layer's RUN reads it.
+STAGING_DIRECTORY = "/opt/amika-build"
+STAGING_SCRIPT = f"{STAGING_DIRECTORY}/step.sh"
+STAGING_ASSETS = f"{STAGING_DIRECTORY}/step-assets"
+
+MAX_DOCKERFILE_COLUMNS = 79
+
 
 def main() -> int:
     parser = argparse.ArgumentParser()
@@ -192,29 +202,25 @@ def render_dockerfile(
         for version in step["versions"]:
             lines.append(f"ARG {version}={versions[version]}")
 
-        cleanup = ["/tmp/amika-step.sh"]
         asset_argument = step.get("asset_argument")
         if asset_argument:
             lines.append(
-                f"COPY sandbox-image/{asset_argument} /tmp/amika-step-assets"
+                f"COPY sandbox-image/{asset_argument} {STAGING_ASSETS}"
             )
-            cleanup.append("/tmp/amika-step-assets")
         for copy in step.get("docker_copies", []):
             lines.append(
                 f"COPY sandbox-image/{copy['source']} {copy['destination']}"
             )
 
-        lines.append(
-            f"COPY sandbox-image/{step['script']} /tmp/amika-step.sh"
-        )
+        lines.append(f"COPY sandbox-image/{step['script']} {STAGING_SCRIPT}")
         command = []
         preset_environment = step.get("preset_environment")
         if preset_environment:
             command.append(f"{preset_environment}={preset_name}")
-        command.append("/tmp/amika-step.sh")
+        command.append(STAGING_SCRIPT)
         if asset_argument:
-            command.append("/tmp/amika-step-assets")
-        lines.extend(render_run(command, cleanup))
+            command.append(STAGING_ASSETS)
+        lines.extend(render_run(command))
 
     lines.extend(
         [
@@ -228,14 +234,19 @@ def render_dockerfile(
     return "\n".join(lines)
 
 
-def render_run(command: list[str], cleanup: list[str]) -> list[str]:
+def render_run(command: list[str]) -> list[str]:
+    """Runs a staged step, then clears the staging directory it read from.
+
+    Removing the whole directory, rather than the paths the step used, keeps
+    the image free of an empty /opt/amika-build once the build finishes.
+    """
     command_text = " ".join(command)
-    cleanup_text = " ".join(cleanup)
-    if len(command_text) + len(cleanup_text) < 72:
-        return [f"RUN {command_text} && rm -rf {cleanup_text}"]
+    single_line = f"RUN {command_text} && rm -rf {STAGING_DIRECTORY}"
+    if len(single_line) <= MAX_DOCKERFILE_COLUMNS:
+        return [single_line]
     return [
         f"RUN {command_text} \\",
-        f"    && rm -rf {cleanup_text}",
+        f"    && rm -rf {STAGING_DIRECTORY}",
     ]
 
 

--- a/sandbox-image/generated/coder-dind.Dockerfile
+++ b/sandbox-image/generated/coder-dind.Dockerfile
@@ -7,68 +7,68 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG DOCKER_VERSION=28.3.3
 ARG BUILDX_VERSION=0.25.0
-COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/90-dind.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_PRESET=coder-dind /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_PRESET=coder-dind /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/sandbox-image/generated/coder.Dockerfile
+++ b/sandbox-image/generated/coder.Dockerfile
@@ -7,63 +7,63 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_PRESET=coder /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_PRESET=coder /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika


### PR DESCRIPTION
The E2B build of every preset fails at the first step that takes an asset argument:

```
[builder 11/52] [stderr]: tic: cannot open
  '/tmp/amika-step-assets/ghostty.terminfo': No such file or directory
Build failed: failed to run command '/tmp/amika-step.sh /tmp/amika-step-assets'
```

E2B's builder reboots the VM between cached layers, and a boot wipes `/tmp`, so a `COPY` into `/tmp` is gone by the time the next layer's `RUN` reads it. The generator now stages each step's script and assets under `/opt/amika-build` instead, which is ordinary image content and survives a boot. Each `RUN` removes the whole staging directory rather than the two paths it read, so no empty directory is left in the finished image.

The same reboot-mid-build behavior is what `Drop ephemeral paths from the image contract` addressed for the verification checks; this is the build side of it.