### PR TITLE
Restore Pi Web's request identity behind the proxy

### DIFF
--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -213,13 +213,14 @@ Amika reserves container ports **60899–60999** (101 ports) for internal
 services that run inside sandboxes. User workloads and setup scripts should
 avoid binding to ports in this range.
 
-| Port        | Service                          | Status   |
-| ----------- | -------------------------------- | -------- |
-| 60999       | amikad daemon                    | Reserved |
-| 60998       | OpenCode web UI                  | Active   |
-| 60997       | amikad managed sshd (loopback)   | Active   |
-| 60996       | Pi Web UI                        | Active   |
-| 60899–60995 | _(unassigned, reserved for use)_ | Reserved |
+| Port        | Service                            | Status   |
+| ----------- | ---------------------------------- | -------- |
+| 60999       | amikad daemon                      | Reserved |
+| 60998       | OpenCode web UI                    | Active   |
+| 60997       | amikad managed sshd (loopback)     | Active   |
+| 60996       | Pi Web UI (X-Forwarded-Proto shim) | Active   |
+| 60995       | Pi Web itself (loopback)           | Active   |
+| 60899–60994 | _(unassigned, reserved for use)_   | Reserved |
 
 The OpenCode web server starts automatically on port 60998 when OpenCode is
 installed in the container and `AMIKA_OPENCODE_WEB` is not set to `0`. The
@@ -235,3 +236,23 @@ It is opt-in (`AMIKA_PI_WEB=1`) and refuses to start without two things:
 reached through. Pi Web answers `403 Untrusted request` to any other Host
 header and accepts no wildcard, so an endpoint without it could serve nothing.
 The port number is written to `/run/amikad/pi-web.port` at startup.
