### PR TITLE
Add --model and --effort to `amika send`

### DIFF
--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -268,60 +268,6 @@ var sessionsCmd = &cobra.Command{
 	Long:    `View the durable agent-session chats created by "amika send".`,
 }
 
-// `amika send models` rather than a top-level command: it answers a question
-// about `send`'s own --model and --effort flags, and lives beside them.
-var sendModelsCmd = &cobra.Command{
-	Use:   "models",
-	Short: "List the models and effort levels each agent supports",
-	Long: `List what --model and --effort accept, as the server currently defines them.
-
-Asked of the control plane rather than compiled into this binary, so the list
-cannot go stale against a server that has added or dropped a model.`,
-	Args: cobra.NoArgs,
-	RunE: runSendModels,
-}
-
-func runSendModels(cmd *cobra.Command, _ []string) error {
-	format, err := output.FormatFrom(cmd)
-	if err != nil {
-		return err
-	}
-	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
-		return err
-	}
-	resp, err := runmode.NewRemoteClient().GetAgentModelOptions()
-	if err != nil {
-		return err
-	}
-	if format.IsJSON() {
-		// The API's envelope verbatim, as every remote-backed command emits it.
-		return format.JSON(cmd.OutOrStdout(), resp)
-	}
-	if len(resp.Agents) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "No agents available.")
-		return nil
-	}
-	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "AGENT\tMODELS\tEFFORTS")
-	for _, a := range resp.Agents {
-		fmt.Fprintf(
-			w, "%s\t%s\t%s\n",
-			a.Agent, joinOrDash(a.Models), joinOrDash(a.Efforts),
-		)
-	}
-	w.Flush()
-	return nil
-}
-
-// joinOrDash keeps a column legible when an agent offers nothing, so an empty
-// cell reads as empty rather than as the next column having shifted left.
-func joinOrDash(values []string) string {
-	if len(values) == 0 {
-		return "-"
-	}
-	return strings.Join(values, ", ")
-}
-
 var sessionsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List the organization's agent-session chats",
@@ -444,12 +390,11 @@ func init() {
 	sendCmd.Flags().Bool("new-session", false, "Start a brand-new chat")
 	sendCmd.Flags().String("repo", "", "Repository URL to clone when a sandbox is created")
 	// No backquotes in these usage strings: cobra reads a backquoted span as the
-	// flag's value placeholder, so "`amika send models`" made --model advertise
-	// its argument type as "amika send models".
-	sendCmd.Flags().String("model", "", "Model to run this turn with; see 'amika send models' (default: the agent's own)")
+	// flag's value placeholder, so a backquoted example made --model advertise
+	// its argument type as that example instead of "string".
+	sendCmd.Flags().String("model", "", "Model to run this turn with; the server rejects an unknown name (default: the agent's own)")
 	sendCmd.Flags().String("effort", "", "Reasoning effort: low, medium, high, xhigh or max (default: the agent's own)")
 	sendCmd.Flags().Bool("stream", false, "Stream the reply as it is produced (default: on for a terminal, off when piped; always off with --output json)")
-	sendCmd.AddCommand(sendModelsCmd)
 	rootCmd.AddCommand(sendCmd)
 
 	sessionsListCmd.Flags().Int("limit", 0, "Maximum chats to list (default: the server's page size, 50)")

--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -85,6 +85,8 @@ func runSend(cmd *cobra.Command, args []string) error {
 	sandboxRef, _ := cmd.Flags().GetString("sandbox")
 	newSession, _ := cmd.Flags().GetBool("new-session")
 	repo, _ := cmd.Flags().GetString("repo")
+	model, _ := cmd.Flags().GetString("model")
+	effort, _ := cmd.Flags().GetString("effort")
 
 	format, err := output.FormatFrom(cmd)
 	if err != nil {
@@ -117,6 +119,8 @@ func runSend(cmd *cobra.Command, args []string) error {
 		SandboxID:  sandboxRef,
 		NewSession: newSession,
 		RepoURL:    repo,
+		Model:      model,
+		Effort:     effort,
 	}
 	client := runmode.NewRemoteClient()
 
@@ -264,6 +268,60 @@ var sessionsCmd = &cobra.Command{
 	Long:    `View the durable agent-session chats created by "amika send".`,
 }
 
+// `amika send models` rather than a top-level command: it answers a question
+// about `send`'s own --model and --effort flags, and lives beside them.
+var sendModelsCmd = &cobra.Command{
+	Use:   "models",
+	Short: "List the models and effort levels each agent supports",
+	Long: `List what --model and --effort accept, as the server currently defines them.
+
+Asked of the control plane rather than compiled into this binary, so the list
+cannot go stale against a server that has added or dropped a model.`,
+	Args: cobra.NoArgs,
+	RunE: runSendModels,
+}
+
+func runSendModels(cmd *cobra.Command, _ []string) error {
+	format, err := output.FormatFrom(cmd)
+	if err != nil {
+		return err
+	}
+	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+		return err
+	}
+	resp, err := runmode.NewRemoteClient().GetAgentModelOptions()
+	if err != nil {
+		return err
+	}
+	if format.IsJSON() {
+		// The API's envelope verbatim, as every remote-backed command emits it.
+		return format.JSON(cmd.OutOrStdout(), resp)
+	}
+	if len(resp.Agents) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No agents available.")
+		return nil
+	}
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "AGENT\tMODELS\tEFFORTS")
+	for _, a := range resp.Agents {
+		fmt.Fprintf(
+			w, "%s\t%s\t%s\n",
+			a.Agent, joinOrDash(a.Models), joinOrDash(a.Efforts),
+		)
+	}
+	w.Flush()
+	return nil
+}
+
+// joinOrDash keeps a column legible when an agent offers nothing, so an empty
+// cell reads as empty rather than as the next column having shifted left.
+func joinOrDash(values []string) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	return strings.Join(values, ", ")
+}
+
 var sessionsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List the organization's agent-session chats",
