### PR TITLE
Decode the response fields the API client drops

### DIFF
--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -146,12 +146,15 @@ type RemoteSandbox struct {
 	SnapshotName             *string                   `json:"snapshot_name,omitempty"`
 	SandboxPreset            *string                   `json:"sandbox_preset,omitempty"`
 	SandboxSize              *string                   `json:"sandbox_size,omitempty"`
+	GithubAuthMode           *string                   `json:"github_auth_mode,omitempty"`
+	GithubCredProvisioned    *bool                     `json:"github_credential_provisioned,omitempty"`
 	ErrorMessage             *string                   `json:"error_message,omitempty"`
 	State                    string                    `json:"state,omitempty"`
 	Status                   string                    `json:"status,omitempty"`
 	SetupStatus              *string                   `json:"setup_status,omitempty"`
 	URLsExpireAt             *string                   `json:"urls_expire_at,omitempty"`
 	SecretNames              []string                  `json:"secret_names,omitempty"`
+	MountedSecrets           []MountedSecret           `json:"mounted_secrets,omitempty"`
 	HasWorkflow              bool                      `json:"has_workflow,omitempty"`
 	ResolvedAgentCredentials []ResolvedAgentCredential `json:"resolved_agent_credentials,omitempty"`
 	CreatedBy                *RemoteSandboxCreator     `json:"created_by,omitempty"`
@@ -169,6 +172,20 @@ type RemoteSandbox struct {
 type RemoteSandboxCreator struct {
 	Name  *string `json:"name"`
 	Email *string `json:"email"`
+}
+
+// MountedSecret is one entry in RemoteSandbox.MountedSecrets: which secrets a
+// sandbox carries, by name and scope. The API deliberately returns no value and
+// no vault handle, so neither has a field here. Managed distinguishes a
+// credential Amika manages for a provider from a plain user-defined secret; it
+// is the discriminator rather than a null CredentialType, which a managed entry
+// is allowed to have.
+type MountedSecret struct {
+	Name           string  `json:"name"`
+	Scope          string  `json:"scope"`
+	Managed        bool    `json:"managed"`
+	CredentialType *string `json:"credential_type"`
+	Provider       *string `json:"provider"`
 }
 
 // ListSandboxes fetches sandboxes from the remote API.
@@ -455,9 +472,15 @@ func (c *Client) WaitForSandboxSnapshot(ref string) (*SandboxSnapshot, error) {
 
 // SandboxScrubPreview lists the injected secrets a "snapshot and delete" would
 // remove from a sandbox (file paths + env var names only, no values).
+//
+// The schema requires all three fields. RestoredFiles is a third category the
+// scrub performs — paths reset to a retained clean baseline rather than deleted
+// — and is decoded here so the response is not silently truncated; the
+// confirmation prompt does not yet mention it.
 type SandboxScrubPreview struct {
-	Files   []string `json:"files"`
-	EnvVars []string `json:"env_vars"`
+	Files         []string `json:"files"`
+	RestoredFiles []string `json:"restored_files"`
+	EnvVars       []string `json:"env_vars"`
 }
 
 // GetSandboxScrubPreview previews which injected secrets a scrub-and-delete
@@ -747,8 +770,11 @@ type Session struct {
 	StartedAt string                 `json:"started_at"`
 	EndedAt   *string                `json:"ended_at"`
 	Metadata  map[string]interface{} `json:"metadata"`
-	CreatedAt string                 `json:"created_at"`
-	UpdatedAt string                 `json:"updated_at"`
+	// First user message, capped, as computed by the server. Returned on list
+	// responses only, hence omitempty; nullable there, hence a pointer.
+	Preview   *string `json:"preview,omitempty"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
 }
 
 // CreateSessionRequest is the request body for POST /api/v0beta1/sandboxes/{id}/sessions.
@@ -858,9 +884,9 @@ type AgentSessionSendResponse struct {
 }
 
 // AgentSessionSummary is one row of the agent-sessions list. SandboxName,
-// Preview, and EndedAt are nullable in the schema — a chat can outlive the
-// sandbox whose name it shows, carry no user message to preview, and still be
-// running.
+// Preview, Model, Effort, and EndedAt are nullable in the schema — a chat can
+// outlive the sandbox whose name it shows, carry no user message to preview,
+// run at the agent CLI's own model and effort, and still be running.
 type AgentSessionSummary struct {
 	SessionID   string  `json:"session_id"`
 	SandboxID   string  `json:"sandbox_id"`
@@ -868,10 +894,15 @@ type AgentSessionSummary struct {
 	Agent       string  `json:"agent"`
 	Status      string  `json:"status"`
 	Preview     *string `json:"preview"`
-	StartedAt   string  `json:"started_at"`
-	EndedAt     *string `json:"ended_at"`
-	CreatedAt   string  `json:"created_at"`
-	UpdatedAt   string  `json:"updated_at"`
+	// What the chat is set to run and to think at. Null (not absent) means the
+	// agent CLI's own default, which is what every chat ran before these were
+	// settable — so pointers, and no `omitempty`.
+	Model     *string `json:"model"`
+	Effort    *string `json:"effort"`
+	StartedAt string  `json:"started_at"`
+	EndedAt   *string `json:"ended_at"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
 }
 
 // AgentSessionMessage is one turn in an agent-session chat's transcript,

--- a/go/internal/apiclient/client_agent_sessions_test.go
+++ b/go/internal/apiclient/client_agent_sessions_test.go
@@ -104,7 +104,7 @@ func TestSendAgentSession_OmitsUsageWhenAbsent(t *testing.T) {
 
 // TestListAgentSessions_ParsesEnvelope checks the list method unwraps the
 // {sessions,total} envelope and parses the nullable sandbox_name/preview/
-// ended_at fields.
+// model/effort/ended_at fields.
 func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v0beta1/agent-sessions" {
@@ -113,10 +113,12 @@ func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{"sessions":[
           {"session_id":"as_1","sandbox_id":"sbx_1","sandbox_name":"silver-wuhan","agent":"claude",
-           "status":"active","preview":"hi there","started_at":"t0","ended_at":null,
+           "status":"active","preview":"hi there","model":"opus","effort":"high",
+           "started_at":"t0","ended_at":null,
            "created_at":"t0","updated_at":"t1"},
           {"session_id":"as_2","sandbox_id":"sbx_2","sandbox_name":null,"agent":"codex",
-           "status":"ended","preview":null,"started_at":"t0","ended_at":"t2",
+           "status":"ended","preview":null,"model":null,"effort":null,
+           "started_at":"t0","ended_at":"t2",
            "created_at":"t0","updated_at":"t2"}
         ],"total":2}`)
 	}))
@@ -143,11 +145,22 @@ func TestListAgentSessions_ParsesEnvelope(t *testing.T) {
 	if sessions[0].Preview == nil || *sessions[0].Preview != "hi there" {
 		t.Errorf("sessions[0].Preview = %v", sessions[0].Preview)
 	}
+	if sessions[0].Model == nil || *sessions[0].Model != "opus" {
+		t.Errorf("sessions[0].Model = %v", sessions[0].Model)
+	}
+	if sessions[0].Effort == nil || *sessions[0].Effort != "high" {
+		t.Errorf("sessions[0].Effort = %v", sessions[0].Effort)
+	}
 	if sessions[0].EndedAt != nil {
 		t.Errorf("sessions[0].EndedAt = %v, want nil", sessions[0].EndedAt)
 	}
 	if sessions[1].SandboxName != nil || sessions[1].Preview != nil {
 		t.Errorf("sessions[1] should have null sandbox_name/preview: %+v", sessions[1])
+	}
+	// Null means the agent CLI's own default, which is a different fact from
+	// the field being absent; both must survive as a nil pointer.
+	if sessions[1].Model != nil || sessions[1].Effort != nil {
+		t.Errorf("sessions[1] should have null model/effort: %+v", sessions[1])
 	}
 	if sessions[1].EndedAt == nil || *sessions[1].EndedAt != "t2" {
 		t.Errorf("sessions[1].EndedAt = %v, want t2", sessions[1].EndedAt)
@@ -240,6 +253,53 @@ func TestListAgentSessions_ReEmitsEnvelope(t *testing.T) {
 	}
 	if string(out) != `{"sessions":[],"total":7}` {
 		t.Errorf("re-emitted = %s, want the {sessions,total} envelope with []", out)
+	}
+}
+
+// TestListAgentSessions_ReEmitsEveryRequiredKey pins the summary's re-emitted
+// shape against the response schema's required property list. `sessions list
+// -o json` re-encodes what it decoded, so a field the struct has no home for is
+// dropped silently: the CLI parses 12 keys and prints 10, and nothing fails
+// until an e2e schema assertion happens to cover it. Asserting the key set (not
+// just the values) is what catches that, since a dropped key leaves every
+// remaining assertion passing.
+func TestListAgentSessions_ReEmitsEveryRequiredKey(t *testing.T) {
+	// The 12 properties AgentSessionSummary marks required. A nullable field is
+	// still required: the key is always present and may be null.
+	required := []string{
+		"session_id", "sandbox_id", "sandbox_name", "agent", "status",
+		"preview", "model", "effort", "started_at", "ended_at",
+		"created_at", "updated_at",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"sessions":[
+          {"session_id":"as_1","sandbox_id":"sbx_1","sandbox_name":null,"agent":"claude",
+           "status":"active","preview":null,"model":null,"effort":null,
+           "started_at":"t0","ended_at":null,"created_at":"t0","updated_at":"t1"}
+        ],"total":1}`)
+	}))
+	defer srv.Close()
+
+	resp, err := NewClient(srv.URL, "test-token").ListAgentSessions(0)
+	if err != nil {
+		t.Fatalf("ListAgentSessions: %v", err)
+	}
+	out, err := json.Marshal(resp.Sessions[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal re-emitted: %v", err)
+	}
+	for _, k := range required {
+		if _, ok := got[k]; !ok {
+			t.Errorf("re-emitted summary drops required key %q: %s", k, out)
+		}
+	}
+	if len(got) != len(required) {
+		t.Errorf("re-emitted %d keys, want %d: %s", len(got), len(required), out)
 	}
 }
 


### PR DESCRIPTION
## The bug

The server's `AgentSessionSummary` response schema has 12 required
properties. Two of them — `model` and `effort` — had no corresponding field
in the CLI's Go struct, so the client parsed a response, silently dropped
both, and re-emitted only 10 keys under `-o json`. Users of
`amika sessions list` and `amika sessions show` could not see which model or
effort level a chat was running.

Both are `z.string().nullable()` on the response schema (nullable but *not*
optional, so the key is always present and may be null), the same shape as
the existing `sandbox_name`, `preview` and `ended_at` fields. They are
therefore pointers, placed after `Preview` so the marshalled key order
mirrors the server's. `AgentSessionDetail` embeds `AgentSessionSummary`, so
the detail endpoint is covered by the same edit — the fields are not
duplicated there.

The request schema has them as `.nullable().optional()`; that side was
already correct and is unchanged.

## The audit

Every other struct in `client.go` that mirrors a server response schema was
compared field-by-field against the deployed OpenAPI document, checking for
three things: a returned key with no home in the struct, a nullable field
typed as a Go value (where `null` would decode to a zero value), and a
required field marked `omitempty` (where the key vanishes when empty).

Three more instances of the same defect, all fixed here:

| Struct                | Dropped                                                            |
| --------------------- | ------------------------------------------------------------------ |
| `RemoteSandbox`       | `github_auth_mode`, `github_credential_provisioned`, `mounted_secrets` |
| `SandboxScrubPreview` | `restored_files`                                                   |
| `Session`             | `preview`                                                          |

`RemoteSandbox` matters most of the three: its doc comment designates it the
single decode/encode type for round-trip fidelity under `sandbox list -o
json`, so a dropped key is a fact withheld from every consumer.
`mounted_secrets` brings a new `MountedSecret` type, which carries no value
and no vault handle because the API deliberately returns neither.

### Left alone deliberately

`SSHInfo` omits `web_socket_proxy_url` and `private_key`, and types a
nullable `repo_name` as a plain `string`. Unlike the structs above it is
consumed field by field rather than re-emitted as JSON, and the WebSocket
SSH transport reads its credentials by another path, so nothing is currently
lost. Changing it is a behavioral question rather than this mechanical fix,
so it is reported rather than changed.

## Verification

`go -C go build ./...`, `go vet` and the package unit tests pass. (The
`internal/materialize` tests fail in my environment for want of `rsync` on
`PATH`, unrelated to this change.)

The e2e case `api-agent-sessions` needs staging credentials I do not have —
the key available to me authenticates against production, where the case
would create billable sandboxes — so I did not run it. Instead I reproduced
its three failing schema assertions exactly, read-only, against the live API
with `sessions list` and `sessions show`, validating both payloads against
the deployed OpenAPI document:

| Assertion                                    | Before             | After |
| -------------------------------------------- | ------------------ | ----- |
| `ListAgentSessionsResponse` (list as json)   | 10 keys per row    | PASS  |
| `AgentSessionSummary` at `/sessions/0`       | missing `model`, `effort` | PASS |
| `AgentSessionDetail` (show)                  | missing `model`, `effort` | PASS |

The pre-fix binary reproduces the reported error verbatim
(`at '/sessions/0': missing properties 'model', 'effort'`); the fixed one
emits all 12 keys in the server's order. Running the real e2e case against
staging is still worth doing before merge.

### Regression tests (second commit)

The live chat I could read had `model` and `effort` both null, so the check
above proves the keys are present and that null round-trips, but not that a
non-null value survives. The unit tests now cover both, and close the gap that
let this land in the first place:

- `ParsesEnvelope` gains `model`/`effort` in its fixture, in both the set and
  the null case, beside the sibling nullable fields it already covered.
- `ReEmitsEveryRequiredKey` is new: it marshals a summary and asserts all 12
  required properties survive. Asserting the *key set* rather than the values
  is the point — a dropped key leaves every value assertion passing, which is
  why nothing but an e2e caught this.

Both were confirmed to fail against the bug: removing the fields is a compile
error (the parse test references them), and the subtler drift of marking them
`omitempty` — which compiles and only misbehaves when the value is null —
fails with `re-emitted 10 keys, want 12`, the original symptom exactly.

## Out of scope

The human-readable text output of `sessions list` and `sessions show` is
unchanged — surfacing model and effort there is a separate product decision.
I think it is worth doing for `sessions show`, which is already a
detail-oriented vertical listing where two more rows cost nothing; for
`sessions list` the table is already five columns wide, so it would want a
`--long` flag rather than more default columns.