### PR TITLE
Fix E2E case size handling to be provider-correct

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -45,7 +45,7 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().String("git", "", "Mount a git repo into the sandbox. Accepts a local path or a git URL (HTTPS, SSH). If omitted and the cwd is in a git repo, that repo is used automatically.")
 	sandboxCreateCmd.Flags().Bool("no-git", false, "Skip git repo auto-detection; create a sandbox without mounting any repo.")
 	sandboxCreateCmd.Flags().Bool("no-clean", false, "With a local-path git source, include untracked files from the working tree instead of a clean clone. Local sandboxes only.")
-	sandboxCreateCmd.Flags().String("size", "", "Sandbox size: \"xs\", \"m\", \"l\", or \"xl\" (default \"m\", remote only)")
+	sandboxCreateCmd.Flags().String("size", "", "Sandbox size, e.g. \"m\" or \"a1.medium\"; the API validates it and lists what your provider offers (default \"m\", remote only)")
 	sandboxCreateCmd.Flags().String("snapshot", "", "Fork the sandbox from a captured snapshot slug (remote only)")
 	sandboxCreateCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	sandboxCreateCmd.Flags().StringArray("secret", nil, "Inject a remote secret (env:FOO=SECRET_NAME or env:SECRET_NAME)")

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -334,10 +334,11 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 	if err := sandbox.ValidatePreset(preset); err != nil {
 		return err
 	}
+	// Not validated here: the size vocabulary (generations, per-provider
+	// availability, preset exclusions) lives in the API, so a client-side list
+	// would be a second copy that silently rejects sizes the server accepts.
+	// An unknown size comes back as a 400 from the server instead.
 	size, _ := cmd.Flags().GetString("size")
-	if err := sandbox.ValidateSize(size); err != nil {
-		return err
-	}
 	// Validated in RunE before the auth gate; only the value is read here.
 	githubAuthMode, _ := cmd.Flags().GetString("github-auth-mode")
 	githubAuthMode = sandbox.CanonicalGithubAuthMode(githubAuthMode)

--- a/go/internal/sandbox/image_resolution.go
+++ b/go/internal/sandbox/image_resolution.go
@@ -15,9 +15,6 @@ const DefaultCoderImage = "amika/coder:latest"
 // AllowedPresets lists the preset names available for user selection via --preset.
 var AllowedPresets = []string{"coder", "coder-dind"}
 
-// AllowedSizes lists the size names available for user selection via --size.
-var AllowedSizes = []string{"xs", "m", "l", "xl"}
-
 // ValidatePreset returns an error if preset is non-empty and not in AllowedPresets.
 func ValidatePreset(preset string) error {
 	if preset == "" {
@@ -29,19 +26,6 @@ func ValidatePreset(preset string) error {
 		}
 	}
 	return fmt.Errorf("unknown preset %q; allowed presets: %s", preset, strings.Join(AllowedPresets, ", "))
-}
-
-// ValidateSize returns an error if size is non-empty and not in AllowedSizes.
-func ValidateSize(size string) error {
-	if size == "" {
-		return nil
-	}
-	for _, s := range AllowedSizes {
-		if size == s {
-			return nil
-		}
-	}
-	return fmt.Errorf("unknown size %q; allowed sizes: %s", size, strings.Join(AllowedSizes, ", "))
 }
 
 // PresetImageOptions controls how image/preset resolution and auto-build work.

--- a/go/test/e2e/README.md
+++ b/go/test/e2e/README.md
@@ -156,6 +156,48 @@ with a previously `capture`d value. Referencing a variable that was never
 captured is an error: the step fails immediately rather than sending a
 literal `{{typo}}` to the CLI.
 