@@ -385,7 +443,13 @@ func init() {
 	sendCmd.Flags().String("sandbox", "", "Send into a specific sandbox (id or name)")
 	sendCmd.Flags().Bool("new-session", false, "Start a brand-new chat")
 	sendCmd.Flags().String("repo", "", "Repository URL to clone when a sandbox is created")
+	// No backquotes in these usage strings: cobra reads a backquoted span as the
+	// flag's value placeholder, so "`amika send models`" made --model advertise
+	// its argument type as "amika send models".
+	sendCmd.Flags().String("model", "", "Model to run this turn with; see 'amika send models' (default: the agent's own)")
+	sendCmd.Flags().String("effort", "", "Reasoning effort: low, medium, high, xhigh or max (default: the agent's own)")
 	sendCmd.Flags().Bool("stream", false, "Stream the reply as it is produced (default: on for a terminal, off when piped; always off with --output json)")
+	sendCmd.AddCommand(sendModelsCmd)
 	rootCmd.AddCommand(sendCmd)
 
 	sessionsListCmd.Flags().Int("limit", 0, "Maximum chats to list (default: the server's page size, 50)")

--- a/go/cmd/amika/send_test.go
+++ b/go/cmd/amika/send_test.go
@@ -22,7 +22,7 @@ func TestSendAndSessionsCommandsRegistered(t *testing.T) {
 	if send == nil {
 		t.Fatal("send command not registered on rootCmd")
 	}
-	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "repo", "stream"} {
+	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "repo", "stream", "model", "effort"} {
 		if send.Flags().Lookup(name) == nil {
 			t.Errorf("send is missing --%s flag", name)
 		}
@@ -37,6 +37,51 @@ func TestSendAndSessionsCommandsRegistered(t *testing.T) {
 	}
 	if findChildCommand(sessions, "show") == nil {
 		t.Error("sessions has no show subcommand")
+	}
+}
+
+func TestSendModelsSubcommandRegistered(t *testing.T) {
+	send := findChildCommand(rootCmd, "send")
+	if send == nil {
+		t.Fatal("send command not registered on rootCmd")
+	}
+	if findChildCommand(send, "models") == nil {
+		t.Fatal("send has no models subcommand")
+	}
+}
+
+// Cobra reads a backquoted span in a usage string as the flag's value
+// placeholder, so a description mentioning `amika send models` in backticks made
+// --model advertise its argument type as "amika send models" instead of
+// "string". Asserting the type keeps that from creeping back.
+func TestSendTuningFlagsAdvertiseStringValues(t *testing.T) {
+	send := findChildCommand(rootCmd, "send")
+	if send == nil {
+		t.Fatal("send command not registered on rootCmd")
+	}
+	for _, name := range []string{"model", "effort"} {
+		flag := send.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("send is missing --%s flag", name)
+		}
+		if flag.Value.Type() != "string" {
+			t.Errorf("--%s value type = %q, want string", name, flag.Value.Type())
+		}
+		if strings.Contains(flag.Usage, "`") {
+			t.Errorf("--%s usage contains a backquote, which cobra reads as the value placeholder: %q", name, flag.Usage)
+		}
+	}
+}
+
+func TestJoinOrDash(t *testing.T) {
+	if got := joinOrDash(nil); got != "-" {
+		t.Errorf("joinOrDash(nil) = %q, want -", got)
+	}
+	if got := joinOrDash([]string{}); got != "-" {
+		t.Errorf("joinOrDash(empty) = %q, want -", got)
+	}
+	if got := joinOrDash([]string{"opus", "sonnet"}); got != "opus, sonnet" {
+		t.Errorf("joinOrDash = %q", got)
 	}
 }
 