+
+Port 60996 is a small proxy rather than Pi Web itself, and Pi Web listens on
+loopback behind it at 60995. The proxy exists because of a second check Pi Web
+applies to `/api/*` routes: it requires the browser's `Origin` to equal
+`<scheme from X-Forwarded-Proto>://<Host header>`. Both halves are whatever the
+provider's proxy makes them. Daytona's terminates TLS, rewrites `Host` to
+`localhost:60996`, and sends no `X-Forwarded-Proto`, so Pi Web expects
+`http://localhost:60996` while the browser sends
+`https://<sandbox>.daytonaproxy01.net`. Every write is then answered
+`403 {"error":"Untrusted API request"}` while reads keep working, because
+browsers omit `Origin` on same-origin GETs — the Pi UI loads and then fails to
+open a project.
+
+The shim restores that identity before Pi Web sees the request, stamping the
+`Host` and scheme the browser actually used. It rewrites only towards the
+public hostname in `AMIKA_PI_WEB_ALLOWED_HOSTS` or the `Host` already present,
+so an `Origin` naming anything else is passed through for Pi Web to reject. It
+exists because Pi Web offers no origin allow-list to configure instead
+([pi-web#497](https://github.com/agegr/pi-web/issues/497)), and can be dropped
+once an upstream release compares hosts rather than full origins.

--- a/go/internal/sandbox/pre_setup_test.go
+++ b/go/internal/sandbox/pre_setup_test.go
@@ -124,9 +124,13 @@ func TestPresetPreSetup_PiWebGatingContract(t *testing.T) {
 	if !strings.Contains(content, "PI_WEB_PORT=60996") {
 		t.Fatal("pre-setup.sh should serve the Pi web terminal on the reserved port 60996")
 	}
+	// 60996 is the shim; Pi Web itself sits one port below it, on loopback.
+	if !strings.Contains(content, "PI_WEB_INTERNAL_PORT=60995") {
+		t.Fatal("pre-setup.sh should run Pi Web itself on the reserved port 60995")
+	}
 }
 
-func TestPresetPiSetup_ServesPiWebAuthenticatedOnEveryInterface(t *testing.T) {
+func TestPresetPiSetup_ServesPiWebAuthenticatedBehindTheShim(t *testing.T) {
 	data, err := sandboxImageFS.ReadFile("sandbox-image/assets/hooks/pi-setup.sh")
 	if err != nil {
 		t.Fatalf("ReadFile failed: %v", err)
@@ -138,13 +142,37 @@ func TestPresetPiSetup_ServesPiWebAuthenticatedOnEveryInterface(t *testing.T) {
 		// visible in `ps` to anything else in the sandbox.
 		`export PI_WEB_PASSWORD="$AMIKA_PI_WEB_PASSWORD"`,
 		`export PI_WEB_ALLOWED_HOSTS="$AMIKA_PI_WEB_ALLOWED_HOSTS"`,
-		"exec pi-web",
-		"--hostname 0.0.0.0",
-		"--no-open",
+		// Pi Web is reachable only through the shim, which repairs the Host and
+		// scheme a provider's proxy rewrites before Pi Web's API guard sees them.
+		`pi-web --port "$pi_web_port" --hostname 127.0.0.1 --no-open`,
+		`/usr/lib/amikad/pi-web-shim.js "$public_port" "$pi_web_port" "$pi_web_public_host"`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("pi-setup.sh should contain %q", want)
 		}
+	}
+}
+
+func TestPresetPiWebShim_PublishesPiWebFromLoopback(t *testing.T) {
+	data, err := sandboxImageFS.ReadFile("sandbox-image/assets/hooks/pi-web-shim.js")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	content := string(data)
+	// The shim is the half the provider maps, so it takes every interface and
+	// reaches Pi Web over loopback.
+	if !strings.Contains(content, `server.listen(listenPort, "0.0.0.0"`) {
+		t.Fatal("pi-web-shim.js should listen on every interface")
+	}
+	if !strings.Contains(content, `const UPSTREAM_HOST = "127.0.0.1"`) {
+		t.Fatal("pi-web-shim.js should forward to Pi Web over loopback")
+	}
+	// Rewriting towards an arbitrary Origin would hand Pi Web's Host allow-list
+	// whatever a cross-origin page claimed, so the public host is the only name
+	// the shim may introduce.
+	if !strings.Contains(content, "originAuthority === publicHost") {
+		t.Fatal("pi-web-shim.js should rewrite only towards the sandbox's public host")
 	}
 }
 

--- a/go/internal/sandbox/sandbox-image/assets/hooks/pi-setup.sh
+++ b/go/internal/sandbox/sandbox-image/assets/hooks/pi-setup.sh
@@ -2,13 +2,14 @@
 
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "usage: $0 <working-directory> <port>" >&2
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <working-directory> <public-port> <pi-web-port>" >&2
   exit 1
 fi
 
 amika_agent_cwd="$1"
-pi_web_port="$2"
+public_port="$2"
+pi_web_port="$3"
 
 if [[ -z "${AMIKA_PI_WEB_PASSWORD:-}" ]]; then
   echo "ERROR: AMIKA_PI_WEB_PASSWORD must be set" >&2
@@ -19,17 +20,35 @@ fi
 # ("Untrusted request", HTTP 403), and it accepts no wildcard — so without the
 # sandbox's public hostname the server would answer nothing but 403s. Amika
 # passes the host it minted for this service; refusing to start without it
-# beats serving an endpoint that cannot work.
+# beats serving an endpoint that cannot work. The shim needs the same name to
+# rebuild the identity the provider's proxy rewrites away, and takes the first
+# entry because that is the URL Amika hands the user.
 if [[ -z "${AMIKA_PI_WEB_ALLOWED_HOSTS:-}" ]]; then
   echo "ERROR: AMIKA_PI_WEB_ALLOWED_HOSTS must be set" >&2
   exit 1
 fi
+pi_web_public_host="${AMIKA_PI_WEB_ALLOWED_HOSTS%%,*}"
 
 cd "$amika_agent_cwd"
-# `--no-open` because there is no browser to launch here, and 0.0.0.0 so the
-# provider's port mapping can reach it. `PI_WEB_PASSWORD` turns on HTTP Basic
-# Auth with the fixed username `pi`; it travels in the environment rather than
-# argv, so it is not visible in `ps` to anything else in the sandbox.
+# `--no-open` because there is no browser to launch here. `PI_WEB_PASSWORD`
+# turns on HTTP Basic Auth with the fixed username `pi`; it travels in the
+# environment rather than argv, so it is not visible in `ps` to anything else in
+# the sandbox.
 export PI_WEB_PASSWORD="$AMIKA_PI_WEB_PASSWORD"
 export PI_WEB_ALLOWED_HOSTS="$AMIKA_PI_WEB_ALLOWED_HOSTS"
-exec pi-web --port "$pi_web_port" --hostname 0.0.0.0 --no-open
+
+# Pi Web binds loopback and the shim owns the public port, because Pi Web's own
+# API guard rejects every write whose Host and scheme the provider's proxy
+# rewrote on the way in (see pi-web-shim.js). Only the shim's port is mapped by
+# the provider, so loopback is all Pi Web needs.
+pi-web --port "$pi_web_port" --hostname 127.0.0.1 --no-open &
+pi_web_pid=$!
+
+/usr/lib/amikad/pi-web-shim.js "$public_port" "$pi_web_port" "$pi_web_public_host" &
+shim_pid=$!
+
+# Neither half is useful alone: the shim without Pi Web serves 502s, and Pi Web
+# on loopback is reachable by nobody. Take both down as soon as one exits so a
+# failure closes the port instead of leaving a half-working endpoint behind.
+trap 'kill "$pi_web_pid" "$shim_pid" 2>/dev/null || true' EXIT
+wait -n

--- a/go/internal/sandbox/sandbox-image/assets/hooks/pi-web-shim.js
+++ b/go/internal/sandbox/sandbox-image/assets/hooks/pi-web-shim.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+"use strict";
+
+// Restores the request identity a sandbox provider's proxy erases in front of
+// Pi Web.
+//
+// Pi Web guards its `/api/*` routes by rebuilding the origin it expects as
+// `new URL(request.url).protocol + "//" + <Host header>` and requiring the
+// browser's `Origin` to equal it (`isApiRequestOriginAllowed` in Pi Web's
+// `lib/request-security.ts`). Both halves of that expectation depend on headers
+// a proxy controls: Next.js takes the protocol from `X-Forwarded-Proto`, and the
+// host comes from `Host`. Daytona's sandbox proxy terminates TLS, rewrites
+// `Host` to `localhost:<port>`, and sends no `X-Forwarded-Proto` at all, so Pi
+// Web expects `http://localhost:60996` while the browser sends
+// `Origin: https://<sandbox>.daytonaproxy01.net`. Every request carrying an
+// Origin is then answered `403 {"error":"Untrusted API request"}`; browsers omit
+// Origin on same-origin GETs, so the UI loads and only writes fail — selecting a
+// project in the Pi UI was impossible.
+//
+// Upstream bug: https://github.com/agegr/pi-web/issues/497. Pi Web exposes no
+// origin allow-list to configure around it — `PI_WEB_ALLOWED_HOSTS` only feeds
+// its separate Host check — so the identity has to be restored before Pi Web
+// sees the request.
+//
+// Both headers are rewritten only towards a host the shim already trusts: the
+// public hostname Amika minted for this sandbox, or the `Host` the request
+// already carries. An `Origin` naming anything else is forwarded untouched and
+// still rejected by Pi Web, so a cross-origin page gains nothing by asking. That
+// keeps the check Pi Web's own Host allow-list performs, which is where the CSRF
+// and DNS-rebinding signal actually lives.
+
+const http = require("node:http");
+
+const UPSTREAM_HOST = "127.0.0.1";
+
+const [listenPortArgument, upstreamPortArgument, publicHostArgument] = process.argv.slice(2);
+const listenPort = Number(listenPortArgument);
+const upstreamPort = Number(upstreamPortArgument);
+
+if (!Number.isInteger(listenPort) || !Number.isInteger(upstreamPort)) {
+  console.error(`usage: ${process.argv[1]} <listen-port> <pi-web-port> [public-host]`);
+  process.exit(64);
+}
+
+// RFC 9110 hop-by-hop headers: they describe this connection, not the message,
+// so they must not be copied onto the upstream one. Dropping `transfer-encoding`
+// also lets Node frame the forwarded body itself instead of double-encoding it.
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+/**
+ * `host:port` in the spelling Pi Web compares, or null when the value could not
+ * be one. Rejecting a `Host` that carries a path, userinfo or whitespace keeps a
+ * malformed header from matching anything.
+ */
+function normalizeAuthority(value) {
+  if (!value || /[\s/@\\]/.test(value)) return null;
+  let parsed;
+  try {
+    parsed = new URL(`http://${value}`);
+  } catch {
+    return null;
+  }
+  if (parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash) {
+    return null;
+  }
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase().replace(/\.$/, "");
+  return parsed.port ? `${hostname}:${parsed.port}` : hostname;
+}
+
+const publicHost = normalizeAuthority(publicHostArgument);
+
+/**
+ * The `Host` and scheme to hand Pi Web, or null to forward the request as it
+ * arrived.
+ *
+ * Trusting the `Origin` here would hand Pi Web's Host allow-list whatever a page
+ * claimed, so the header is only ever restored to the sandbox's own public
+ * hostname or to the `Host` the request already carries.
+ */
+function repairedIdentity(headers) {
+  const origin = headers.origin;
+  if (!origin) return null; // same-origin GETs and non-browser clients
+
+  let parsed;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return null; // includes the opaque `Origin: null`
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+
+  const originAuthority = normalizeAuthority(parsed.host);
+  if (originAuthority === null) return null;
+
+  const scheme = parsed.protocol.slice(0, -1);
+  if (publicHost !== null && originAuthority === publicHost) {
+    return { host: parsed.host, scheme };
+  }
+  // A proxy that keeps Host intact and only loses the scheme needs no rewrite,
+  // just the scheme it dropped.
+  if (headers.host && normalizeAuthority(headers.host) === originAuthority) {
+    return { host: headers.host, scheme };
+  }
+  return null;
+}
+
+function forwardedHeaders(headers) {
+  const forwarded = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (!HOP_BY_HOP_HEADERS.has(name)) forwarded[name] = value;
+  }
+
+  const identity = repairedIdentity(headers);
+  if (identity !== null) {
+    forwarded.host = identity.host;
+    // A real proxy in front that already reported the scheme knows better.
+    if (!forwarded["x-forwarded-proto"]) forwarded["x-forwarded-proto"] = identity.scheme;
+  }
+
+  return forwarded;
+}
+
+const server = http.createServer((request, response) => {
+  const upstream = http.request({
+    host: UPSTREAM_HOST,
+    port: upstreamPort,
+    method: request.method,
+    path: request.url,
+    headers: forwardedHeaders(request.headers),
+  });
+
+  upstream.on("response", (upstreamResponse) => {
+    // Raw headers keep repeated fields such as `Set-Cookie` intact, and piping
+    // without buffering keeps Pi Web's streaming responses live.
+    response.writeHead(
+      upstreamResponse.statusCode,
+      upstreamResponse.statusMessage,
+      upstreamResponse.rawHeaders,
+    );
+    upstreamResponse.pipe(response);
+  });
+
+  upstream.on("error", (error) => {
+    console.error(`pi-web-shim: upstream request failed: ${error.message}`);
+    if (!response.headersSent) {
+      response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+    }
+    response.end("pi-web-shim: Pi Web is unreachable\n");
+  });
+
+  request.on("aborted", () => upstream.destroy());
+  request.pipe(upstream);
+});
+
+// An upgraded connection never reaches the request handler above, so it needs
+// its own tunnel.
+server.on("upgrade", (request, clientSocket, head) => {
+  const upstream = http.request({
+    host: UPSTREAM_HOST,
+    port: upstreamPort,
+    method: request.method,
+    path: request.url,
+    headers: { ...request.headers, ...forwardedHeaders(request.headers) },
+  });
+
+  upstream.on("upgrade", (upstreamResponse, upstreamSocket, upstreamHead) => {
+    const statusLine = `HTTP/1.1 ${upstreamResponse.statusCode} ${upstreamResponse.statusMessage}`;
+    const headerLines = [];
+    for (let index = 0; index < upstreamResponse.rawHeaders.length; index += 2) {
+      headerLines.push(
+        `${upstreamResponse.rawHeaders[index]}: ${upstreamResponse.rawHeaders[index + 1]}`,
+      );
+    }
+    clientSocket.write(`${[statusLine, ...headerLines].join("\r\n")}\r\n\r\n`);
+
+    for (const socket of [clientSocket, upstreamSocket]) {
+      socket.setTimeout(0);
+      socket.setNoDelay(true);
+      socket.on("error", () => socket.destroy());
+    }
+
+    // Bytes that arrived alongside the handshake belong at the front of each
+    // stream; unshifting them lets the pipes below carry them in order.
+    if (upstreamHead?.length) upstreamSocket.unshift(upstreamHead);
+    if (head?.length) clientSocket.unshift(head);
+
+    upstreamSocket.pipe(clientSocket);
+    clientSocket.pipe(upstreamSocket);
+  });
+
+  upstream.on("error", (error) => {
+    console.error(`pi-web-shim: upstream upgrade failed: ${error.message}`);
+    clientSocket.destroy();
+  });
+
+  clientSocket.on("error", () => upstream.destroy());
+  upstream.end();
+});
+
+server.on("error", (error) => {
+  console.error(`pi-web-shim: ${error.message}`);
+  process.exit(1);
+});
+
+server.listen(listenPort, "0.0.0.0", () => {
+  console.log(
+    `pi-web-shim listening on 0.0.0.0:${listenPort}, forwarding to ${UPSTREAM_HOST}:${upstreamPort}` +
+      (publicHost === null ? "" : ` as ${publicHost}`),
+  );
+});

--- a/go/internal/sandbox/sandbox-image/assets/hooks/pre-setup.sh
+++ b/go/internal/sandbox/sandbox-image/assets/hooks/pre-setup.sh
@@ -12,10 +12,12 @@ set -euo pipefail
 #   60999 — amikad daemon
 #   60998 — OpenCode web UI
 #   60997 — amikad's managed sshd (loopback; go/internal/constants)
-#   60996 — Pi Web UI
-#   60899-60995 — unassigned (reserved for future use)
+#   60996 — Pi Web UI (the X-Forwarded-Proto shim; the mapped port)
+#   60995 — Pi Web itself (loopback, behind that shim)
+#   60899-60994 — unassigned (reserved for future use)
 OPENCODE_WEB_PORT=60998
 PI_WEB_PORT=60996
+PI_WEB_INTERNAL_PORT=60995
 
 AMIKA_STATE_DIR="/var/lib/amikad"
 AMIKA_USER_STATE_DIR="/var/lib/amika"
@@ -94,6 +96,7 @@ if command -v pi-web &> /dev/null && [[ "${AMIKA_PI_WEB:-0}" == "1" ]]; then
     nohup env AMIKA_PI_WEB_PASSWORD="$AMIKA_PI_WEB_PASSWORD" \
     AMIKA_PI_WEB_ALLOWED_HOSTS="$AMIKA_PI_WEB_ALLOWED_HOSTS" \
     /usr/lib/amikad/pi-setup.sh "$amika_agent_cwd" "$PI_WEB_PORT" \
+    "$PI_WEB_INTERNAL_PORT" \
     > "$AMIKA_LOG_DIR/pi-web.log" 2>&1 &
 
   echo "$!" > "$AMIKA_RUN_DIR/pi-web.pid"

--- a/go/internal/sandbox/sandbox-image/generated/bundle.json
+++ b/go/internal/sandbox/sandbox-image/generated/bundle.json
@@ -55,6 +55,7 @@
       "/usr/lib/amikad/run-hook.sh",
       "/usr/lib/amikad/opencode-setup.sh",
       "/usr/lib/amikad/pi-setup.sh",
+      "/usr/lib/amikad/pi-web-shim.js",
       "/usr/lib/amikad/docker-setup.sh",
       "/usr/lib/amikad/restore-setuid.sh"
     ],
@@ -155,6 +156,7 @@
             "assets/hooks/docker-setup.sh",
             "assets/hooks/opencode-setup.sh",
             "assets/hooks/pi-setup.sh",
+            "assets/hooks/pi-web-shim.js",
             "assets/hooks/post-setup.sh",
             "assets/hooks/pre-setup.sh",
             "assets/hooks/restore-setuid.sh",
@@ -293,6 +295,7 @@
             "assets/hooks/docker-setup.sh",
             "assets/hooks/opencode-setup.sh",
             "assets/hooks/pi-setup.sh",
+            "assets/hooks/pi-web-shim.js",
             "assets/hooks/post-setup.sh",
             "assets/hooks/pre-setup.sh",
             "assets/hooks/restore-setuid.sh",

--- a/go/internal/sandbox/sandbox-image/manifest.toml
+++ b/go/internal/sandbox/sandbox-image/manifest.toml
@@ -18,6 +18,7 @@ hook_scripts = [
   "/usr/lib/amikad/run-hook.sh",
   "/usr/lib/amikad/opencode-setup.sh",
   "/usr/lib/amikad/pi-setup.sh",
+  "/usr/lib/amikad/pi-web-shim.js",
   "/usr/lib/amikad/docker-setup.sh",
   "/usr/lib/amikad/restore-setuid.sh",
 ]
@@ -76,6 +77,7 @@ assets = [
   "assets/hooks/docker-setup.sh",
   "assets/hooks/opencode-setup.sh",
   "assets/hooks/pi-setup.sh",
+  "assets/hooks/pi-web-shim.js",
   "assets/hooks/post-setup.sh",
   "assets/hooks/pre-setup.sh",
   "assets/hooks/restore-setuid.sh",

--- a/go/internal/sandbox/sandbox-image/steps/70-hook-assets.sh
+++ b/go/internal/sandbox/sandbox-image/steps/70-hook-assets.sh
@@ -13,6 +13,7 @@ for script in \
   docker-setup.sh \
   opencode-setup.sh \
   pi-setup.sh \
+  pi-web-shim.js \
   post-setup.sh \
   pre-setup.sh \
   restore-setuid.sh \

--- a/sandbox-image/assets/hooks/pi-setup.sh
+++ b/sandbox-image/assets/hooks/pi-setup.sh
@@ -2,13 +2,14 @@
 
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "usage: $0 <working-directory> <port>" >&2
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <working-directory> <public-port> <pi-web-port>" >&2
   exit 1
 fi
 
 amika_agent_cwd="$1"
-pi_web_port="$2"
+public_port="$2"
+pi_web_port="$3"
 
 if [[ -z "${AMIKA_PI_WEB_PASSWORD:-}" ]]; then
   echo "ERROR: AMIKA_PI_WEB_PASSWORD must be set" >&2
@@ -19,17 +20,35 @@ fi
 # ("Untrusted request", HTTP 403), and it accepts no wildcard — so without the
 # sandbox's public hostname the server would answer nothing but 403s. Amika
 # passes the host it minted for this service; refusing to start without it
-# beats serving an endpoint that cannot work.
+# beats serving an endpoint that cannot work. The shim needs the same name to
+# rebuild the identity the provider's proxy rewrites away, and takes the first
+# entry because that is the URL Amika hands the user.
 if [[ -z "${AMIKA_PI_WEB_ALLOWED_HOSTS:-}" ]]; then
   echo "ERROR: AMIKA_PI_WEB_ALLOWED_HOSTS must be set" >&2
   exit 1
 fi
+pi_web_public_host="${AMIKA_PI_WEB_ALLOWED_HOSTS%%,*}"
 
 cd "$amika_agent_cwd"
-# `--no-open` because there is no browser to launch here, and 0.0.0.0 so the
-# provider's port mapping can reach it. `PI_WEB_PASSWORD` turns on HTTP Basic
-# Auth with the fixed username `pi`; it travels in the environment rather than
-# argv, so it is not visible in `ps` to anything else in the sandbox.
+# `--no-open` because there is no browser to launch here. `PI_WEB_PASSWORD`
+# turns on HTTP Basic Auth with the fixed username `pi`; it travels in the
+# environment rather than argv, so it is not visible in `ps` to anything else in
+# the sandbox.
 export PI_WEB_PASSWORD="$AMIKA_PI_WEB_PASSWORD"
 export PI_WEB_ALLOWED_HOSTS="$AMIKA_PI_WEB_ALLOWED_HOSTS"
-exec pi-web --port "$pi_web_port" --hostname 0.0.0.0 --no-open
+
+# Pi Web binds loopback and the shim owns the public port, because Pi Web's own
+# API guard rejects every write whose Host and scheme the provider's proxy
+# rewrote on the way in (see pi-web-shim.js). Only the shim's port is mapped by
+# the provider, so loopback is all Pi Web needs.
+pi-web --port "$pi_web_port" --hostname 127.0.0.1 --no-open &
+pi_web_pid=$!
+
+/usr/lib/amikad/pi-web-shim.js "$public_port" "$pi_web_port" "$pi_web_public_host" &
+shim_pid=$!
+
+# Neither half is useful alone: the shim without Pi Web serves 502s, and Pi Web
+# on loopback is reachable by nobody. Take both down as soon as one exits so a
+# failure closes the port instead of leaving a half-working endpoint behind.
+trap 'kill "$pi_web_pid" "$shim_pid" 2>/dev/null || true' EXIT
+wait -n

--- a/sandbox-image/assets/hooks/pi-web-shim.js
+++ b/sandbox-image/assets/hooks/pi-web-shim.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+"use strict";
+
+// Restores the request identity a sandbox provider's proxy erases in front of
+// Pi Web.
+//
+// Pi Web guards its `/api/*` routes by rebuilding the origin it expects as
+// `new URL(request.url).protocol + "//" + <Host header>` and requiring the
+// browser's `Origin` to equal it (`isApiRequestOriginAllowed` in Pi Web's
+// `lib/request-security.ts`). Both halves of that expectation depend on headers
+// a proxy controls: Next.js takes the protocol from `X-Forwarded-Proto`, and the
+// host comes from `Host`. Daytona's sandbox proxy terminates TLS, rewrites
+// `Host` to `localhost:<port>`, and sends no `X-Forwarded-Proto` at all, so Pi
+// Web expects `http://localhost:60996` while the browser sends
+// `Origin: https://<sandbox>.daytonaproxy01.net`. Every request carrying an
+// Origin is then answered `403 {"error":"Untrusted API request"}`; browsers omit
+// Origin on same-origin GETs, so the UI loads and only writes fail — selecting a
+// project in the Pi UI was impossible.
+//
+// Upstream bug: https://github.com/agegr/pi-web/issues/497. Pi Web exposes no
+// origin allow-list to configure around it — `PI_WEB_ALLOWED_HOSTS` only feeds
+// its separate Host check — so the identity has to be restored before Pi Web
+// sees the request.
+//
+// Both headers are rewritten only towards a host the shim already trusts: the
+// public hostname Amika minted for this sandbox, or the `Host` the request
+// already carries. An `Origin` naming anything else is forwarded untouched and
+// still rejected by Pi Web, so a cross-origin page gains nothing by asking. That
+// keeps the check Pi Web's own Host allow-list performs, which is where the CSRF
+// and DNS-rebinding signal actually lives.
+
+const http = require("node:http");
+
+const UPSTREAM_HOST = "127.0.0.1";
+
+const [listenPortArgument, upstreamPortArgument, publicHostArgument] = process.argv.slice(2);
+const listenPort = Number(listenPortArgument);
+const upstreamPort = Number(upstreamPortArgument);
+
+if (!Number.isInteger(listenPort) || !Number.isInteger(upstreamPort)) {
+  console.error(`usage: ${process.argv[1]} <listen-port> <pi-web-port> [public-host]`);
+  process.exit(64);
+}
+
+// RFC 9110 hop-by-hop headers: they describe this connection, not the message,
+// so they must not be copied onto the upstream one. Dropping `transfer-encoding`
+// also lets Node frame the forwarded body itself instead of double-encoding it.
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+/**
+ * `host:port` in the spelling Pi Web compares, or null when the value could not
+ * be one. Rejecting a `Host` that carries a path, userinfo or whitespace keeps a
+ * malformed header from matching anything.
+ */
+function normalizeAuthority(value) {
+  if (!value || /[\s/@\\]/.test(value)) return null;
+  let parsed;
+  try {
+    parsed = new URL(`http://${value}`);
+  } catch {
+    return null;
+  }
+  if (parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash) {
+    return null;
+  }
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase().replace(/\.$/, "");
+  return parsed.port ? `${hostname}:${parsed.port}` : hostname;
+}
+
+const publicHost = normalizeAuthority(publicHostArgument);
+
+/**
+ * The `Host` and scheme to hand Pi Web, or null to forward the request as it
+ * arrived.
+ *
+ * Trusting the `Origin` here would hand Pi Web's Host allow-list whatever a page
+ * claimed, so the header is only ever restored to the sandbox's own public
+ * hostname or to the `Host` the request already carries.
+ */
+function repairedIdentity(headers) {
+  const origin = headers.origin;
+  if (!origin) return null; // same-origin GETs and non-browser clients
+
+  let parsed;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return null; // includes the opaque `Origin: null`
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+
+  const originAuthority = normalizeAuthority(parsed.host);
+  if (originAuthority === null) return null;
+
+  const scheme = parsed.protocol.slice(0, -1);
+  if (publicHost !== null && originAuthority === publicHost) {
+    return { host: parsed.host, scheme };
+  }
+  // A proxy that keeps Host intact and only loses the scheme needs no rewrite,
+  // just the scheme it dropped.
+  if (headers.host && normalizeAuthority(headers.host) === originAuthority) {
+    return { host: headers.host, scheme };
+  }
+  return null;
+}
+
+function forwardedHeaders(headers) {
+  const forwarded = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (!HOP_BY_HOP_HEADERS.has(name)) forwarded[name] = value;
+  }
+
+  const identity = repairedIdentity(headers);
+  if (identity !== null) {
+    forwarded.host = identity.host;
+    // A real proxy in front that already reported the scheme knows better.
+    if (!forwarded["x-forwarded-proto"]) forwarded["x-forwarded-proto"] = identity.scheme;
+  }
+
+  return forwarded;
+}
+
+const server = http.createServer((request, response) => {
+  const upstream = http.request({
+    host: UPSTREAM_HOST,
+    port: upstreamPort,
+    method: request.method,
+    path: request.url,
+    headers: forwardedHeaders(request.headers),
+  });
+
+  upstream.on("response", (upstreamResponse) => {
+    // Raw headers keep repeated fields such as `Set-Cookie` intact, and piping
+    // without buffering keeps Pi Web's streaming responses live.
+    response.writeHead(
+      upstreamResponse.statusCode,
+      upstreamResponse.statusMessage,
+      upstreamResponse.rawHeaders,
+    );
+    upstreamResponse.pipe(response);
+  });
+
+  upstream.on("error", (error) => {
+    console.error(`pi-web-shim: upstream request failed: ${error.message}`);
+    if (!response.headersSent) {
+      response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+    }
+    response.end("pi-web-shim: Pi Web is unreachable\n");
+  });
+
+  request.on("aborted", () => upstream.destroy());
+  request.pipe(upstream);
+});
+
+// An upgraded connection never reaches the request handler above, so it needs
+// its own tunnel.
+server.on("upgrade", (request, clientSocket, head) => {
+  const upstream = http.request({
+    host: UPSTREAM_HOST,
+    port: upstreamPort,
+    method: request.method,
+    path: request.url,
+    headers: { ...request.headers, ...forwardedHeaders(request.headers) },
+  });
+
+  upstream.on("upgrade", (upstreamResponse, upstreamSocket, upstreamHead) => {
+    const statusLine = `HTTP/1.1 ${upstreamResponse.statusCode} ${upstreamResponse.statusMessage}`;
+    const headerLines = [];
+    for (let index = 0; index < upstreamResponse.rawHeaders.length; index += 2) {
+      headerLines.push(
+        `${upstreamResponse.rawHeaders[index]}: ${upstreamResponse.rawHeaders[index + 1]}`,
+      );
+    }
+    clientSocket.write(`${[statusLine, ...headerLines].join("\r\n")}\r\n\r\n`);
+
+    for (const socket of [clientSocket, upstreamSocket]) {
+      socket.setTimeout(0);
+      socket.setNoDelay(true);
+      socket.on("error", () => socket.destroy());
+    }
+
+    // Bytes that arrived alongside the handshake belong at the front of each
+    // stream; unshifting them lets the pipes below carry them in order.
+    if (upstreamHead?.length) upstreamSocket.unshift(upstreamHead);
+    if (head?.length) clientSocket.unshift(head);
+
+    upstreamSocket.pipe(clientSocket);
+    clientSocket.pipe(upstreamSocket);
+  });
+
+  upstream.on("error", (error) => {
+    console.error(`pi-web-shim: upstream upgrade failed: ${error.message}`);
+    clientSocket.destroy();
+  });
+
+  clientSocket.on("error", () => upstream.destroy());
+  upstream.end();
+});
+
+server.on("error", (error) => {
+  console.error(`pi-web-shim: ${error.message}`);
+  process.exit(1);
+});
+
+server.listen(listenPort, "0.0.0.0", () => {
+  console.log(
+    `pi-web-shim listening on 0.0.0.0:${listenPort}, forwarding to ${UPSTREAM_HOST}:${upstreamPort}` +
+      (publicHost === null ? "" : ` as ${publicHost}`),
+  );
+});

--- a/sandbox-image/assets/hooks/pre-setup.sh
+++ b/sandbox-image/assets/hooks/pre-setup.sh
@@ -12,10 +12,12 @@ set -euo pipefail
 #   60999 — amikad daemon
 #   60998 — OpenCode web UI
 #   60997 — amikad's managed sshd (loopback; go/internal/constants)
-#   60996 — Pi Web UI
-#   60899-60995 — unassigned (reserved for future use)
+#   60996 — Pi Web UI (the X-Forwarded-Proto shim; the mapped port)
+#   60995 — Pi Web itself (loopback, behind that shim)
+#   60899-60994 — unassigned (reserved for future use)
 OPENCODE_WEB_PORT=60998
 PI_WEB_PORT=60996
+PI_WEB_INTERNAL_PORT=60995
 
 AMIKA_STATE_DIR="/var/lib/amikad"
 AMIKA_USER_STATE_DIR="/var/lib/amika"
@@ -94,6 +96,7 @@ if command -v pi-web &> /dev/null && [[ "${AMIKA_PI_WEB:-0}" == "1" ]]; then
     nohup env AMIKA_PI_WEB_PASSWORD="$AMIKA_PI_WEB_PASSWORD" \
     AMIKA_PI_WEB_ALLOWED_HOSTS="$AMIKA_PI_WEB_ALLOWED_HOSTS" \
     /usr/lib/amikad/pi-setup.sh "$amika_agent_cwd" "$PI_WEB_PORT" \
+    "$PI_WEB_INTERNAL_PORT" \
     > "$AMIKA_LOG_DIR/pi-web.log" 2>&1 &
 
   echo "$!" > "$AMIKA_RUN_DIR/pi-web.pid"

--- a/sandbox-image/generated/bundle.json
+++ b/sandbox-image/generated/bundle.json
@@ -55,6 +55,7 @@
       "/usr/lib/amikad/run-hook.sh",
       "/usr/lib/amikad/opencode-setup.sh",
       "/usr/lib/amikad/pi-setup.sh",
+      "/usr/lib/amikad/pi-web-shim.js",
       "/usr/lib/amikad/docker-setup.sh",
       "/usr/lib/amikad/restore-setuid.sh"
     ],
