### PR TITLE
Fix WSL interop binary resolution when appendWindowsPath=false

### DIFF
--- a/go/internal/ssh/wslmirror.go
+++ b/go/internal/ssh/wslmirror.go
@@ -25,7 +25,12 @@ var safeWindowsConfigPath = regexp.MustCompile(`^[A-Za-z]:\\[^/*?:"<>|%\r\n\t'` 
 // runIcacls is a seam over the Windows ACL tool, so tests observe the
 // permission hardening without a Windows side.
 var runIcacls = func(path, user string) error {
-	cmd := exec.Command("icacls.exe", path, "/inheritance:r", "/grant:r", user+":F")
+	binPath, err := wslbridge.ResolveWindowsBin("icacls.exe")
+	if err != nil {
+		return fmt.Errorf("resolve icacls.exe: %w", err)
+	}
+
+	cmd := exec.Command(binPath, path, "/inheritance:r", "/grant:r", user+":F")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("icacls %s: %w: %s", path, err, strings.TrimSpace(string(out)))
 	}

--- a/go/internal/wslbridge/wslbridge.go
+++ b/go/internal/wslbridge/wslbridge.go
@@ -95,7 +95,11 @@ func ResolveTarget() (Target, error) {
 // UserProfile returns the Windows user profile directory (for example
 // C:\Users\name) by asking cmd.exe to expand %USERPROFILE%.
 func UserProfile() (string, error) {
-	out, err := runInterop("cmd.exe", "/c", "echo", "%USERPROFILE%")
+	cmdExe, err := ResolveWindowsBin("cmd.exe")
+	if err != nil {
+		return "", fmt.Errorf("locate cmd.exe (is WSL interop enabled?): %w", err)
+	}
+	out, err := runInterop(cmdExe, "/c", "echo", "%USERPROFILE%")
 	if err != nil {
 		return "", fmt.Errorf("expand %%USERPROFILE%% (is WSL interop enabled?): %w", err)
 	}
@@ -123,17 +127,23 @@ func EditorExe(cli string) (string, error) {
 		return "", fmt.Errorf("unsupported Windows editor %q", cli)
 	}
 	var candidates []string
-	if where, err := runInterop("where.exe", cli); err == nil {
-		if line := firstLine(where); line != "" {
-			if idx := strings.LastIndexByte(line, '\\'); idx > 2 {
-				dir := line[:idx]
-				// The CLI launcher sits one bin\ or cmd\ level below the application
-				// executable, so search the install root it belongs to.
-				lower := strings.ToLower(dir)
-				if strings.HasSuffix(lower, "\\bin") || strings.HasSuffix(lower, "\\cmd") {
-					dir = dir[:strings.LastIndexByte(dir, '\\')]
+	
+	// --- CHANGED BLOCK START ---
+	if whereExe, err := ResolveWindowsBin("where.exe"); err == nil {
+		if where, err := runInterop(whereExe, cli); err == nil {
+			if line := firstLine(where); line != "" {
+	// --- CHANGED BLOCK END ---
+	
+				if idx := strings.LastIndexByte(line, '\\'); idx > 2 {
+					dir := line[:idx]
+					// The CLI launcher sits one bin\ or cmd\ level below the application
+					// executable, so search the install root it belongs to.
+					lower := strings.ToLower(dir)
+					if strings.HasSuffix(lower, "\\bin") || strings.HasSuffix(lower, "\\cmd") {
+						dir = dir[:strings.LastIndexByte(dir, '\\')]
+					}
+					candidates = append(candidates, dir+"\\"+install.exe)
 				}
-				candidates = append(candidates, dir+"\\"+install.exe)
 			}
 		}
 	}
@@ -206,11 +216,39 @@ func LaunchDetached(windowsExe string, args ...string) error {
 			return err
 		}
 	}
+	
+	cmdExe, err := ResolveWindowsBin("cmd.exe")
+	if err != nil {
+		return fmt.Errorf("locate cmd.exe: %w", err)
+	}
+	
 	startArgs := append([]string{"/c", "start", "", windowsExe}, args...)
-	if err := execDetached("cmd.exe", startArgs...); err != nil {
+	if err := execDetached(cmdExe, startArgs...); err != nil {
 		return fmt.Errorf("launch %s: %w", windowsExe, err)
 	}
 	return nil
+}
+
+// ResolveWindowsBin attempts to locate a core Windows executable (e.g. "cmd.exe").
+// It checks the standard $PATH first. If appendWindowsPath=false in wsl.conf,
+// it falls back to dynamically resolving the mount point for System32 via wslpath.
+func ResolveWindowsBin(binName string) (string, error) {
+	if path, err := exec.LookPath(binName); err == nil {
+		return path, nil
+	}
+
+	// Fallback for strict PATH hygiene: derive mount point via wslpath.
+	winPath := `C:\Windows\System32\` + binName
+	wslPath, err := toWSLPath(winPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s via fallback: %w", binName, err)
+	}
+
+	if info, err := os.Stat(wslPath); err != nil || !info.Mode().IsRegular() {
+		return "", fmt.Errorf("fallback %s not found or invalid: %w", wslPath, err)
+	}
+
+	return wslPath, nil
 }
 
 // toWSLPath converts an absolute Windows path to its WSL mount path via


### PR DESCRIPTION
## Description
Fixes #369

When a WSL user configures `/etc/wsl.conf` with `[interop] appendWindowsPath=false` (a common PATH-hygiene practice), core Windows utilities like `cmd.exe`, `where.exe`, and `icacls.exe` fail to resolve via bare execution. This results in misleading errors such as `expand %USERPROFILE% (is WSL interop enabled?)`, even though interop itself is fully enabled.

This PR introduces a fallback mechanism that dynamically resolves these binaries using `wslpath` when they are absent from the Linux `$PATH`. This ensures the CLI and editor handoffs work seamlessly regardless of the user's `appendWindowsPath` setting or custom `automount.root` configurations.

## Changes Made
* **`go/internal/wslbridge/wslbridge.go`**:
  * Added `ResolveWindowsBin`, a helper that attempts standard `$PATH` resolution first, then falls back to resolving `C:\Windows\System32\<bin>` via the existing `toWSLPath` utility.
  * Updated `UserProfile`, `EditorExe`, and `LaunchDetached` to route `cmd.exe` and `where.exe` through the new resolver.
* **`go/internal/ssh/wslmirror.go`**:
  * Updated the `runIcacls` var to resolve `icacls.exe` using `wslbridge.ResolveWindowsBin`.

## Validation
* Standard resolution remains the fast path for default WSL setups (`appendWindowsPath=true`).
* The fallback leverages the existing `toWSLPath` interop seam, ensuring that tests currently mocking `runInterop` continue to function gracefully without requiring major test rewrites.
* Relies on `wslpath` rather than hardcoded `/mnt/c/` paths to strictly respect any custom `automount.root` definitions in `wsl.conf`.