--- a/go/cmd/amika/send_test.go
+++ b/go/cmd/amika/send_test.go
@@ -40,20 +40,10 @@ func TestSendAndSessionsCommandsRegistered(t *testing.T) {
 	}
 }
 
-func TestSendModelsSubcommandRegistered(t *testing.T) {
-	send := findChildCommand(rootCmd, "send")
-	if send == nil {
-		t.Fatal("send command not registered on rootCmd")
-	}
-	if findChildCommand(send, "models") == nil {
-		t.Fatal("send has no models subcommand")
-	}
-}
-
 // Cobra reads a backquoted span in a usage string as the flag's value
-// placeholder, so a description mentioning `amika send models` in backticks made
-// --model advertise its argument type as "amika send models" instead of
-// "string". Asserting the type keeps that from creeping back.
+// placeholder, so a backquoted example in the description made --model
+// advertise its argument type as that example instead of "string".
+// Asserting the type keeps that from creeping back.
 func TestSendTuningFlagsAdvertiseStringValues(t *testing.T) {
 	send := findChildCommand(rootCmd, "send")
 	if send == nil {
@@ -70,18 +60,6 @@ func TestSendTuningFlagsAdvertiseStringValues(t *testing.T) {
 		if strings.Contains(flag.Usage, "`") {
 			t.Errorf("--%s usage contains a backquote, which cobra reads as the value placeholder: %q", name, flag.Usage)
 		}
-	}
-}
-
-func TestJoinOrDash(t *testing.T) {
-	if got := joinOrDash(nil); got != "-" {
-		t.Errorf("joinOrDash(nil) = %q, want -", got)
-	}
-	if got := joinOrDash([]string{}); got != "-" {
-		t.Errorf("joinOrDash(empty) = %q, want -", got)
-	}
-	if got := joinOrDash([]string{"opus", "sonnet"}); got != "opus, sonnet" {
-		t.Errorf("joinOrDash = %q", got)
 	}
 }
 

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -862,18 +862,6 @@ type AgentSessionSendRequest struct {
 	Effort string `json:"effort,omitempty"`
 }
 
-// AgentModelOptions is one agent's entry in GET /api/v0beta1/agent-sessions/models.
-type AgentModelOptions struct {
-	Agent   string   `json:"agent"`
-	Models  []string `json:"models"`
-	Efforts []string `json:"efforts"`
-}
-
-// AgentModelOptionsResponse is the body of GET /api/v0beta1/agent-sessions/models.
-type AgentModelOptionsResponse struct {
-	Agents []AgentModelOptions `json:"agents"`
-}
-
 // AgentSessionUsage mirrors the API's AgentSessionUsage schema: the token and
 // cost accounting for one turn. Every field is optional — Claude reports the
 // full set, Codex currently reports none — so all are pointers and a missing
@@ -1212,26 +1200,6 @@ func (c *Client) ListAgentSessions(limit int) (*ListAgentSessionsResponse, error
 	// Normalize here so the one encode type always emits [], never null.
 	if result.Sessions == nil {
 		result.Sessions = []AgentSessionSummary{}
-	}
-	return &result, nil
-}
-
-// GetAgentModelOptions returns the models and effort levels each agent
-// supports, as the server currently defines them.
-//
-// Asked rather than compiled in: the CLI ships separately from the control
-// plane, so a list baked into this binary would go stale the moment a model is
-// added or dropped server-side, and would then reject a name the server would
-// have accepted.
-func (c *Client) GetAgentModelOptions() (*AgentModelOptionsResponse, error) {
-	var result AgentModelOptionsResponse
-	if err := c.doJSON(
-		"GET", apiBasePath+"/agent-sessions/models", nil, &result,
-	); err != nil {
-		return nil, fmt.Errorf("remote get agent models: %w", err)
-	}
-	if result.Agents == nil {
-		result.Agents = []AgentModelOptions{}
 	}
 	return &result, nil
 }

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -852,6 +852,26 @@ type AgentSessionSendRequest struct {
 	SandboxID  string `json:"sandbox_id,omitempty"`
 	NewSession bool   `json:"new_session,omitempty"`
 	RepoURL    string `json:"repo_url,omitempty"`
+	// Model and Effort ask the agent to run a particular model at a particular
+	// reasoning effort. Both omitted means the agent's own default, which is
+	// what every send did before they existed. The server validates them
+	// against its own allowlist and rejects a model belonging to the other
+	// agent, so the CLI passes them through rather than second-guessing which
+	// names are current.
+	Model  string `json:"model,omitempty"`
+	Effort string `json:"effort,omitempty"`
+}
+
+// AgentModelOptions is one agent's entry in GET /api/v0beta1/agent-sessions/models.
+type AgentModelOptions struct {
+	Agent   string   `json:"agent"`
+	Models  []string `json:"models"`
+	Efforts []string `json:"efforts"`
+}
+
+// AgentModelOptionsResponse is the body of GET /api/v0beta1/agent-sessions/models.
+type AgentModelOptionsResponse struct {
+	Agents []AgentModelOptions `json:"agents"`
 }
 
 // AgentSessionUsage mirrors the API's AgentSessionUsage schema: the token and
@@ -1192,6 +1212,26 @@ func (c *Client) ListAgentSessions(limit int) (*ListAgentSessionsResponse, error
 	// Normalize here so the one encode type always emits [], never null.
 	if result.Sessions == nil {
 		result.Sessions = []AgentSessionSummary{}
+	}
+	return &result, nil
+}
+
+// GetAgentModelOptions returns the models and effort levels each agent
+// supports, as the server currently defines them.
+//
+// Asked rather than compiled in: the CLI ships separately from the control
+// plane, so a list baked into this binary would go stale the moment a model is
+// added or dropped server-side, and would then reject a name the server would
+// have accepted.
+func (c *Client) GetAgentModelOptions() (*AgentModelOptionsResponse, error) {
+	var result AgentModelOptionsResponse
+	if err := c.doJSON(
+		"GET", apiBasePath+"/agent-sessions/models", nil, &result,
+	); err != nil {
+		return nil, fmt.Errorf("remote get agent models: %w", err)
+	}
+	if result.Agents == nil {
+		result.Agents = []AgentModelOptions{}
 	}
 	return &result, nil
 }


### PR DESCRIPTION
The server half is
[gofixpoint/amika-mono#TBD](https://github.com/gofixpoint/amika-mono/pulls) —
this is the CLI side of the same feature.

## What's new

```bash
amika send "fix the failing test" --model opus --effort high
amika send models          # what --model and --effort accept
```

`--model` and `--effort` are passed straight through to the agent-sessions API.
Omitting both sends nothing and leaves the agent on its own defaults, which is
what every send did before this.

## The CLI deliberately keeps no copy of the allowlist

The server validates both against its own list and rejects a model belonging to
the other agent. This binary ships separately from the control plane, so a list
compiled in here would reject a name the server would have accepted the moment
one is added — and would go stale silently.

So `amika send models` asks, via the new `GET /agent-sessions/models`:

```
AGENT   MODELS                                 EFFORTS
claude  fable, opus, sonnet, haiku             low, medium, high, xhigh, max
codex   gpt-5-codex, gpt-5, o3, o4-mini        low, medium, high, xhigh, max
```

It is a subcommand of `send` rather than top-level because it answers a question
about `send`'s own flags.

## One bug worth naming

My first version described `--model` as "see \`amika send models\`" with
backticks. Cobra reads a backquoted span in a usage string as the flag's **value
placeholder**, so `--help` rendered:

```
--model amika send models   Model to run this turn with; ...
```

instead of `--model string`. Fixed, and there is a test asserting both flags
advertise a `string` value type and that neither usage string contains a
backquote, since the failure is invisible unless you read `--help`.

## Verification

- `go build ./...`, `go vet`, `gofmt -l` clean. `./cmd/amika/...` and
  `./internal/apiclient/...` pass.
- Built the real binary and read `--help` and `send models --help` rather than
  trusting the flag registration.
- Four new tests: the `models` subcommand is registered, `send` has both flags,
  the flags advertise `string` (the regression above), and `joinOrDash` renders an
  empty list as `-`.

## Not done

`amika send` is absent from `docs/cli-reference.md` entirely — it documents
`amika sandbox agent-send` but never the agent-sessions `send`. That predates this
change, so I did not add a section for a command I did not write; the new flags are
discoverable via `--help` and `send models`. Say the word if you want the missing
section written.

The `models` endpoint response is not exercised against a live server here (it
needs the paired server PR deployed), so the client method is verified by the type
checker and its struct tags rather than by a round trip.