### PR TITLE
Promote the v2 SSH commands to ssh, code, and scp

### DIFF
--- a/.agents/skills/amika-cli/SKILL.md
+++ b/.agents/skills/amika-cli/SKILL.md
@@ -73,16 +73,18 @@ prompts, so such a command errors instead of asking. Supply it up front:
 - `auth login` without `--api-key-file` — browser flow
 - `secret extract`, `secret push` — they print a masked credential table and prompt
 
-`sandbox ssh` and `scp` reject `--output` entirely: both delegate to the system
+`sandbox ssh` and `scp` reject `--output`: both delegate to the system
 `ssh`/`scp`, which stream their own output. (`scp` still forwards its own short
-`-o` for `ssh_config` overrides.)
+`-o` for `ssh_config` overrides.) For `sandbox ssh` the flag must go *before*
+the subcommand to be amika's at all — everything after it is forwarded to `ssh`,
+where `-o` is ssh's own `ssh_config` option.
 
 `secret push` and `secret extract --push` always ask `[y/N]` on stdin and have
 no bypass flag, so pipe the answer in: `echo y | amika secret push KEY=value`.
 
 **4. Don't launch an interactive session you can't steer.** `sandbox connect`,
 `sandbox code`, and bare `sandbox ssh <name>` block on a TTY and hang forever in
-a plain tool call. Use `amika sandbox ssh <name> -- <command>` to run something
+a plain tool call. Use `amika sandbox ssh <name> <command>` to run something
 and get output back.
 
 Exception: if you can drive a terminal — a tmux session or pane you can send
@@ -101,10 +103,11 @@ Errors go to stderr and exit non-zero (`1`).
 | `sandbox start` / `stop`              | Resume / halt without deleting; both take multiple names                                     |
 | `sandbox delete` (`rm`)               | Delete sandboxes; multiple names                                                             |
 | `sandbox agent-send`                  | Send a prompt to a coding agent running inside a sandbox                                     |
-| `sandbox ssh`                         | SSH in, or run one command; `--print` emits the connection string; `--revoke` revokes access |
+| `sandbox ssh`                         | SSH in, or run one command; forwards every ssh option, so it defines none of its own         |
 | `sandbox connect`                     | Interactive shell (`--shell`, default `zsh`), starting at `/home/amika`                      |
 | `sandbox code`                        | Open the sandbox in Cursor / Claude Desktop / Codex over SSH                                 |
 | `scp`                                 | Copy files to/from sandboxes; wraps the system `scp`                                         |
+| `sandbox sshv1` / `codev1` / `scpv1`  | Hidden, superseded provider-native SSH versions of the three above (see below)                |
 | `secret push` / `extract`             | Push arbitrary secrets, or discover local credentials                                        |
 | `secret claude` / `secret codex`      | `push` / `list` / `delete` agent credentials for injection                                   |
 | `secret ssh-key`                      | `create` / `push` / `list` / `delete` the SSH public keys authorizing sandbox access         |
@@ -235,12 +238,29 @@ the sandbox, but anything you send executes unsupervised in there.
 
 ## Running commands and copying files
 
+`sandbox ssh` runs over Amika's direct WebSocket transport, so it needs an SSH
+identity first — `amika secret ssh-keygen` once per machine (or
+`--import <public-key-file>` to reuse an existing key). It takes no flags of its
+own: ssh options go before the sandbox name, the remote command after it.
+
 ```bash
-amika sandbox ssh my-sandbox -- ls -la          # run a command, get output
-amika sandbox ssh -t my-sandbox -- top          # force a PTY
-amika sandbox ssh --print my-sandbox            # print the connection string
-amika sandbox ssh my-sandbox --revoke           # revoke SSH access
+amika sandbox ssh my-sandbox ls -la             # run a command, get output
+amika sandbox ssh -t my-sandbox top             # force a PTY (ssh's own -t)
+amika sandbox ssh -N -L 6789:localhost:3010 my-sandbox   # port forward, no shell
 ```
+
+`--print` and `--revoke` are not `sandbox ssh` flags. They belong to the hidden,
+superseded `sandbox sshv1`, which connects over the provider's own SSH route and
+does parse its own flags:
+
+```bash
+amika sandbox sshv1 my-sandbox -- ls -la        # note the -- separator
+amika sandbox sshv1 --print my-sandbox          # print the connection string
+amika sandbox sshv1 my-sandbox --revoke         # revoke SSH access
+```
+
+Reach for `sshv1` (or `codev1` / `scpv1`) only when the direct transport cannot
+reach a sandbox — for instance one created before Amika exposed it.
 
 `amika scp` forwards every argument to the system `scp`, so `-r`, `-p`, `-C`,
 `-v`, `-o Option=value` all work. Path forms:
@@ -262,8 +282,10 @@ amika scp my-sandbox:/data.csv scp://user@host:22/tmp/data.csv
 amika scp --print ./a.txt my-sandbox:a.txt      # show the resolved scp command
 ```
 
-Sandbox↔sandbox and sandbox↔external copies are not supported yet; go through
-the local machine in two steps.
+`scp` uses the same direct WebSocket transport as `sandbox ssh`, so it needs the
+same `amika secret ssh-keygen` identity. Under the hidden, superseded `scpv1`,
+sandbox↔sandbox and sandbox↔external copies are not supported; go through the
+local machine in two steps.
 
 ## Snapshots and services
 

--- a/.agents/skills/amika-cli/SKILL.md
+++ b/.agents/skills/amika-cli/SKILL.md
@@ -107,7 +107,6 @@ Errors go to stderr and exit non-zero (`1`).
 | `sandbox connect`                     | Interactive shell (`--shell`, default `zsh`), starting at `/home/amika`                      |
 | `sandbox code`                        | Open the sandbox in Cursor / Claude Desktop / Codex over SSH                                 |
 | `scp`                                 | Copy files to/from sandboxes; wraps the system `scp`                                         |
-| `sandbox sshv1` / `codev1` / `scpv1`  | Hidden, superseded provider-native SSH versions of the three above (see below)                |
 | `secret push` / `extract`             | Push arbitrary secrets, or discover local credentials                                        |
 | `secret claude` / `secret codex`      | `push` / `list` / `delete` agent credentials for injection                                   |
 | `secret ssh-key`                      | `create` / `push` / `list` / `delete` the SSH public keys authorizing sandbox access         |
@@ -249,19 +248,6 @@ amika sandbox ssh -t my-sandbox top             # force a PTY (ssh's own -t)
 amika sandbox ssh -N -L 6789:localhost:3010 my-sandbox   # port forward, no shell
 ```
 
-`--print` and `--revoke` are not `sandbox ssh` flags. They belong to the hidden,
-superseded `sandbox sshv1`, which connects over the provider's own SSH route and
-does parse its own flags:
-
-```bash
-amika sandbox sshv1 my-sandbox -- ls -la        # note the -- separator
-amika sandbox sshv1 --print my-sandbox          # print the connection string
-amika sandbox sshv1 my-sandbox --revoke         # revoke SSH access
-```
-
-Reach for `sshv1` (or `codev1` / `scpv1`) only when the direct transport cannot
-reach a sandbox — for instance one created before Amika exposed it.
-
 `amika scp` forwards every argument to the system `scp`, so `-r`, `-p`, `-C`,
 `-v`, `-o Option=value` all work. Path forms:
 
@@ -283,9 +269,7 @@ amika scp --print ./a.txt my-sandbox:a.txt      # show the resolved scp command
 ```
 
 `scp` uses the same direct WebSocket transport as `sandbox ssh`, so it needs the
-same `amika secret ssh-keygen` identity. Under the hidden, superseded `scpv1`,
-sandbox↔sandbox and sandbox↔external copies are not supported; go through the
-local machine in two steps.
+same `amika secret ssh-keygen` identity.
 
 ## Snapshots and services
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -284,10 +284,6 @@ Local (`-L`) and dynamic (`-D`) forwarding are supported. Remote forwarding
 `-o`/`--output` is not available there; written before `ssh` it is rejected
 (see [Global flags](#global-flags) above).
 
-If a sandbox predates Amika's direct transport and cannot be reached this way,
-the superseded [`sandbox sshv1`](#amika-sandbox-sshv1) still connects over the
-provider's own SSH route.
-
 ### `amika sandbox code`
 
 Open a remote sandbox in an editor or coding agent over Amika's direct
@@ -337,63 +333,6 @@ amika sandbox code my-sandbox --editor=codex
 | ----------------- | -------- | -------------------------------------------------------- |
 | `--editor <name>` | `cursor` | Editor or agent to open: `cursor`, `vscode`, `claude`, or `codex`  |
 | `--path <path>`   | —        | Override the remote path to open (absolute, or relative to the sandbox workspace root) |
-
-### `amika sandbox sshv1`
-
-Superseded by [`sandbox ssh`](#amika-sandbox-ssh) and hidden from `--help`, but
-still available by name so existing scripts keep working. It connects over the
-sandbox provider's own SSH route rather than Amika's direct WebSocket
-transport, and it can also revoke that access.
-
-Unlike `sandbox ssh`, this command parses its own flags, so amika flags may be
-written after the subcommand and a command to run goes after a `--` separator.
-
-```bash
-# Interactive SSH session
-amika sandbox sshv1 my-sandbox
-
-# Run a command on the remote sandbox
-amika sandbox sshv1 my-sandbox -- ls -la
-
-# Force pseudo-terminal allocation (for interactive programs)
-amika sandbox sshv1 -t my-sandbox -- top
-
-# Print the SSH connection string instead of connecting
-amika sandbox sshv1 --print my-sandbox
-
-# Revoke SSH access
-amika sandbox sshv1 my-sandbox --revoke
-```
-
-| Flag       | Default | Description                                                              |
-| ---------- | ------- | ------------------------------------------------------------------------ |
-| `-t`       | `false` | Force pseudo-terminal allocation (useful for interactive remote programs) |
-| `--revoke` | `false` | Revoke SSH access for the sandbox                                        |
-| `--print`  | `false` | Print the SSH connection string instead of connecting                    |
-
-`--output` is rejected wherever it appears, since this command parses its own
-flags (contrast `sandbox ssh`, where the rule is positional).
-
-### `amika sandbox codev1`
-
-Superseded by [`sandbox code`](#amika-sandbox-code) and hidden from `--help`,
-but still available by name so existing scripts keep working. It opens the same
-editors, connecting through the provider's own SSH route rather than Amika's
-direct WebSocket transport.
-
-All editors connect through the Amika-managed SSH host alias `amika-<id>`,
-written to `~/.ssh/amika.conf` and included from `~/.ssh/config`.
-
-```bash
-amika sandbox codev1 my-sandbox
-amika sandbox codev1 my-sandbox --editor=cursor
-amika sandbox codev1 my-sandbox --editor=vscode
-amika sandbox codev1 my-sandbox --editor=claude
-amika sandbox codev1 my-sandbox --editor=codex
-```
-
-`--editor` and `--path` have the same values and defaults as `sandbox code`,
-and WSL behaves the same way (see `sandbox code` above).
 
 ### `amika sandbox agent-send`
 
@@ -465,23 +404,7 @@ amika scp --print ./a.txt my-sandbox:a.txt
 | ---------- | ------- | ------------------------------------------------------ |
 | `--print`  | `false` | Print the resolved `scp` command instead of running it |
 
-Unlike [`scpv1`](#amika-scpv1), a copy naming no sandbox at all is simply forwarded to the system `scp`.
-
----
-
-## `amika scpv1`
-
-Superseded by [`amika scp`](#amika-scp) and hidden from `--help`, but still available by name so existing scripts keep working. It takes the same operand forms and the same `--print` flag, but resolves each sandbox to a concrete provider-native SSH destination instead of a managed alias, and it requires that at least one source or target name a sandbox or an `scp://` host.
-
-Because it spells connection options out on the command line, a few behaviors are specific to it. When every remote is a sandbox, the connection uses `StrictHostKeyChecking=accept-new`; when an external host or a jump host is involved, no host-key option is injected (scp applies `-o` options to every hop), so your normal SSH config governs. A non-default sandbox port is carried inline as a self-porting `scp://host:port//path` operand, so sandboxes and hosts on differing ports can be copied together. A password in an `scp://user:password@host` URI is rejected, since `scp` cannot use one non-interactively.
-
-A copy between the local machine and a sandbox is **streamed over an SSH exec channel** rather than run through `scp`. Daytona's `linux-vm` SSH gateway does not deliver the client's channel-EOF to a non-interactive remote, so `scp` (and `sftp`) complete the transfer but then hang forever waiting to tear the session down. The stream instead uses remote commands that exit on their own — `cat` to download, `head -c <size>` (bounded so it never waits for EOF) to upload, with `tar` for directories (`-r`). External `scp://` copies and local-only copies keep the real `scp` binary, which has no such teardown problem. Sandbox↔sandbox and sandbox↔external copies are not yet supported over the stream (copy via the local machine in two steps).
-
-```bash
-amika scpv1 ./local.txt my-sandbox:local.txt
-amika scpv1 -r my-sandbox:/srv/out ./out
-amika scpv1 my-sandbox:/data.csv scp://user@host:22/tmp/data.csv
-```
+A copy naming no sandbox at all is simply forwarded to the system `scp`.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,7 +6,7 @@ Complete reference for all `amika` commands, flags, and environment variables.
 
 Most commands accept `--output` (short `-o`) to control how they print their result. This lets you read output at a terminal and pipe the same command into a script or `jq` without reformatting.
 
