### PR TITLE
fix the cursor install hint

### DIFF
--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -248,7 +248,7 @@ func openSandboxInEditor(cmd *cobra.Command, editor string, paths basedir.Paths,
 // openSandboxInCursorTarget launches Cursor connected to a prepared SSH target.
 func openSandboxInCursorTarget(cmd *cobra.Command, paths basedir.Paths, target sandboxSSHAlias, pathOverride string) error {
 	return launchRemoteSSHEditor(cmd, "cursor", "Cursor",
-		"Cursor > Settings > Extensions > cursor-cli", paths, target, pathOverride)
+		"cursor.com and ensure the 'cursor' binary is added to your system PATH", paths, target, pathOverride)
 }
 
 // openSandboxInVSCodeTarget launches VS Code connected to a prepared SSH target.


### PR DESCRIPTION
the error message pointed to a setting that does not exist. point to cursor.com and PATH instead