### PR TITLE
Add provider-qualified sandbox image steps

### DIFF
--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -15,7 +15,7 @@ set -euo pipefail
 #/   --no-cache              Pass --no-cache to docker build (disable layer cache entirely)
 #/   --ignore-unstaged       Continue even if there are unstaged changes
 #/   --push-daytona       Push built images to Daytona orgs amika-prod and Fixpoint (requires linux/amd64)
-#/   --push-daytona-vm    Also publish linux-vm snapshots
+#/   --push-daytona-vm    Build the Daytona provider variant and publish linux-vm snapshots
 #/                        (`a0.<size>.amika-<preset>-<revision>`): uploads the coder
 #/                        image into Daytona's registry, then
 #/                        `daytona snapshot create --image … --sandbox-class linux-vm`
@@ -28,7 +28,7 @@ set -euo pipefail
 #/                        executable used by either path.
 #/   --ci                 Authenticate via DAYTONA_PROD_API_KEY (amika-prod) and DAYTONA_STAGING_API_KEY (Fixpoint)
 #/                        before each org switch instead of relying on existing daytona login state.
-#/                        Requires --push-daytona.
+#/                        Requires --push-daytona or --push-daytona-vm.
 #/   --help               Show this help message
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -353,13 +353,9 @@ BUILT_IMAGES=()
 PUSHED_SNAPSHOTS=()
 EXISTING_SNAPSHOTS=()
 
-# Build images
-for preset in "${PRESETS[@]}"; do
-  image_tag="amika/${preset}:${VERSION}"
-  latest_tag="amika/${preset}:latest"
-  dockerfile="$REPO_ROOT/sandbox-image/generated/${preset}.Dockerfile"
-
-  docker_args=(build)
+build_image() {
+  local image_tag="$1" latest_tag="$2" dockerfile="$3"
+  local docker_args=(build)
   if [ "$NO_CACHE" = true ]; then
     docker_args+=(--no-cache)
   fi
@@ -373,6 +369,23 @@ for preset in "${PRESETS[@]}"; do
   docker_args+=(-f "$dockerfile" -t "$image_tag" -t "$latest_tag" "$REPO_ROOT")
   docker "${docker_args[@]}"
   BUILT_IMAGES+=("$image_tag" "$latest_tag")
+}
+
+# Build images
+for preset in "${PRESETS[@]}"; do
+  image_tag="amika/${preset}:${VERSION}"
+  latest_tag="amika/${preset}:latest"
+  dockerfile="$REPO_ROOT/sandbox-image/generated/${preset}.Dockerfile"
+  if [ "$PUSH_DAYTONA_VM" = false ] || [ "$PUSH_DAYTONA" = true ]; then
+    build_image "$image_tag" "$latest_tag" "$dockerfile"
+  fi
+
+  if [ "$PUSH_DAYTONA_VM" = true ]; then
+    vm_image_tag="amika/${preset}:${VERSION}-daytona-vm"
+    vm_latest_tag="amika/${preset}:latest-daytona-vm"
+    vm_dockerfile="$REPO_ROOT/sandbox-image/generated/daytona/${preset}.Dockerfile"
+    build_image "$vm_image_tag" "$vm_latest_tag" "$vm_dockerfile"
+  fi
 
   if [ "$PUSH_DAYTONA" = true ]; then
     for i in "${!SIZES[@]}"; do
@@ -475,10 +488,10 @@ for preset in "${PRESETS[@]}"; do
       # wrong region ('us'), and the VM create below cannot inspect it. So target
       # the VM region, tolerate the push's exit code, and read the uploaded ref
       # from its output.
-      echo "Uploading ${image_tag} into Daytona's ${VM_REGION} registry (org ${org})..."
+      echo "Uploading ${vm_image_tag} into Daytona's ${VM_REGION} registry (org ${org})..."
       # Capture directly (no `tee`): the pipe/TTY plumbing seems to make Daytona
       # emit ANSI redraws into the captured stream. Echo it afterward for the log.