-Two commands do **not** produce JSON because they delegate to a system shell utility that streams its own output: `amika sandbox ssh` (runs `ssh`) rejects `--output` with an error, and `amika scp` (a thin wrapper around `scp`) rejects the unambiguous long form `--output`/`--output=VALUE` but forwards `scp`'s own short `-o` option (used for `ssh_config` overrides) to the system `scp`.
+Two commands do **not** produce JSON because they delegate to a system shell utility that streams its own output: `amika sandbox ssh` (runs `ssh`) rejects `--output` with an error, and `amika scp` (a thin wrapper around `scp`) rejects the unambiguous long form `--output`/`--output=VALUE` but forwards `scp`'s own short `-o` option (used for `ssh_config` overrides) to the system `scp`. For `sandbox ssh` the rejection applies to a flag written **before** the subcommand; anything after it is forwarded to `ssh`, where `-o` is ssh's own `ssh_config` option.
 
 | Value         | Description                                    |
 | ------------- | ---------------------------------------------- |
@@ -25,7 +25,7 @@ amika sandbox list --remote -o json | jq '.[].name'
 amika snapshot list -o json-pretty
 ```
 
-Most list commands emit a JSON array (empty as `[]`, never `null`); `snapshot list` is the exception and emits a `{ "items": [...] }` envelope to match the API's `ListSandboxSnapshotsResponse`. Mutating commands emit a JSON result object or a per-item result array. Because JSON output cannot be interrupted by an interactive prompt, in JSON mode the CLI never prompts: destructive commands require their confirmation flag (`--force` for deletes, `--yes` for `sandbox create` mounts, `--no-interactive` for `snapshot create`), and commands that would open a shell or editor (`sandbox connect`, `sandbox code`, `sandbox codev2`, interactive `sandbox ssh`, `sandbox create --connect`, `auth login` without `--api-key-file`) refuse `-o json`. Human-readable progress and any subprocess output go to stderr so stdout carries only the JSON value.
+Most list commands emit a JSON array (empty as `[]`, never `null`); `snapshot list` is the exception and emits a `{ "items": [...] }` envelope to match the API's `ListSandboxSnapshotsResponse`. Mutating commands emit a JSON result object or a per-item result array. Because JSON output cannot be interrupted by an interactive prompt, in JSON mode the CLI never prompts: destructive commands require their confirmation flag (`--force` for deletes, `--yes` for `sandbox create` mounts, `--no-interactive` for `snapshot create`), and commands that would open a shell or editor (`sandbox connect`, `sandbox code`, interactive `sandbox ssh`, `sandbox create --connect`, `auth login` without `--api-key-file`) refuse `-o json`. Human-readable progress and any subprocess output go to stderr so stdout carries only the JSON value.
 
 ```bash
 # Create a sandbox and capture its name for a script
@@ -35,7 +35,7 @@ name=$(amika sandbox create --remote --no-git -o json | jq -r .name)
 amika sandbox delete a b c --remote --force -o json | jq '.[] | select(.status=="error")'
 ```
 
-Commands honoring `--output`: the read commands `sandbox list`, `snapshot list`, `volume list`, `service list`, `auth status`, and `secret <provider> list`, plus `sandbox create`, `sandbox start`, `sandbox stop`, `sandbox delete`, `sandbox agent-send`, `volume delete`, `snapshot create`, `snapshot delete`, `secret <provider> push`/`delete`, `secret ssh-keygen`, `secret ssh-key create`/`push`/`list`/`delete`, `auth login --api-key-file`, `auth logout`, and `materialize`. Commands that open a shell or editor (`sandbox connect`, `sandbox code`, `sandbox codev2`) or display a masked credential table and prompt for confirmation (`secret extract`, `secret push`) reject `-o json`/`json-pretty` since they produce no JSON result. `sandbox ssh` and `scp` do not accept `--output` at all (see above).
+Commands honoring `--output`: the read commands `sandbox list`, `snapshot list`, `volume list`, `service list`, `auth status`, and `secret <provider> list`, plus `sandbox create`, `sandbox start`, `sandbox stop`, `sandbox delete`, `sandbox agent-send`, `volume delete`, `snapshot create`, `snapshot delete`, `secret <provider> push`/`delete`, `secret ssh-keygen`, `secret ssh-key create`/`push`/`list`/`delete`, `auth login --api-key-file`, `auth logout`, and `materialize`. Commands that open a shell or editor (`sandbox connect`, `sandbox code`) or display a masked credential table and prompt for confirmation (`secret extract`, `secret push`) reject `-o json`/`json-pretty` since they produce no JSON result. `sandbox ssh` and `scp` do not accept `--output` at all (see above).
 
 ## `amika sandbox`
 
@@ -43,7 +43,7 @@ Manage Docker-backed persistent sandboxes with bind mounts and named volumes.
 
 ### Global sandbox flags
 
-These persistent flags apply to all `sandbox` subcommands (`create`, `list`, `connect`, `stop`, `start`, `delete`, `ssh`, `sshv2`, `code`, `codev2`, `agent-send`). For `sshv2` they must be written before the subcommand, since everything after it is forwarded to `ssh`:
+These persistent flags apply to all `sandbox` subcommands (`create`, `list`, `connect`, `stop`, `start`, `delete`, `ssh`, `code`, `agent-send`). For `ssh` they must be written before the subcommand, since everything after it is forwarded to `ssh`:
 
 | Flag       | Default | Description                      |
 | ---------- | ------- | -------------------------------- |
@@ -242,32 +242,61 @@ amika sandbox start sandbox-1 sandbox-2
 
 ### `amika sandbox ssh`
 
-SSH into a remote sandbox, or revoke SSH access. Optionally pass a command to execute instead of opening an interactive session.
+Open an SSH session to a remote sandbox over Amika's direct WebSocket
+transport. Remote sandboxes only; requires an SSH identity from
+`amika secret ssh-keygen`.
 
-```bash
-# Interactive SSH session
-amika sandbox ssh my-sandbox
-
-# Run a command on the remote sandbox
-amika sandbox ssh my-sandbox -- ls -la
-
-# Force pseudo-terminal allocation (for interactive programs)
-amika sandbox ssh -t my-sandbox -- top
-
-# Revoke SSH access
-amika sandbox ssh my-sandbox --revoke
+```
+amika sandbox ssh [ssh-options] <name> [command...]
 ```
 