@@ -155,6 +156,7 @@
             "assets/hooks/docker-setup.sh",
             "assets/hooks/opencode-setup.sh",
             "assets/hooks/pi-setup.sh",
+            "assets/hooks/pi-web-shim.js",
             "assets/hooks/post-setup.sh",
             "assets/hooks/pre-setup.sh",
             "assets/hooks/restore-setuid.sh",
@@ -293,6 +295,7 @@
             "assets/hooks/docker-setup.sh",
             "assets/hooks/opencode-setup.sh",
             "assets/hooks/pi-setup.sh",
+            "assets/hooks/pi-web-shim.js",
             "assets/hooks/post-setup.sh",
             "assets/hooks/pre-setup.sh",
             "assets/hooks/restore-setuid.sh",

--- a/sandbox-image/manifest.toml
+++ b/sandbox-image/manifest.toml
@@ -18,6 +18,7 @@ hook_scripts = [
   "/usr/lib/amikad/run-hook.sh",
   "/usr/lib/amikad/opencode-setup.sh",
   "/usr/lib/amikad/pi-setup.sh",
+  "/usr/lib/amikad/pi-web-shim.js",
   "/usr/lib/amikad/docker-setup.sh",
   "/usr/lib/amikad/restore-setuid.sh",
 ]
@@ -76,6 +77,7 @@ assets = [
   "assets/hooks/docker-setup.sh",
   "assets/hooks/opencode-setup.sh",
   "assets/hooks/pi-setup.sh",
+  "assets/hooks/pi-web-shim.js",
   "assets/hooks/post-setup.sh",
   "assets/hooks/pre-setup.sh",
   "assets/hooks/restore-setuid.sh",

--- a/sandbox-image/steps/70-hook-assets.sh
+++ b/sandbox-image/steps/70-hook-assets.sh
@@ -13,6 +13,7 @@ for script in \
   docker-setup.sh \
   opencode-setup.sh \
   pi-setup.sh \
+  pi-web-shim.js \
   post-setup.sh \
   pre-setup.sh \
   restore-setuid.sh \


### PR DESCRIPTION
## The bug

Selecting a project in the Pi Web UI answers `403 {"error":"Untrusted API request"}` on every sandbox reached through Daytona's proxy. `POST /api/cwd/validate` fails; the page itself loads fine.

Pi Web guards `/api/*` by requiring the browser's `Origin` to equal `<scheme from X-Forwarded-Proto>://<Host header>` (`isApiRequestOriginAllowed`, Pi Web's `lib/request-security.ts`). Both halves are whatever the provider's proxy makes them, and a header capture — taken by standing a recording server on the mapped port — shows Daytona keeps neither:

