### PR TITLE
Require the host as well as the scheme in buildCloneUrl, and export it

### DIFF
--- a/js/sandbox/src/index.ts
+++ b/js/sandbox/src/index.ts
@@ -74,6 +74,7 @@ export { buildLifecycleCommands } from "./providers/shared/lifecycle-commands";
 export { EXEC_INPUT_STAGING_ROOT } from "./providers/shared/exec-input";
 export { shellQuote } from "./util/shell";
 export {
+  buildCloneUrl,
   buildGitCheckoutNewBranchCmd,
   buildGitSetPlainRemoteCmd,
   buildRefreshClonedRepoScript,

--- a/js/sandbox/src/util/git-clone.test.ts
+++ b/js/sandbox/src/util/git-clone.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildCloneUrl,
   buildGitCheckoutNewBranchCmd,
   buildGitSetPlainRemoteCmd,
   buildRefreshClonedRepoScript,
@@ -76,5 +77,75 @@ describe("buildRefreshClonedRepoScript", () => {
 
     expect(script).not.toContain("git submodule");
     expect(script).toContain("git checkout -f -B 'main'");
+  });
+});
+
+// The token is a GitHub App installation token or a PAT. Git sends whatever is in
+// a URL's userinfo to whatever host the URL names, and a clone may persist the
+// result into `.git/config` — so what this embeds it into decides where a
+// credential can end up.
+describe("buildCloneUrl", () => {
+  const TOKEN = "ghs_installation_token";
+
+  it("authenticates an https github.com clone", () => {
+    expect(buildCloneUrl("https://github.com/acme/widgets", TOKEN)).toBe(
+      `https://x-access-token:${TOKEN}@github.com/acme/widgets`,
+    );
+  });
+
+  it("never sends the token to another host", () => {
+    for (const url of [
+      "https://gitlab.com/group/project",
+      "https://github.com.example.test/acme/widgets",
+      "https://example.test/acme/widgets",
+      "https://127.0.0.1:8080/acme/widgets",
+    ]) {
+      expect(buildCloneUrl(url, TOKEN), url).toBe(url);
+    }
+  });
+
+  it("never sends the token over plaintext http", () => {
+    expect(buildCloneUrl("http://github.com/acme/widgets", TOKEN)).toBe(
+      "http://github.com/acme/widgets",
+    );
+  });
+
+  it("ignores the case of the host", () => {
+    expect(buildCloneUrl("https://GitHub.com/acme/widgets", TOKEN)).toContain(
+      `x-access-token:${TOKEN}@`,
+    );
+  });
+
+  it("leaves a non-URL alone rather than making it usable", () => {
+    for (const value of [
+      "ext::sh -c id",
+      "--upload-pack=/bin/sh",
+      "/etc/passwd",
+      "git@github.com:acme/widgets.git",
+    ]) {
+      expect(buildCloneUrl(value, TOKEN), value).toBe(value);
+    }
+  });
+
+  it("clones anonymously when there is no token", () => {
+    for (const token of [undefined, null, ""]) {
+      expect(buildCloneUrl("https://github.com/acme/widgets", token)).toBe(
+        "https://github.com/acme/widgets",
+      );
+    }
+  });
+
+  // Percent-encoded via URL.password rather than spliced into the authority, so
+  // a token containing URL-significant characters cannot reshape the URL.
+  it("encodes the token rather than splicing it in", () => {
+    const built = buildCloneUrl(
+      "https://github.com/acme/widgets",
+      "tok/en?with#chars",
+    );
+
+    expect(built).toBe(
+      "https://x-access-token:tok%2Fen%3Fwith%23chars@github.com/acme/widgets",
+    );
+    expect(new URL(built).hostname).toBe("github.com");
   });
 });

--- a/js/sandbox/src/util/git-clone.ts
+++ b/js/sandbox/src/util/git-clone.ts
@@ -93,7 +93,27 @@ export function assertValidGitRemoteUrl(repoUrl: string): void {
   }
 }
 
-/** Embed a `x-access-token:<token>` credential into an HTTPS clone URL. */
+/**
+ * The clone URL, carrying an `x-access-token:<token>` credential **only when the
+ * URL is github.com over https**.
+ *
+ * Both conditions matter, because git sends whatever is in a URL's userinfo to
+ * whatever host the URL names, and a clone may `git remote set-url` the result
+ * into `.git/config`:
+ *
+ *  - **the scheme**, or the credential travels in the clear;
+ *  - **the host**, or a caller that takes a repository URL from untrusted input
+ *    hands its GitHub credential to whatever host that URL named.
+ *
+ * The host check costs nothing: the token is a GitHub App installation token or
+ * a PAT, so it is only ever meaningful to github.com. Anything else clones
+ * anonymously — which works for a public repository and fails to authenticate
+ * for a private one, the correct failure either way.
+ *
+ * Exported from the package barrel deliberately. Consumers that build their own
+ * clone commands need this decision made in one place; without it they each grow
+ * a near-copy, and the weakest one becomes reachable.
+ */
 export function buildCloneUrl(
   repoUrl: string,
   githubToken?: string | null,
@@ -103,13 +123,18 @@ export function buildCloneUrl(
   }
   try {
     const url = new URL(repoUrl);
-    if (url.protocol !== "https:") {
+    if (
+      url.protocol !== "https:" ||
+      url.hostname.toLowerCase() !== "github.com"
+    ) {
       return repoUrl;
     }
     url.username = "x-access-token";
     url.password = githubToken;
     return url.toString();
   } catch {
+    // Not a URL at all — an `ext::` transport, a bare path. Nothing to
+    // authenticate, and nothing this should make more usable.
     return repoUrl;
   }
 }


### PR DESCRIPTION
`buildCloneUrl` embeds an `x-access-token:<token>` credential into a clone URL,
and checked only that the scheme was https — not the host.

Git sends whatever is in a URL's userinfo to whatever host the URL names, and a
clone may `git remote set-url` the result into `.git/config`. So a caller that
takes a repository URL from untrusted input could have the credential delivered
to the host that URL named, and left on disk there.

Requiring the host as well **costs nothing**: the token is a GitHub App
installation token or a PAT, so it is only ever meaningful to github.com.
Anything else now clones anonymously — which works for a public repository and
fails to authenticate for a private one, the correct failure either way.

## Also exported from the barrel

It wasn't exported, so consumers that build their own clone commands each grew a
near-copy with its own guard. A decision about where a credential may travel
wants one implementation rather than several that can drift apart — and when they
do drift, the weakest one is the one that becomes reachable.

## Tests

`buildCloneUrl` had none. It has seven now:

- each condition **independently** — dropping the host check fails
  "never sends the token to another host", dropping the scheme check fails
  "never sends the token over plaintext http" (both verified by mutation)
- the host comparison is case-insensitive
- non-URL inputs (`ext::`, a leading `-`, a bare path, scp-style) are returned
  untouched rather than made more usable
- the no-token path, for `undefined` / `null` / `""`
- the token is percent-encoded via `URL.password` rather than spliced into the
  authority, so one containing URL-significant characters can't reshape the URL

Package suite: 380 passing, typecheck and lint clean.