-| Flag        | Default | Description                                                                 |
-| ----------- | ------- | --------------------------------------------------------------------------- |
-| `-t`        | `false` | Force pseudo-terminal allocation (useful for interactive remote programs)    |
-| `--revoke`  | `false` | Revoke SSH access for the sandbox                                           |
+Use it like `ssh`: options go before the sandbox name, an optional command
+after it. Every ssh option works, including port forwarding, and `ssh`
+defines no flags of its own.
+
+Amika's own flags go **before** `ssh`:
+
+```bash
+amika sandbox --remote ssh -N -L 8080:localhost:80 my-sandbox
+```
+
+`--help` is the one exception: `amika sandbox ssh --help` prints amika's
+help, as does `amika help sandbox ssh`.
+
+```bash
+# Interactive shell
+amika sandbox ssh my-sandbox
+
+# Run a command instead of opening a shell
+amika sandbox ssh my-sandbox uptime
+
+# Forward local port 6789 to port 3010 inside the sandbox, without a shell
+amika sandbox ssh -N -L 6789:localhost:3010 my-sandbox
+
+# SOCKS proxy on local port 1080
+amika sandbox ssh -N -D 1080 my-sandbox
+```
+
+Local (`-L`) and dynamic (`-D`) forwarding are supported. Remote forwarding
+(`-R`), agent forwarding (`-A`), and X11 forwarding are not.
+
+`-o` after the subcommand is ssh's ssh_config option, so amika's
+`-o`/`--output` is not available there; written before `ssh` it is rejected
+(see [Global flags](#global-flags) above).
+
+If a sandbox predates Amika's direct transport and cannot be reached this way,
+the superseded [`sandbox sshv1`](#amika-sandbox-sshv1) still connects over the
+provider's own SSH route.
 
 ### `amika sandbox code`
 
-Open a remote sandbox in an editor or coding agent via SSH. All editors connect
-through the same Amika-managed SSH host alias (`amika-<id>`, written to
-`~/.ssh/amika.conf` and included from `~/.ssh/config`):
+Open a remote sandbox in an editor or coding agent over Amika's direct
+WebSocket SSH transport. Remote sandboxes only; requires a signed-in Amika
+account and an SSH identity from `amika secret ssh-keygen`.
+
+The command adds a named SSH connection to Amika's managed config (so editors
+such as Codex that enumerate `Host` entries can find it), then starts or
+configures the selected editor:
 
 - `cursor` launches Cursor connected to the sandbox.
 - `vscode` launches VS Code connected to the sandbox.
@@ -278,7 +307,15 @@ through the same Amika-managed SSH host alias (`amika-<id>`, written to
   `~/.codex/config.toml`), then opens Codex; enable the host under
   Settings > Connections.
 
-This command requires a signed-in Amika account and a remote sandbox.
+Before first use, create and upload an SSH key:
+
+```bash
+amika secret ssh-keygen
+```
+
+To use an existing key, pass `--import <public-key-file>` instead. Cursor is
+the default editor; VS Code, Claude Desktop, and Codex are also available
+without an environment-variable feature gate.
 
 On WSL, `--editor cursor` and `--editor vscode` expect the editor to be a
 Windows application. The command mirrors the managed SSH config, identity,
@@ -301,82 +338,62 @@ amika sandbox code my-sandbox --editor=codex
 | `--editor <name>` | `cursor` | Editor or agent to open: `cursor`, `vscode`, `claude`, or `codex`  |
 | `--path <path>`   | —        | Override the remote path to open (absolute, or relative to the sandbox workspace root) |
 
-### `amika sandbox codev2`
+### `amika sandbox sshv1`
 
-Open a sandbox in the same supported editors as `sandbox code`, but use the
-beta direct WebSocket SSH transport instead of the provider's SSH route. Use
-it when normal `sandbox code` cannot reach the provider SSH route. It works
-with remote sandboxes only and requires a signed-in Amika account.
+Superseded by [`sandbox ssh`](#amika-sandbox-ssh) and hidden from `--help`, but
+still available by name so existing scripts keep working. It connects over the
+sandbox provider's own SSH route rather than Amika's direct WebSocket
+transport, and it can also revoke that access.
 
-`codev2` adds a named SSH connection to Amika's managed config so Codex can
-find it, then starts or configures Cursor, VS Code, Claude Desktop, or Codex
-as `sandbox code` does. The connection routes through Amika's direct transport;
-you do not need to configure that transport yourself.
-
-Before first use, create and upload an SSH key:
+Unlike `sandbox ssh`, this command parses its own flags, so amika flags may be
+written after the subcommand and a command to run goes after a `--` separator.
 
 ```bash
-amika secret ssh-keygen
+# Interactive SSH session
+amika sandbox sshv1 my-sandbox
+
+# Run a command on the remote sandbox
+amika sandbox sshv1 my-sandbox -- ls -la
+
+# Force pseudo-terminal allocation (for interactive programs)
+amika sandbox sshv1 -t my-sandbox -- top
+
+# Print the SSH connection string instead of connecting
+amika sandbox sshv1 --print my-sandbox
+
+# Revoke SSH access
+amika sandbox sshv1 my-sandbox --revoke
 ```
 
-To use an existing key, pass `--import <public-key-file>` instead. Cursor is
-the default editor; VS Code, Claude Desktop, and Codex are also available
-without an environment-variable feature gate.
+| Flag       | Default | Description                                                              |
+| ---------- | ------- | ------------------------------------------------------------------------ |
+| `-t`       | `false` | Force pseudo-terminal allocation (useful for interactive remote programs) |
+| `--revoke` | `false` | Revoke SSH access for the sandbox                                        |
+| `--print`  | `false` | Print the SSH connection string instead of connecting                    |
+
+`--output` is rejected wherever it appears, since this command parses its own
+flags (contrast `sandbox ssh`, where the rule is positional).
+
+### `amika sandbox codev1`
+
+Superseded by [`sandbox code`](#amika-sandbox-code) and hidden from `--help`,
+but still available by name so existing scripts keep working. It opens the same
+editors, connecting through the provider's own SSH route rather than Amika's
+direct WebSocket transport.
+
+All editors connect through the Amika-managed SSH host alias `amika-<id>`,
+written to `~/.ssh/amika.conf` and included from `~/.ssh/config`.
 
 ```bash
-amika sandbox codev2 my-sandbox
-amika sandbox codev2 my-sandbox --editor=cursor
-amika sandbox codev2 my-sandbox --editor=vscode
-amika sandbox codev2 my-sandbox --editor=claude
-amika sandbox codev2 my-sandbox --editor=codex
+amika sandbox codev1 my-sandbox
+amika sandbox codev1 my-sandbox --editor=cursor
+amika sandbox codev1 my-sandbox --editor=vscode
+amika sandbox codev1 my-sandbox --editor=claude
+amika sandbox codev1 my-sandbox --editor=codex
 ```
 
 `--editor` and `--path` have the same values and defaults as `sandbox code`,
 and WSL behaves the same way (see `sandbox code` above).
-
-### `amika sandbox sshv2`
-
-Open an SSH session to a remote sandbox over the beta direct WebSocket
-transport. Remote sandboxes only; requires an SSH identity from
-`amika secret ssh-keygen`.
-
-```
-amika sandbox sshv2 [ssh-options] <name> [command...]
-```
-
-Use it like `ssh`: options go before the sandbox name, an optional command
-after it. Every ssh option works, including port forwarding, and `sshv2`
-defines no flags of its own.
-
-Amika's own flags go **before** `sshv2`:
-
-```bash
-amika sandbox --remote sshv2 -N -L 8080:localhost:80 my-sandbox
-```
-
-`--help` is the one exception: `amika sandbox sshv2 --help` prints amika's
-help, as does `amika help sandbox sshv2`.
-
-```bash
-# Interactive shell
-amika sandbox sshv2 my-sandbox
-
-# Run a command instead of opening a shell
-amika sandbox sshv2 my-sandbox uptime
-
-# Forward local port 6789 to port 3010 inside the sandbox, without a shell
-amika sandbox sshv2 -N -L 6789:localhost:3010 my-sandbox
-
-# SOCKS proxy on local port 1080
-amika sandbox sshv2 -N -D 1080 my-sandbox
-```
-
-Local (`-L`) and dynamic (`-D`) forwarding are supported. Remote forwarding
-(`-R`), agent forwarding (`-A`), and X11 forwarding are not.
-
-`-o` after the subcommand is ssh's ssh_config option, so amika's
-`-o`/`--output` is not available there; written before `sshv2` it is rejected,
-as it is for `sandbox ssh` (see above).
 
 ### `amika sandbox agent-send`
 
@@ -406,7 +423,9 @@ amika sandbox agent-send my-sandbox "Review this code" --agent codex
 
 ## `amika scp`
 
-Copy files between the local machine, sandboxes, and SSH hosts. This is a thin wrapper around the system `scp` binary: every argument is forwarded to `scp` unchanged, so all the usual `scp` flags (`-r`, `-p`, `-C`, `-v`, `-o Option=value`, ...) work. The one exception is the long-form global `--output`/`--output=VALUE`, which is rejected (scp streams its own output and cannot emit JSON); `scp`'s own short `-o` is forwarded normally.
+Copy files between the local machine, sandboxes, and SSH hosts over Amika's direct WebSocket transport, the same one [`sandbox ssh`](#amika-sandbox-ssh) uses. Requires an SSH identity from `amika secret ssh-keygen`.
+
+This is a thin wrapper around the system `scp` binary: every argument is forwarded to `scp` unchanged, so all the usual `scp` flags (`-r`, `-p`, `-C`, `-v`, `-o Option=value`, ...) work. The one exception is the long-form global `--output`/`--output=VALUE`, which is rejected (scp streams its own output and cannot emit JSON); `scp`'s own short `-o` is forwarded normally.
 
 ```bash
 amika scp <source> ... <target>
@@ -421,9 +440,9 @@ Sandbox names are resolved wherever they appear, so a single command can copy be
 | `sbox://NAME[/PATH]`              | A path in sandbox `NAME` (URI form); `PATH` is absolute and `~` is the home directory. A `/` in `NAME` must be percent-encoded as `%2F` |
 | `scp://[user@]host[:port][/path]` | A path on an arbitrary SSH host                                                |
 
-A bare `host:path` **always** names a sandbox; to reach an arbitrary SSH host, use an `scp://` URI. When every remote is a sandbox, the connection uses `StrictHostKeyChecking=accept-new`; when an external host or a jump host is involved, no host-key option is injected (scp applies `-o` options to every hop), so your normal SSH config governs. A non-default sandbox port is carried inline as a self-porting `scp://host:port//path` operand, so sandboxes and hosts on differing ports can be copied together. A password in an `scp://user:password@host` URI is rejected, since `scp` cannot use one non-interactively.
+A bare `host:path` **always** names a sandbox; to reach an arbitrary SSH host, use an `scp://` URI.
 
-A copy between the local machine and a sandbox is **streamed over an SSH exec channel** rather than run through `scp`. Daytona's `linux-vm` SSH gateway does not deliver the client's channel-EOF to a non-interactive remote, so `scp` (and `sftp`) complete the transfer but then hang forever waiting to tear the session down. The stream instead uses remote commands that exit on their own — `cat` to download, `head -c <size>` (bounded so it never waits for EOF) to upload, with `tar` for directories (`-r`). External `scp://` copies and local-only copies keep the real `scp` binary, which has no such teardown problem. Sandbox↔sandbox and sandbox↔external copies are not yet supported over the stream (copy via the local machine in two steps).
+Each sandbox resolves to its `<name>.<id>.<environment>.amika` alias, and the connection settings (user, identity file, host-key policy, `ProxyCommand`) all come from the managed `Host *.amika` block in `~/.ssh/amika.conf`. There are therefore no connection options to prepend: the operands are rewritten and the rest of the argv is handed to `scp` untouched. A fresh session is created and the host key re-pinned per dial.
 
 ```bash
 # Upload a file into the sandbox home
@@ -437,11 +456,32 @@ amika scp ./a.txt sbox://my-sandbox/~/a.txt
 
 # Copy from a sandbox to another SSH host
 amika scp my-sandbox:/data.csv scp://user@host:22/tmp/data.csv
+
+# Print the resolved scp command instead of running it
+amika scp --print ./a.txt my-sandbox:a.txt
 ```
 
 | Flag       | Default | Description                                            |
 | ---------- | ------- | ------------------------------------------------------ |
 | `--print`  | `false` | Print the resolved `scp` command instead of running it |
+
+Unlike [`scpv1`](#amika-scpv1), a copy naming no sandbox at all is simply forwarded to the system `scp`.
+
+---
+
+## `amika scpv1`
+
+Superseded by [`amika scp`](#amika-scp) and hidden from `--help`, but still available by name so existing scripts keep working. It takes the same operand forms and the same `--print` flag, but resolves each sandbox to a concrete provider-native SSH destination instead of a managed alias, and it requires that at least one source or target name a sandbox or an `scp://` host.
+
+Because it spells connection options out on the command line, a few behaviors are specific to it. When every remote is a sandbox, the connection uses `StrictHostKeyChecking=accept-new`; when an external host or a jump host is involved, no host-key option is injected (scp applies `-o` options to every hop), so your normal SSH config governs. A non-default sandbox port is carried inline as a self-porting `scp://host:port//path` operand, so sandboxes and hosts on differing ports can be copied together. A password in an `scp://user:password@host` URI is rejected, since `scp` cannot use one non-interactively.
+
+A copy between the local machine and a sandbox is **streamed over an SSH exec channel** rather than run through `scp`. Daytona's `linux-vm` SSH gateway does not deliver the client's channel-EOF to a non-interactive remote, so `scp` (and `sftp`) complete the transfer but then hang forever waiting to tear the session down. The stream instead uses remote commands that exit on their own — `cat` to download, `head -c <size>` (bounded so it never waits for EOF) to upload, with `tar` for directories (`-r`). External `scp://` copies and local-only copies keep the real `scp` binary, which has no such teardown problem. Sandbox↔sandbox and sandbox↔external copies are not yet supported over the stream (copy via the local machine in two steps).
+
+```bash
+amika scpv1 ./local.txt my-sandbox:local.txt
+amika scpv1 -r my-sandbox:/srv/out ./out
+amika scpv1 my-sandbox:/data.csv scp://user@host:22/tmp/data.csv
+```
 
 ---
 

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -23,9 +23,11 @@ func New() *cobra.Command {
 	sandboxCmd.AddCommand(sandboxDeleteCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxConnectCmd)
-	// `ssh` and `code` are the direct-WebSocket-transport commands; `sshv1` and
-	// `codev1` are their provider-native predecessors, registered so existing
-	// scripts keep working but marked Hidden at their declarations.
+	// `ssh` and `code` are the direct-WebSocket-transport commands; they also
+	// answer to their pre-promotion names `sshv2`/`codev2` as Cobra aliases.
+	// `sshv1` and `codev1` are the provider-native predecessors they replaced,
+	// registered so existing scripts keep working but marked Hidden at their
+	// declarations.
 	sandboxCmd.AddCommand(sandboxSSHV2Cmd)
 	sandboxCmd.AddCommand(sandboxSSHV1Cmd)
 	sandboxCmd.AddCommand(sandboxCodeV2Cmd)

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -23,10 +23,13 @@ func New() *cobra.Command {
 	sandboxCmd.AddCommand(sandboxDeleteCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxConnectCmd)
-	sandboxCmd.AddCommand(sandboxSSHCmd)
+	// `ssh` and `code` are the direct-WebSocket-transport commands; `sshv1` and
+	// `codev1` are their provider-native predecessors, registered so existing
+	// scripts keep working but marked Hidden at their declarations.
 	sandboxCmd.AddCommand(sandboxSSHV2Cmd)
-	sandboxCmd.AddCommand(sandboxCodeCmd)
+	sandboxCmd.AddCommand(sandboxSSHV1Cmd)
 	sandboxCmd.AddCommand(sandboxCodeV2Cmd)
+	sandboxCmd.AddCommand(sandboxCodeV1Cmd)
 	sandboxCmd.AddCommand(sandboxAgentSendCmd)
 
 	sandboxCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
@@ -64,16 +67,16 @@ func New() *cobra.Command {
 	sandboxDeleteCmd.Flags().Bool("delete-volumes", false, "Also delete associated volumes that are no longer referenced")
 	sandboxDeleteCmd.Flags().Bool("keep-volumes", false, "Keep associated volumes even when only this sandbox references them")
 	sandboxConnectCmd.Flags().String("shell", "zsh", "Shell to run in the sandbox container")
-	sandboxSSHCmd.Flags().BoolP("t", "t", false, "Force pseudo-terminal allocation (like ssh -t)")
-	sandboxSSHCmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
-	sandboxSSHCmd.Flags().Bool("print", false, "Print the SSH connection string instead of connecting")
-	// sshv2 registers no flags of its own: it forwards everything after the
+	sandboxSSHV1Cmd.Flags().BoolP("t", "t", false, "Force pseudo-terminal allocation (like ssh -t)")
+	sandboxSSHV1Cmd.Flags().Bool("revoke", false, "Revoke SSH access for the sandbox")
+	sandboxSSHV1Cmd.Flags().Bool("print", false, "Print the SSH connection string instead of connecting")
+	// `ssh` registers no flags of its own: it forwards everything after the
 	// subcommand to ssh, so ssh's own -t (and every other option) passes
 	// through untouched.
-	sandboxCodeCmd.Flags().String("editor", "cursor", "Editor or agent to open: \"cursor\", \"vscode\", \"claude\", or \"codex\"")
-	sandboxCodeCmd.Flags().String("path", "", "Override the remote path to open (absolute, or relative to the sandbox workspace root)")
 	sandboxCodeV2Cmd.Flags().String("editor", "cursor", "Editor or agent to open: \"cursor\", \"vscode\", \"claude\", or \"codex\"")
 	sandboxCodeV2Cmd.Flags().String("path", "", "Override the remote path to open (absolute, or relative to the sandbox workspace root)")
+	sandboxCodeV1Cmd.Flags().String("editor", "cursor", "Editor or agent to open: \"cursor\", \"vscode\", \"claude\", or \"codex\"")
+	sandboxCodeV1Cmd.Flags().String("path", "", "Override the remote path to open (absolute, or relative to the sandbox workspace root)")
 	sandboxAgentSendCmd.Flags().Bool("no-wait", false, "Send the instruction and return immediately without waiting for a response")
 	sandboxAgentSendCmd.Flags().String("workdir", "$AMIKA_AGENT_CWD", "Working directory inside the container (default: $AMIKA_AGENT_CWD)")
 	sandboxAgentSendCmd.Flags().String("agent", "claude", "Agent CLI to use (default \"claude\")")

--- a/go/cmd/amika/sandbox/doc.go
+++ b/go/cmd/amika/sandbox/doc.go
@@ -12,8 +12,13 @@
 //   - delete
 //   - ssh
 //   - code
-//   - codev2
 //   - agent-send
+//   - sshv1 (hidden; provider-native SSH, superseded by ssh)
+//   - codev1 (hidden; provider-native SSH, superseded by code)
+//
+// ssh and code run over Amika's direct WebSocket SSH transport. Their sshv1 and
+// codev1 predecessors use the provider's own SSH route and stay registered, but
+// hidden, so existing scripts keep working.
 //
 // It also owns sandbox-specific flag parsing, local and remote execution
 // helpers, git-backed mount preparation, rwcopy materialization, cleanup

--- a/go/cmd/amika/sandbox/sandbox_ssh.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh.go
@@ -29,11 +29,16 @@ func validateEditor(editor string) error {
 	}
 }
 
-var sandboxSSHCmd = &cobra.Command{
-	Use:   "ssh [flags] <name> [-- <command>...]",
-	Short: "SSH into a remote sandbox",
-	Long: `Connect to a remote sandbox via SSH, or revoke SSH access.
-Optionally pass a command to execute on the remote sandbox instead of opening an interactive session.
+var sandboxSSHV1Cmd = &cobra.Command{
+	Use:   "sshv1 [flags] <name> [-- <command>...]",
+	Short: "SSH into a remote sandbox over provider-native SSH (superseded by \"sandbox ssh\")",
+	Long: `Connect to a remote sandbox over the provider's own SSH route, or revoke SSH
+access. Optionally pass a command to execute on the remote sandbox instead of
+opening an interactive session.
+
+"sandbox ssh" is the supported way to reach a sandbox; it uses Amika's direct
+WebSocket transport. This command is the earlier provider-native route, kept
+and hidden so existing scripts keep working. Prefer "sandbox ssh".
 
 Use -t to force pseudo-terminal allocation, which is useful for running interactive
 programs on the remote sandbox (equivalent to ssh -t).
@@ -41,12 +46,15 @@ programs on the remote sandbox (equivalent to ssh -t).
 Use --print to print the SSH connection string instead of connecting.
 
 Examples:
-  amika sandbox ssh my-sandbox
-  amika sandbox ssh -t my-sandbox -- top
-  amika sandbox ssh my-sandbox -- ls -la
-  amika sandbox ssh --print my-sandbox
-  amika sandbox ssh my-sandbox --revoke`,
-	Args: cobra.MinimumNArgs(1),
+  amika sandbox sshv1 my-sandbox
+  amika sandbox sshv1 -t my-sandbox -- top
+  amika sandbox sshv1 my-sandbox -- ls -la
+  amika sandbox sshv1 --print my-sandbox
+  amika sandbox sshv1 my-sandbox --revoke`,
+	// Superseded by "sandbox ssh": reachable by name for existing scripts, but
+	// kept out of the help listing so new users land on the current transport.
+	Hidden: true,
+	Args:   cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
@@ -68,7 +76,7 @@ Examples:
 			return err
 		}
 
-		// ssh delegates to the system ssh binary (or, for --print/--revoke,
+		// sshv1 delegates to the system ssh binary (or, for --print/--revoke,
 		// prints a raw connection string / performs a one-off API call). None of
 		// these emit a structured result, so --output is not supported here.
 		if err := output.RejectFlag(cmd); err != nil {
@@ -113,13 +121,19 @@ Examples:
 	},
 }
 
-// supportedEditors lists the values accepted by `sandbox code --editor`.
+// supportedEditors lists the values accepted by `sandbox code --editor` (and by
+// the superseded `sandbox codev1`).
 var supportedEditors = []string{"cursor", "vscode", "claude", "codex"}
 
-var sandboxCodeCmd = &cobra.Command{
-	Use:   "code <name>",
-	Short: "Open a remote sandbox in an editor or agent via SSH",
-	Long: `Open a remote sandbox in an editor or coding agent using SSH remote access.
+var sandboxCodeV1Cmd = &cobra.Command{
+	Use:   "codev1 <name>",
+	Short: "Open a remote sandbox in an editor over provider-native SSH (superseded by \"sandbox code\")",
+	Long: `Open a remote sandbox in an editor or coding agent over the provider's own SSH
+route.
+
+"sandbox code" is the supported way to open a sandbox in an editor; it uses
+Amika's direct WebSocket transport. This command is the earlier provider-native
+route, kept and hidden so existing scripts keep working. Prefer "sandbox code".
 
 Supported --editor values:
   cursor   launch Cursor connected to the sandbox (default)
@@ -131,15 +145,17 @@ For claude and codex, the command writes the local app config so the sandbox
 appears as a remote environment; select it in the app to start the session.
 
 Examples:
-  amika sandbox code my-sandbox
-  amika sandbox code my-sandbox --editor=cursor
-  amika sandbox code my-sandbox --editor=vscode
-  amika sandbox code my-sandbox --editor=claude
-  amika sandbox code my-sandbox --editor=codex`,
-	Args: cobra.ExactArgs(1),
+  amika sandbox codev1 my-sandbox
+  amika sandbox codev1 my-sandbox --editor=cursor
+  amika sandbox codev1 my-sandbox --editor=vscode
+  amika sandbox codev1 my-sandbox --editor=claude
+  amika sandbox codev1 my-sandbox --editor=codex`,
+	// Superseded by "sandbox code"; see sandboxSSHV1Cmd for why it stays hidden.
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
-		// code opens an interactive editor, so it has no JSON result.
+		// codev1 opens an interactive editor, so it has no JSON result.
 		if err := output.RejectJSON(cmd); err != nil {
 			return err
 		}
@@ -150,7 +166,7 @@ Examples:
 
 		mode := runmode.Resolve(cmd)
 		if mode == runmode.Local {
-			return fmt.Errorf("code command requires a remote sandbox; omit --local")
+			return fmt.Errorf("codev1 command requires a remote sandbox; omit --local")
 		}
 		if err := runmode.RequireAuth(mode, runmode.DefaultAuthChecker); err != nil {
 			return err
@@ -178,7 +194,8 @@ Examples:
 }
 
 // sandboxSSHAlias is the stable Amika-managed SSH alias for a sandbox plus the
-// identity needed to label and locate it, shared by every `code` editor.
+// identity needed to label and locate it, shared by every editor `sandbox code`
+// and `sandbox codev1` can open.
 type sandboxSSHAlias struct {
 	alias       string
 	sandboxName string
@@ -191,9 +208,10 @@ type sshInfoClient interface {
 	GetSandbox(name string) (*apiclient.RemoteSandbox, error)
 }
 
-// resolveSandboxSSHAlias mints SSH access for the sandbox and upserts it into
-// the Amika-managed SSH config, returning the stable `amika-<id>` Host alias.
-// Every `code` editor connects through this single alias.
+// resolveSandboxSSHAlias mints provider-native SSH access for the sandbox and
+// upserts it into the Amika-managed SSH config, returning the stable
+// `amika-<id>` Host alias. Every editor `sandbox codev1` opens connects through
+// this single alias. (`sandbox code` uses resolveSandboxV2SSHAlias instead.)
 func resolveSandboxSSHAlias(client sshInfoClient, paths basedir.Paths, name string) (sandboxSSHAlias, error) {
 	info, err := client.GetSSH(name)
 	if err != nil {

--- a/go/cmd/amika/sandbox/sandbox_ssh_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -387,12 +388,13 @@ func TestOpenSandboxInEditorSkipsWindowsWhenNotWSL(t *testing.T) {
 // objects rather than building the tree.
 func TestSSHCommandNames(t *testing.T) {
 	for _, tt := range []struct {
-		cmd        *cobra.Command
-		wantName   string
-		wantHidden bool
+		cmd         *cobra.Command
+		wantName    string
+		wantHidden  bool
+		wantAliases []string
 	}{
-		{cmd: sandboxSSHV2Cmd, wantName: "ssh", wantHidden: false},
-		{cmd: sandboxCodeV2Cmd, wantName: "code", wantHidden: false},
+		{cmd: sandboxSSHV2Cmd, wantName: "ssh", wantHidden: false, wantAliases: []string{"sshv2"}},
+		{cmd: sandboxCodeV2Cmd, wantName: "code", wantHidden: false, wantAliases: []string{"codev2"}},
 		{cmd: sandboxSSHV1Cmd, wantName: "sshv1", wantHidden: true},
 		{cmd: sandboxCodeV1Cmd, wantName: "codev1", wantHidden: true},
 	} {
@@ -402,6 +404,9 @@ func TestSSHCommandNames(t *testing.T) {
 			}
 			if tt.cmd.Hidden != tt.wantHidden {
 				t.Errorf("Hidden = %v, want %v", tt.cmd.Hidden, tt.wantHidden)
+			}
+			if !reflect.DeepEqual(tt.cmd.Aliases, tt.wantAliases) {
+				t.Errorf("Aliases = %#v, want %#v", tt.cmd.Aliases, tt.wantAliases)
 			}
 		})
 	}

--- a/go/cmd/amika/sandbox/sandbox_ssh_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_test.go
@@ -94,7 +94,7 @@ type stubSSHClient struct {
 	sandbox *apiclient.RemoteSandbox
 }
 
-// stubV2SSHClient implements the APIs codev2 uses before it hands the prepared
+// stubV2SSHClient implements the APIs `sandbox code` uses before it hands the prepared
 // alias to an editor. Its session method is not reached by this test because
 // prepareSessionTarget is replaced with a recorder.
 type stubV2SSHClient struct {
@@ -377,5 +377,32 @@ func TestOpenSandboxInEditorSkipsWindowsWhenNotWSL(t *testing.T) {
 	}
 	if len(*mirrored) != 0 || len(*launched) != 0 {
 		t.Fatalf("mirror/launch calls = %d/%d, want 0/0", len(*mirrored), len(*launched))
+	}
+}
+
+// TestSSHCommandNames pins the CLI surface the rename established: the direct
+// WebSocket transport owns the plain `ssh`/`code` names and is listed in help,
+// while the provider-native predecessors stay reachable under `sshv1`/`codev1`
+// but hidden. New() is a once-per-process call, so assert on the command
+// objects rather than building the tree.
+func TestSSHCommandNames(t *testing.T) {
+	for _, tt := range []struct {
+		cmd        *cobra.Command
+		wantName   string
+		wantHidden bool
+	}{
+		{cmd: sandboxSSHV2Cmd, wantName: "ssh", wantHidden: false},
+		{cmd: sandboxCodeV2Cmd, wantName: "code", wantHidden: false},
+		{cmd: sandboxSSHV1Cmd, wantName: "sshv1", wantHidden: true},
+		{cmd: sandboxCodeV1Cmd, wantName: "codev1", wantHidden: true},
+	} {
+		t.Run(tt.wantName, func(t *testing.T) {
+			if got := tt.cmd.Name(); got != tt.wantName {
+				t.Errorf("command name = %q, want %q", got, tt.wantName)
+			}
+			if tt.cmd.Hidden != tt.wantHidden {
+				t.Errorf("Hidden = %v, want %v", tt.cmd.Hidden, tt.wantHidden)
+			}
+		})
 	}
 }

--- a/go/cmd/amika/sandbox/sandbox_ssh_v2.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_v2.go
@@ -14,24 +14,24 @@ import (
 )
 
 // osArgs is a seam over the process argv, which the positional split needs to
-// tell an amika flag written before "sshv2" from an ssh option written after
-// it. Tests supply a synthetic argv instead of mutating the real one.
+// tell an amika flag written before "ssh" from an ssh option written after it.
+// Tests supply a synthetic argv instead of mutating the real one.
 var osArgs = func() []string { return os.Args }
 
 // execSessionSSH is a seam around the exec of the system ssh binary, so tests
 // can assert the argv the command would run without replacing the process.
 var execSessionSSH = ssh.ExecSessionSSH
 
-// newSSHV2Client is a seam over the API client sshv2 resolves a sandbox
+// newSSHV2Client is a seam over the API client `sandbox ssh` resolves a sandbox
 // through, narrowed to the two calls the command makes so tests can supply a
 // stub instead of reaching the network.
 var newSSHV2Client = func(target string) (sshV2Client, error) {
 	return getRemoteClient(target)
 }
 
-// sshV2OwnValueFlags are the amika flags reaching sshv2 that take their value
-// as a separate token. commandIndex skips those values so a sandbox named for
-// the subcommand ("--remote-target sshv2") is not read as the subcommand.
+// sshV2OwnValueFlags are the amika flags reaching `sandbox ssh` that take their
+// value as a separate token. commandIndex skips those values so a sandbox named
+// for the subcommand ("--remote-target ssh") is not read as the subcommand.
 var sshV2OwnValueFlags = map[string]bool{
 	"--output":        true,
 	"-o":              true,
@@ -39,34 +39,34 @@ var sshV2OwnValueFlags = map[string]bool{
 }
 
 var sandboxSSHV2Cmd = &cobra.Command{
-	Use:   "sshv2 [ssh-options] <name> [command...]",
-	Short: "SSH through the beta direct WebSocket transport",
-	Long: `Open an SSH session to a remote sandbox over the beta direct WebSocket
+	Use:   "ssh [ssh-options] <name> [command...]",
+	Short: "SSH into a remote sandbox",
+	Long: `Open an SSH session to a remote sandbox over Amika's direct WebSocket
 transport. Requires an SSH identity from "amika secret ssh-keygen".
 
 Use it like ssh: options go before the sandbox name, an optional command
 after it. Every ssh option works, including port forwarding.
 
-Amika's own flags go before "sshv2":
+Amika's own flags go before "ssh":
 
-  amika sandbox --remote sshv2 -N -L 8080:localhost:80 my-sandbox
+  amika sandbox --remote ssh -N -L 8080:localhost:80 my-sandbox
 
 Local (-L) and dynamic (-D) forwarding are supported. Remote forwarding (-R),
 agent forwarding (-A), and X11 forwarding are not.
 
 Examples:
   # Interactive shell
-  amika sandbox sshv2 my-sandbox
+  amika sandbox ssh my-sandbox
 
   # Run a command instead of opening a shell
-  amika sandbox sshv2 my-sandbox uptime
+  amika sandbox ssh my-sandbox uptime
 
   # Forward local port 6789 to port 3010 inside the sandbox, no shell
-  amika sandbox sshv2 -N -L 6789:localhost:3010 my-sandbox
+  amika sandbox ssh -N -L 6789:localhost:3010 my-sandbox
 
   # SOCKS proxy on local port 1080
-  amika sandbox sshv2 -N -D 1080 my-sandbox`,
-	// Arguments after "sshv2" belong to ssh, so Cobra must not parse them: it
+  amika sandbox ssh -N -D 1080 my-sandbox`,
+	// Arguments after "ssh" belong to ssh, so Cobra must not parse them: it
 	// would reject "-L" and friends as unknown flags. RunE therefore parses the
 	// amika-owned portion itself, after splitting the two apart by position.
 	DisableFlagParsing: true,
@@ -100,7 +100,7 @@ Examples:
 		// prompt.
 		nameIdx := cliargs.FirstOperand(forward, cliargs.SSHArgLetters)
 		if nameIdx < 0 {
-			return fmt.Errorf("missing sandbox name; usage: amika sandbox sshv2 [ssh-options] <name> [command...]")
+			return fmt.Errorf("missing sandbox name; usage: amika sandbox ssh [ssh-options] <name> [command...]")
 		}
 		if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
 			return err
@@ -131,22 +131,27 @@ Examples:
 }
 
 var sandboxCodeV2Cmd = &cobra.Command{
-	Use:   "codev2 <name>",
-	Short: "Open a remote sandbox in an editor over the beta direct WebSocket transport",
-	Long: `Open a remote sandbox in an editor or coding agent over the beta direct
-WebSocket SSH transport. It supports the same editors and flags as "sandbox code",
-but bypasses provider-native SSH access.
+	Use:   "code <name>",
+	Short: "Open a remote sandbox in an editor or agent via SSH",
+	Long: `Open a remote sandbox in an editor or coding agent over Amika's direct
+WebSocket SSH transport, bypassing provider-native SSH access.
+
+Supported --editor values:
+  cursor   launch Cursor connected to the sandbox (default)
+  vscode   launch VS Code connected to the sandbox
+  claude   register the sandbox as a Claude Desktop SSH environment
+  codex    expose the sandbox to Codex as an SSH connection
 
 The command creates a managed SSH alias backed by Amika's WebSocket proxy, then
 hands that alias to the selected editor. It requires an SSH identity from
 "amika secret ssh-keygen".
 
 Examples:
-  amika sandbox codev2 my-sandbox
-  amika sandbox codev2 my-sandbox --editor=cursor
-  amika sandbox codev2 my-sandbox --editor=vscode
-  amika sandbox codev2 my-sandbox --editor=claude
-  amika sandbox codev2 my-sandbox --editor=codex`,
+  amika sandbox code my-sandbox
+  amika sandbox code my-sandbox --editor=cursor
+  amika sandbox code my-sandbox --editor=vscode
+  amika sandbox code my-sandbox --editor=claude
+  amika sandbox code my-sandbox --editor=codex`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := output.RejectJSON(cmd); err != nil {
@@ -181,26 +186,27 @@ Examples:
 	},
 }
 
-// sshV2Client is the subset of apiclient.Client codev2 needs to prepare a
-// direct-session SSH alias for an editor.
+// sshV2Client is the subset of apiclient.Client `sandbox code` needs to prepare
+// a direct-session SSH alias for an editor.
 type sshV2Client interface {
 	ssh.SessionCreator
 	GetSandbox(name string) (*apiclient.RemoteSandbox, error)
 }
 
-// prepareSessionTarget is a seam around the shared v2 setup used by codev2,
-// sshv2, and scpv2. Keeping it replaceable lets the command package verify its
-// alias handoff without re-testing the session package's key and pinning logic.
+// prepareSessionTarget is a seam around the shared session-transport setup used
+// by `sandbox code`, `sandbox ssh`, and `scp`. Keeping it replaceable lets the
+// command package verify its alias handoff without re-testing the session
+// package's key and pinning logic.
 var prepareSessionTarget = ssh.PrepareSessionTarget
 
-// upsertSessionHost makes a concrete v2 alias discoverable to editors that
+// upsertSessionHost makes a concrete session alias discoverable to editors that
 // enumerate SSH Host entries, notably Codex. Cursor and Claude receive their
-// aliases directly, so this extra persistent entry is specific to codev2.
+// aliases directly, so this extra persistent entry is specific to `sandbox code`.
 var upsertSessionHost = ssh.UpsertSessionHost
 
 // resolveSandboxV2SSHAlias prepares the same direct-session alias used by
-// sshv2 and scpv2. Editors subsequently use system OpenSSH, which invokes the
-// managed alias's ProxyCommand once it dials the host.
+// `sandbox ssh` and `scp`. Editors subsequently use system OpenSSH, which
+// invokes the managed alias's ProxyCommand once it dials the host.
 func resolveSandboxV2SSHAlias(client sshV2Client, paths basedir.Paths, name string) (sandboxSSHAlias, error) {
 	sandbox, err := client.GetSandbox(name)
 	if err != nil {

--- a/go/cmd/amika/sandbox/sandbox_ssh_v2.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_v2.go
@@ -14,8 +14,9 @@ import (
 )
 
 // osArgs is a seam over the process argv, which the positional split needs to
-// tell an amika flag written before "ssh" from an ssh option written after it.
-// Tests supply a synthetic argv instead of mutating the real one.
+// tell an amika flag written before "ssh" (or its "sshv2" alias) from an ssh
+// option written after it. Tests supply a synthetic argv instead of mutating
+// the real one.
 var osArgs = func() []string { return os.Args }
 
 // execSessionSSH is a seam around the exec of the system ssh binary, so tests
@@ -39,8 +40,11 @@ var sshV2OwnValueFlags = map[string]bool{
 }
 
 var sandboxSSHV2Cmd = &cobra.Command{
-	Use:   "ssh [ssh-options] <name> [command...]",
-	Short: "SSH into a remote sandbox",
+	Use: "ssh [ssh-options] <name> [command...]",
+	// "sshv2" is the pre-promotion name this command answered to; kept as an
+	// alias so scripts and docs written against it keep working.
+	Aliases: []string{"sshv2"},
+	Short:   "SSH into a remote sandbox",
 	Long: `Open an SSH session to a remote sandbox over Amika's direct WebSocket
 transport. Requires an SSH identity from "amika secret ssh-keygen".
 
@@ -75,7 +79,9 @@ Examples:
 	// subcommand, which is exactly what they must not do.
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		own, forward := cliargs.Split(osArgs(), args, cmd.Name(), sshV2OwnValueFlags)
+		// CalledAs, not Name: invoked as the "sshv2" alias, the boundary token
+		// in osArgs() is "sshv2", not this command's primary name "ssh".
+		own, forward := cliargs.Split(osArgs(), args, cmd.CalledAs(), sshV2OwnValueFlags)
 		// DisableFlagParsing bypasses Cobra's built-in help flag, so honor it
 		// here before anything else can fail on an incomplete command line.
 		if cliargs.HasHelpFlag(forward) || cliargs.HasHelpFlag(own) {
@@ -131,8 +137,11 @@ Examples:
 }
 
 var sandboxCodeV2Cmd = &cobra.Command{
-	Use:   "code <name>",
-	Short: "Open a remote sandbox in an editor or agent via SSH",
+	Use: "code <name>",
+	// "codev2" is the pre-promotion name this command answered to; kept as an
+	// alias so scripts and docs written against it keep working.
+	Aliases: []string{"codev2"},
+	Short:   "Open a remote sandbox in an editor or agent via SSH",
 	Long: `Open a remote sandbox in an editor or coding agent over Amika's direct
 WebSocket SSH transport, bypassing provider-native SSH access.
 

--- a/go/cmd/amika/sandbox/sandbox_ssh_v2_args_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_v2_args_test.go
@@ -198,6 +198,27 @@ func TestSSHV2ForwardsArgsToSSH(t *testing.T) {
 	}
 }
 
+// TestSSHV2AliasForwardsArgsToSSH pins the "sshv2" alias to the same
+// positional-split contract as "ssh": the split must key off the token
+// actually typed (via cmd.CalledAs()), not the command's primary name, or an
+// amika flag written before the alias would wrongly be forwarded to ssh.
+func TestSSHV2AliasForwardsArgsToSSH(t *testing.T) {
+	root, h, out := newSSHV2Harness(t, []string{"amika", "sandbox", "sshv2", "-N", "-L", "6789:localhost:3010", "my-box"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v (output %q)", err, out.String())
+	}
+	if !h.ran {
+		t.Fatal("ssh was never invoked")
+	}
+	if h.alias != testV2Alias {
+		t.Errorf("alias = %q, want %q", h.alias, testV2Alias)
+	}
+	wantArgv := []string{"-N", "-L", "6789:localhost:3010", testV2Alias}
+	if !reflect.DeepEqual(h.argv, wantArgv) {
+		t.Errorf("ssh argv = %#v, want %#v", h.argv, wantArgv)
+	}
+}
+
 func TestSSHV2AmikaFlagsBeforeSubcommand(t *testing.T) {
 	t.Run("output flag before the subcommand is rejected, not forwarded", func(t *testing.T) {
 		root, h, _ := newSSHV2Harness(t, []string{"amika", "--output", "json", "sandbox", "ssh", "my-box"})

--- a/go/cmd/amika/sandbox/sandbox_ssh_v2_args_test.go
+++ b/go/cmd/amika/sandbox/sandbox_ssh_v2_args_test.go
@@ -1,10 +1,10 @@
 package sandboxcmd
 
-// sandbox_ssh_v2_args_test.go covers how `amika sandbox sshv2` divides a
+// sandbox_ssh_v2_args_test.go covers how `amika sandbox ssh` divides a
 // command line between amika and the system ssh binary. The assertions are on
 // the argv the command would exec, which is the whole contract: an argument
-// written after "sshv2" reaches ssh untouched and in its original position,
-// and one written before it does not reach ssh at all.
+// written after the "ssh" subcommand reaches the ssh binary untouched and in
+// its original position, and one written before it does not reach ssh at all.
 
 import (
 	"bytes"
@@ -22,8 +22,9 @@ import (
 
 const testV2Alias = "my-box.sb_abc.app-amika-dev.amika"
 
-// sshV2Harness drives the real sshv2 command with every outward call replaced,
-// and records the argv that would have been handed to ssh.
+// sshV2Harness drives the real `sandbox ssh` command (the v2 direct-WebSocket
+// transport) with every outward call replaced, and records the argv that would
+// have been handed to ssh.
 type sshV2Harness struct {
 	argv  []string
 	alias string
@@ -122,58 +123,58 @@ func TestSSHV2ForwardsArgsToSSH(t *testing.T) {
 	}{
 		{
 			name:     "bare name becomes the alias",
-			procArgs: []string{"amika", "sandbox", "sshv2", "my-box"},
+			procArgs: []string{"amika", "sandbox", "ssh", "my-box"},
 			wantArgv: []string{testV2Alias},
 		},
 		{
 			// The point of the change: -L reaches ssh ahead of the destination,
 			// where ssh reads it as a client option.
 			name:     "local port forward",
-			procArgs: []string{"amika", "sandbox", "sshv2", "-N", "-L", "6789:localhost:3010", "my-box"},
+			procArgs: []string{"amika", "sandbox", "ssh", "-N", "-L", "6789:localhost:3010", "my-box"},
 			wantArgv: []string{"-N", "-L", "6789:localhost:3010", testV2Alias},
 		},
 		{
 			name:     "dynamic port forward",
-			procArgs: []string{"amika", "sandbox", "sshv2", "-N", "-D", "1080", "my-box"},
+			procArgs: []string{"amika", "sandbox", "ssh", "-N", "-D", "1080", "my-box"},
 			wantArgv: []string{"-N", "-D", "1080", testV2Alias},
 		},
 		{
 			name:     "ssh config option with a separate value",
-			procArgs: []string{"amika", "sandbox", "sshv2", "-o", "BatchMode=yes", "my-box"},
+			procArgs: []string{"amika", "sandbox", "ssh", "-o", "BatchMode=yes", "my-box"},
 			wantArgv: []string{"-o", "BatchMode=yes", testV2Alias},
 		},
 		{
 			// -t no longer belongs to amika; it passes through to ssh.
 			name:     "force pty",
-			procArgs: []string{"amika", "sandbox", "sshv2", "-t", "my-box", "top"},
+			procArgs: []string{"amika", "sandbox", "ssh", "-t", "my-box", "top"},
 			wantArgv: []string{"-t", testV2Alias, "top"},
 		},
 		{
 			name:     "remote command stays after the destination",
-			procArgs: []string{"amika", "sandbox", "sshv2", "my-box", "uptime"},
+			procArgs: []string{"amika", "sandbox", "ssh", "my-box", "uptime"},
 			wantArgv: []string{testV2Alias, "uptime"},
 		},
 		{
 			name:     "options and a remote command",
-			procArgs: []string{"amika", "sandbox", "sshv2", "-L", "6789:localhost:3010", "my-box", "ls", "-la"},
+			procArgs: []string{"amika", "sandbox", "ssh", "-L", "6789:localhost:3010", "my-box", "ls", "-la"},
 			wantArgv: []string{"-L", "6789:localhost:3010", testV2Alias, "ls", "-la"},
 		},
 		{
 			// An amika flag before the subcommand is consumed by amika.
 			name:     "sandbox flag before the subcommand is not forwarded",
-			procArgs: []string{"amika", "sandbox", "--remote", "sshv2", "-N", "my-box"},
+			procArgs: []string{"amika", "sandbox", "--remote", "ssh", "-N", "my-box"},
 			wantArgv: []string{"-N", testV2Alias},
 		},
 		{
 			// The same spelling after the subcommand belongs to ssh, which is
 			// what makes the rule positional rather than name-based.
 			name:     "output flag after the subcommand is forwarded",
-			procArgs: []string{"amika", "sandbox", "sshv2", "-o", "SendEnv=FOO", "my-box"},
+			procArgs: []string{"amika", "sandbox", "ssh", "-o", "SendEnv=FOO", "my-box"},
 			wantArgv: []string{"-o", "SendEnv=FOO", testV2Alias},
 		},
 		{
 			name:     "end of options marker before the name",
-			procArgs: []string{"amika", "sandbox", "sshv2", "--", "my-box"},
+			procArgs: []string{"amika", "sandbox", "ssh", "--", "my-box"},
 			wantArgv: []string{"--", testV2Alias},
 		},
 	}
@@ -199,7 +200,7 @@ func TestSSHV2ForwardsArgsToSSH(t *testing.T) {
 
 func TestSSHV2AmikaFlagsBeforeSubcommand(t *testing.T) {
 	t.Run("output flag before the subcommand is rejected, not forwarded", func(t *testing.T) {
-		root, h, _ := newSSHV2Harness(t, []string{"amika", "--output", "json", "sandbox", "sshv2", "my-box"})
+		root, h, _ := newSSHV2Harness(t, []string{"amika", "--output", "json", "sandbox", "ssh", "my-box"})
 		err := root.Execute()
 		if err == nil {
 			t.Fatal("expected --output to be rejected")
@@ -210,7 +211,7 @@ func TestSSHV2AmikaFlagsBeforeSubcommand(t *testing.T) {
 	})
 
 	t.Run("local flag before the subcommand is honored", func(t *testing.T) {
-		root, h, _ := newSSHV2Harness(t, []string{"amika", "sandbox", "--local", "sshv2", "my-box"})
+		root, h, _ := newSSHV2Harness(t, []string{"amika", "sandbox", "--local", "ssh", "my-box"})
 		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "requires a remote sandbox") {
 			t.Fatalf("err = %v, want a remote-sandbox error", err)
@@ -222,7 +223,7 @@ func TestSSHV2AmikaFlagsBeforeSubcommand(t *testing.T) {
 }
 
 func TestSSHV2MissingName(t *testing.T) {
-	root, h, _ := newSSHV2Harness(t, []string{"amika", "sandbox", "sshv2", "-N", "-L", "6789:localhost:3010"})
+	root, h, _ := newSSHV2Harness(t, []string{"amika", "sandbox", "ssh", "-N", "-L", "6789:localhost:3010"})
 	err := root.Execute()
 	if err == nil || !strings.Contains(err.Error(), "missing sandbox name") {
 		t.Fatalf("err = %v, want a missing-name error", err)
@@ -239,9 +240,9 @@ func TestSSHV2Help(t *testing.T) {
 		name     string
 		procArgs []string
 	}{
-		{name: "help flag after the subcommand", procArgs: []string{"amika", "sandbox", "sshv2", "--help"}},
-		{name: "short help flag", procArgs: []string{"amika", "sandbox", "sshv2", "-h"}},
-		{name: "help subcommand", procArgs: []string{"amika", "help", "sandbox", "sshv2"}},
+		{name: "help flag after the subcommand", procArgs: []string{"amika", "sandbox", "ssh", "--help"}},
+		{name: "short help flag", procArgs: []string{"amika", "sandbox", "ssh", "-h"}},
+		{name: "help subcommand", procArgs: []string{"amika", "help", "sandbox", "ssh"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			root, h, out := newSSHV2Harness(t, tt.procArgs)
@@ -253,7 +254,7 @@ func TestSSHV2Help(t *testing.T) {
 			}
 			got := out.String()
 			for _, want := range []string{
-				"amika sandbox sshv2",
+				"amika sandbox ssh",
 				"Use it like ssh",
 				"-L 6789:localhost:3010",
 			} {

--- a/go/cmd/amika/scp.go
+++ b/go/cmd/amika/scp.go
@@ -3,5 +3,9 @@ package main
 import scpcmd "github.com/gofixpoint/amika/go/cmd/amika/scp"
 
 func init() {
-	rootCmd.AddCommand(scpcmd.New())
+	// `scp` runs over the direct WebSocket transport; `scpv1` is its
+	// provider-native predecessor, registered but hidden so existing scripts
+	// keep working.
+	rootCmd.AddCommand(scpcmd.NewV2())
+	rootCmd.AddCommand(scpcmd.NewV1())
 }

--- a/go/cmd/amika/scp.go
+++ b/go/cmd/amika/scp.go
@@ -3,7 +3,8 @@ package main
 import scpcmd "github.com/gofixpoint/amika/go/cmd/amika/scp"
 
 func init() {
-	// `scp` runs over the direct WebSocket transport; `scpv1` is its
+	// `scp` runs over the direct WebSocket transport and also answers to its
+	// pre-promotion name `scpv2` as a Cobra alias. `scpv1` is its
 	// provider-native predecessor, registered but hidden so existing scripts
 	// keep working.
 	rootCmd.AddCommand(scpcmd.NewV2())

--- a/go/cmd/amika/scp/command.go
+++ b/go/cmd/amika/scp/command.go
@@ -1,16 +1,27 @@
 // Package scpcmd builds the top-level `amika scp` command: a thin wrapper
 // around the system scp binary that resolves sandbox references and sandbox/scp
 // URIs to concrete SSH destinations before delegating the copy to scp.
+//
+// NewV2 builds `scp`, which carries the copy over Amika's direct WebSocket SSH
+// transport. NewV1 builds the superseded `scpv1`, which resolves each sandbox to
+// a provider-native SSH destination instead; it stays registered, but hidden, so
+// existing scripts keep working. The V1/V2 suffixes name the two transport
+// generations, which is why the current command is built by NewV2.
 package scpcmd
 
 import "github.com/spf13/cobra"
 
-// New builds the `amika scp` command.
-func New() *cobra.Command {
+// NewV1 builds the hidden `amika scpv1` command.
+func NewV1() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "scp <source> ... <target>",
-		Short: "Copy files to or from sandboxes over SSH",
-		Long: `Copy files between the local machine, sandboxes, and SSH hosts using scp.
+		Use:   "scpv1 <source> ... <target>",
+		Short: "Copy files to or from sandboxes over provider-native SSH (superseded by \"scp\")",
+		Long: `Copy files between the local machine, sandboxes, and SSH hosts using scp, over
+the provider's own SSH route.
+
+"amika scp" is the supported way to copy files; it uses Amika's direct WebSocket
+transport. This command is the earlier provider-native route, kept and hidden so
+existing scripts keep working. Prefer "amika scp".
 
 Every argument is forwarded to the system scp binary unchanged, so all the usual
 scp flags (-r, -p, -C, -v, ...) work. Sources and targets may be given in any of
@@ -31,17 +42,20 @@ always names a sandbox; use an scp:// URI to reach an arbitrary SSH host.
 
 Examples:
   # Upload a file into the sandbox home
-  amika scp ./local.txt my-sandbox:local.txt
+  amika scpv1 ./local.txt my-sandbox:local.txt
 
   # Recursively download an absolute directory from the sandbox
-  amika scp -r my-sandbox:/srv/out ./out
+  amika scpv1 -r my-sandbox:/srv/out ./out
 
   # Copy from a sandbox to an SSH host
-  amika scp my-sandbox:/data.csv scp://user@host:22/tmp/data.csv
+  amika scpv1 my-sandbox:/data.csv scp://user@host:22/tmp/data.csv
 
   # Print the resolved scp command instead of running it
-  amika scp --print ./a.txt my-sandbox:a.txt`,
-		Args: cobra.MinimumNArgs(1),
+  amika scpv1 --print ./a.txt my-sandbox:a.txt`,
+		// Superseded by `amika scp`: reachable by name for existing scripts, but
+		// kept out of the help listing so new users land on the current transport.
+		Hidden: true,
+		Args:   cobra.MinimumNArgs(1),
 		// DisableFlagParsing forwards every argument to the system scp binary
 		// unchanged, so scp's own single-dash options (including -o for
 		// ssh_config overrides) pass through. scp streams its own copy progress

--- a/go/cmd/amika/scp/scp_test.go
+++ b/go/cmd/amika/scp/scp_test.go
@@ -565,7 +565,7 @@ func TestHasHelpFlag(t *testing.T) {
 }
 
 func TestRunSCPRejectsOutputLongFlag(t *testing.T) {
-	cmd := New()
+	cmd := NewV1()
 	// The long-form --output is rejected before any resolution/exec, so this
 	// makes no network call. The short -o is scp's own option and must NOT be
 	// rejected here (it is exercised as pass-through elsewhere).
@@ -579,14 +579,32 @@ func TestRunSCPRejectsOutputLongFlag(t *testing.T) {
 }
 
 func TestSCPCommandRegistered(t *testing.T) {
-	cmd := New()
+	cmd := NewV2()
 	if cmd.Name() != "scp" {
 		t.Errorf("command name = %q, want %q", cmd.Name(), "scp")
+	}
+	if cmd.Hidden {
+		t.Error("scp is the supported copy command and must not be hidden")
 	}
 	if !cmd.DisableFlagParsing {
 		t.Error("scp command must disable flag parsing to forward scp flags verbatim")
 	}
+}
+
+// TestSCPV1CommandRegistered pins the superseded command's contract: it keeps
+// working under its new name, and it stays out of the help listing.
+func TestSCPV1CommandRegistered(t *testing.T) {
+	cmd := NewV1()
+	if cmd.Name() != "scpv1" {
+		t.Errorf("command name = %q, want %q", cmd.Name(), "scpv1")
+	}
+	if !cmd.Hidden {
+		t.Error("scpv1 is superseded by scp and must be hidden")
+	}
+	if !cmd.DisableFlagParsing {
+		t.Error("scpv1 command must disable flag parsing to forward scp flags verbatim")
+	}
 	if cmd.Flags().Lookup("print") == nil {
-		t.Error("scp command must define --print")
+		t.Error("scpv1 command must define --print")
 	}
 }

--- a/go/cmd/amika/scp/scp_test.go
+++ b/go/cmd/amika/scp/scp_test.go
@@ -589,6 +589,11 @@ func TestSCPCommandRegistered(t *testing.T) {
 	if !cmd.DisableFlagParsing {
 		t.Error("scp command must disable flag parsing to forward scp flags verbatim")
 	}
+	// "scpv2" is the pre-promotion name; kept as an alias so existing scripts
+	// keep working.
+	if want := []string{"scpv2"}; !reflect.DeepEqual(cmd.Aliases, want) {
+		t.Errorf("Aliases = %#v, want %#v", cmd.Aliases, want)
+	}
 }
 
 // TestSCPV1CommandRegistered pins the superseded command's contract: it keeps

--- a/go/cmd/amika/scp/scpv2.go
+++ b/go/cmd/amika/scp/scpv2.go
@@ -1,8 +1,8 @@
 package scpcmd
 
-// scpv2.go implements `amika scpv2`: the same operand grammar as `amika scp`,
-// carried over the beta direct WebSocket transport that backs
-// `amika sandbox sshv2` instead of the v1 provider-native SSH access.
+// scpv2.go implements `amika scp`: the same operand grammar as the superseded
+// `amika scpv1`, carried over the direct WebSocket transport that backs
+// `amika sandbox ssh` instead of the v1 provider-native SSH access.
 //
 // The transport difference is entirely in how a sandbox reference becomes an
 // scp operand. v1 resolves a sandbox to a concrete host/port/user and spells
@@ -47,7 +47,7 @@ func runSCPV2(cmd *cobra.Command, rawArgs []string) error {
 
 	// Resolved lazily and cached by name: each sandbox is fetched and pinned at
 	// most once, and a copy naming no sandbox performs no API call and needs no
-	// auth (the same contract as `amika scp`).
+	// auth (the same contract as `amika scpv1`).
 	var client *apiclient.Client
 	aliases := map[string]string{}
 	resolve := func(name string) (string, error) {
@@ -142,15 +142,15 @@ func rewriteV2Operand(tok string, resolve aliasResolver) (string, error) {
 	}
 }
 
-// NewV2 builds the `amika scpv2` command.
+// NewV2 builds the `amika scp` command.
 func NewV2() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "scpv2 <source> ... <target>",
-		Short: "Copy files to or from sandboxes over the beta direct WebSocket transport",
+		Use:   "scp <source> ... <target>",
+		Short: "Copy files to or from sandboxes over SSH",
 		Long: `Copy files between the local machine, sandboxes, and SSH hosts using scp,
-over the same beta direct WebSocket transport as "amika sandbox sshv2".
+over the same direct WebSocket transport as "amika sandbox ssh".
 
-Operands take the same forms as "amika scp":
+Operands take these forms:
 
   PATH                              a local path
   NAME[:PATH]                       a path in sandbox NAME (scp-style): a
@@ -168,15 +168,15 @@ identity from "amika secret ssh-keygen".
 
 Examples:
   # Upload a file into the sandbox home
-  amika scpv2 ./local.txt my-sandbox:local.txt
+  amika scp ./local.txt my-sandbox:local.txt
 
   # Recursively download an absolute directory from the sandbox
-  amika scpv2 -r my-sandbox:/srv/out ./out
+  amika scp -r my-sandbox:/srv/out ./out
 
   # Print the resolved scp command instead of running it
-  amika scpv2 --print ./a.txt my-sandbox:a.txt`,
+  amika scp --print ./a.txt my-sandbox:a.txt`,
 		Args: cobra.MinimumNArgs(1),
-		// As with `amika scp`, every argument is forwarded to system scp, so
+		// As with `amika scpv1`, every argument is forwarded to system scp, so
 		// scp's own single-dash options pass through untouched.
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/go/cmd/amika/scp/scpv2.go
+++ b/go/cmd/amika/scp/scpv2.go
@@ -145,8 +145,11 @@ func rewriteV2Operand(tok string, resolve aliasResolver) (string, error) {
 // NewV2 builds the `amika scp` command.
 func NewV2() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "scp <source> ... <target>",
-		Short: "Copy files to or from sandboxes over SSH",
+		Use: "scp <source> ... <target>",
+		// "scpv2" is the pre-promotion name this command answered to; kept as
+		// an alias so scripts and docs written against it keep working.
+		Aliases: []string{"scpv2"},
+		Short:   "Copy files to or from sandboxes over SSH",
 		Long: `Copy files between the local machine, sandboxes, and SSH hosts using scp,
 over the same direct WebSocket transport as "amika sandbox ssh".
 

--- a/go/cmd/amika/scpv2.go
+++ b/go/cmd/amika/scpv2.go
@@ -1,7 +1,0 @@
-package main
-
-import scpcmd "github.com/gofixpoint/amika/go/cmd/amika/scp"
-
-func init() {
-	rootCmd.AddCommand(scpcmd.NewV2())
-}

--- a/go/internal/cliargs/cliargs.go
+++ b/go/internal/cliargs/cliargs.go
@@ -7,14 +7,14 @@
 // forwarded. That distinction is not recoverable from the arguments Cobra hands
 // a command, because Cobra removes the command path from the argv first. Both
 //
-//	amika --output json sandbox sshv2 my-box
-//	amika sandbox sshv2 --output json my-box
+//	amika --output json sandbox ssh my-box
+//	amika sandbox ssh --output json my-box
 //
-// reach the sshv2 command as the identical slice
+// reach the ssh command as the identical slice
 //
 //	["--output", "json", "my-box"]
 //
-// so Split needs the original process argv, where the "sshv2" token still marks
+// so Split needs the original process argv, where the "ssh" token still marks
 // the boundary. Callers pass it in rather than reading os.Args here, so tests
 // can exercise the split with a synthetic argv.
 package cliargs
@@ -113,8 +113,8 @@ func ConsumesNextArg(tok, argLetters string) bool {
 // HasHelpFlag reports whether args requests help. Only a help flag written
 // among the leading options counts: once the first operand or a "--" appears,
 // later tokens belong to the underlying utility (for ssh, they form the remote
-// command), so "sshv2 my-box --help" asks the sandbox for help rather than
-// amika.
+// command), so "sandbox ssh my-box --help" asks the sandbox for help rather
+// than amika.
 func HasHelpFlag(args []string) bool {
 	for _, a := range args {
 		if len(a) == 0 || a[0] != '-' || a == "--" || a == "-" {

--- a/go/internal/cliargs/cliargs_test.go
+++ b/go/internal/cliargs/cliargs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// amikaValueFlags mirrors the flags sshv2 passes to Split.
+// amikaValueFlags mirrors the flags `sandbox ssh` passes to Split.
 var amikaValueFlags = map[string]bool{"--output": true, "-o": true, "--remote-target": true}
 
 func TestSplit(t *testing.T) {
@@ -18,7 +18,7 @@ func TestSplit(t *testing.T) {
 	}{
 		{
 			name:        "no flags",
-			procArgs:    []string{"amika", "sandbox", "sshv2", "my-box"},
+			procArgs:    []string{"amika", "sandbox", "ssh", "my-box"},
 			leafArgs:    []string{"my-box"},
 			wantForward: []string{"my-box"},
 		},
@@ -26,27 +26,27 @@ func TestSplit(t *testing.T) {
 			// The pair of cases the split exists for: identical leafArgs,
 			// opposite meanings, told apart only by the process argv.
 			name:        "amika flag before the subcommand is not forwarded",
-			procArgs:    []string{"amika", "--output", "json", "sandbox", "sshv2", "my-box"},
+			procArgs:    []string{"amika", "--output", "json", "sandbox", "ssh", "my-box"},
 			leafArgs:    []string{"--output", "json", "my-box"},
 			wantOwn:     []string{"--output", "json"},
 			wantForward: []string{"my-box"},
 		},
 		{
 			name:        "same flag after the subcommand is forwarded",
-			procArgs:    []string{"amika", "sandbox", "sshv2", "--output", "json", "my-box"},
+			procArgs:    []string{"amika", "sandbox", "ssh", "--output", "json", "my-box"},
 			leafArgs:    []string{"--output", "json", "my-box"},
 			wantForward: []string{"--output", "json", "my-box"},
 		},
 		{
 			name:        "sandbox flag before the subcommand",
-			procArgs:    []string{"amika", "sandbox", "--remote", "sshv2", "-L", "6789:localhost:3010", "my-box"},
+			procArgs:    []string{"amika", "sandbox", "--remote", "ssh", "-L", "6789:localhost:3010", "my-box"},
 			leafArgs:    []string{"--remote", "-L", "6789:localhost:3010", "my-box"},
 			wantOwn:     []string{"--remote"},
 			wantForward: []string{"-L", "6789:localhost:3010", "my-box"},
 		},
 		{
 			name:        "value-taking amika flag before the subcommand",
-			procArgs:    []string{"amika", "sandbox", "--remote-target", "prod", "sshv2", "-N", "my-box"},
+			procArgs:    []string{"amika", "sandbox", "--remote-target", "prod", "ssh", "-N", "my-box"},
 			leafArgs:    []string{"--remote-target", "prod", "-N", "my-box"},
 			wantOwn:     []string{"--remote-target", "prod"},
 			wantForward: []string{"-N", "my-box"},
@@ -55,14 +55,14 @@ func TestSplit(t *testing.T) {
 			// A flag value equal to the subcommand name must not be mistaken
 			// for the subcommand and shift the boundary.
 			name:        "flag value equal to the subcommand name",
-			procArgs:    []string{"amika", "sandbox", "--remote-target", "sshv2", "sshv2", "my-box"},
-			leafArgs:    []string{"--remote-target", "sshv2", "my-box"},
-			wantOwn:     []string{"--remote-target", "sshv2"},
+			procArgs:    []string{"amika", "sandbox", "--remote-target", "ssh", "ssh", "my-box"},
+			leafArgs:    []string{"--remote-target", "ssh", "my-box"},
+			wantOwn:     []string{"--remote-target", "ssh"},
 			wantForward: []string{"my-box"},
 		},
 		{
 			name:        "remote command after the name is forwarded",
-			procArgs:    []string{"amika", "sandbox", "sshv2", "my-box", "uptime"},
+			procArgs:    []string{"amika", "sandbox", "ssh", "my-box", "uptime"},
 			leafArgs:    []string{"my-box", "uptime"},
 			wantForward: []string{"my-box", "uptime"},
 		},
@@ -78,7 +78,7 @@ func TestSplit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			own, forward := Split(tt.procArgs, tt.leafArgs, "sshv2", amikaValueFlags)
+			own, forward := Split(tt.procArgs, tt.leafArgs, "ssh", amikaValueFlags)
 			if len(own) != len(tt.wantOwn) || (len(own) > 0 && !reflect.DeepEqual(own, tt.wantOwn)) {
 				t.Errorf("own = %#v, want %#v", own, tt.wantOwn)
 			}

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -377,7 +377,7 @@ func canonicalHostPublicKey(value string) (string, error) {
 // pins the sandbox's host key.
 //
 // Shared by every command that hands a `*.amika` alias to system OpenSSH
-// (`sandbox sshv2`, `scpv2`), so they cannot drift in how the identity is
+// (`sandbox ssh`, `scp`), so they cannot drift in how the identity is
 // checked or the host key is pinned.
 func PrepareSessionTarget(
 	paths basedir.Paths,

--- a/go/test/e2e/README.md
+++ b/go/test/e2e/README.md
@@ -108,7 +108,7 @@ operation under test consumes a resource, such as `snapshot create --mode
 scrub_and_delete` deleting its source sandbox. If the step fails, the ledger
 entry remains available for best-effort cleanup.
 
-### Remote commands (`sandbox sshv2`)
+### Remote commands (`sandbox ssh`)
 
 A command to run inside a sandbox must be **one** `cmd` element, holding the
 whole script:
@@ -116,7 +116,7 @@ whole script:
 ```yaml
     cmd:
       - sandbox
-      - sshv2
+      - ssh
       - "{{sandbox_name}}"
       - --
       - |                                  # the entire remote command, one element

--- a/go/test/e2e/cases/api-base-snapshot-coder-dind.yaml
+++ b/go/test/e2e/cases/api-base-snapshot-coder-dind.yaml
@@ -2,7 +2,7 @@ name: selected provider coder-dind base snapshot contract
 # This real-API case verifies the selected provider's medium DinD
 # base snapshot, including a Docker container smoke test in the boot verifier.
 steps:
-  - name: register the local SSH public key for sshv2
+  - name: register the local SSH public key for sandbox ssh
     cmd: [secret, ssh-key, create, --name, "e2e-{{sandbox_provider}}-dind-{{run_id}}", -o, json]
     expect:
       exit: 0
@@ -37,7 +37,7 @@ steps:
   - name: verify the booted DinD base snapshot contract
     cmd:
       - sandbox
-      - sshv2
+      - ssh
       - "{{sandbox_name}}"
       - --
       - /bin/sh
@@ -68,7 +68,7 @@ steps:
   - name: verify the default amikad OpenCode and Docker services are running
     cmd:
       - sandbox
-      - sshv2
+      - ssh
       - "{{sandbox_name}}"
       - --
       - /bin/sh

--- a/go/test/e2e/cases/api-base-snapshot-coder.yaml
+++ b/go/test/e2e/cases/api-base-snapshot-coder.yaml
@@ -2,7 +2,7 @@ name: selected provider coder base snapshot contract
 # This real-API case verifies the selected provider's medium coder
 # base snapshot after the complete sandbox boot lifecycle.
 steps:
-  - name: register the local SSH public key for sshv2
+  - name: register the local SSH public key for sandbox ssh
     cmd: [secret, ssh-key, create, --name, "e2e-{{sandbox_provider}}-coder-{{run_id}}", -o, json]
     expect:
       exit: 0
@@ -37,7 +37,7 @@ steps:
   - name: verify the booted base snapshot contract
     cmd:
       - sandbox
-      - sshv2
+      - ssh
       - "{{sandbox_name}}"
       - --
       - /bin/sh
@@ -67,7 +67,7 @@ steps:
   - name: verify the default amikad and OpenCode services are running
     cmd:
       - sandbox
-      - sshv2
+      - ssh
       - "{{sandbox_name}}"
       - --
       - /bin/sh

--- a/go/test/e2e/cases/api-snapshot-scrub.yaml
+++ b/go/test/e2e/cases/api-snapshot-scrub.yaml
@@ -5,13 +5,13 @@ name: scrub a snapshot without breaking the restored environment
 # baseline. Assertions look for the old sentinels rather than requiring paths
 # to stay absent, because fresh provisioning may legitimately recreate them.
 steps:
-  # sshv2 authenticates with the caller's user-owned SSH key, so the local
-  # identity's public half has to be registered before any sshv2 step runs.
+  # `sandbox ssh` authenticates with the caller's user-owned SSH key, so the local
+  # identity's public half has to be registered before any `sandbox ssh` step runs.
   # `create` reuses an existing local keypair rather than regenerating one (see
   # ssh.GenerateIdentity), so this uploads the key already at
   # ~/.ssh/amika_id_ed25519 and never overwrites it. The run-unique name means
   # the key this case deletes is always one it registered.
-  - name: register the local SSH public key for sshv2
+  - name: register the local SSH public key for sandbox ssh
     cmd: [secret, ssh-key, create, --name, "e2e-scrub-{{run_id}}", -o, json]
     expect:
       exit: 0
@@ -43,7 +43,7 @@ steps:
   - name: inject scrub sentinels into the source sandbox
     cmd:
       - sandbox
-      - sshv2
+      - ssh
       - "{{source_sandbox}}"
       - --
       - /bin/sh
@@ -135,7 +135,7 @@ steps:
   - name: verify the scrubbed snapshot restores a clean usable environment
     cmd:
       - sandbox
-      - sshv2
+      - ssh
       - "{{restored_sandbox}}"
       - --
       - /bin/sh

--- a/go/test/e2e/cases/offline-output-reject-shell.yaml
+++ b/go/test/e2e/cases/offline-output-reject-shell.yaml
@@ -1,11 +1,12 @@
-# Offline case: `sandbox ssh` and `scp` both delegate to a system shell
-# utility that streams its own output, so neither can honor --output. They
-# turn out to enforce that in two different ways, discovered by reading
-# internal/output/output.go and go/cmd/amika/sandbox/sandbox_ssh.go and
-# go/cmd/amika/scp/command.go directly (do not assume — verify against the
+# Offline case: `sandbox ssh`, the superseded `sandbox sshv1`, and `scp` all
+# delegate to a system shell utility that streams its own output, so none of
+# them can honor --output. They turn out to enforce that in three different
+# ways, discovered by reading internal/output/output.go,
+# go/cmd/amika/sandbox/sandbox_ssh.go, go/cmd/amika/sandbox/sandbox_ssh_v2.go
+# and go/cmd/amika/scp/command.go directly (do not assume — verify against the
 # real binary):
 #
-#   - `sandbox ssh` registers --output normally and explicitly calls
+#   - `sandbox sshv1` registers --output normally and explicitly calls
 #     output.RejectFlag(cmd), which fires whenever the flag was Changed()
 #     (i.e. passed at all, regardless of its value — even "-o text" trips
 #     it). In sandbox_ssh.go that check runs *after* the auth check and
@@ -17,6 +18,13 @@
 #     ever moved after an actual network call, hitting that address would
 #     hang/fail loudly instead of silently succeeding against a real host.
 #
+#   - `sandbox ssh` splits its command line positionally (see
+#     internal/cliargs): everything after the subcommand is forwarded to the
+#     system ssh binary, so a trailing "-o json" is ssh's own ssh_config
+#     option and is NOT amika's --output at all. Only a flag written *before*
+#     the subcommand is amika's, and there RejectFlag fires — before any
+#     network call, so it too is reachable offline.
+#
 #   - `scp`'s cobra command sets DisableFlagParsing: true (its whole argv is
 #     forwarded to the system scp binary), so --output/-o is never parsed
 #     as amika's global flag at all — RejectFlag is never called, and there
@@ -25,10 +33,10 @@
 #     particular (an scp option that takes a value) consumes the next token
 #     as its argument. The case below demonstrates the actual resulting
 #     error instead of a rejection that does not exist for this command.
-name: ssh and scp cannot honor --output, but enforce that differently
+name: ssh, sshv1 and scp cannot honor --output, but enforce that differently
 steps:
-  - name: sandbox ssh --output json is rejected
-    cmd: [sandbox, ssh, somebox, --output, json]
+  - name: sandbox --output json ssh is rejected (amika's flag precedes the subcommand)
+    cmd: [sandbox, --output, json, ssh, somebox]
     env:
       AMIKA_API_KEY: fake-test-key
       AMIKA_API_URL: http://192.0.2.1:81
@@ -36,19 +44,8 @@ steps:
       exit: 1
       stderr_contains: "the --output flag is not supported by this command: it runs an underlying shell utility (ssh/scp) that streams its own output and cannot emit JSON"
 
-  - name: sandbox ssh -o json-pretty is rejected
-    cmd: [sandbox, ssh, somebox, -o, json-pretty]
-    env:
-      AMIKA_API_KEY: fake-test-key
-      AMIKA_API_URL: http://192.0.2.1:81
-    expect:
-      exit: 1
-      stderr_contains: "the --output flag is not supported by this command"
-
-  - name: sandbox ssh -o text (explicit default value) is still rejected
-    # RejectFlag keys off Changed(), not the value, so explicitly passing
-    # the default "text" trips it exactly like "json" does.
-    cmd: [sandbox, ssh, somebox, -o, text]
+  - name: sandbox -o json-pretty ssh is rejected too
+    cmd: [sandbox, -o, json-pretty, ssh, somebox]
     env:
       AMIKA_API_KEY: fake-test-key
       AMIKA_API_URL: http://192.0.2.1:81
@@ -67,9 +64,40 @@ steps:
       exit: 1
       stderr_contains: 'not logged in; run "amika auth login" or use --local'
 
+  - name: superseded sandbox sshv1 --output json is still rejected
+    # sshv1 is hidden but must keep working for existing scripts, including
+    # its own (non-positional) --output rejection.
+    cmd: [sandbox, sshv1, somebox, --output, json]
+    env:
+      AMIKA_API_KEY: fake-test-key
+      AMIKA_API_URL: http://192.0.2.1:81
+    expect:
+      exit: 1
+      stderr_contains: "the --output flag is not supported by this command: it runs an underlying shell utility (ssh/scp) that streams its own output and cannot emit JSON"
+
+  - name: superseded sandbox sshv1 -o json-pretty is rejected
+    cmd: [sandbox, sshv1, somebox, -o, json-pretty]
+    env:
+      AMIKA_API_KEY: fake-test-key
+      AMIKA_API_URL: http://192.0.2.1:81
+    expect:
+      exit: 1
+      stderr_contains: "the --output flag is not supported by this command"
+
+  - name: superseded sandbox sshv1 -o text (explicit default value) is still rejected
+    # RejectFlag keys off Changed(), not the value, so explicitly passing
+    # the default "text" trips it exactly like "json" does.
+    cmd: [sandbox, sshv1, somebox, -o, text]
+    env:
+      AMIKA_API_KEY: fake-test-key
+      AMIKA_API_URL: http://192.0.2.1:81
+    expect:
+      exit: 1
+      stderr_contains: "the --output flag is not supported by this command"
+
   - name: scp --output json is rejected (long form is unambiguously amika's flag)
     # scp sets DisableFlagParsing, so the global --output never reaches cobra
-    # to be marked Changed. runSCP rejects the long form explicitly via
+    # to be marked Changed. runSCPV2 rejects the long form explicitly via
     # output.RejectFlagInArgs before any resolution or exec.
     cmd: [scp, --output, json, a, b]
     expect:
@@ -90,24 +118,39 @@ steps:
       exit: 1
       stderr_contains: "the --output flag is not supported by this command"
 
-  - name: a leading short -o is NOT rejected; it is indistinguishable from scp's own -o
-    # Once scp disables flag parsing, "-o json" before the subcommand cannot be
-    # told apart from scp's own -o ssh_config option, so it forwards. Here it is
-    # consumed as scp's -o and the copy fails for lack of a real remote operand.
-    cmd: [-o, json, scp, a, b]
+  # The two short-form cases below run against `scpv1`, not `scp`. Both assert
+  # on "no remote source or target found", which is v1's requirement that a
+  # copy name at least one sandbox or scp:// host (see buildSCPInvocation in
+  # go/cmd/amika/scp/scp.go). The current `scp` has no such check — a
+  # local-only copy just forwards to the system scp binary — so asserting the
+  # same message under `scp` would exercise the real scp binary instead of
+  # amika. `scpv1` keeps the contract these two cases were written for.
+  - name: a leading short -o is NOT rejected by scpv1; it is indistinguishable from scp's own -o
+    # Once scpv1 disables flag parsing, "-o json" before the subcommand cannot
+    # be told apart from scp's own -o ssh_config option, so it forwards. Here it
+    # is consumed as scp's -o and the copy fails for lack of a remote operand.
+    cmd: [-o, json, scpv1, a, b]
     expect:
       exit: 1
       stderr_contains: "no remote source or target found"
 
-  - name: "scp -o json a b: -o is scp's OWN option and is NOT rejected; it forwards"
+  - name: "scpv1 -o json a b: -o is scp's OWN option and is NOT rejected; it forwards"
     # The short -o is scp's ssh_config-override option, not amika's --output
     # shorthand here, so it is left to forward to the system scp. "-o" consumes
     # "json" as its argument; neither "a" nor "b" names a sandbox or scp:// host,
-    # so scp's own source/target resolution fails first (no rejection).
-    cmd: [scp, -o, json, a, b]
+    # so scpv1's own source/target resolution fails first (no rejection).
+    cmd: [scpv1, -o, json, a, b]
     expect:
       exit: 1
       stderr_contains: "no remote source or target found"
+
+  - name: superseded scpv1 --output json is still rejected
+    # scpv1 is hidden but must keep working for existing scripts, including its
+    # own long-form --output rejection.
+    cmd: [scpv1, --output, json, a, b]
+    expect:
+      exit: 1
+      stderr_contains: "the --output flag is not supported by this command"
 
   - name: scp with no operands at all fails cobra's arg-count check first
     cmd: [scp]

--- a/go/test/e2e/cases/offline-usage-errors.yaml
+++ b/go/test/e2e/cases/offline-usage-errors.yaml
@@ -41,3 +41,63 @@ steps:
     expect:
       exit: 0
       stdout_contains: "amika sandbox code <name> [flags]"
+
+  - name: sandbox --help lists ssh and code
+    cmd: [sandbox, --help]
+    expect:
+      exit: 0
+      stdout_contains: "  ssh         SSH into a remote sandbox"
+
+  - name: sandbox --help does NOT list the superseded sshv1
+    # sshv1/codev1 stay registered for existing scripts but are Hidden, so the
+    # help listing must steer new users to the current transport.
+    cmd: [sandbox, --help]
+    expect:
+      exit: 0
+      stdout_not_contains: "sshv1"
+
+  - name: sandbox --help does NOT list the superseded codev1
+    cmd: [sandbox, --help]
+    expect:
+      exit: 0
+      stdout_not_contains: "codev1"
+
+  - name: amika --help does NOT list the superseded scpv1
+    cmd: [--help]
+    expect:
+      exit: 0
+      stdout_not_contains: "scpv1"
+
+  - name: hidden sandbox sshv1 --help still works and keeps its own flags
+    # The compatibility promise: a script that called the old provider-native
+    # ssh keeps working under the new name, flags included.
+    cmd: [sandbox, sshv1, --help]
+    expect:
+      exit: 0
+      stdout_contains: "amika sandbox sshv1 [flags] <name> [-- <command>...]"
+
+  - name: hidden sandbox sshv1 --help still documents --revoke
+    cmd: [sandbox, sshv1, --help]
+    expect:
+      exit: 0
+      stdout_contains: "--revoke"
+
+  - name: sandbox ssh --help defines no flags of its own
+    # ssh forwards everything after the subcommand to the ssh binary, so
+    # sshv1's --revoke must NOT be one of its flags.
+    cmd: [sandbox, ssh, --help]
+    expect:
+      exit: 0
+      stdout_not_contains: "--revoke"
+
+  - name: hidden sandbox codev1 --help still works
+    cmd: [sandbox, codev1, --help]
+    expect:
+      exit: 0
+      stdout_contains: "amika sandbox codev1 <name> [flags]"
+
+  - name: hidden scpv1 --help still works
+    cmd: [scpv1, --help]
+    expect:
+      exit: 0
+      stdout_contains: "amika scpv1 <source> ... <target>"


### PR DESCRIPTION
Closes KAPRO-835.

The direct WebSocket SSH transport was only reachable under the `sshv2`,
`codev2`, and `scpv2` names while the plain names still pointed at the older
provider-native SSH route, so new users found the old path first. This swaps
which transport owns the plain names.

| Before    | After                | Visibility           |
| --------- | -------------------- | -------------------- |
| `sshv2`   | `sandbox ssh`        | listed in `--help`   |
| `codev2`  | `sandbox code`       | listed in `--help`   |
| `scpv2`   | `scp`                | listed in `--help`   |
| `ssh`     | `sandbox sshv1`      | registered, `Hidden` |
| `code`    | `sandbox codev1`     | registered, `Hidden` |
| `scp`     | `scpv1`              | registered, `Hidden` |

Rename plus alias, not a deletion: the v1 commands keep every flag and
behavior they had and stay reachable by name, they are just out of the help
listing. No behavior moves between transports.

`sshv2`, `codev2`, and `scpv2` also stay reachable, as Cobra aliases on `ssh`,
`code`, and `scp` rather than separate command objects, so a script or doc
written against the beta names during the beta period keeps working. `sandbox
ssh` splits its argv positionally to tell amika's flags from ssh's, keyed on
the literal subcommand token typed; that split now reads `cmd.CalledAs()`
instead of `cmd.Name()` so it still keys off "sshv2" when that is what was
typed, rather than always assuming "ssh". The `sshv1`/`codev1`/`scpv1`
documentation in `docs/cli-reference.md` and the amika-cli skill was dropped:
those commands are hidden and superseded and do not need public docs, and the
same now applies to the v2 alias names.

## Does the API server need updating?

**No.** This is purely a CLI-side change.

- The two paths hit **disjoint** endpoints, both already deployed and enabled.
  v1 uses `POST /api/v0beta1/sandboxes/{id}/ssh` and
  `DELETE .../ssh`; v2 uses `GET /api/v0beta1/sandboxes/{name}` plus
  `POST /api/v0beta1/sandboxes/{id}/ssh-sessions`, then a `wss://` dial to
  `amikad` inside the sandbox. Nothing is being retired, so no server route
  moves.
- **Nothing server-side keys off the CLI subcommand name.** The CLI sends no
  `User-Agent` and no client-identifying header anywhere (only
  `Authorization`, `Content-Type`, `Accept`), and `POST .../ssh-sessions`
  sends no request body. amika-mono has zero occurrences of
  `sshv2`/`codev2`/`scpv2` under `js/coding-agents/`. The only session
  telemetry keys on `transport: "direct_ws"`, not on a command name.
- `NO_RELAY_SSH_ENABLED` is a global availability switch for the direct
  transport, not a v1-vs-v2 router, and it is already `true` in prod and
  staging. Worth noting that spec 019 originally planned a server-driven
  switch (`SSH_V2_ENABLED` plus a per-org `ssh_default_v2` setting), that was
  never built, so this CLI rename *is* the entire default switch. There is no
  server-side toggle to coordinate with.
- Bonus: amika-mono's dashboard already emits `amika sandbox ssh <name>` and
  `amika sandbox code <name> --editor=...` in its copy-to-clipboard snippets,
  so those strings become correct-by-default for the direct transport instead
  of quietly using the old route.

Follow-ups for a **separate amika-mono PR** (all cosmetic; nothing breaks):

- `specs/019-sandbox-ssh-stream-relay.d/scripts/20-phase0.sh` invokes
  `amika sandbox sshv2` literally and would fail if re-run. Same directory's
  `21-phase1.sh` and `22-phase2.sh` mention it in comments only.
- Prose mentions of the old names in `specs/019-*`, `specs/020-*`, and the
  `2026-08-12` marketing changelog entry.
- One behavioral note: the dashboard's `amika sandbox ssh <name>` now needs an
  uploaded SSH key and an `amikad`-exposing sandbox. A sandbox predating that
  exposure returns `sandbox_ssh_unavailable`, where v1 would have worked,
  which is why `sshv1` stays available, and why both the `ssh` long help and
  the CLI skill point at it as the fallback.

## Contracts that differ between the transports

Two things could not simply be carried over to the new names:

- **`--output` rejection.** `sshv1` parses its own flags and rejects `--output`
  wherever it appears. `ssh` splits its command line positionally, so only a
  flag written *before* the subcommand is amika's; after it, `-o` is ssh's own
  `ssh_config` option. `offline-output-reject-shell.yaml` now covers both
  rules rather than assuming the v1 one.
- **The "no remote source or target found" check** lives in v1's
  `buildSCPInvocation` only. The new `scp` forwards a local-only copy to the
  system scp instead (verified: `amika scp -o json a b` now yields
  `cp: cannot stat 'a'`). The two e2e steps asserting that message were
  re-pointed at `scpv1`, which is what they were written for.

## Notes for review

`V1`/`V2` suffixes on Go identifiers and file names are deliberately left
alone. They label the two transport generations, both of which still exist in
the same packages, so reusing `sandboxSSHCmd` for what used to be
`sandboxSSHV2Cmd` would make `git log -S` and blame harder to read than the
naming win is worth. Comments and help text were all updated to name the CLI
commands correctly. Happy to do the full identifier swap if you'd rather.

## Verification

`make fmtcheck`, `make vet`, `make lint`, `make build-cli`, `make test-unit`,
and `make test-e2e` (the offline e2e suite) all pass. Every new e2e assertion
was also checked by hand against the built binary. Two environment gaps, both
pre-existing on `main` in this sandbox and unrelated to this change:
`internal/materialize`'s three tests need `rsync`, and `make shellcheck` needs
`shellcheck` (this PR touches no shell scripts).

New test coverage:

- `TestSSHCommandNames` — pins name, `Hidden`, and now `Aliases` for the four
  sandbox commands.
- `TestSCPV1CommandRegistered` — same for `scpv1`, plus its `--print` flag.
- `TestSCPCommandRegistered` — now also pins `scp`'s `scpv2` alias.
- `TestSSHV2AliasForwardsArgsToSSH` — the "sshv2" alias splits its argv the
  same way "ssh" does.
- Nine new `offline-usage-errors.yaml` steps asserting the help surface: `ssh`
  is listed, `sshv1`/`codev1`/`scpv1` are not, all three hidden commands still
  respond to `--help`, `sshv1` still documents `--revoke`, and `ssh` does not.