+### Case-level `vars`: provider-conditional values
+
+Some values a case must assert exactly still differ legitimately per provider.
+A top-level `vars` block declares them once, resolved against the run's
+provider before the first step:
+
+```yaml
+name: selected provider coder base snapshot contract
+vars:
+  plain_value: always-this          # a scalar: the same on every provider
+  expected_size:
+    default: m                      # used when no provider entry matches
+    daytona: a0.m                   # this provider's value wins
+steps:
+  - name: create a medium sandbox
+    cmd: [sandbox, create, --remote, --size, m, ...]
+    expect:
+      stdout_json:
+        sandbox_size: "{{expected_size}}"
+```
+
+Resolved vars join `{{run_id}}` and `{{sandbox_provider}}` in the same
+substitution pass, so they work anywhere a `{{var}}` works — argv and
+`resource.name` included, not just assertions.
+
+Prefer this over loosening an assertion to `` `@oneof: m, a0.m` ``. The
+`@oneof` form also passes when a provider returns the *other* provider's
+value, so it stops catching a wrong size; a resolved var keeps the assertion
+exact per provider.
+
+Rejected at **load** time (so `TestE2ECaseFilesLoad` catches it offline, with
+no API run):
+
+- An unknown provider key (`daytonaa: ...`). Left to fall through to
+  `default`, a typo would make the case assert nothing provider-specific
+  while still passing everywhere.
+- A mapping with no `default` that doesn't list every supported provider,
+  which would otherwise fail mid-case on the missing one.
+- Redeclaring `run_id` or `sandbox_provider`, or a `capture` reusing a
+  declared var's name — either would change what `{{name}}` means partway
+  through a case.
+
 ### Capture: a minimal JSONPath
 
 `capture` extracts values from a step's stdout, parsed as JSON, into named

--- a/go/test/e2e/cases/api-agent-sessions.yaml
+++ b/go/test/e2e/cases/api-agent-sessions.yaml
@@ -24,9 +24,16 @@ name: agent-session chats via send and sessions (send, continue, stream, list, s
 # covered for that reason: `--stream` combined with `-o json` (which must stay
 # buffered so the emitted object remains valid) — that decision is local flag
 # logic inlined in runSend, reachable only with a live client.
+vars:
+  # A bare size alias ("xs") is normalized by the API to the a0 generation for
+  # every provider. E2B publishes no a0 images (see snapshots.cue: a1 only), so
+  # it must be asked for the equivalent a1 name instead.
+  request_size:
+    default: xs
+    e2b: a1.tiny
 steps:
   - name: create the sandbox the chat will run in
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, xs, --yes, -o, json]
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, "{{request_size}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox

--- a/go/test/e2e/cases/api-base-snapshot-coder-dind.yaml
+++ b/go/test/e2e/cases/api-base-snapshot-coder-dind.yaml
@@ -2,11 +2,15 @@ name: selected provider coder-dind base snapshot contract
 # This real-API case verifies the selected provider's medium DinD
 # base snapshot, including a Docker container smoke test in the boot verifier.
 vars:
-  # See api-base-snapshot-coder.yaml: the requested `--size m` comes back with
-  # a generation prefix on Daytona and bare elsewhere.
-  expected_size:
+  # See api-base-snapshot-coder.yaml for why the request and the expectation
+  # are both provider-conditional. coder-dind excludes the xs tier, so a1.tiny
+  # has no dind image; a1.medium does.
+  request_size:
     default: m
-    daytona: a0.m
+    e2b: a1.medium
+  expected_size:
+    default: a0.m
+    e2b: a1.medium
 steps:
   - name: register the local SSH public key for sshv2
     cmd: [secret, ssh-key, create, --name, "e2e-{{sandbox_provider}}-dind-{{run_id}}", -o, json]
@@ -23,7 +27,7 @@ steps:
       cleanup: [secret, ssh-key, delete, "{{ssh_key_id}}", --force, -o, json]
 
   - name: create a medium coder-dind sandbox from the selected provider base snapshot
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder-dind, --size, m, --yes, -o, json]
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder-dind, --size, "{{request_size}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox

--- a/go/test/e2e/cases/api-base-snapshot-coder-dind.yaml
+++ b/go/test/e2e/cases/api-base-snapshot-coder-dind.yaml
@@ -1,6 +1,12 @@
 name: selected provider coder-dind base snapshot contract
 # This real-API case verifies the selected provider's medium DinD
 # base snapshot, including a Docker container smoke test in the boot verifier.