```
host: localhost:60996                                     <- external host erased
origin: https://60996-<sandbox>.daytonaproxy01.net        <- real browser origin
x-forwarded-port: 443    (no x-forwarded-proto, no x-forwarded-host)
```

Pi Web therefore expects `http://localhost:60996` and compares it against an `https://…daytonaproxy01.net` Origin: mismatched on host *and* scheme. Browsers omit `Origin` on same-origin GETs, so reads pass and every write 403s, which is exactly the reported symptom.

`AMIKA_PI_WEB_ALLOWED_HOSTS` cannot help. It feeds only Pi Web's separate Host check, and that check already passes on the rewritten loopback Host — so the allow-list was not what made the endpoint work.

## Why a shim

Pi Web has no origin allow-list to configure instead: `lib/request-security.ts` reads only `PI_WEB_HOSTNAME` and `PI_WEB_ALLOWED_HOSTS`, and 0.8.9 (what `versions.env` pins) is the latest release. Upstream [pi-web#497](https://github.com/agegr/pi-web/issues/497) is the same defect, open since 14 Aug with no maintainer response; [#511](https://github.com/agegr/pi-web/pull/511) would not fix our variant (it requires `X-Forwarded-Proto` to be present) and [#544](https://github.com/agegr/pi-web/pull/544) would, but both are unreviewed.

## The change

Pi Web moves to **60995 on loopback**; a shim owns the mapped port **60996** and restores the `Host` and scheme the browser actually used before Pi Web sees the request.

The rewrite only ever targets a host already trusted: the public hostname Amika minted for this sandbox (`AMIKA_PI_WEB_ALLOWED_HOSTS`), or the `Host` the request already carries. An `Origin` naming anything else is forwarded untouched and still rejected by Pi Web, so a cross-origin page gains nothing by asking, and Pi Web's Host allow-list — where the CSRF and DNS-rebinding signal actually lives — keeps doing its job on a `Host` that now means something. An existing `X-Forwarded-Proto` is left alone.

The shim also tunnels `Upgrade` connections and pipes without buffering so streaming responses stay live, and `pi-setup.sh` takes both halves down together so a failure closes the port instead of serving 502s.

## Test plan

Verified against a live Daytona sandbox through the public HTTPS URL (not loopback — the bug is invisible over loopback, since it lives in the headers the proxy rewrites):

| Case | Before | After |
| --- | --- | --- |
| `POST /api/cwd/validate`, browser-like `Origin` | 403 `Untrusted API request` | **200** `{"success":true,…}` |
| Same, unauthenticated | 403 | 401 (trust gate passes, auth still enforced) |
| `GET /` page load | 200 | 200 |
| `POST` with `Origin: https://evil.example` | 403 | **403** |
| `POST` with `Sec-Fetch-Site: cross-site` | 403 | **403** |
| `POST` with lookalike `…daytonaproxy01.net.evil.example` | 403 | **403** |
| API reads (`/api/sessions`, `/api/home`) | 200 | 200 |
| SSE `/api/agent/running/events` | — | events delivered, `text/event-stream` preserved |

Also run: `python3 sandbox-image/generate.py --check` (generated files current), `make test-sandbox-image` (bundle consistent, verification suite passes), `make shellcheck` (clean), `node --check` on the shim.

`make vet`/`lint`/`build` were not run — no Go toolchain in the sandbox this was developed in, and no `.go` sources changed (the `go/internal/sandbox/sandbox-image/` files are the generated asset mirror). CI covers them.

## Notes

- No control-plane change needed: the mapped port and service URL are unchanged, so `PI_WEB_PORT` in amika-mono's `sandbox-provisioning` still points at the right place. Its doc comment there could gain a line about 60995 being taken.
- The shim can be deleted once an upstream release compares hosts rather than full origins; the docs say so at the call site.
- Not addressed: [pi-web#542](https://github.com/agegr/pi-web/issues/542), where Chromium 150+ strips the port from `Origin`. It would bite local-docker sandboxes on a non-default port, and it is a separate upstream bug — the shim deliberately compares authority including port rather than papering over it.