### PR TITLE
Stop compinit aborting in E2B sandboxes

### DIFF
--- a/go/internal/sandbox/sandbox-image/assets/stable/.zshrc
+++ b/go/internal/sandbox/sandbox-image/assets/stable/.zshrc
@@ -28,9 +28,27 @@ HISTSIZE=1000
 SAVEHIST=1000
 HISTFILE=~/.zsh_history
 
-# Use modern completion system
+# Use modern completion system.
+#
+# -u skips compinit's security audit of $fpath. Without it, a world-writable
+# completion directory makes compinit stop and ask
+#
+#   Ignore insecure directories and files and continue [y] or abort compinit [n]?
+#
+# There is nobody to answer that in a sandbox and usually no terminal either, so
+# zsh gives up and every shell starts with "compinit: initialization aborted"
+# and zero completions. E2B's template builder ends with an unconditional
+# `chmod -R 777 /usr/local`, which hits /usr/local/share/zsh/site-functions, so
+# this is reachable on a stock image with no user involvement.
+#
+# Skipping the audit rather than ignoring it (-i) is deliberate: -i drops the
+# offending directory from $fpath, silently losing any completion installed
+# there. A sandbox is a single trust domain — the runtime user already has
+# passwordless sudo — so there is no privilege boundary for the audit to
+# protect. Amika still repairs the directory modes at boot; this only keeps a
+# permissions surprise from ever hanging a shell.
 autoload -Uz compinit
-compinit
+compinit -u
 
 zstyle ':completion:*' auto-description 'specify: %d'
 zstyle ':completion:*' completer _expand _complete _correct _approximate

--- a/sandbox-image/assets/stable/.zshrc
+++ b/sandbox-image/assets/stable/.zshrc
@@ -28,9 +28,27 @@ HISTSIZE=1000
 SAVEHIST=1000
 HISTFILE=~/.zsh_history
 
-# Use modern completion system
+# Use modern completion system.
+#
+# -u skips compinit's security audit of $fpath. Without it, a world-writable
+# completion directory makes compinit stop and ask
+#
+#   Ignore insecure directories and files and continue [y] or abort compinit [n]?
+#
+# There is nobody to answer that in a sandbox and usually no terminal either, so
+# zsh gives up and every shell starts with "compinit: initialization aborted"
+# and zero completions. E2B's template builder ends with an unconditional
+# `chmod -R 777 /usr/local`, which hits /usr/local/share/zsh/site-functions, so
+# this is reachable on a stock image with no user involvement.
+#
+# Skipping the audit rather than ignoring it (-i) is deliberate: -i drops the
+# offending directory from $fpath, silently losing any completion installed
+# there. A sandbox is a single trust domain — the runtime user already has
+# passwordless sudo — so there is no privilege boundary for the audit to
+# protect. Amika still repairs the directory modes at boot; this only keeps a
+# permissions surprise from ever hanging a shell.
 autoload -Uz compinit
-compinit
+compinit -u
 
 zstyle ':completion:*' auto-description 'specify: %d'
 zstyle ':completion:*' completer _expand _complete _correct _approximate


### PR DESCRIPTION
## Problem

Every shell in an E2B sandbox starts like this:

```
not interactive and can't open terminal
compinit: initialization aborted
```

and loads **zero** completions. With a TTY it's worse — it blocks on a `[y/n]` prompt.

## Root cause

E2B's template builder ends its finalize phase with an unconditional `chmod -R 777 /usr/local` ([`e2b-dev/infra`, `packages/orchestrator/pkg/template/build/phases/finalize/configure.sh#L95`](https://github.com/e2b-dev/infra/blob/main/packages/orchestrator/pkg/template/build/phases/finalize/configure.sh)). It's indiscriminate — in a built template all ~68k paths under `/usr/local`, files included, come back `0777`.

Two of them are in zsh's default `$fpath`:

```
$ zsh -f -c 'autoload -Uz compaudit; compaudit'
There are insecure directories:
/usr/local/share/zsh/site-functions
/usr/local/share/zsh
```

`compinit` audits `$fpath` and its parents, refuses a world-writable entry, and stops to ask whether to continue. Nothing in a sandbox answers that prompt, and there's usually no terminal, so zsh gives up.

Confirmed it's E2B and not our build: every mode under `/usr/local` has a ctime in the same 5-second window that E2B dropped `/usr/local/share/e2b` in — two days after our Docker build finished. `/usr/share/zsh`, outside `/usr/local`, is untouched at `0755`.

## Change

`compinit` → `compinit -u` in the sandbox `.zshrc`, plus the regenerated mirror under `go/internal/sandbox/`.

`-u` skips the audit. A sandbox is a single trust domain — the runtime user already holds passwordless sudo — so the audit protects a boundary that doesn't exist here.

**Why not `-i`:** it silences the prompt by *dropping* the offending directory from `$fpath`, silently losing any completion later installed there. `-u` keeps it.

## Verification

Run in a live E2B sandbox with the directories set back to `0777`:

| `.zshrc` | result |
|----------|--------|
| before   | `compinit: initialization aborted`, `comps=0` |
| after    | clean, `comps=1748`, `site-functions` still in `$fpath` |

`python3 sandbox-image/generate.py --check` clean; `make test-sandbox-image` passes (its `shellcheck` step couldn't run in my sandbox — no apt network — but this change touches no linted shell script).

## Related

The companion change in `amika-mono` restores `0755` on those two directories at boot, so the audit passes honestly and completions installed there keep working. This PR is the seatbelt: it stops a permissions surprise from ever hanging a shell again.