+vars:
+  # See api-base-snapshot-coder.yaml: the requested `--size m` comes back with
+  # a generation prefix on Daytona and bare elsewhere.
+  expected_size:
+    default: m
+    daytona: a0.m
 steps:
   - name: register the local SSH public key for sshv2
     cmd: [secret, ssh-key, create, --name, "e2e-{{sandbox_provider}}-dind-{{run_id}}", -o, json]
@@ -26,7 +32,7 @@ steps:
         provider: "{{sandbox_provider}}"
         snapshot: "@string"
         sandbox_preset: coder-dind
-        sandbox_size: m
+        sandbox_size: "{{expected_size}}"
     capture:
       sandbox_name: $.name
     resource:

--- a/go/test/e2e/cases/api-base-snapshot-coder.yaml
+++ b/go/test/e2e/cases/api-base-snapshot-coder.yaml
@@ -2,13 +2,18 @@ name: selected provider coder base snapshot contract
 # This real-API case verifies the selected provider's medium coder
 # base snapshot after the complete sandbox boot lifecycle.
 vars:
-  # `--size m` is what the case requests; what the API echoes back is
-  # provider-specific, because Daytona's size codes carry a generation prefix
-  # while other providers report the bare code. Assert the exact value per
-  # provider rather than loosening the match, so a wrong size is still caught.
-  expected_size:
+  # A bare size alias ("m") is normalized by the API to the a0 generation for
+  # every provider, so a0 is what both the request and the echoed value default
+  # to. E2B publishes no a0 images at all (see snapshots.cue: a1 only), so it
+  # must be asked for an explicit a1 name, which it then echoes back. Assert the
+  # exact value per provider rather than loosening the match, so a wrong size is
+  # still caught.
+  request_size:
     default: m
-    daytona: a0.m
+    e2b: a1.medium
+  expected_size:
+    default: a0.m
+    e2b: a1.medium
 steps:
   - name: register the local SSH public key for sshv2
     cmd: [secret, ssh-key, create, --name, "e2e-{{sandbox_provider}}-coder-{{run_id}}", -o, json]
@@ -25,7 +30,7 @@ steps:
       cleanup: [secret, ssh-key, delete, "{{ssh_key_id}}", --force, -o, json]
 
   - name: create a medium coder sandbox from the selected provider base snapshot
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, m, --yes, -o, json]
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, "{{request_size}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox

--- a/go/test/e2e/cases/api-base-snapshot-coder.yaml
+++ b/go/test/e2e/cases/api-base-snapshot-coder.yaml
@@ -1,6 +1,14 @@
 name: selected provider coder base snapshot contract
 # This real-API case verifies the selected provider's medium coder
 # base snapshot after the complete sandbox boot lifecycle.
+vars:
+  # `--size m` is what the case requests; what the API echoes back is
+  # provider-specific, because Daytona's size codes carry a generation prefix
+  # while other providers report the bare code. Assert the exact value per
+  # provider rather than loosening the match, so a wrong size is still caught.
+  expected_size:
+    default: m
+    daytona: a0.m
 steps:
   - name: register the local SSH public key for sshv2
     cmd: [secret, ssh-key, create, --name, "e2e-{{sandbox_provider}}-coder-{{run_id}}", -o, json]
@@ -26,7 +34,7 @@ steps:
         provider: "{{sandbox_provider}}"
         snapshot: "@string"
         sandbox_preset: coder
-        sandbox_size: m
+        sandbox_size: "{{expected_size}}"
     capture:
       sandbox_name: $.name
     resource:

--- a/go/test/e2e/cases/api-sandbox-lifecycle.yaml
+++ b/go/test/e2e/cases/api-sandbox-lifecycle.yaml
@@ -10,9 +10,16 @@ name: remote sandbox lifecycle (create, list, agent-send, stop, start, delete)
 # depends on the sandbox provider and can fail transiently (HTTP 502), which
 # would redden this core lifecycle and orphan a snapshot. They live in
 # api-snapshot-lifecycle.yaml so that flakiness stays isolated.
+vars:
+  # A bare size alias ("xs") is normalized by the API to the a0 generation for
+  # every provider. E2B publishes no a0 images (see snapshots.cue: a1 only), so
+  # it must be asked for the equivalent a1 name instead.
+  request_size:
+    default: xs
+    e2b: a1.tiny
 steps:
   - name: create a remote sandbox and wait until it is provisioned
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, xs, --yes, -o, json]
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, "{{request_size}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox

--- a/go/test/e2e/cases/api-service-lifecycle.yaml
+++ b/go/test/e2e/cases/api-service-lifecycle.yaml
@@ -6,9 +6,16 @@ name: remote service lifecycle (create source sandbox, create service, list, del
 # lifecycle. Both the service and the sandbox are registered as resources for
 # reverse-order ledger cleanup: the service (registered last) is deleted first,
 # then the sandbox.
+vars:
+  # A bare size alias ("xs") is normalized by the API to the a0 generation for
+  # every provider. E2B publishes no a0 images (see snapshots.cue: a1 only), so
+  # it must be asked for the equivalent a1 name instead.
+  request_size:
+    default: xs
+    e2b: a1.tiny
 steps:
   - name: create a source sandbox and wait until it is provisioned
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, xs, --yes, -o, json]
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, "{{request_size}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox

--- a/go/test/e2e/cases/api-snapshot-lifecycle.yaml
+++ b/go/test/e2e/cases/api-snapshot-lifecycle.yaml
@@ -11,9 +11,16 @@ name: remote snapshot lifecycle (create source sandbox, capture, list, delete)
 # is isolated from api-sandbox-lifecycle.yaml precisely so that flakiness
 # does not redden the core sandbox lifecycle. Both `resource` blocks register
 # their targets so cleanup runs regardless of which step fails.
+vars:
+  # A bare size alias ("xs") is normalized by the API to the a0 generation for
+  # every provider. E2B publishes no a0 images (see snapshots.cue: a1 only), so
+  # it must be asked for the equivalent a1 name instead.
+  request_size:
+    default: xs
+    e2b: a1.tiny
 steps:
   - name: create a source sandbox and wait until it is provisioned
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, xs, --yes, -o, json]
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, "{{request_size}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox

--- a/go/test/e2e/cases/api-snapshot-scrub.yaml
+++ b/go/test/e2e/cases/api-snapshot-scrub.yaml
@@ -4,6 +4,13 @@ name: scrub a snapshot without breaking the restored environment
 # remote token removal, and restoration of `/etc/environment` from its clean
 # baseline. Assertions look for the old sentinels rather than requiring paths
 # to stay absent, because fresh provisioning may legitimately recreate them.
+vars:
+  # A bare size alias ("xs") is normalized by the API to the a0 generation for
+  # every provider. E2B publishes no a0 images (see snapshots.cue: a1 only), so
+  # it must be asked for the equivalent a1 name instead.
+  request_size:
+    default: xs
+    e2b: a1.tiny
 steps:
   # sshv2 authenticates with the caller's user-owned SSH key, so the local
   # identity's public half has to be registered before any sshv2 step runs.
@@ -26,7 +33,7 @@ steps:
       cleanup: [secret, ssh-key, delete, "{{ssh_key_id}}", --force, -o, json]
 
   - name: create a source sandbox
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, xs, --yes, -o, json]
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, "{{request_size}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox
@@ -118,7 +125,7 @@ steps:
       name: "{{source_sandbox}}"
 
   - name: fork a sandbox from the scrubbed snapshot
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, xs, --snapshot, "{{snapshot_ref}}", --yes, -o, json]
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder, --size, "{{request_size}}", --snapshot, "{{snapshot_ref}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox

--- a/go/test/e2e/e2e_test.go
+++ b/go/test/e2e/e2e_test.go
@@ -55,12 +55,7 @@ func providerFromEnv() string {
 }
 
 func validSandboxProvider(provider string) bool {
-	switch provider {
-	case "daytona", "e2b", "freestyle", "vercel":
-		return true
-	default:
-		return false
-	}
+	return runner.SupportedSandboxProviders[provider]
 }
 
 // cleanupReserve is how much of the `go test` -timeout budget is held back