-      push_output=$(daytona snapshot push "$image_tag" \
+      push_output=$(daytona snapshot push "$vm_image_tag" \
         --name "${vm_name_base}-base:${VERSION}" \
         --region "$VM_REGION" --cpu 1 --memory 1 --disk 3 2>&1)
       printf '%s\n' "$push_output"

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -40,7 +40,9 @@ if ! [[ "$VERSION" =~ ^[0-9a-f]{7,40}$ ]]; then
   exit 1
 fi
 VERSION="${VERSION:0:12}"
-DAYTONA_CLI="${DAYTONA_CLI:-daytona}"
+if [ -z "${DAYTONA_CLI:-}" ]; then
+  DAYTONA_CLI="$(command -v daytona 2>/dev/null || true)"
+fi
 
 # Allow release jobs and canaries to pin an explicit CLI binary without
 # depending on a login shell preserving PATH. `command` is required: the default

--- a/go/internal/sandbox/sandbox-image/assets/providers/daytona/99-amika-user.conf
+++ b/go/internal/sandbox/sandbox-image/assets/providers/daytona/99-amika-user.conf
@@ -1,0 +1,3 @@
+[Service]
+User=amika
+WorkingDirectory=/home/amika

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder-dind.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder-dind.Dockerfile
@@ -1,0 +1,72 @@
+# syntax=docker/dockerfile:1
+
+ARG UBUNTU_TAG=24.04
+FROM ubuntu:${UBUNTU_TAG}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+ARG GIT_VERSION=2.43.0
+COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG NODE_VERSION=22.19.0
+ARG GH_VERSION=2.76.2
+COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG PNPM_VERSION=10.15.1
+ARG TYPESCRIPT_VERSION=5.9.2
+ARG TSX_VERSION=4.20.3
+COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+COPY sandbox-image/assets/hooks /tmp/amika-step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG CLAUDE_CODE_VERSION=2.1.224
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.4
+ARG PI_VERSION=0.84.1
+COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG AMIKA_VERSION=0.14.1
+ARG AMIKALOG_VERSION=0.2.0
+ARG AMIKAD_VERSION=0.1.0
+COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG DOCKER_VERSION=28.3.3
+ARG BUILDX_VERSION=0.25.0
+COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
+COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
+COPY sandbox-image/verify /usr/lib/amika-image/verify
+COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-dind /tmp/amika-step.sh \
+    && rm -rf /tmp/amika-step.sh
+
+USER amika
+ENV HOME=/home/amika
+WORKDIR /home/amika

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder-dind.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder-dind.Dockerfile
@@ -7,74 +7,74 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/providers/daytona /tmp/amika-step-assets
-COPY sandbox-image/steps/55-daytona-vm-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/providers/daytona /opt/amika-build/step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-ARG AMIKA_VERSION=0.14.1
+ARG AMIKA_VERSION=0.15.0
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG DOCKER_VERSION=28.3.3
 ARG BUILDX_VERSION=0.25.0
-COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/90-dind.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-dind /tmp/amika-step.sh \
-    && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-dind /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder-dind.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder-dind.Dockerfile
@@ -29,6 +29,11 @@ RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+COPY sandbox-image/assets/providers/daytona /tmp/amika-step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
 COPY sandbox-image/assets/stable /tmp/amika-step-assets
 COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh /tmp/amika-step-assets \

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder-dind.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder-dind.Dockerfile
@@ -51,6 +51,10 @@ ARG PI_VERSION=0.84.1
 COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+ARG PI_WEB_VERSION=0.8.9
+COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder.Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+
+ARG UBUNTU_TAG=24.04
+FROM ubuntu:${UBUNTU_TAG}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+ARG GIT_VERSION=2.43.0
+COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG NODE_VERSION=22.19.0
+ARG GH_VERSION=2.76.2
+COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG PNPM_VERSION=10.15.1
+ARG TYPESCRIPT_VERSION=5.9.2
+ARG TSX_VERSION=4.20.3
+COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+COPY sandbox-image/assets/hooks /tmp/amika-step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG CLAUDE_CODE_VERSION=2.1.224
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.4
+ARG PI_VERSION=0.84.1
+COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG AMIKA_VERSION=0.14.1
+ARG AMIKALOG_VERSION=0.2.0
+ARG AMIKAD_VERSION=0.1.0
+COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
+COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
+COPY sandbox-image/verify /usr/lib/amika-image/verify
+COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder /tmp/amika-step.sh \
+    && rm -rf /tmp/amika-step.sh
+
+USER amika
+ENV HOME=/home/amika
+WORKDIR /home/amika

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder.Dockerfile
@@ -29,6 +29,11 @@ RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+COPY sandbox-image/assets/providers/daytona /tmp/amika-step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
 COPY sandbox-image/assets/stable /tmp/amika-step-assets
 COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh /tmp/amika-step-assets \

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder.Dockerfile
@@ -7,69 +7,69 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/providers/daytona /tmp/amika-step-assets
-COPY sandbox-image/steps/55-daytona-vm-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/providers/daytona /opt/amika-build/step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-ARG AMIKA_VERSION=0.14.1
+ARG AMIKA_VERSION=0.15.0
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder /tmp/amika-step.sh \
-    && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder.Dockerfile
@@ -51,6 +51,10 @@ ARG PI_VERSION=0.84.1
 COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+ARG PI_WEB_VERSION=0.8.9
+COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0

--- a/go/internal/sandbox/sandbox-image/generated/e2b/coder-dind.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/e2b/coder-dind.Dockerfile
@@ -7,69 +7,69 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-ARG AMIKA_VERSION=0.14.1
+ARG AMIKA_VERSION=0.15.0
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG DOCKER_VERSION=28.3.3
 ARG BUILDX_VERSION=0.25.0
-COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/90-dind.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-dind /tmp/amika-step.sh \
-    && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-dind /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/go/internal/sandbox/sandbox-image/generated/e2b/coder-dind.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/e2b/coder-dind.Dockerfile
@@ -1,0 +1,72 @@
+# syntax=docker/dockerfile:1
+
+ARG UBUNTU_TAG=24.04
+FROM ubuntu:${UBUNTU_TAG}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+ARG GIT_VERSION=2.43.0
+COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG NODE_VERSION=22.19.0
+ARG GH_VERSION=2.76.2
+COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG PNPM_VERSION=10.15.1
+ARG TYPESCRIPT_VERSION=5.9.2
+ARG TSX_VERSION=4.20.3
+COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+COPY sandbox-image/assets/hooks /tmp/amika-step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG CLAUDE_CODE_VERSION=2.1.224
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.4
+ARG PI_VERSION=0.84.1
+COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG AMIKA_VERSION=0.14.1
+ARG AMIKALOG_VERSION=0.2.0
+ARG AMIKAD_VERSION=0.1.0
+COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG DOCKER_VERSION=28.3.3
+ARG BUILDX_VERSION=0.25.0
+COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
+COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
+COPY sandbox-image/verify /usr/lib/amika-image/verify
+COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-dind /tmp/amika-step.sh \
+    && rm -rf /tmp/amika-step.sh
+
+USER amika
+ENV HOME=/home/amika
+WORKDIR /home/amika

--- a/go/internal/sandbox/sandbox-image/generated/e2b/coder-dind.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/e2b/coder-dind.Dockerfile
@@ -46,6 +46,10 @@ ARG PI_VERSION=0.84.1
 COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+ARG PI_WEB_VERSION=0.8.9
+COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0

--- a/go/internal/sandbox/sandbox-image/generated/e2b/coder.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/e2b/coder.Dockerfile
@@ -7,64 +7,64 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-ARG AMIKA_VERSION=0.14.1
+ARG AMIKA_VERSION=0.15.0
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder /tmp/amika-step.sh \
-    && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/go/internal/sandbox/sandbox-image/generated/e2b/coder.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/e2b/coder.Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+
+ARG UBUNTU_TAG=24.04
+FROM ubuntu:${UBUNTU_TAG}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+ARG GIT_VERSION=2.43.0
+COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG NODE_VERSION=22.19.0
+ARG GH_VERSION=2.76.2
+COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG PNPM_VERSION=10.15.1
+ARG TYPESCRIPT_VERSION=5.9.2
+ARG TSX_VERSION=4.20.3
+COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+COPY sandbox-image/assets/hooks /tmp/amika-step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG CLAUDE_CODE_VERSION=2.1.224
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.4
+ARG PI_VERSION=0.84.1
+COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG AMIKA_VERSION=0.14.1
+ARG AMIKALOG_VERSION=0.2.0
+ARG AMIKAD_VERSION=0.1.0
+COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
+COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
+COPY sandbox-image/verify /usr/lib/amika-image/verify
+COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder /tmp/amika-step.sh \
+    && rm -rf /tmp/amika-step.sh
+
+USER amika
+ENV HOME=/home/amika
+WORKDIR /home/amika

--- a/go/internal/sandbox/sandbox-image/generated/e2b/coder.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/e2b/coder.Dockerfile
@@ -46,6 +46,10 @@ ARG PI_VERSION=0.84.1
 COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+ARG PI_WEB_VERSION=0.8.9
+COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0

--- a/go/internal/sandbox/sandbox-image/manifest.toml
+++ b/go/internal/sandbox/sandbox-image/manifest.toml
@@ -58,6 +58,12 @@ script = "steps/50-runtime-user.sh"
 versions = []
 assets = []
 
+[steps.daytona-vm-user]
+script = "steps/55-daytona-vm-user.sh"
+versions = []
+assets = ["assets/providers/daytona/99-amika-user.conf"]
+asset_argument = "assets/providers/daytona"
+
 [steps.dotfiles]
 script = "steps/60-dotfiles.sh"
 versions = []
@@ -172,6 +178,7 @@ steps = [
   "node-gh",
   "npm-toolchain",
   "runtime-user",
+  { step = "daytona-vm-user", providers = ["daytona"] },
   "dotfiles",
   "hook-assets",
   "agent-clis",
@@ -205,6 +212,7 @@ steps = [
   "node-gh",
   "npm-toolchain",
   "runtime-user",
+  { step = "daytona-vm-user", providers = ["daytona"] },
   "dotfiles",
   "hook-assets",
   "agent-clis",

--- a/go/internal/sandbox/sandbox-image/manifest.toml
+++ b/go/internal/sandbox/sandbox-image/manifest.toml
@@ -30,6 +30,7 @@ agent_hook_paths = [
   ".claude/settings.json",
   ".codex/hooks.json",
 ]
+provider_variants = ["daytona", "e2b"]
 
 [steps.os-packages]
 script = "steps/10-os-packages.sh"

--- a/go/internal/sandbox/sandbox-image/steps/55-daytona-vm-user.sh
+++ b/go/internal/sandbox/sandbox-image/steps/55-daytona-vm-user.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Selects the unprivileged runtime user for Daytona linux-vm sandboxes.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <daytona-assets-directory>" >&2
+  exit 64
+fi
+
+install -d -o root -g root -m 0755 \
+  /etc/systemd/system/daytona.service.d
+install -o root -g root -m 0644 \
+  "$1/99-amika-user.conf" \
+  /etc/systemd/system/daytona.service.d/99-amika-user.conf

--- a/go/internal/sandbox/sandbox-image/verify/checks/17-daytona-vm-user.sh
+++ b/go/internal/sandbox/sandbox-image/verify/checks/17-daytona-vm-user.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Verifies the Daytona variant's systemd user override does not leak elsewhere.
+# shellcheck disable=SC1091,SC2034
+CHECK_ID="daytona-vm-user"
+CHECK_CONTEXTS="build"
+source "$(dirname "$0")/../lib/check.sh" "$@"
+
+provider="${AMIKA_IMAGE_PROVIDER:-shared}"
+override_path="/etc/systemd/system/daytona.service.d/99-amika-user.conf"
+
+if [[ "$provider" != "daytona" ]]; then
+  [[ ! -e "$override_path" ]] && \
+    pass "Daytona override exists only in the Daytona image variant" "absent for $provider"
+  fail "Daytona override exists only in the Daytona image variant" "present for $provider"
+fi
+
+expected=$'[Service]\nUser=amika\nWorkingDirectory=/home/amika'
+actual_content="$(cat "$override_path" 2>/dev/null || true)"
+actual_metadata="$(stat -c '%U:%G:%a' "$override_path" 2>/dev/null || true)"
+if [[ "$actual_content" == "$expected" && "$actual_metadata" == "root:root:644" ]]; then
+  pass "Daytona override selects the runtime user with safe metadata" "$actual_metadata"
+fi
+fail \
+  "Daytona override selects the runtime user with safe metadata" \
+  "metadata=$actual_metadata content_match=$([[ "$actual_content" == "$expected" ]] && echo yes || echo no)"

--- a/sandbox-image/README.md
+++ b/sandbox-image/README.md
@@ -38,11 +38,33 @@ The generator writes these provider-facing artifacts:
 
 - `generated/coder.Dockerfile`
 - `generated/coder-dind.Dockerfile`
+- `generated/daytona/{coder,coder-dind}.Dockerfile`
+- `generated/e2b/{coder,coder-dind}.Dockerfile`
 - `generated/bundle.json`
 
-The Dockerfiles are the OCI build inputs for local Docker, Daytona, and Vercel.
-`bundle.json` is the ordered execution plan consumed by Freestyle's shared-step
-fallback.
+The top-level Dockerfiles contain the shared preset steps and remain the OCI
+build inputs for local Docker and consumers without an explicit provider
+variant. Provider directories contain the same preset after filtering its
+provider-qualified entries. `bundle.json` contains only shared steps and is the
+ordered execution plan consumed by Freestyle's shared-step fallback.
+
+Preset step entries are either a string, which applies to every output, or an
+inline table restricted to declared `image.provider_variants`:
+
+```toml
+[image]
+provider_variants = ["daytona", "e2b"]
+
+[presets.coder]
+steps = [
+  "runtime-user",
+  { step = "daytona-vm-user", providers = ["daytona"] },
+  "dotfiles",
+]
+```
+
+The array position remains the single source of step order. The shared output
+omits provider-qualified entries.
 
 The generator also synchronizes `go/internal/sandbox/sandbox-image/`. That is
 the Go-embed mirror of the bundle, including generated Dockerfiles, scripts,

--- a/sandbox-image/README.md
+++ b/sandbox-image/README.md
@@ -66,6 +66,11 @@ steps = [
 The array position remains the single source of step order. The shared output
 omits provider-qualified entries.
 
+`bin/build-docker-images --push-daytona-vm` builds the Daytona variant under a
+distinct local tag and publishes that image to linux-vm snapshots. The
+container-class Daytona path continues to build the shared Dockerfile because
+it honors OCI runtime metadata without the VM-specific systemd override.
+
 The generator also synchronizes `go/internal/sandbox/sandbox-image/`. That is
 the Go-embed mirror of the bundle, including generated Dockerfiles, scripts,
 assets, and verification files. It is committed because `go install` must build

--- a/sandbox-image/assets/providers/daytona/99-amika-user.conf
+++ b/sandbox-image/assets/providers/daytona/99-amika-user.conf
@@ -1,0 +1,3 @@
+[Service]
+User=amika
+WorkingDirectory=/home/amika

--- a/sandbox-image/generate.py
+++ b/sandbox-image/generate.py
@@ -42,6 +42,14 @@ def main() -> int:
             path = generated / name
             if not path.is_file() or path.read_text(encoding="utf-8") != expected:
                 stale.append(name)
+        actual = {
+            str(path.relative_to(generated))
+            for path in generated.rglob("*")
+            if path.is_file()
+        }
+        stale.extend(
+            f"unexpected:{name}" for name in sorted(actual - outputs.keys())
+        )
         if stale:
             print(
                 "generated sandbox image artifacts are stale: "
@@ -59,23 +67,28 @@ def main() -> int:
             return 1
         return 0
 
-    for name, content in outputs.items():
-        (generated / name).write_text(content, encoding="utf-8")
+    write_outputs(generated, outputs)
     write_embed_outputs(embed_root, embed_outputs)
     return 0
 
 
 def build_outputs(manifest: dict, versions: dict[str, str]) -> dict[str, str]:
+    image = manifest["image"]
     execution_plan = {
         "schemaVersion": 1,
-        "image": manifest["image"],
+        "image": {
+            key: value
+            for key, value in image.items()
+            if key != "provider_variants"
+        },
         "presets": {},
     }
     outputs = {}
     for preset_name, preset in manifest["presets"].items():
+        shared_step_ids = preset_step_ids(preset)
         steps = [
             execution_step(step_id, manifest["steps"][step_id], versions)
-            for step_id in preset["steps"]
+            for step_id in shared_step_ids
         ]
         execution_plan["presets"][preset_name] = {
             "steps": steps,
@@ -83,17 +96,53 @@ def build_outputs(manifest: dict, versions: dict[str, str]) -> dict[str, str]:
         }
         dockerfile = render_dockerfile(
             preset_name,
-            preset,
-            manifest["image"],
+            shared_step_ids,
+            image,
             manifest["steps"],
             versions,
         )
         outputs[f"{preset_name}.Dockerfile"] = dockerfile
+        for provider in image.get("provider_variants", []):
+            provider_step_ids = preset_step_ids(preset, provider)
+            outputs[f"{provider}/{preset_name}.Dockerfile"] = (
+                render_dockerfile(
+                    preset_name,
+                    provider_step_ids,
+                    image,
+                    manifest["steps"],
+                    versions,
+                    provider,
+                )
+            )
 
     outputs["bundle.json"] = (
         json.dumps(execution_plan, indent=2, sort_keys=True) + "\n"
     )
     return outputs
+
+
+def preset_step_ids(preset: dict, provider: str | None = None) -> list[str]:
+    """Resolve ordered preset steps for the shared or selected provider build."""
+    selected = []
+    for entry in preset["steps"]:
+        if isinstance(entry, str):
+            selected.append(entry)
+        elif provider is not None and provider in entry["providers"]:
+            selected.append(entry["step"])
+    return selected
+
+
+def write_outputs(root: Path, outputs: dict[str, str]) -> None:
+    expected = set(outputs)
+    for path in sorted(root.rglob("*"), reverse=True):
+        if path.is_file() and str(path.relative_to(root)) not in expected:
+            path.unlink()
+        elif path.is_dir() and not any(path.iterdir()):
+            path.rmdir()
+    for name, content in outputs.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
 
 
 def build_embed_outputs(
@@ -180,10 +229,11 @@ def execution_step(
 
 def render_dockerfile(
     preset_name: str,
-    preset: dict,
+    step_ids: list[str],
     image: dict,
     steps: dict,
     versions: dict[str, str],
+    provider: str | None = None,
 ) -> str:
     base_version = image["base_version"]
     lines = [
@@ -196,7 +246,7 @@ def render_dockerfile(
         "ENV LANG=C.UTF-8",
     ]
 
-    for step_id in preset["steps"]:
+    for step_id in step_ids:
         step = steps[step_id]
         lines.append("")
         for version in step["versions"]:
@@ -214,6 +264,8 @@ def render_dockerfile(
 
         lines.append(f"COPY sandbox-image/{step['script']} {STAGING_SCRIPT}")
         command = []
+        if provider is not None and step_id == "verify":
+            command.append(f"AMIKA_IMAGE_PROVIDER={provider}")
         preset_environment = step.get("preset_environment")
         if preset_environment:
             command.append(f"{preset_environment}={preset_name}")

--- a/sandbox-image/generated/daytona/coder-dind.Dockerfile
+++ b/sandbox-image/generated/daytona/coder-dind.Dockerfile
@@ -1,0 +1,72 @@
+# syntax=docker/dockerfile:1
+
+ARG UBUNTU_TAG=24.04
+FROM ubuntu:${UBUNTU_TAG}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+ARG GIT_VERSION=2.43.0
+COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG NODE_VERSION=22.19.0
+ARG GH_VERSION=2.76.2
+COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG PNPM_VERSION=10.15.1
+ARG TYPESCRIPT_VERSION=5.9.2
+ARG TSX_VERSION=4.20.3
+COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+COPY sandbox-image/assets/hooks /tmp/amika-step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG CLAUDE_CODE_VERSION=2.1.224
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.4
+ARG PI_VERSION=0.84.1
+COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG AMIKA_VERSION=0.14.1
+ARG AMIKALOG_VERSION=0.2.0
+ARG AMIKAD_VERSION=0.1.0
+COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG DOCKER_VERSION=28.3.3
+ARG BUILDX_VERSION=0.25.0
+COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
+COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
+COPY sandbox-image/verify /usr/lib/amika-image/verify
+COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-dind /tmp/amika-step.sh \
+    && rm -rf /tmp/amika-step.sh
+
+USER amika
+ENV HOME=/home/amika
+WORKDIR /home/amika

--- a/sandbox-image/generated/daytona/coder-dind.Dockerfile
+++ b/sandbox-image/generated/daytona/coder-dind.Dockerfile
@@ -7,74 +7,74 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/providers/daytona /tmp/amika-step-assets
-COPY sandbox-image/steps/55-daytona-vm-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/providers/daytona /opt/amika-build/step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-ARG AMIKA_VERSION=0.14.1
+ARG AMIKA_VERSION=0.15.0
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG DOCKER_VERSION=28.3.3
 ARG BUILDX_VERSION=0.25.0
-COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/90-dind.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-dind /tmp/amika-step.sh \
-    && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-dind /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/sandbox-image/generated/daytona/coder-dind.Dockerfile
+++ b/sandbox-image/generated/daytona/coder-dind.Dockerfile
@@ -29,6 +29,11 @@ RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+COPY sandbox-image/assets/providers/daytona /tmp/amika-step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
 COPY sandbox-image/assets/stable /tmp/amika-step-assets
 COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh /tmp/amika-step-assets \

--- a/sandbox-image/generated/daytona/coder-dind.Dockerfile
+++ b/sandbox-image/generated/daytona/coder-dind.Dockerfile
@@ -51,6 +51,10 @@ ARG PI_VERSION=0.84.1
 COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+ARG PI_WEB_VERSION=0.8.9
+COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0

--- a/sandbox-image/generated/daytona/coder.Dockerfile
+++ b/sandbox-image/generated/daytona/coder.Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+
+ARG UBUNTU_TAG=24.04
+FROM ubuntu:${UBUNTU_TAG}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+ARG GIT_VERSION=2.43.0
+COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG NODE_VERSION=22.19.0
+ARG GH_VERSION=2.76.2
+COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG PNPM_VERSION=10.15.1
+ARG TYPESCRIPT_VERSION=5.9.2
+ARG TSX_VERSION=4.20.3
+COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+COPY sandbox-image/assets/hooks /tmp/amika-step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG CLAUDE_CODE_VERSION=2.1.224
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.4
+ARG PI_VERSION=0.84.1
+COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG AMIKA_VERSION=0.14.1
+ARG AMIKALOG_VERSION=0.2.0
+ARG AMIKAD_VERSION=0.1.0
+COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
+COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
+COPY sandbox-image/verify /usr/lib/amika-image/verify
+COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder /tmp/amika-step.sh \
+    && rm -rf /tmp/amika-step.sh
+
+USER amika
+ENV HOME=/home/amika
+WORKDIR /home/amika

--- a/sandbox-image/generated/daytona/coder.Dockerfile
+++ b/sandbox-image/generated/daytona/coder.Dockerfile
@@ -29,6 +29,11 @@ RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+COPY sandbox-image/assets/providers/daytona /tmp/amika-step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
 COPY sandbox-image/assets/stable /tmp/amika-step-assets
 COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh /tmp/amika-step-assets \

--- a/sandbox-image/generated/daytona/coder.Dockerfile
+++ b/sandbox-image/generated/daytona/coder.Dockerfile
@@ -7,69 +7,69 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/providers/daytona /tmp/amika-step-assets
-COPY sandbox-image/steps/55-daytona-vm-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/providers/daytona /opt/amika-build/step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-ARG AMIKA_VERSION=0.14.1
+ARG AMIKA_VERSION=0.15.0
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder /tmp/amika-step.sh \
-    && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/sandbox-image/generated/daytona/coder.Dockerfile
+++ b/sandbox-image/generated/daytona/coder.Dockerfile
@@ -51,6 +51,10 @@ ARG PI_VERSION=0.84.1
 COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+ARG PI_WEB_VERSION=0.8.9
+COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0

--- a/sandbox-image/generated/e2b/coder-dind.Dockerfile
+++ b/sandbox-image/generated/e2b/coder-dind.Dockerfile
@@ -7,69 +7,69 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-ARG AMIKA_VERSION=0.14.1
+ARG AMIKA_VERSION=0.15.0
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG DOCKER_VERSION=28.3.3
 ARG BUILDX_VERSION=0.25.0
-COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/90-dind.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-dind /tmp/amika-step.sh \
-    && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-dind /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/sandbox-image/generated/e2b/coder-dind.Dockerfile
+++ b/sandbox-image/generated/e2b/coder-dind.Dockerfile
@@ -1,0 +1,72 @@
+# syntax=docker/dockerfile:1
+
+ARG UBUNTU_TAG=24.04
+FROM ubuntu:${UBUNTU_TAG}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+ARG GIT_VERSION=2.43.0
+COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG NODE_VERSION=22.19.0
+ARG GH_VERSION=2.76.2
+COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG PNPM_VERSION=10.15.1
+ARG TYPESCRIPT_VERSION=5.9.2
+ARG TSX_VERSION=4.20.3
+COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+COPY sandbox-image/assets/hooks /tmp/amika-step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG CLAUDE_CODE_VERSION=2.1.224
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.4
+ARG PI_VERSION=0.84.1
+COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG AMIKA_VERSION=0.14.1
+ARG AMIKALOG_VERSION=0.2.0
+ARG AMIKAD_VERSION=0.1.0
+COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG DOCKER_VERSION=28.3.3
+ARG BUILDX_VERSION=0.25.0
+COPY sandbox-image/steps/90-dind.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
+COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
+COPY sandbox-image/verify /usr/lib/amika-image/verify
+COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-dind /tmp/amika-step.sh \
+    && rm -rf /tmp/amika-step.sh
+
+USER amika
+ENV HOME=/home/amika
+WORKDIR /home/amika

--- a/sandbox-image/generated/e2b/coder-dind.Dockerfile
+++ b/sandbox-image/generated/e2b/coder-dind.Dockerfile
@@ -46,6 +46,10 @@ ARG PI_VERSION=0.84.1
 COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+ARG PI_WEB_VERSION=0.8.9
+COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0

--- a/sandbox-image/generated/e2b/coder.Dockerfile
+++ b/sandbox-image/generated/e2b/coder.Dockerfile
@@ -7,64 +7,64 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
 ARG GIT_VERSION=2.43.0
-COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/10-os-packages.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/20-static-config.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG NODE_VERSION=22.19.0
 ARG GH_VERSION=2.76.2
-COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/30-node-gh.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PNPM_VERSION=10.15.1
 ARG TYPESCRIPT_VERSION=5.9.2
 ARG TSX_VERSION=4.20.3
-COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/40-npm-toolchain.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/stable /tmp/amika-step-assets
-COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/stable /opt/amika-build/step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/hooks /tmp/amika-step-assets
-COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh /tmp/amika-step-assets \
-    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+COPY sandbox-image/assets/hooks /opt/amika-build/step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
 
 ARG CLAUDE_CODE_VERSION=2.1.224
 ARG CODEX_VERSION=0.147.0
 ARG OPENCODE_VERSION=1.18.4
 ARG PI_VERSION=0.84.1
-COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/80-agent-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 ARG PI_WEB_VERSION=0.8.9
-COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/82-pi-web.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-ARG AMIKA_VERSION=0.14.1
+ARG AMIKA_VERSION=0.15.0
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0
-COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/85-amika-clis.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
-RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/94-setuid-manifest.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
 COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
-COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
-RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder /tmp/amika-step.sh \
-    && rm -rf /tmp/amika-step.sh
+COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/sandbox-image/generated/e2b/coder.Dockerfile
+++ b/sandbox-image/generated/e2b/coder.Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+
+ARG UBUNTU_TAG=24.04
+FROM ubuntu:${UBUNTU_TAG}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+ARG GIT_VERSION=2.43.0
+COPY sandbox-image/steps/10-os-packages.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/20-static-config.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG NODE_VERSION=22.19.0
+ARG GH_VERSION=2.76.2
+COPY sandbox-image/steps/30-node-gh.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG PNPM_VERSION=10.15.1
+ARG TYPESCRIPT_VERSION=5.9.2
+ARG TSX_VERSION=4.20.3
+COPY sandbox-image/steps/40-npm-toolchain.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/50-runtime-user.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/assets/stable /tmp/amika-step-assets
+COPY sandbox-image/steps/60-dotfiles.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+COPY sandbox-image/assets/hooks /tmp/amika-step-assets
+COPY sandbox-image/steps/70-hook-assets.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh /tmp/amika-step-assets \
+    && rm -rf /tmp/amika-step.sh /tmp/amika-step-assets
+
+ARG CLAUDE_CODE_VERSION=2.1.224
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.4
+ARG PI_VERSION=0.84.1
+COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+ARG AMIKA_VERSION=0.14.1
+ARG AMIKALOG_VERSION=0.2.0
+ARG AMIKAD_VERSION=0.1.0
+COPY sandbox-image/steps/85-amika-clis.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/steps/94-setuid-manifest.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
+COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
+COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
+COPY sandbox-image/verify /usr/lib/amika-image/verify
+COPY sandbox-image/steps/95-verify.sh /tmp/amika-step.sh
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder /tmp/amika-step.sh \
+    && rm -rf /tmp/amika-step.sh
+
+USER amika
+ENV HOME=/home/amika
+WORKDIR /home/amika

--- a/sandbox-image/generated/e2b/coder.Dockerfile
+++ b/sandbox-image/generated/e2b/coder.Dockerfile
@@ -46,6 +46,10 @@ ARG PI_VERSION=0.84.1
 COPY sandbox-image/steps/80-agent-clis.sh /tmp/amika-step.sh
 RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
 
+ARG PI_WEB_VERSION=0.8.9
+COPY sandbox-image/steps/82-pi-web.sh /tmp/amika-step.sh
+RUN /tmp/amika-step.sh && rm -rf /tmp/amika-step.sh
+
 ARG AMIKA_VERSION=0.14.1
 ARG AMIKALOG_VERSION=0.2.0
 ARG AMIKAD_VERSION=0.1.0

--- a/sandbox-image/manifest.toml
+++ b/sandbox-image/manifest.toml
@@ -58,6 +58,12 @@ script = "steps/50-runtime-user.sh"
 versions = []
 assets = []
 
+[steps.daytona-vm-user]
+script = "steps/55-daytona-vm-user.sh"
+versions = []
+assets = ["assets/providers/daytona/99-amika-user.conf"]
+asset_argument = "assets/providers/daytona"
+
 [steps.dotfiles]
 script = "steps/60-dotfiles.sh"
 versions = []
@@ -172,6 +178,7 @@ steps = [
   "node-gh",
   "npm-toolchain",
   "runtime-user",
+  { step = "daytona-vm-user", providers = ["daytona"] },
   "dotfiles",
   "hook-assets",
   "agent-clis",
@@ -205,6 +212,7 @@ steps = [
   "node-gh",
   "npm-toolchain",
   "runtime-user",
+  { step = "daytona-vm-user", providers = ["daytona"] },
   "dotfiles",
   "hook-assets",
   "agent-clis",

--- a/sandbox-image/manifest.toml
+++ b/sandbox-image/manifest.toml
@@ -30,6 +30,7 @@ agent_hook_paths = [
   ".claude/settings.json",
   ".codex/hooks.json",
 ]
+provider_variants = ["daytona", "e2b"]
 
 [steps.os-packages]
 script = "steps/10-os-packages.sh"

--- a/sandbox-image/steps/55-daytona-vm-user.sh
+++ b/sandbox-image/steps/55-daytona-vm-user.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Selects the unprivileged runtime user for Daytona linux-vm sandboxes.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <daytona-assets-directory>" >&2
+  exit 64
+fi
+
+install -d -o root -g root -m 0755 \
+  /etc/systemd/system/daytona.service.d
+install -o root -g root -m 0644 \
+  "$1/99-amika-user.conf" \
+  /etc/systemd/system/daytona.service.d/99-amika-user.conf

--- a/sandbox-image/tests/check-bundle.py
+++ b/sandbox-image/tests/check-bundle.py
@@ -47,8 +47,22 @@ def validate_manifest_files(
 ) -> list[str]:
     errors = []
     steps = manifest["steps"]
+    providers = manifest["image"].get("provider_variants", [])
+    if (
+        not isinstance(providers, list)
+        or not all(isinstance(provider, str) and provider for provider in providers)
+        or len(set(providers)) != len(providers)
+    ):
+        errors.append("image.provider_variants: expected unique non-empty strings")
+        providers = []
     for preset_name, preset in manifest["presets"].items():
-        for step_id in preset["steps"]:
+        for position, entry in enumerate(preset["steps"]):
+            entry_errors, step_id = validate_step_entry(
+                preset_name, position, entry, providers
+            )
+            errors.extend(entry_errors)
+            if step_id is None:
+                continue
             if step_id not in steps:
                 errors.append(f"{preset_name}: unknown step {step_id}")
 
@@ -60,6 +74,53 @@ def validate_manifest_files(
             if version not in versions:
                 errors.append(f"{step_id}: unknown version {version}")
     return errors
+
+
+def validate_step_entry(
+    preset_name: str,
+    position: int,
+    entry: object,
+    providers: list[str],
+) -> tuple[list[str], str | None]:
+    label = f"{preset_name}.steps[{position}]"
+    if isinstance(entry, str):
+        return ([], entry)
+    if not isinstance(entry, dict):
+        return ([f"{label}: expected a step string or table"], None)
+    if set(entry) != {"step", "providers"}:
+        return ([f"{label}: expected only step and providers"], None)
+
+    step_id = entry["step"]
+    selected_providers = entry["providers"]
+    errors = []
+    if not isinstance(step_id, str) or not step_id:
+        errors.append(f"{label}.step: expected a non-empty string")
+        step_id = None
+    if (
+        not isinstance(selected_providers, list)
+        or not selected_providers
+        or not all(
+            isinstance(provider, str) and provider
+            for provider in selected_providers
+        )
+        or len(set(selected_providers)) != len(selected_providers)
+    ):
+        errors.append(f"{label}.providers: expected unique non-empty strings")
+    else:
+        for provider in selected_providers:
+            if provider not in providers:
+                errors.append(f"{label}: unknown provider {provider}")
+    return (errors, step_id)
+
+
+def preset_step_ids(preset: dict, provider: str | None = None) -> list[str]:
+    selected = []
+    for entry in preset["steps"]:
+        if isinstance(entry, str):
+            selected.append(entry)
+        elif provider is not None and provider in entry["providers"]:
+            selected.append(entry["step"])
+    return selected
 
 
 def validate_step_version_literals(bundle: Path) -> list[str]:
@@ -81,10 +142,23 @@ def validate_generated_dockerfiles(
 ) -> list[str]:
     errors = []
     steps = manifest["steps"]
-    for preset_name, preset in manifest["presets"].items():
-        dockerfile = bundle / "generated" / f"{preset_name}.Dockerfile"
+    variants = [(None, "")]
+    variants.extend(
+        (provider, f"{provider}/")
+        for provider in manifest["image"].get("provider_variants", [])
+    )
+    for (preset_name, preset), (provider, prefix) in (
+        (preset_item, variant)
+        for preset_item in manifest["presets"].items()
+        for variant in variants
+    ):
+        variant_name = provider or "shared"
+        step_ids = preset_step_ids(preset, provider)
+        dockerfile = bundle / "generated" / f"{prefix}{preset_name}.Dockerfile"
         if not dockerfile.is_file():
-            errors.append(f"{preset_name}: missing generated Dockerfile")
+            errors.append(
+                f"{preset_name}/{variant_name}: missing generated Dockerfile"
+            )
             continue
 
         content = dockerfile.read_text(encoding="utf-8")
@@ -93,25 +167,37 @@ def validate_generated_dockerfiles(
         )
         expected_versions = {
             version
-            for step_id in preset["steps"]
+            for step_id in step_ids
             for version in steps[step_id]["versions"]
         }
         expected_versions.add("UBUNTU_TAG")
         for version in sorted(expected_versions):
             if arguments.get(version) != versions[version]:
                 errors.append(
-                    f"{preset_name}: ARG {version} differs from versions.env"
+                    f"{preset_name}/{variant_name}: ARG {version} differs from versions.env"
                 )
 
         positions = []
-        for step_id in preset["steps"]:
+        for step_id in step_ids:
             reference = f"sandbox-image/{steps[step_id]['script']}"
             position = content.find(reference)
             if position < 0:
-                errors.append(f"{preset_name}: missing step {step_id}")
+                errors.append(
+                    f"{preset_name}/{variant_name}: missing step {step_id}"
+                )
             positions.append(position)
         if positions != sorted(positions):
-            errors.append(f"{preset_name}: steps differ from manifest order")
+            errors.append(
+                f"{preset_name}/{variant_name}: steps differ from manifest order"
+            )
+
+        excluded_step_ids = set(steps) - set(step_ids)
+        for step_id in excluded_step_ids:
+            reference = f"sandbox-image/{steps[step_id]['script']}"
+            if reference in content:
+                errors.append(
+                    f"{preset_name}/{variant_name}: unexpected step {step_id}"
+                )
     return errors
 
 

--- a/sandbox-image/tests/run-tests.sh
+++ b/sandbox-image/tests/run-tests.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 bundle_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 python3 "$bundle_dir/tests/check-bundle.py"
+python3 -m unittest discover -s "$bundle_dir/tests" -p 'test_*.py'
 "$bundle_dir/verify/tests/run-tests.sh"
 shellcheck \
   "$bundle_dir/build.sh" \

--- a/sandbox-image/tests/test_provider_steps.py
+++ b/sandbox-image/tests/test_provider_steps.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+BUNDLE = Path(__file__).resolve().parent.parent
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+generate = load_module("sandbox_image_generate", BUNDLE / "generate.py")
+check_bundle = load_module(
+    "sandbox_image_check_bundle", BUNDLE / "tests" / "check-bundle.py"
+)
+
+
+class ProviderStepTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.preset = {
+            "steps": [
+                "shared-before",
+                {"step": "daytona-only", "providers": ["daytona"]},
+                {"step": "both", "providers": ["daytona", "e2b"]},
+                "shared-after",
+            ]
+        }
+
+    def test_shared_output_omits_provider_steps(self) -> None:
+        self.assertEqual(
+            generate.preset_step_ids(self.preset),
+            ["shared-before", "shared-after"],
+        )
+
+    def test_provider_output_filters_without_reordering(self) -> None:
+        self.assertEqual(
+            generate.preset_step_ids(self.preset, "daytona"),
+            ["shared-before", "daytona-only", "both", "shared-after"],
+        )
+        self.assertEqual(
+            generate.preset_step_ids(self.preset, "e2b"),
+            ["shared-before", "both", "shared-after"],
+        )
+
+    def test_validator_rejects_unknown_provider(self) -> None:
+        errors, step_id = check_bundle.validate_step_entry(
+            "coder",
+            1,
+            {"step": "conditional", "providers": ["missing"]},
+            ["daytona", "e2b"],
+        )
+        self.assertEqual(step_id, "conditional")
+        self.assertEqual(errors, ["coder.steps[1]: unknown provider missing"])
+
+    def test_validator_requires_exact_object_shape(self) -> None:
+        errors, step_id = check_bundle.validate_step_entry(
+            "coder",
+            1,
+            {
+                "step": "conditional",
+                "providers": ["daytona"],
+                "after": "runtime-user",
+            },
+            ["daytona", "e2b"],
+        )
+        self.assertIsNone(step_id)
+        self.assertEqual(
+            errors, ["coder.steps[1]: expected only step and providers"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sandbox-image/verify/checks/17-daytona-vm-user.sh
+++ b/sandbox-image/verify/checks/17-daytona-vm-user.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Verifies the Daytona variant's systemd user override does not leak elsewhere.
+# shellcheck disable=SC1091,SC2034
+CHECK_ID="daytona-vm-user"
+CHECK_CONTEXTS="build"
+source "$(dirname "$0")/../lib/check.sh" "$@"
+
+provider="${AMIKA_IMAGE_PROVIDER:-shared}"
+override_path="/etc/systemd/system/daytona.service.d/99-amika-user.conf"
+
+if [[ "$provider" != "daytona" ]]; then
+  [[ ! -e "$override_path" ]] && \
+    pass "Daytona override exists only in the Daytona image variant" "absent for $provider"
+  fail "Daytona override exists only in the Daytona image variant" "present for $provider"
+fi
+
+expected=$'[Service]\nUser=amika\nWorkingDirectory=/home/amika'
+actual_content="$(cat "$override_path" 2>/dev/null || true)"
+actual_metadata="$(stat -c '%U:%G:%a' "$override_path" 2>/dev/null || true)"
+if [[ "$actual_content" == "$expected" && "$actual_metadata" == "root:root:644" ]]; then
+  pass "Daytona override selects the runtime user with safe metadata" "$actual_metadata"
+fi
+fail \
+  "Daytona override selects the runtime user with safe metadata" \
+  "metadata=$actual_metadata content_match=$([[ "$actual_content" == "$expected" ]] && echo yes || echo no)"


### PR DESCRIPTION
Adds provider-qualified image build steps and generated Daytona/E2B Dockerfile variants.

Also bakes the Daytona VM user override and uses the E2B-specific generated Dockerfile when publishing E2B templates.

Required by gofixpoint/amika-mono PR #1013, which pins this branch until this PR merges.