--- a/go/test/e2e/runner/runner.go
+++ b/go/test/e2e/runner/runner.go
@@ -23,12 +23,154 @@ import (
 // Case is a parsed E2E case file: a human-readable name and an ordered
 // sequence of steps run against the amika binary.
 type Case struct {
-	Name  string `yaml:"name"`
-	Steps []Step `yaml:"steps"`
+	Name string `yaml:"name"`
+	// Vars declares case-level "{{var}}" values, resolved once against the
+	// run's sandbox provider before the first step. Use them for values a
+	// case must assert exactly but which legitimately differ per provider.
+	Vars  map[string]VarSpec `yaml:"vars"`
+	Steps []Step             `yaml:"steps"`
 
 	// SourcePath is the file the case was loaded from. Not part of the
 	// YAML schema; set by LoadCase for diagnostics.
 	SourcePath string `yaml:"-"`
+}
+
+// SupportedSandboxProviders is the set of provider names a case may select or
+// key a VarSpec on. It is the single source of truth shared by the E2E entry
+// point's -sandbox-provider validation and VarSpec's load-time key checking,
+// so a provider added in one place cannot be silently unknown in the other.
+var SupportedSandboxProviders = map[string]bool{
+	"daytona":   true,
+	"e2b":       true,
+	"freestyle": true,
+	"vercel":    true,
+}
+
+// varDefaultKey is the VarSpec mapping key holding the value used when no
+// per-provider entry matches the run's provider.
+const varDefaultKey = "default"
+
+// reservedVarNames are the "{{var}}" names the runner defines itself. A case
+// may not declare them, because shadowing e.g. {{run_id}} would silently
+// break the uniqueness that remote resource names depend on.
+var reservedVarNames = map[string]bool{
+	"run_id":           true,
+	"sandbox_provider": true,
+}
+
+// VarSpec is one entry in a case's "vars" block: either a plain scalar (a
+// constant for every provider) or a mapping of provider names to values with
+// an optional "default".
+//
+//	vars:
+//	  plain_value: always-this
+//	  expected_size:
+//	    default: m
+//	    daytona: a0.m
+//
+// A mapping without a "default" must enumerate every provider in
+// SupportedSandboxProviders, so a run on an unlisted provider fails at load
+// time rather than mid-case with an undefined-variable error.
+type VarSpec struct {
+	// Value is the resolved value for a scalar spec.
+	Value string
+	// Default is the fallback for a mapping spec; DefaultSet distinguishes an
+	// absent "default" from one explicitly set to the empty string.
+	Default    string
+	DefaultSet bool
+	// ByProvider maps a provider name to its value, excluding "default".
+	ByProvider map[string]string
+
+	// scalar records that the spec was written as a plain scalar, so an
+	// explicit empty string is not mistaken for an empty mapping.
+	scalar bool
+}
+
+// UnmarshalYAML accepts either a scalar or a mapping, so the common
+// (non-conditional) case stays a one-liner in the case file.
+func (v *VarSpec) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		var s string
+		if err := node.Decode(&s); err != nil {
+			return err
+		}
+		v.Value = s
+		v.scalar = true
+		return nil
+	case yaml.MappingNode:
+		raw := map[string]string{}
+		if err := node.Decode(&raw); err != nil {
+			return err
+		}
+		v.ByProvider = make(map[string]string, len(raw))
+		for key, value := range raw {
+			if key == varDefaultKey {
+				v.Default = value
+				v.DefaultSet = true
+				continue
+			}
+			v.ByProvider[key] = value
+		}
+		return nil
+	default:
+		return fmt.Errorf("must be a scalar or a mapping of provider names to values")
+	}
+}
+
+// Resolve returns the spec's value for provider, reporting false when a
+// mapping spec has neither an entry for provider nor a default.
+func (v VarSpec) Resolve(provider string) (string, bool) {
+	if v.scalar {
+		return v.Value, true
+	}
+	if value, ok := v.ByProvider[provider]; ok {
+		return value, true
+	}
+	if v.DefaultSet {
+		return v.Default, true
+	}
+	return "", false
+}
+
+// validate checks one declared var, named for diagnostics.
+func (v VarSpec) validate(name string) error {
+	if v.scalar {
+		return nil
+	}
+	if !v.DefaultSet && len(v.ByProvider) == 0 {
+		return fmt.Errorf("var %q: mapping must set %q or at least one provider", name, varDefaultKey)
+	}
+	// Reject an unknown provider key rather than letting it fall through to
+	// the default: a typo like "daytonaa" would otherwise make the case pass
+	// against the default value on every provider, asserting nothing.
+	unknown := make([]string, 0, len(v.ByProvider))
+	for key := range v.ByProvider {
+		if !SupportedSandboxProviders[key] {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("var %q: unknown provider key(s) %s", name, strings.Join(unknown, ", "))
+	}
+	if v.DefaultSet {
+		return nil
+	}
+	// No default, so every provider must be covered or a run on the missing
+	// one would fail mid-case on an undefined variable.
+	missing := make([]string, 0, len(SupportedSandboxProviders))
+	for provider := range SupportedSandboxProviders {
+		if _, ok := v.ByProvider[provider]; !ok {
+			missing = append(missing, provider)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("var %q: no %q, so every provider must be listed; missing %s",
+			name, varDefaultKey, strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // Step is a single command execution and the assertions to make about its
@@ -176,6 +318,23 @@ func LoadCase(path string) (*Case, error) {
 	if len(c.Steps) == 0 {
 		return nil, fmt.Errorf("case %s: at least one step is required", path)
 	}
+	// Validate declared vars in sorted order for a deterministic error.
+	varNames := make([]string, 0, len(c.Vars))
+	for name := range c.Vars {
+		varNames = append(varNames, name)
+	}
+	sort.Strings(varNames)
+	for _, name := range varNames {
+		if !validVarNamePattern.MatchString(name) {
+			return nil, fmt.Errorf("case %s: var name %q must match %s", path, name, validVarNameGrammar)
+		}
+		if reservedVarNames[name] {
+			return nil, fmt.Errorf("case %s: var %q is defined by the runner and cannot be redeclared", path, name)
+		}
+		if err := c.Vars[name].validate(name); err != nil {
+			return nil, fmt.Errorf("case %s: %w", path, err)
+		}
+	}
 	for i, step := range c.Steps {
 		if step.Name == "" {
 			return nil, fmt.Errorf("case %s: step %d: \"name\" is required", path, i+1)
@@ -196,6 +355,13 @@ func LoadCase(path string) (*Case, error) {
 		for _, name := range captureNames {
 			if !validVarNamePattern.MatchString(name) {
 				return nil, fmt.Errorf("case %s: step %d (%s): capture name %q must match %s", path, i+1, step.Name, name, validVarNameGrammar)
+			}
+			// A capture that reuses a declared var's name would overwrite the
+			// provider-resolved value partway through the case, so every
+			// "{{name}}" before this step means something different from every
+			// one after it. Reject the shadowing instead.
+			if _, declared := c.Vars[name]; declared {
+				return nil, fmt.Errorf("case %s: step %d (%s): capture name %q shadows a declared var", path, i+1, step.Name, name)
 			}
 		}
 		if step.Resource != nil {
@@ -419,10 +585,34 @@ func (r *Runner) Vars() map[string]string {
 // runs on the normal failure path rather than being skipped by a killed
 // process.
 func (r *Runner) RunCase(ctx context.Context, c *Case) error {
+	if err := r.applyCaseVars(c); err != nil {
+		return fmt.Errorf("case %q: %w", c.Name, err)
+	}
 	for i, step := range c.Steps {
 		if err := r.runStep(ctx, i, step); err != nil {
 			return fmt.Errorf("case %q step %d (%s): %w", c.Name, i+1, step.Name, err)
 		}
+	}
+	return nil
+}
+
+// applyCaseVars resolves the case's declared vars against the run's sandbox
+// provider and merges them into the template vars, before any step runs. Load
+// time already rejected an unresolvable spec, so a failure here means the run
+// selected a provider the case does not cover.
+func (r *Runner) applyCaseVars(c *Case) error {
+	names := make([]string, 0, len(c.Vars))
+	for name := range c.Vars {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		value, ok := c.Vars[name].Resolve(r.opts.SandboxProvider)
+		if !ok {
+			return fmt.Errorf("var %q has no value for provider %q and no %q",
+				name, r.opts.SandboxProvider, varDefaultKey)
+		}
+		r.vars[name] = value
 	}
 	return nil
 }

--- a/go/test/e2e/runner/runner_vars_test.go
+++ b/go/test/e2e/runner/runner_vars_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -57,5 +58,131 @@ func TestNewExposesSandboxProviderAsTemplateVar(t *testing.T) {
 	}
 	if got != "--provider=e2b" {
 		t.Fatalf("got %q, want %q", got, "--provider=e2b")
+	}
+}
+
+// A case-level var resolves per provider so a case can assert a value exactly
+// even when the API legitimately reports a different one on each provider
+// (e.g. Daytona's generation-prefixed sandbox sizes).
+func TestCaseVarsResolvePerProvider(t *testing.T) {
+	spec := VarSpec{
+		Default:    "m",
+		DefaultSet: true,
+		ByProvider: map[string]string{"daytona": "a0.m"},
+	}
+	c := &Case{Name: "c", Vars: map[string]VarSpec{"expected_size": spec}}
+
+	for _, tc := range []struct{ provider, want string }{
+		{"daytona", "a0.m"}, // provider entry wins
+		{"e2b", "m"},        // falls back to the default
+		{"", "m"},           // no provider selected (runner unit tests)
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			r, err := New(Options{
+				BinPath:         "/bin/true",
+				RunDir:          t.TempDir(),
+				SandboxProvider: tc.provider,
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if err := r.applyCaseVars(c); err != nil {
+				t.Fatalf("applyCaseVars: %v", err)
+			}
+			got, err := substituteString("{{expected_size}}", r.vars)
+			if err != nil {
+				t.Fatalf("substituteString: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("provider %q: got %q, want %q", tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
+// A scalar var is a constant for every provider, so the common
+// non-conditional case stays a one-liner in the case file.
+func TestCaseVarScalarAppliesToEveryProvider(t *testing.T) {
+	c := &Case{
+		Name: "c",
+		Vars: map[string]VarSpec{"fixed": {Value: "always", scalar: true}},
+	}
+	r, err := New(Options{BinPath: "/bin/true", RunDir: t.TempDir(), SandboxProvider: "vercel"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := r.applyCaseVars(c); err != nil {
+		t.Fatalf("applyCaseVars: %v", err)
+	}
+	if got := r.vars["fixed"]; got != "always" {
+		t.Fatalf("got %q, want %q", got, "always")
+	}
+}
+
+// A mapping with no default that does not cover the selected provider is
+// rejected at load time, but guard the runtime path too: resolution must fail
+// loudly rather than leave the var undefined and surface as a confusing
+// "undefined template var" mid-case.
+func TestCaseVarsUnresolvableProviderIsAnError(t *testing.T) {
+	c := &Case{
+		Name: "c",
+		Vars: map[string]VarSpec{
+			"expected_size": {ByProvider: map[string]string{"daytona": "a0.m"}},
+		},
+	}
+	r, err := New(Options{BinPath: "/bin/true", RunDir: t.TempDir(), SandboxProvider: "e2b"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	err = r.applyCaseVars(c)
+	if err == nil {
+		t.Fatal("expected an error for a provider the var does not cover")
+	}
+	if !strings.Contains(err.Error(), "expected_size") || !strings.Contains(err.Error(), "e2b") {
+		t.Fatalf("error should name the var and the provider, got: %v", err)
+	}
+}
+
+func TestLoadCaseVarsValidation(t *testing.T) {
+	valid := map[string]string{
+		"scalar":             "name: c\nvars:\n  v: fixed\nsteps: [{name: s, cmd: [x]}]\n",
+		"default only":       "name: c\nvars:\n  v:\n    default: m\nsteps: [{name: s, cmd: [x]}]\n",
+		"default plus one":   "name: c\nvars:\n  v:\n    default: m\n    daytona: a0.m\nsteps: [{name: s, cmd: [x]}]\n",
+		"all providers":      "name: c\nvars:\n  v:\n    daytona: a\n    e2b: b\n    freestyle: c\n    vercel: d\nsteps: [{name: s, cmd: [x]}]\n",
+		"empty string value": "name: c\nvars:\n  v:\n    default: \"\"\nsteps: [{name: s, cmd: [x]}]\n",
+	}
+	for label, content := range valid {
+		t.Run("valid/"+label, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "case.yaml")
+			writeFile(t, path, content)
+			if _, err := LoadCase(path); err != nil {
+				t.Fatalf("expected %s to load, got: %v", label, err)
+			}
+		})
+	}
+
+	invalid := map[string]string{
+		// A typo'd provider key would otherwise fall through to the default on
+		// every provider, so the case asserts nothing provider-specific.
+		"unknown provider key": "name: c\nvars:\n  v:\n    default: m\n    daytonaa: a0.m\nsteps: [{name: s, cmd: [x]}]\n",
+		// No default and an unlisted provider would fail mid-case instead.
+		"partial without default": "name: c\nvars:\n  v:\n    daytona: a0.m\nsteps: [{name: s, cmd: [x]}]\n",
+		"empty mapping":           "name: c\nvars:\n  v: {}\nsteps: [{name: s, cmd: [x]}]\n",
+		"reserved run_id":         "name: c\nvars:\n  run_id: x\nsteps: [{name: s, cmd: [x]}]\n",
+		"reserved provider":       "name: c\nvars:\n  sandbox_provider: x\nsteps: [{name: s, cmd: [x]}]\n",
+		"unreferenceable name":    "name: c\nvars:\n  \"a/b\": x\nsteps: [{name: s, cmd: [x]}]\n",
+		"not scalar or mapping":   "name: c\nvars:\n  v: [a, b]\nsteps: [{name: s, cmd: [x]}]\n",
+		// A capture reusing the name would change what {{v}} means partway
+		// through the case.
+		"capture shadows var": "name: c\nvars:\n  v: x\nsteps: [{name: s, cmd: [x], capture: {v: $.name}}]\n",
+	}
+	for label, content := range invalid {
+		t.Run("invalid/"+label, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "case.yaml")
+			writeFile(t, path, content)
+			if _, err := LoadCase(path); err == nil {
+				t.Fatalf("expected %s to be rejected", label)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes E2E case handling so size assertions and requested sizes are provider-correct instead of hardcoded for Daytona.

## Problem

- `expected_size` assertions in the base-snapshot cases were hardcoded to a single value, but sandbox size strings are provider-specific (Daytona returns `a0.m`, others returned bare `m`).
- The CLI's `--size` flag validated against a hardcoded `{xs,m,l,xl}` list that duplicated (and had drifted from) the API's vocabulary, which spans two generations (`a0.xs`..`a0.xl`, `a1.tiny`..`a1.xlarge`) gated per provider. This made E2B sandbox creation impossible from the CLI, since E2B only publishes `a1.*` templates and the CLI refused to send anything but `a0.*` aliases.

## Changes

- Add a case-level `vars` block that resolves per-provider values (`default` plus optional per-provider overrides) before substitution, so cases can request/assert provider-appropriate values via `{{var}}` in argv, `resource.name`, and assertions.
- Reject invalid `vars` at load time (unknown provider key, missing `default` when a provider is omitted, or a name collision with `run_id`/`sandbox_provider`/a `capture` var), caught offline by `TestE2ECaseFilesLoad`.
- Move the supported-provider set into the runner (`SupportedSandboxProviders`) as the single source shared by `-sandbox-provider` validation and `vars` key checking.
- Drop the CLI's `AllowedSizes`/`ValidateSize`; pass `--size` through and let the server reject unknown values with a 400. `ValidatePreset` stays, since presets are a closed local-image concern.
- Update affected case files to request/assert sizes per provider (e.g. `xs` default, `a1.tiny` for e2b; base-snapshot cases now expect `a0.m` rather than bare `m`).

## Verification

Ran the full `api-*.yaml` suite against a local API server, serially, for both providers:

- daytona: 12/12
- e2b: 12/12 (was 5/12 before; every sandbox-creating case previously failed at its first step with `snapshot_not_found`)

`a1.small`, `a1.large`, and `a1.xlarge` have templates but no case exercises them yet.
