### PR TITLE
Give the TypeScript SDK parity with the amika CLI

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -59,45 +59,116 @@ new AmikaClient({
 
 ## API surface
 
-Methods on `AmikaClient` mirror Go's `*apiclient.Client` 1:1:
+Methods on `AmikaClient` mirror Go's `*apiclient.Client` 1:1, so everything the `amika` CLI can do over the network is reachable from here.
 
-| Method                                | Endpoint                                              |
-| ------------------------------------- | ----------------------------------------------------- |
-| `listSandboxes()`                     | `GET /sandboxes`                                      |
-| `createSandbox(req)`                  | `POST /sandboxes`                                     |
-| `getSandbox(name)`                    | `GET /sandboxes/{name}`                               |
-| `waitForSandbox(name)`                | polls `GET /sandboxes/{name}` until ready             |
-| `getSSH(name)`                        | `POST /sandboxes/{name}/ssh`                          |
-| `revokeSSH(name, token)`              | `DELETE /sandboxes/{name}/ssh`                        |
-| `startSandbox(name)`                  | `POST /sandboxes/{name}/start`                        |
-| `waitForSandboxStart(name)`           | polls until ready                                     |
-| `stopSandbox(name)`                   | `POST /sandboxes/{name}/stop`                         |
-| `waitForSandboxStop(name)`            | polls until `stopped`                                 |
-| `deleteSandbox(name)`                 | `DELETE /sandboxes/{name}`                            |
-| `listSecrets()`                       | `GET /secrets`                                        |
-| `createSecret(req)`                   | `POST /secrets`                                       |
-| `updateSecret(id, req)`               | `PUT /secrets/{id}`                                   |
-| `createProviderSecret(provider, req)` | `POST /secrets/{provider}`                            |
-| `listProviderSecrets(provider)`       | `GET /secrets/{provider}`                             |
-| `deleteProviderSecret(provider, id)`  | `DELETE /secrets/{provider}/{id}`                     |
-| `agentSend(name, req)`                | `POST /sandboxes/{name}/agent-send` (10-min timeout)  |
-| `createSession(name, req)`            | `POST /sandboxes/{name}/sessions`                     |
-| `listSessions(name)`                  | `GET /sandboxes/{name}/sessions`                      |
-| `getLatestSession(name)`              | `GET /sandboxes/{name}/sessions/latest` (null on 404) |
-| `getSession(name, sessionId)`         | `GET /sandboxes/{name}/sessions/{sessionId}`          |
-| `updateSession(name, sessionId, req)` | `PATCH /sandboxes/{name}/sessions/{sessionId}`        |
-| `listSandboxSnapshots(filters?)`      | `GET /sandbox-snapshots`                              |
-| `createSandboxSnapshot(req)`          | `POST /sandbox-snapshots`                             |
-| `getSandboxScrubPreview(ref)`         | `GET /sandbox-snapshots/scrub-preview`                |
-| `deleteSandboxSnapshot(ref)`          | `DELETE /sandbox-snapshots/{ref}`                     |
+### Sandboxes
+
+| Method                      | Endpoint                                  |
+| --------------------------- | ----------------------------------------- |
+| `listSandboxes()`           | `GET /sandboxes`                          |
+| `createSandbox(req)`        | `POST /sandboxes`                         |
+| `getSandbox(name)`          | `GET /sandboxes/{name}`                   |
+| `waitForSandbox(name)`      | polls `GET /sandboxes/{name}` until ready |
+| `startSandbox(name)`        | `POST /sandboxes/{name}/start`            |
+| `waitForSandboxStart(name)` | polls until ready                         |
+| `stopSandbox(name)`         | `POST /sandboxes/{name}/stop`             |
+| `waitForSandboxStop(name)`  | polls until `stopped`                     |
+| `deleteSandbox(name)`       | `DELETE /sandboxes/{name}`                |
+| `listRepositories()`        | `GET /repositories`                       |
+
+### Services
+
+| Method                                           | Endpoint                                        |
+| ------------------------------------------------ | ----------------------------------------------- |
+| `listSandboxServices(sandboxRef?)`               | `GET /sandbox-services`                         |
+| `createSandboxService(sandboxRef, req)`          | `POST /sandboxes/{ref}/services`                |
+| `putSandboxService(sandboxRef, serviceRef, req)` | `PUT /sandboxes/{ref}/services/{serviceRef}`    |
+| `deleteSandboxService(sandboxRef, serviceRef)`   | `DELETE /sandboxes/{ref}/services/{serviceRef}` |
+
+### SSH
+
+| Method                        | Endpoint                               |
+| ----------------------------- | -------------------------------------- |
+| `getSSH(name)`                | `POST /sandboxes/{name}/ssh`           |
+| `revokeSSH(name, token)`      | `DELETE /sandboxes/{name}/ssh`         |
+| `createSSHSession(sandboxId)` | `POST /sandboxes/{id}/ssh-sessions`    |
+| `createSSHPublicKey(req)`     | `POST /secrets/ssh-public-keys`        |
+| `listSSHPublicKeys()`         | `GET /secrets/ssh-public-keys`         |
+| `deleteSSHPublicKey(id)`      | `DELETE /secrets/ssh-public-keys/{id}` |
+
+### Secrets
+
+| Method                                | Endpoint                          |
+| ------------------------------------- | --------------------------------- |
+| `listSecrets()`                       | `GET /secrets`                    |
+| `createSecret(req)`                   | `POST /secrets`                   |
+| `updateSecret(id, req)`               | `PUT /secrets/{id}`               |
+| `createProviderSecret(provider, req)` | `POST /secrets/{provider}`        |
+| `listProviderSecrets(provider)`       | `GET /secrets/{provider}`         |
+| `deleteProviderSecret(provider, id)`  | `DELETE /secrets/{provider}/{id}` |
+
+### Agents and sessions
+
+| Method                                  | Endpoint                                              |
+| --------------------------------------- | ----------------------------------------------------- |
+| `agentSend(name, req)`                  | `POST /sandboxes/{name}/agent-send` (10-min timeout)  |
+| `sendAgentSession(req)`                 | `POST /agent-sessions` (10-min timeout)               |
+| `sendAgentSessionStream(req, handlers)` | `POST /agent-sessions/stream` (SSE)                   |
+| `listAgentSessions(limit?)`             | `GET /agent-sessions`                                 |
+| `getAgentSession(sessionId)`            | `GET /agent-sessions/{sessionId}`                     |
+| `createSession(name, req)`              | `POST /sandboxes/{name}/sessions`                     |
+| `listSessions(name)`                    | `GET /sandboxes/{name}/sessions`                      |
+| `getLatestSession(name)`                | `GET /sandboxes/{name}/sessions/latest` (null on 404) |
+| `getSession(name, sessionId)`           | `GET /sandboxes/{name}/sessions/{sessionId}`          |
+| `updateSession(name, sessionId, req)`   | `PATCH /sandboxes/{name}/sessions/{sessionId}`        |
+
+### Snapshots
+
+| Method                           | Endpoint                               |
+| -------------------------------- | -------------------------------------- |
+| `listSandboxSnapshots(filters?)` | `GET /sandbox-snapshots`               |
+| `createSandboxSnapshot(req)`     | `POST /sandbox-snapshots`              |
+| `getSandboxSnapshot(ref)`        | `GET /sandbox-snapshots/{ref}`         |
+| `waitForSandboxSnapshot(ref)`    | polls until `active` or `failed`       |
+| `getSandboxScrubPreview(ref)`    | `GET /sandbox-snapshots/scrub-preview` |
+| `deleteSandboxSnapshot(ref)`     | `DELETE /sandbox-snapshots/{ref}`      |
 
 Fork a new sandbox from a captured snapshot by passing its slug as `snapshot` to `createSandbox({ snapshot })`.
 
-Types are camelCased and translated to/from snake_case on the wire. See `src/types.ts` for the full set: `CreateSandboxRequest`, `RemoteSandbox`, `SSHInfo`, `Secret`, `CreateProviderSecretRequest`, `AgentSendRequest`, `AgentSendResponse`, `Session`, `SandboxSnapshot`, `CreateSandboxSnapshotRequest`, etc.
+Types are camelCased and translated to/from snake_case on the wire. See `src/types.ts` and `src/agent-sessions.ts` for the full set: `CreateSandboxRequest`, `RemoteSandbox`, `SSHInfo`, `Secret`, `CreateProviderSecretRequest`, `AgentSendRequest`, `AgentSendResponse`, `Session`, `SandboxSnapshot`, `SandboxServiceResource`, `AgentSessionSendRequest`, `AgentSessionDetail`, etc.
+
+### Nullability
+
+Field optionality follows the API schema, not TypeScript convenience:
+
+- a field the schema marks required and non-nullable is `x: string`;
+- a field it marks nullable is `x: string | null` (it is always present, and `null` is meaningful — e.g. a sandbox with no repository);
+- a field it marks optional is `x?: string`, with `null` and absent both surfacing as `undefined`.
+
+## Streaming an agent turn
+
+`sendAgentSessionStream` reads the SSE endpoint and resolves with the same response `sendAgentSession` returns, after forwarding progress to your handlers:
+
+```ts
+const result = await amika.sendAgentSessionStream(
+  { message: "Add a CHANGELOG", repoUrl: "git@github.com:org/proj.git" },
+  {
+    onStatus: (phase, sandboxId) => console.error(`[${phase}] ${sandboxId}`),
+    onDelta: (text) => process.stdout.write(text),
+  },
+);
+console.log(`\nsession ${result.sessionId} on sandbox ${result.sandboxId}`);
+```
+
+The server enforces a 300s ceiling on the request, below the client's 10-minute timeout. If it cuts the stream before a terminal frame, the call throws and the turn may still have completed — check `listAgentSessions()` for the session rather than assuming the work was lost.
 
 ## Polling behavior
 
-`waitForSandbox`, `waitForSandboxStart`, and `waitForSandboxStop` poll `getSandbox` every **3 seconds** with **no client-side timeout**, matching Go's `WaitForSandbox`. They throw `AmikaError` if the sandbox enters `failed` state, including the server's `errorMessage` when present.
+`waitForSandbox`, `waitForSandboxStart`, and `waitForSandboxStop` poll `getSandbox` every **3 seconds** with **no client-side timeout**, matching Go's `WaitForSandbox`. They throw `AmikaError` if the sandbox enters `failed` state, including the server's `errorMessage` when present. `waitForSandboxSnapshot` polls `getSandboxSnapshot` the same way, returning once the snapshot is `active` and throwing if it ends up `failed`.
+
+## SSH helpers
+
+`createSSHSession` returns a one-shot transport descriptor for dialing a sandbox over SSH, and validates it before handing it back — a descriptor for the wrong sandbox, on the wrong transport, or with a malformed connect URL, credential, or host key throws `InvalidSSHSessionError`. `isValidSSHSession` exposes the same check, and `canonicalEd25519PublicKey` validates an OpenSSH ed25519 public key line and returns it in the canonical, comment-stripped form the server stores (`""` if it is not a well-formed ed25519 key). Use it before `createSSHPublicKey` so a typo fails locally.
 
 ## Errors
 
@@ -149,3 +220,5 @@ pnpm test:functional
 Optional env vars: `AMIKA_TEST_REPO_URL`, `AMIKA_TEST_PRESET`, `AMIKA_TEST_AGENT_NAME`, `AMIKA_TEST_AGENT_CREDENTIAL_NAME`, `AMIKA_TEST_AGENT_CREDENTIAL_TYPE`, `AMIKA_TEST_BRANCH`, `AMIKA_TEST_SANDBOX_NAME_PREFIX`, `AMIKA_TEST_PROVIDER`, `AMIKA_TEST_SANDBOX_PROVIDER`. See `test/functional/helpers.ts` for details.
 
 The suite provisions a real sandbox and runs the full lifecycle (create → wait → list → get → SSH → sessions → agentSend → stop → start → delete), so a single run takes several minutes and creates billable resources. Sandboxes are cleaned up in `afterAll`, but the secrets API has no delete endpoint — test-created secrets accumulate.
+
+`org-resources.functional.test.ts` is the exception: it only reads org-scoped listings and round-trips one SSH public key, so it provisions nothing and finishes in seconds. Run it alone with `pnpm test:functional org-resources`.

--- a/sdk/typescript/src/agent-sessions.ts
+++ b/sdk/typescript/src/agent-sessions.ts
@@ -1,0 +1,296 @@
+// Types and stream handling for the `/agent-sessions` endpoints — the chat
+// surface behind `amika send` and `amika sessions list|show`. Mirrors the Go
+// types in go/internal/apiclient/client.go; see src/types.ts for the
+// nullability convention.
+
+import { AmikaError } from "@/errors";
+import { readSSEFrames } from "@/sse";
+import {
+  bool,
+  mapArray,
+  nullableStr,
+  num,
+  optionalBool,
+  optionalNum,
+  optionalStr,
+  str,
+} from "@/types";
+
+/**
+ * Request body for POST /api/v0beta1/agent-sessions. Only `message` is
+ * required: `sessionId` continues an existing chat, `sandboxId` routes into a
+ * specific sandbox, and `repoUrl` is used only when a sandbox has to be
+ * created behind the scenes.
+ */
+export interface AgentSessionSendRequest {
+  message: string;
+  agent?: string;
+  sessionId?: string;
+  sandboxId?: string;
+  newSession?: boolean;
+  repoUrl?: string;
+}
+
+export function agentSessionSendRequestToWire(
+  r: AgentSessionSendRequest,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { message: r.message };
+  if (r.agent !== undefined) out["agent"] = r.agent;
+  if (r.sessionId !== undefined) out["session_id"] = r.sessionId;
+  if (r.sandboxId !== undefined) out["sandbox_id"] = r.sandboxId;
+  if (r.newSession !== undefined) out["new_session"] = r.newSession;
+  if (r.repoUrl !== undefined) out["repo_url"] = r.repoUrl;
+  return out;
+}
+
+/**
+ * Token and cost accounting for one turn. Every field is optional — Claude
+ * reports the full set, Codex currently reports none.
+ */
+export interface AgentSessionUsage {
+  costUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  durationMs?: number;
+  numTurns?: number;
+}
+
+function agentSessionUsageFromWire(
+  w: Record<string, unknown>,
+): AgentSessionUsage {
+  return {
+    costUsd: optionalNum(w["cost_usd"]),
+    inputTokens: optionalNum(w["input_tokens"]),
+    outputTokens: optionalNum(w["output_tokens"]),
+    cacheReadTokens: optionalNum(w["cache_read_tokens"]),
+    cacheCreationTokens: optionalNum(w["cache_creation_tokens"]),
+    durationMs: optionalNum(w["duration_ms"]),
+    numTurns: optionalNum(w["num_turns"]),
+  };
+}
+
+/**
+ * Response of POST /api/v0beta1/agent-sessions. `sessionId` is the durable
+ * chat id to pass back as `sessionId` to continue the chat.
+ */
+export interface AgentSessionSendResponse {
+  sessionId: string;
+  sandboxId: string;
+  agent: string;
+  response: string;
+  isError: boolean;
+  isNewSession: boolean;
+  createdSandbox: boolean;
+  usage?: AgentSessionUsage;
+}
+
+export function agentSessionSendResponseFromWire(
+  w: Record<string, unknown>,
+): AgentSessionSendResponse {
+  const usage = w["usage"];
+  return {
+    sessionId: str(w["session_id"]),
+    sandboxId: str(w["sandbox_id"]),
+    agent: str(w["agent"]),
+    response: str(w["response"]),
+    isError: bool(w["is_error"]),
+    isNewSession: bool(w["is_new_session"]),
+    createdSandbox: bool(w["created_sandbox"]),
+    usage:
+      typeof usage === "object" && usage !== null
+        ? agentSessionUsageFromWire(usage as Record<string, unknown>)
+        : undefined,
+  };
+}
+
+/**
+ * One row of the agent-sessions list. `sandboxName`, `preview`, `model`,
+ * `effort`, and `endedAt` are nullable: a chat can outlive the sandbox whose
+ * name it shows, carry no user message to preview, run at the agent CLI's own
+ * model and effort, and still be running.
+ */
+export interface AgentSessionSummary {
+  sessionId: string;
+  sandboxId: string;
+  sandboxName: string | null;
+  agent: string;
+  status: string;
+  preview: string | null;
+  model: string | null;
+  effort: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function agentSessionSummaryFromWire(
+  w: Record<string, unknown>,
+): AgentSessionSummary {
+  return {
+    sessionId: str(w["session_id"]),
+    sandboxId: str(w["sandbox_id"]),
+    sandboxName: nullableStr(w["sandbox_name"]),
+    agent: str(w["agent"]),
+    status: str(w["status"]),
+    preview: nullableStr(w["preview"]),
+    model: nullableStr(w["model"]),
+    effort: nullableStr(w["effort"]),
+    startedAt: str(w["started_at"]),
+    endedAt: nullableStr(w["ended_at"]),
+    createdAt: str(w["created_at"]),
+    updatedAt: str(w["updated_at"]),
+  };
+}
+
+/**
+ * One turn in a chat transcript. `isError` marks an assistant turn the agent
+ * reported as failed; it is absent on user turns and on transcripts that
+ * predate per-turn error tracking.
+ */
+export interface AgentSessionMessage {
+  role: string;
+  content: string;
+  timestamp: string;
+  isError?: boolean;
+}
+
+function agentSessionMessageFromWire(
+  w: Record<string, unknown>,
+): AgentSessionMessage {
+  return {
+    role: str(w["role"]),
+    content: str(w["content"]),
+    timestamp: str(w["timestamp"]),
+    isError: optionalBool(w["is_error"]),
+  };
+}
+
+/** An {@link AgentSessionSummary} plus the chat's full transcript. */
+export interface AgentSessionDetail extends AgentSessionSummary {
+  messages: AgentSessionMessage[];
+}
+
+export function agentSessionDetailFromWire(
+  w: Record<string, unknown>,
+): AgentSessionDetail {
+  return {
+    ...agentSessionSummaryFromWire(w),
+    messages: mapArray(w["messages"], agentSessionMessageFromWire),
+  };
+}
+
+/**
+ * One page of chats plus the total matching the query. `total` exceeds
+ * `sessions.length` when the page cuts the list short; report that rather than
+ * presenting a truncated list as the whole of it.
+ */
+export interface ListAgentSessionsResponse {
+  sessions: AgentSessionSummary[];
+  total: number;
+}
+
+export function listAgentSessionsResponseFromWire(
+  w: Record<string, unknown>,
+): ListAgentSessionsResponse {
+  return {
+    sessions: mapArray(w["sessions"], agentSessionSummaryFromWire),
+    total: num(w["total"]),
+  };
+}
+
+/**
+ * Progress callbacks for {@link AmikaClient.sendAgentSessionStream}. Both are
+ * optional and are awaited in order as frames arrive. `onStatus` reports
+ * lifecycle milestones (`creating_sandbox` / `sandbox_ready`, the latter
+ * carrying the sandbox id); `onDelta` receives agent reply text as it is
+ * produced.
+ */
+export interface AgentSessionStreamHandlers {
+  onStatus?: (phase: string, sandboxId: string) => void;
+  onDelta?: (text: string) => void;
+}
+
+/**
+ * Consume the send SSE stream, dispatching `status`/`delta` frames to the
+ * handlers and returning the terminal `done` result.
+ *
+ * A completed turn wins over an `error` frame: `done` carries the persisted
+ * result, so if both somehow arrive the send succeeded and reporting the error
+ * would discard a real session id.
+ */
+export async function readAgentSessionStream(
+  body: ReadableStream<Uint8Array>,
+  handlers: AgentSessionStreamHandlers,
+): Promise<AgentSessionSendResponse> {
+  let streamError = "";
+
+  for await (const frame of readSSEFrames(body)) {
+    switch (frame.event) {
+      case "status": {
+        if (!handlers.onStatus) break;
+        // Cosmetic progress only, so an unparseable frame is ignored.
+        const parsed = tryParse(frame.data);
+        if (parsed) {
+          handlers.onStatus(str(parsed["phase"]), str(parsed["sandbox_id"]));
+        }
+        break;
+      }
+      case "delta": {
+        // A delta carries reply text, so an unparseable one is lost output.
+        // Fail loudly rather than silently returning a truncated reply.
+        const parsed = tryParse(frame.data);
+        if (!parsed) {
+          throw new AmikaError(
+            "remote agent-session send: parsing delta frame failed",
+          );
+        }
+        const text = str(parsed["text"]);
+        if (text !== "" && handlers.onDelta) handlers.onDelta(text);
+        break;
+      }
+      case "done": {
+        const parsed = tryParse(frame.data);
+        if (!parsed) {
+          throw new AmikaError(
+            "remote agent-session send: parsing done frame failed",
+          );
+        }
+        // `done` is terminal: stop reading so a later frame cannot discard a
+        // completed turn's result.
+        return agentSessionSendResponseFromWire(parsed);
+      }
+      case "error": {
+        const parsed = tryParse(frame.data);
+        streamError = optionalStr(parsed?.["error"]) || "stream error";
+        break;
+      }
+    }
+  }
+
+  if (streamError !== "") {
+    throw new AmikaError(`remote agent-session send: ${streamError}`);
+  }
+  // No terminal frame. The most likely cause is the server's own request
+  // ceiling (300s) cutting the stream mid-turn — the turn may well have
+  // completed and persisted, so point at the session list rather than
+  // implying the work was lost.
+  throw new AmikaError(
+    "remote agent-session send: stream ended without a result " +
+      "(the server may have hit its request time limit; " +
+      "check listAgentSessions() for the session)",
+  );
+}
+
+function tryParse(data: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,5 +1,23 @@
+import {
+  type AgentSessionDetail,
+  agentSessionDetailFromWire,
+  type AgentSessionSendRequest,
+  type AgentSessionSendResponse,
+  agentSessionSendRequestToWire,
+  agentSessionSendResponseFromWire,
+  type AgentSessionStreamHandlers,
+  type ListAgentSessionsResponse,
+  listAgentSessionsResponseFromWire,
+  readAgentSessionStream,
+} from "@/agent-sessions";
 import { AmikaError, AmikaHTTPError, extractAgentAuthError } from "@/errors";
 import { HTTPClient } from "@/http";
+import {
+  InvalidSSHSessionError,
+  isValidSSHSession,
+  type SSHSession,
+  sshSessionFromWire,
+} from "@/ssh-session";
 import { StaticTokenSource, type TokenSource } from "@/token";
 import {
   type AgentSendRequest,
@@ -12,22 +30,34 @@ import {
   createSandboxSnapshotRequestToWire,
   type CreateSecretRequest,
   type CreateSessionRequest,
+  type CreateSSHPublicKeyRequest,
   createSandboxRequestToWire,
   createSessionRequestToWire,
+  createSSHPublicKeyRequestToWire,
+  mapArray,
   type ProviderSecretListItem,
   type ProviderSecretSummary,
+  type RemoteRepository,
+  remoteRepositoryFromWire,
   type RemoteSandbox,
   remoteSandboxFromWire,
   type RevokeSSHRequest,
   type SandboxScrubPreview,
   sandboxScrubPreviewFromWire,
+  type SandboxServiceRequest,
+  type SandboxServiceResource,
+  sandboxServiceRequestToWire,
+  sandboxServiceResourceFromWire,
   type SandboxSnapshot,
   sandboxSnapshotFromWire,
   type Secret,
+  secretFromWire,
   type Session,
   sessionFromWire,
   type SSHInfo,
   sshInfoFromWire,
+  type SSHPublicKeySummary,
+  sshPublicKeySummaryFromWire,
   type UpdateSecretRequest,
   type UpdateSessionRequest,
   updateSessionRequestToWire,
@@ -70,14 +100,11 @@ export class AmikaClient {
   // ---------- Sandboxes ----------
 
   async listSandboxes(): Promise<RemoteSandbox[]> {
-    const data =
-      (await this.http.doJSON<unknown[]>(
-        "GET",
-        `${API_BASE_PATH}/sandboxes`,
-      )) ?? [];
-    return data.map((item) =>
-      remoteSandboxFromWire(item as Record<string, unknown>),
+    const data = await this.http.doJSON<unknown[]>(
+      "GET",
+      `${API_BASE_PATH}/sandboxes`,
     );
+    return mapArray(data, remoteSandboxFromWire);
   }
 
   async createSandbox(req: CreateSandboxRequest): Promise<RemoteSandbox> {
@@ -167,13 +194,141 @@ export class AmikaClient {
     );
   }
 
+  // ---------- Repositories ----------
+
+  /** List the repositories the caller's org knows about. */
+  async listRepositories(): Promise<RemoteRepository[]> {
+    const data = await this.http.doJSON<unknown[]>(
+      "GET",
+      `${API_BASE_PATH}/repositories`,
+    );
+    return mapArray(data, remoteRepositoryFromWire);
+  }
+
+  // ---------- Sandbox services ----------
+
+  /**
+   * List live services for the caller's org. `sandboxRef` is an optional
+   * name-or-id filter; omit it to list every service in the org.
+   */
+  async listSandboxServices(
+    sandboxRef?: string,
+  ): Promise<SandboxServiceResource[]> {
+    const params = new URLSearchParams();
+    if (sandboxRef) params.set("sandbox_ref", sandboxRef);
+    const qs = params.toString();
+    const envelope = await this.http.doJSON<{ items?: unknown[] }>(
+      "GET",
+      `${API_BASE_PATH}/sandbox-services${qs ? `?${qs}` : ""}`,
+    );
+    return mapArray(envelope?.items, sandboxServiceResourceFromWire);
+  }
+
+  /**
+   * Create a service on the sandbox referenced by name or id (the server
+   * resolves id first, then name).
+   */
+  async createSandboxService(
+    sandboxRef: string,
+    req: SandboxServiceRequest,
+  ): Promise<SandboxServiceResource> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "POST",
+      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services`,
+      sandboxServiceRequestToWire(req),
+    );
+    return sandboxServiceResourceFromWire(data ?? {});
+  }
+
+  /**
+   * Fully replace the service identified by `serviceRef` within a sandbox.
+   * `by` selects how `serviceRef` is resolved and defaults to `name`.
+   */
+  async putSandboxService(
+    sandboxRef: string,
+    serviceRef: string,
+    req: SandboxServiceRequest,
+    by: "name" | "id" | "ref" = "name",
+  ): Promise<SandboxServiceResource> {
+    const params = new URLSearchParams({ by });
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "PUT",
+      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?${params.toString()}`,
+      sandboxServiceRequestToWire(req),
+    );
+    return sandboxServiceResourceFromWire(data ?? {});
+  }
+
+  /** Delete the service with the given name within a sandbox. */
+  async deleteSandboxService(
+    sandboxRef: string,
+    serviceRef: string,
+  ): Promise<void> {
+    await this.http.doJSON(
+      "DELETE",
+      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?by=name`,
+    );
+  }
+
+  // ---------- SSH sessions and public keys ----------
+
+  /**
+   * Create a fresh transport descriptor for one SSH dial into a sandbox, and
+   * validate it. Throws {@link InvalidSSHSessionError} if the server returns a
+   * descriptor that is unsafe or is not for `sandboxId`.
+   */
+  async createSSHSession(sandboxId: string): Promise<SSHSession> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "POST",
+      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxId)}/ssh-sessions`,
+    );
+    const session = sshSessionFromWire(data ?? {});
+    if (!isValidSSHSession(session, sandboxId)) {
+      throw new InvalidSSHSessionError();
+    }
+    return session;
+  }
+
+  /**
+   * Store a user-scoped SSH public key. The endpoint upserts by name, so
+   * re-uploading identical material under the same name is a no-op.
+   */
+  async createSSHPublicKey(
+    req: CreateSSHPublicKeyRequest,
+  ): Promise<SSHPublicKeySummary> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "POST",
+      `${API_BASE_PATH}/secrets/ssh-public-keys`,
+      createSSHPublicKeyRequestToWire(req),
+    );
+    return sshPublicKeySummaryFromWire(data ?? {});
+  }
+
+  /** List the caller's user-scoped SSH public keys. */
+  async listSSHPublicKeys(): Promise<SSHPublicKeySummary[]> {
+    const data = await this.http.doJSON<unknown[]>(
+      "GET",
+      `${API_BASE_PATH}/secrets/ssh-public-keys`,
+    );
+    return mapArray(data, sshPublicKeySummaryFromWire);
+  }
+
+  /** Remove one of the caller's SSH public keys by id. */
+  async deleteSSHPublicKey(id: string): Promise<void> {
+    await this.http.doJSON(
+      "DELETE",
+      `${API_BASE_PATH}/secrets/ssh-public-keys/${encodeURIComponent(id)}`,
+    );
+  }
+
   // ---------- Secrets ----------
 
   async listSecrets(): Promise<Secret[]> {
-    const data =
-      (await this.http.doJSON<Secret[]>("GET", `${API_BASE_PATH}/secrets`)) ??
-      [];
-    return data;
+    const data = await this.http.doJSON<unknown[]>(
+      "GET",
+      `${API_BASE_PATH}/secrets`,
+    );
+    return mapArray(data, secretFromWire);
   }
 
   async createSecret(req: CreateSecretRequest): Promise<void> {
@@ -347,6 +502,37 @@ export class AmikaClient {
   }
 
   /**
+   * Fetch a single snapshot by name or id (the server resolves id first, then
+   * name).
+   */
+  async getSandboxSnapshot(ref: string): Promise<SandboxSnapshot> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "GET",
+      `${API_BASE_PATH}/sandbox-snapshots/${encodeURIComponent(ref)}?by=ref`,
+    );
+    return sandboxSnapshotFromWire(data ?? {});
+  }
+
+  /**
+   * Poll {@link getSandboxSnapshot} every 3 seconds until the snapshot reaches
+   * a terminal state. Returns it once `active`; throws `AmikaError` if it ends
+   * up `failed`. No client-side timeout — matches Go's
+   * `WaitForSandboxSnapshot`.
+   */
+  async waitForSandboxSnapshot(ref: string): Promise<SandboxSnapshot> {
+    for (;;) {
+      const snapshot = await this.getSandboxSnapshot(ref);
+      if (snapshot.state === "active") return snapshot;
+      if (snapshot.state === "failed") {
+        throw new AmikaError(
+          snapshot.errorMessage || "sandbox snapshot capture failed",
+        );
+      }
+      await sleep(WAIT_POLL_INTERVAL_MS);
+    }
+  }
+
+  /**
    * Preview which injected secrets a scrub-and-delete snapshot would remove
    * from a sandbox (file paths + env var names only, no values). `sandboxRef`
    * is a name or id; the server resolves id first, then name.
@@ -371,6 +557,80 @@ export class AmikaClient {
       "DELETE",
       `${API_BASE_PATH}/sandbox-snapshots/${encodeURIComponent(ref)}?by=ref`,
     );
+  }
+
+  // ---------- Agent sessions ----------
+
+  /**
+   * Send a message to a coding agent, creating a sandbox behind the scenes
+   * when the chat has none, or routing to an existing sandbox or session. The
+   * endpoint is synchronous, so it uses the same 10-minute timeout as
+   * {@link agentSend}.
+   *
+   * Unlike {@link agentSend}, a provider auth failure comes back as a normal
+   * response with `isError` set and the agent CLI's own message in `response`,
+   * not as an HTTP error.
+   */
+  async sendAgentSession(
+    req: AgentSessionSendRequest,
+  ): Promise<AgentSessionSendResponse> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "POST",
+      `${API_BASE_PATH}/agent-sessions`,
+      agentSessionSendRequestToWire(req),
+      { timeoutMs: AGENT_SEND_TIMEOUT_MS },
+    );
+    return agentSessionSendResponseFromWire(data ?? {});
+  }
+
+  /**
+   * The streaming counterpart to {@link sendAgentSession}: forwards `status`
+   * and `delta` frames to `handlers` as they arrive and resolves with the same
+   * response the buffered endpoint returns.
+   *
+   * The effective time limit is the server's (a 300s request ceiling), which
+   * is lower than the client's 10 minutes: it ends the stream first, without a
+   * terminal frame, and the client timeout only guards a connection that hangs
+   * past even that.
+   */
+  async sendAgentSessionStream(
+    req: AgentSessionSendRequest,
+    handlers: AgentSessionStreamHandlers = {},
+  ): Promise<AgentSessionSendResponse> {
+    const { body, release } = await this.http.openStream(
+      "POST",
+      `${API_BASE_PATH}/agent-sessions/stream`,
+      agentSessionSendRequestToWire(req),
+      { timeoutMs: AGENT_SEND_TIMEOUT_MS },
+    );
+    try {
+      return await readAgentSessionStream(body, handlers);
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * List the org's agent-session chats, newest first. Omitting `limit` leaves
+   * the server's default page size (50) in place. The response's `total`
+   * exceeds `sessions.length` when the page cuts the list short.
+   */
+  async listAgentSessions(limit?: number): Promise<ListAgentSessionsResponse> {
+    const qs = limit && limit > 0 ? `?limit=${limit}` : "";
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "GET",
+      `${API_BASE_PATH}/agent-sessions${qs}`,
+    );
+    return listAgentSessionsResponseFromWire(data ?? {});
+  }
+
+  /** Fetch one agent-session chat with its message history. */
+  async getAgentSession(sessionId: string): Promise<AgentSessionDetail> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "GET",
+      `${API_BASE_PATH}/agent-sessions/${encodeURIComponent(sessionId)}`,
+    );
+    return agentSessionDetailFromWire(data ?? {});
   }
 }
 

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -1,4 +1,4 @@
-import { AmikaHTTPError } from "@/errors";
+import { AmikaError, AmikaHTTPError } from "@/errors";
 import type { TokenSource } from "@/token";
 
 export interface HTTPClientOptions {
@@ -13,6 +13,17 @@ export interface HTTPClientOptions {
 export interface RequestOptions {
   /** Override the default timeout for a single request. */
   timeoutMs?: number;
+}
+
+/**
+ * A streaming response body plus the cleanup its caller owes. `release` clears
+ * the request's timeout, so it must be called once the body is fully consumed
+ * (or abandoned) — until then the timeout still applies to the whole stream,
+ * not just the response headers.
+ */
+export interface StreamHandle {
+  body: ReadableStream<Uint8Array>;
+  release: () => void;
 }
 
 /**
@@ -44,10 +55,82 @@ export class HTTPClient {
     body?: unknown,
     requestOptions?: RequestOptions,
   ): Promise<T | null> {
-    const url = this.baseUrl + path;
+    const { response, release } = await this.send(
+      method,
+      path,
+      body,
+      undefined,
+      requestOptions,
+    );
+
+    let text: string;
+    try {
+      text = await response.text();
+    } finally {
+      release();
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new AmikaHTTPError(response.status, text);
+    }
+
+    if (text.length === 0) return null;
+    return JSON.parse(text) as T;
+  }
+
+  /**
+   * Open a Server-Sent Events response and hand back its body unread. A
+   * rejection (auth, validation) arrives as a normal JSON error before the
+   * stream opens and is surfaced as `AmikaHTTPError`, exactly as it would be
+   * on the buffered path.
+   */
+  async openStream(
+    method: string,
+    path: string,
+    body?: unknown,
+    requestOptions?: RequestOptions,
+  ): Promise<StreamHandle> {
+    const { response, release } = await this.send(
+      method,
+      path,
+      body,
+      "text/event-stream",
+      requestOptions,
+    );
+
+    if (response.status < 200 || response.status >= 300) {
+      let text: string;
+      try {
+        text = await response.text();
+      } finally {
+        release();
+      }
+      throw new AmikaHTTPError(response.status, text);
+    }
+
+    if (!response.body) {
+      release();
+      throw new AmikaError("stream response has no body");
+    }
+    return { body: response.body, release };
+  }
+
+  /**
+   * Issue one authenticated request and return the response with the timeout
+   * still armed. The caller must invoke `release` once it is done with the
+   * body; nothing else here clears the timer.
+   */
+  private async send(
+    method: string,
+    path: string,
+    body: unknown,
+    accept: string | undefined,
+    requestOptions: RequestOptions | undefined,
+  ): Promise<{ response: Response; release: () => void }> {
     const headers: Record<string, string> = {};
     const token = await this.tokenSource.token();
     headers["Authorization"] = `Bearer ${token}`;
+    if (accept) headers["Accept"] = accept;
 
     let serialized: string | undefined;
     if (body !== undefined && body !== null) {
@@ -58,26 +141,20 @@ export class HTTPClient {
     const timeoutMs = requestOptions?.timeoutMs ?? this.defaultTimeoutMs;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const release = () => clearTimeout(timer);
 
     let response: Response;
     try {
-      response = await this.fetchImpl(url, {
+      response = await this.fetchImpl(this.baseUrl + path, {
         method,
         headers,
         body: serialized,
         signal: controller.signal,
       });
-    } finally {
-      clearTimeout(timer);
+    } catch (err) {
+      release();
+      throw err;
     }
-
-    const text = await response.text();
-
-    if (response.status < 200 || response.status >= 300) {
-      throw new AmikaHTTPError(response.status, text);
-    }
-
-    if (text.length === 0) return null;
-    return JSON.parse(text) as T;
+    return { response, release };
   }
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -6,6 +6,25 @@ export { AmikaError, AmikaHTTPError, extractAgentAuthError } from "@/errors";
 export { StaticTokenSource } from "@/token";
 export type { TokenSource } from "@/token";
 
+export {
+  canonicalEd25519PublicKey,
+  InvalidSSHSessionError,
+  isValidSSHSession,
+  SSH_SESSION_TRANSPORT_DIRECT_WS,
+} from "@/ssh-session";
+export type { SSHSession, SSHSessionTransport } from "@/ssh-session";
+
+export type {
+  AgentSessionDetail,
+  AgentSessionMessage,
+  AgentSessionSendRequest,
+  AgentSessionSendResponse,
+  AgentSessionStreamHandlers,
+  AgentSessionSummary,
+  AgentSessionUsage,
+  ListAgentSessionsResponse,
+} from "@/agent-sessions";
+
 export type {
   AgentCredentialRef,
   AgentSendRequest,
@@ -15,15 +34,23 @@ export type {
   CreateSandboxSnapshotRequest,
   CreateSecretRequest,
   CreateSessionRequest,
+  CreateSSHPublicKeyRequest,
+  ExperimentalDaytonaSnapshot,
+  MountedSecret,
   ProviderSecretListItem,
   ProviderSecretSummary,
+  RemoteRepository,
   RemoteSandbox,
   RemoteSandboxCreator,
+  RemoteSandboxService,
   ResolvedAgentCredential,
   RevokeSSHRequest,
   SandboxScrubPreview,
+  SandboxServiceRequest,
+  SandboxServiceResource,
   SandboxSnapshot,
   SSHInfo,
+  SSHPublicKeySummary,
   Secret,
   Session,
   UpdateSecretRequest,

--- a/sdk/typescript/src/sse.ts
+++ b/sdk/typescript/src/sse.ts
@@ -1,0 +1,87 @@
+/**
+ * Minimal Server-Sent Events frame reader, matching the parser Go's
+ * `readAgentSessionStream` uses so both transports accept the same streams.
+ *
+ * Only the subset the Amika API emits is handled: `event:` and `data:` lines
+ * terminated by a blank line. Comments (`:`), `id:`, and `retry:` are ignored,
+ * and a frame with no `event:` line is dropped (the protocol never sends the
+ * default `message` event) — but its buffered data is still discarded, so it
+ * cannot bleed into the next frame.
+ */
+export interface SSEFrame {
+  event: string;
+  data: string;
+}
+
+/**
+ * Yield each complete frame from an SSE response body. A trailing frame not
+ * followed by a blank line is flushed at end of stream, and a final line
+ * without a newline is parsed. Cancels the underlying reader when the consumer
+ * stops early.
+ */
+export async function* readSSEFrames(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<SSEFrame> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+
+  let event = "";
+  let data = "";
+
+  // Returns the completed frame when `line` terminates one, else undefined.
+  const consumeLine = (raw: string): SSEFrame | undefined => {
+    const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+    if (line === "") {
+      const frame = event === "" ? undefined : { event, data };
+      event = "";
+      data = "";
+      return frame;
+    }
+    if (line.startsWith("event:")) {
+      // The space after the colon is optional in SSE; strip exactly one.
+      event = stripOneSpace(line.slice("event:".length));
+      return undefined;
+    }
+    if (line.startsWith("data:")) {
+      // SSE joins multiple data lines with \n; the server emits one line.
+      if (data.length > 0) data += "\n";
+      data += stripOneSpace(line.slice("data:".length));
+    }
+    return undefined;
+  };
+
+  let buffer = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      buffer += value
+        ? decoder.decode(value, { stream: true })
+        : decoder.decode();
+
+      let newline = buffer.indexOf("\n");
+      while (newline !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        const frame = consumeLine(line);
+        if (frame) yield frame;
+        newline = buffer.indexOf("\n");
+      }
+
+      if (done) break;
+    }
+
+    // A final line need not be newline-terminated.
+    if (buffer.length > 0) {
+      const frame = consumeLine(buffer);
+      if (frame) yield frame;
+    }
+    // Flush a trailing frame that never saw its blank line (defensive).
+    if (event !== "") yield { event, data };
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+}
+
+function stripOneSpace(value: string): string {
+  return value.startsWith(" ") ? value.slice(1) : value;
+}

--- a/sdk/typescript/src/ssh-session.ts
+++ b/sdk/typescript/src/ssh-session.ts
@@ -1,0 +1,231 @@
+// The SSH transport descriptor behind `amika ssh`, `amika code`, and
+// `amika scp`, plus the key validation those commands rely on. Mirrors
+// go/internal/apiclient/ssh_session.go.
+
+import { AmikaError } from "@/errors";
+import { str } from "@/types";
+
+/** Thrown when an SSH session descriptor is unsafe or internally inconsistent. */
+export class InvalidSSHSessionError extends AmikaError {
+  override name = "InvalidSSHSessionError";
+
+  constructor() {
+    super("invalid SSH session descriptor");
+  }
+}
+
+/** How the stdio proxy reaches the sandbox. Only `direct_ws` exists today. */
+export type SSHSessionTransport = "direct_ws";
+
+/** The provider-exposed no-relay transport. */
+export const SSH_SESSION_TRANSPORT_DIRECT_WS: SSHSessionTransport = "direct_ws";
+
+/** The transport descriptor returned for one SSH dial. */
+export interface SSHSession {
+  sessionId: string;
+  transport: SSHSessionTransport | string;
+  connectUrl: string;
+  connectCredential: string;
+  sandboxId: string;
+  sshUser: string;
+  hostPublicKey: string;
+}
+
+export function sshSessionFromWire(w: Record<string, unknown>): SSHSession {
+  return {
+    sessionId: str(w["session_id"]),
+    transport: str(w["transport"]),
+    connectUrl: str(w["connect_url"]),
+    connectCredential: str(w["connect_credential"]),
+    sandboxId: str(w["sandbox_id"]),
+    sshUser: str(w["ssh_user"]),
+    hostPublicKey: str(w["host_public_key"]),
+  };
+}
+
+/**
+ * Check every field OpenSSH or the WebSocket dialer would act on, and that the
+ * descriptor is for the sandbox that was asked for. Returns true when the
+ * descriptor is safe to dial.
+ */
+export function isValidSSHSession(
+  session: SSHSession,
+  expectedSandboxId: string,
+): boolean {
+  if (
+    session.sessionId === "" ||
+    session.sessionId.length > 128 ||
+    !session.sessionId.startsWith("sshs_")
+  ) {
+    return false;
+  }
+  if (
+    session.transport !== SSH_SESSION_TRANSPORT_DIRECT_WS ||
+    session.sandboxId !== expectedSandboxId ||
+    session.sshUser !== "amika"
+  ) {
+    return false;
+  }
+  if (
+    !isCanonicalConnectToken(session.connectCredential) ||
+    canonicalEd25519PublicKey(session.hostPublicKey) === ""
+  ) {
+    return false;
+  }
+
+  let connectUrl: URL;
+  try {
+    connectUrl = new URL(session.connectUrl);
+  } catch {
+    return false;
+  }
+  if (
+    connectUrl.protocol !== "wss:" ||
+    connectUrl.host === "" ||
+    connectUrl.username !== "" ||
+    connectUrl.password !== "" ||
+    connectUrl.search !== "" ||
+    connectUrl.hash !== ""
+  ) {
+    return false;
+  }
+  return connectUrl.pathname.endsWith("/v1/ssh-sessions");
+}
+
+/**
+ * Validate one OpenSSH ed25519 public key line and return it in canonical form
+ * with any comment stripped, or "" if the value is not a well-formed ed25519
+ * key. The control plane canonicalizes the same way, so uploading this form
+ * keeps a locally read key byte-identical to what the server stores.
+ */
+export function canonicalEd25519PublicKey(value: string): string {
+  const line = value.trim();
+  // A single key line only: authorized_keys options, or a second key, are not
+  // accepted (matching Go's rejection of options and trailing content).
+  if (line === "" || /[\r\n]/.test(line)) return "";
+
+  const fields = line.split(/[ \t]+/);
+  const algorithm = fields[0];
+  const encoded = fields[1];
+  if (algorithm !== ED25519_ALGORITHM || encoded === undefined) return "";
+
+  const blob = decodeBase64(encoded);
+  if (!blob) return "";
+
+  const parsed = parseEd25519Blob(blob);
+  if (!parsed) return "";
+
+  // Re-encode from the parsed key so the canonical form does not inherit any
+  // quirk of the input's base64.
+  return `${ED25519_ALGORITHM} ${encodeBase64(buildEd25519Blob(parsed))}`;
+}
+
+const ED25519_ALGORITHM = "ssh-ed25519";
+const ED25519_KEY_BYTES = 32;
+const CONNECT_TOKEN_BYTES = 32;
+
+/** A connect credential is exactly 32 bytes in canonical unpadded base64url. */
+function isCanonicalConnectToken(value: string): boolean {
+  const decoded = decodeBase64Url(value);
+  if (!decoded || decoded.length !== CONNECT_TOKEN_BYTES) return false;
+  return encodeBase64Url(decoded) === value;
+}
+
+/**
+ * Read the SSH wire encoding of an ed25519 public key: the algorithm name and
+ * the 32 key bytes, each length-prefixed, with nothing trailing. Returns the
+ * key bytes, or null if the blob is not exactly that.
+ */
+function parseEd25519Blob(blob: Uint8Array): Uint8Array | null {
+  const name = readString(blob, 0);
+  if (!name) return null;
+  if (decodeAscii(name.value) !== ED25519_ALGORITHM) return null;
+
+  const key = readString(blob, name.next);
+  if (!key || key.value.length !== ED25519_KEY_BYTES) return null;
+  if (key.next !== blob.length) return null;
+
+  return key.value;
+}
+
+function buildEd25519Blob(key: Uint8Array): Uint8Array {
+  const name = new TextEncoder().encode(ED25519_ALGORITHM);
+  const out = new Uint8Array(4 + name.length + 4 + key.length);
+  writeUint32(out, 0, name.length);
+  out.set(name, 4);
+  writeUint32(out, 4 + name.length, key.length);
+  out.set(key, 8 + name.length);
+  return out;
+}
+
+function readString(
+  buf: Uint8Array,
+  offset: number,
+): { value: Uint8Array; next: number } | null {
+  if (offset + 4 > buf.length) return null;
+  const length = readUint32(buf, offset);
+  const start = offset + 4;
+  const end = start + length;
+  if (end > buf.length) return null;
+  return { value: buf.subarray(start, end), next: end };
+}
+
+function readUint32(buf: Uint8Array, offset: number): number {
+  return (
+    (((buf[offset] as number) << 24) |
+      ((buf[offset + 1] as number) << 16) |
+      ((buf[offset + 2] as number) << 8) |
+      (buf[offset + 3] as number)) >>>
+    0
+  );
+}
+
+function writeUint32(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = (value >>> 24) & 0xff;
+  buf[offset + 1] = (value >>> 16) & 0xff;
+  buf[offset + 2] = (value >>> 8) & 0xff;
+  buf[offset + 3] = value & 0xff;
+}
+
+function decodeAscii(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+/** Strict padded base64, as Go's `base64.StdEncoding` accepts. */
+function decodeBase64(value: string): Uint8Array | null {
+  if (value.length % 4 !== 0) return null;
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null;
+  return atobToBytes(value);
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/** Unpadded base64url, as Go's `base64.RawURLEncoding` accepts. */
+function decodeBase64Url(value: string): Uint8Array | null {
+  if (value === "" || !/^[A-Za-z0-9_-]*$/.test(value)) return null;
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  return atobToBytes(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  return encodeBase64(bytes)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function atobToBytes(value: string): Uint8Array | null {
+  let binary: string;
+  try {
+    binary = atob(value);
+  } catch {
+    return null;
+  }
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,7 +1,19 @@
 // CamelCase TS mirrors of the Go SDK types in go/internal/apiclient/client.go.
 // Each request/response has explicit toWire/fromWire mappers to translate
 // between the SDK's camelCase developer surface and the snake_case JSON wire
-// format the server expects.
+// format the server expects. (A few nested objects — sandbox services and
+// Daytona snapshot detail — are camelCase on the wire too; those mappers say so.)
+//
+// Nullability follows the Go struct tags, which in turn follow the OpenAPI
+// document served at /api/openapi.json:
+//
+//   - `string`             (required, not nullable) -> `x: string`
+//   - `*string`            (required, nullable)     -> `x: string | null`
+//   - `*string,omitempty`  (optional, nullable)     -> `x?: string`
+//
+// The last case collapses null and absent into `undefined`: Go's `omitempty`
+// on a pointer encodes nil as an omitted key, so the server never distinguishes
+// the two either.
 
 // ---------- Sandboxes ----------
 
@@ -92,6 +104,8 @@ export interface CreateSandboxRequest {
   agentCredentials?: AgentCredentialRef[];
   branch?: string;
   newBranchName?: string;
+  /** How the sandbox authenticates to GitHub, e.g. "app" or "none". */
+  githubAuthMode?: string;
 }
 
 export function createSandboxRequestToWire(
@@ -114,6 +128,7 @@ export function createSandboxRequestToWire(
     agent_credentials: r.agentCredentials,
     branch: r.branch,
     new_branch_name: r.newBranchName,
+    github_auth_mode: r.githubAuthMode,
   });
 }
 
@@ -126,40 +141,184 @@ export interface ResolvedAgentCredential {
   reason?: string;
 }
 
+/**
+ * One named service exposed by a sandbox: a published port with an optional
+ * generated URL. Wire keys are camelCase here, unlike the rest of the API.
+ */
+export interface RemoteSandboxService {
+  name: string;
+  url: string;
+  hostPort: number;
+  containerPort: number;
+  protocol: string;
+}
+
+function remoteSandboxServiceFromWire(
+  w: Record<string, unknown>,
+): RemoteSandboxService {
+  return {
+    name: str(w["name"]),
+    url: str(w["url"]),
+    hostPort: num(w["hostPort"]),
+    containerPort: num(w["containerPort"]),
+    protocol: str(w["protocol"]),
+  };
+}
+
+/**
+ * One secret a sandbox carries, by name and scope. The API deliberately
+ * returns no value and no vault handle. `managed` distinguishes a credential
+ * Amika manages for a provider from a plain user-defined secret; it is the
+ * discriminator rather than a null `credentialType`, which a managed entry is
+ * allowed to have.
+ */
+export interface MountedSecret {
+  name: string;
+  scope: string;
+  managed: boolean;
+  credentialType: string | null;
+  provider: string | null;
+}
+
+function mountedSecretFromWire(w: Record<string, unknown>): MountedSecret {
+  return {
+    name: str(w["name"]),
+    scope: str(w["scope"]),
+    managed: bool(w["managed"]),
+    credentialType: nullableStr(w["credential_type"]),
+    provider: nullableStr(w["provider"]),
+  };
+}
+
+/**
+ * Mirrors the API's Sandbox schema (the `Sandbox` component in
+ * /api/openapi.json), the response of the /sandboxes endpoints.
+ *
+ * `containerId` and `image` have no equivalent in the API schema — the CLI
+ * populates them for local Docker sandboxes only, and the schema's
+ * `additionalProperties` allows the extra keys.
+ */
+export interface RemoteSandbox {
+  id: string;
+  userId: string | null;
+  orgId: string;
+  name: string;
+  provider: string | null;
+  providerSandboxId: string | null;
+  providerUrl: string | null;
+  amikaOpencodeWeb: string | null;
+  repoName: string | null;
+  repoProvider: string | null;
+  repoId: string | null;
+  repoUrl: string | null;
+  branch: string | null;
+  commitHash: string | null;
+  snapshot: string | null;
+  currentSessionId: string | null;
+  services: RemoteSandboxService[];
+  createdAt: string;
+  updatedAt: string;
+
+  snapshotName?: string;
+  sandboxPreset?: string;
+  sandboxSize?: string;
+  githubAuthMode?: string;
+  githubCredentialProvisioned?: boolean;
+  errorMessage?: string;
+  state: string;
+  status: string;
+  setupStatus?: string;
+  urlsExpireAt?: string;
+  secretNames?: string[];
+  mountedSecrets?: MountedSecret[];
+  hasWorkflow: boolean;
+  resolvedAgentCredentials?: ResolvedAgentCredential[];
+  createdBy?: RemoteSandboxCreator;
+  origin?: string;
+
+  /** Local Docker sandboxes only; absent for API-backed sandboxes. */
+  containerId?: string;
+  /** Local Docker sandboxes only; absent for API-backed sandboxes. */
+  image?: string;
+}
+
+/**
+ * The human who created a remote sandbox. Either field may be null if the
+ * server could not resolve the user (deleted account, API-key principal, or
+ * noop auth mode).
+ */
 export interface RemoteSandboxCreator {
   name: string | null;
   email: string | null;
-}
-
-export interface RemoteSandbox {
-  id: string;
-  name: string;
-  provider: string;
-  repoUrl: string;
-  state: string;
-  createdAt: string;
-  branch: string;
-  errorMessage: string;
-  resolvedAgentCredentials?: ResolvedAgentCredential[];
-  createdBy?: RemoteSandboxCreator | null;
 }
 
 export function remoteSandboxFromWire(
   w: Record<string, unknown>,
 ): RemoteSandbox {
   return {
-    id: String(w["id"] ?? ""),
-    name: String(w["name"] ?? ""),
-    provider: String(w["provider"] ?? ""),
-    repoUrl: String(w["repo_url"] ?? ""),
-    state: String(w["state"] ?? ""),
-    createdAt: String(w["created_at"] ?? ""),
-    branch: String(w["branch"] ?? ""),
-    errorMessage: String(w["error_message"] ?? ""),
+    id: str(w["id"]),
+    userId: nullableStr(w["user_id"]),
+    orgId: str(w["org_id"]),
+    name: str(w["name"]),
+    provider: nullableStr(w["provider"]),
+    providerSandboxId: nullableStr(w["provider_sandbox_id"]),
+    providerUrl: nullableStr(w["provider_url"]),
+    amikaOpencodeWeb: nullableStr(w["amika_opencode_web"]),
+    repoName: nullableStr(w["repo_name"]),
+    repoProvider: nullableStr(w["repo_provider"]),
+    repoId: nullableStr(w["repo_id"]),
+    repoUrl: nullableStr(w["repo_url"]),
+    branch: nullableStr(w["branch"]),
+    commitHash: nullableStr(w["commit_hash"]),
+    snapshot: nullableStr(w["snapshot"]),
+    currentSessionId: nullableStr(w["current_session_id"]),
+    services: mapArray(w["services"], remoteSandboxServiceFromWire),
+    createdAt: str(w["created_at"]),
+    updatedAt: str(w["updated_at"]),
+
+    snapshotName: optionalStr(w["snapshot_name"]),
+    sandboxPreset: optionalStr(w["sandbox_preset"]),
+    sandboxSize: optionalStr(w["sandbox_size"]),
+    githubAuthMode: optionalStr(w["github_auth_mode"]),
+    githubCredentialProvisioned: optionalBool(
+      w["github_credential_provisioned"],
+    ),
+    errorMessage: optionalStr(w["error_message"]),
+    state: str(w["state"]),
+    status: str(w["status"]),
+    setupStatus: optionalStr(w["setup_status"]),
+    urlsExpireAt: optionalStr(w["urls_expire_at"]),
+    secretNames: optionalStrArray(w["secret_names"]),
+    mountedSecrets: optionalArray(w["mounted_secrets"], mountedSecretFromWire),
+    hasWorkflow: bool(w["has_workflow"]),
     resolvedAgentCredentials: w["resolved_agent_credentials"] as
       | ResolvedAgentCredential[]
       | undefined,
-    createdBy: w["created_by"] as RemoteSandboxCreator | null | undefined,
+    createdBy: optionalObject(w["created_by"], (c) => ({
+      name: nullableStr(c["name"]),
+      email: nullableStr(c["email"]),
+    })),
+    origin: optionalStr(w["origin"]),
+
+    containerId: optionalStr(w["container_id"]),
+    image: optionalStr(w["image"]),
+  };
+}
+
+// ---------- Repositories ----------
+
+/** A repository known to the caller's org, from GET /api/v0beta1/repositories. */
+export interface RemoteRepository {
+  id: string;
+  repoUrl: string;
+}
+
+export function remoteRepositoryFromWire(
+  w: Record<string, unknown>,
+): RemoteRepository {
+  return {
+    id: str(w["id"]),
+    repoUrl: str(w["repo_url"]),
   };
 }
 
@@ -174,10 +333,10 @@ export interface SSHInfo {
 
 export function sshInfoFromWire(w: Record<string, unknown>): SSHInfo {
   return {
-    sshDestination: String(w["ssh_destination"] ?? ""),
-    token: String(w["token"] ?? ""),
-    expiresAt: String(w["expires_at"] ?? ""),
-    repoName: String(w["repo_name"] ?? ""),
+    sshDestination: str(w["ssh_destination"]),
+    token: str(w["token"]),
+    expiresAt: str(w["expires_at"]),
+    repoName: str(w["repo_name"]),
   };
 }
 
@@ -186,12 +345,67 @@ export interface RevokeSSHRequest {
   token: string;
 }
 
-// ---------- Secrets ----------
+/** Request body for POST /api/v0beta1/secrets/ssh-public-keys. */
+export interface CreateSSHPublicKeyRequest {
+  name: string;
+  /** An OpenSSH ed25519 public key line. */
+  publicKey: string;
+}
 
-export interface Secret {
+export function createSSHPublicKeyRequestToWire(
+  r: CreateSSHPublicKeyRequest,
+): Record<string, unknown> {
+  return { name: r.name, public_key: r.publicKey };
+}
+
+/** Non-secret metadata for one stored SSH public key. */
+export interface SSHPublicKeySummary {
   id: string;
   name: string;
+  publicKey: string;
   scope: string;
+}
+
+export function sshPublicKeySummaryFromWire(
+  w: Record<string, unknown>,
+): SSHPublicKeySummary {
+  return {
+    id: str(w["id"]),
+    name: str(w["name"]),
+    publicKey: str(w["public_key"]),
+    scope: str(w["scope"]),
+  };
+}
+
+// ---------- Secrets ----------
+
+/**
+ * Mirrors the API's SecretSummary schema, returned by the /secrets endpoints.
+ * Never carries the secret's value.
+ */
+export interface Secret {
+  id: string;
+  orgId: string;
+  userId: string;
+  name: string;
+  description: string | null;
+  /** "user" or "org". */
+  scope: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function secretFromWire(w: Record<string, unknown>): Secret {
+  return {
+    id: str(w["id"]),
+    orgId: str(w["org_id"]),
+    userId: str(w["user_id"]),
+    name: str(w["name"]),
+    description: nullableStr(w["description"]),
+    scope: str(w["scope"]),
+    createdAt: str(w["created_at"]),
+    updatedAt: str(w["updated_at"]),
+  };
 }
 
 export interface CreateSecretRequest {
@@ -211,6 +425,8 @@ export interface CreateProviderSecretRequest {
   value: string;
   /** "oauth" or "api_key" — required by the server. */
   type: "oauth" | "api_key";
+  /** "user" (default) or "org"; omit to take the server default. */
+  scope?: "user" | "org";
 }
 
 export interface ProviderSecretSummary {
@@ -223,6 +439,8 @@ export interface ProviderSecretListItem {
   id: string;
   name: string;
   type: string;
+  /** "user" or "org". */
+  scope: string;
 }
 
 // ---------- Agent send ----------
@@ -250,15 +468,21 @@ export interface AgentSendResponse {
   result: string;
   sessionId: string;
   isError: boolean;
+  isNewSession: boolean;
+  agentSessionId?: string;
+  costUsd?: number;
 }
 
 export function agentSendResponseFromWire(
   w: Record<string, unknown>,
 ): AgentSendResponse {
   return {
-    result: String(w["response"] ?? ""),
-    sessionId: String(w["session_id"] ?? ""),
-    isError: Boolean(w["is_error"]),
+    result: str(w["response"]),
+    sessionId: str(w["session_id"]),
+    isError: bool(w["is_error"]),
+    isNewSession: bool(w["is_new_session"]),
+    agentSessionId: optionalStr(w["agent_session_id"]),
+    costUsd: optionalNum(w["cost_usd"]),
   };
 }
 
@@ -273,22 +497,25 @@ export interface Session {
   startedAt: string;
   endedAt: string | null;
   metadata: Record<string, unknown>;
+  /** First user message, capped by the server. List responses only. */
+  preview?: string;
   createdAt: string;
   updatedAt: string;
 }
 
 export function sessionFromWire(w: Record<string, unknown>): Session {
   return {
-    id: String(w["id"] ?? ""),
-    sandboxId: String(w["sandbox_id"] ?? ""),
-    orgId: String(w["org_id"] ?? ""),
-    agentName: String(w["agent_name"] ?? ""),
-    status: String(w["status"] ?? ""),
-    startedAt: String(w["started_at"] ?? ""),
-    endedAt: (w["ended_at"] ?? null) as string | null,
+    id: str(w["id"]),
+    sandboxId: str(w["sandbox_id"]),
+    orgId: str(w["org_id"]),
+    agentName: str(w["agent_name"]),
+    status: str(w["status"]),
+    startedAt: str(w["started_at"]),
+    endedAt: nullableStr(w["ended_at"]),
     metadata: (w["metadata"] ?? {}) as Record<string, unknown>,
-    createdAt: String(w["created_at"] ?? ""),
-    updatedAt: String(w["updated_at"] ?? ""),
+    preview: optionalStr(w["preview"]),
+    createdAt: str(w["created_at"]),
+    updatedAt: str(w["updated_at"]),
   };
 }
 
@@ -320,7 +547,95 @@ export function updateSessionRequestToWire(
   });
 }
 
+// ---------- Sandbox services ----------
+
+/**
+ * One service on a sandbox, as returned by the /sandbox-services endpoints.
+ * It unifies rows from the `sandbox_services` table with legacy jsonb entries:
+ * `source` discriminates ("table" or "legacy") and `kind` is "system" or
+ * "user". A legacy or not-yet-provisioned service has a null `url`/`urlScheme`.
+ *
+ * Distinct from {@link RemoteSandboxService}, the abbreviated form nested in a
+ * sandbox resource.
+ */
+export interface SandboxServiceResource {
+  id: string | null;
+  sandboxId: string;
+  name: string;
+  port: number;
+  urlScheme: string | null;
+  protocol: string;
+  url: string | null;
+  hostPort: number | null;
+  source: string;
+  kind: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export function sandboxServiceResourceFromWire(
+  w: Record<string, unknown>,
+): SandboxServiceResource {
+  return {
+    id: nullableStr(w["id"]),
+    sandboxId: str(w["sandbox_id"]),
+    name: str(w["name"]),
+    port: num(w["port"]),
+    urlScheme: nullableStr(w["url_scheme"]),
+    protocol: str(w["protocol"]),
+    url: nullableStr(w["url"]),
+    hostPort: nullableNum(w["host_port"]),
+    source: str(w["source"]),
+    kind: str(w["kind"]),
+    createdAt: nullableStr(w["created_at"]),
+    updatedAt: nullableStr(w["updated_at"]),
+  };
+}
+
+/** Request body for creating (POST) or replacing (PUT) a sandbox service. */
+export interface SandboxServiceRequest {
+  name: string;
+  port: number;
+  urlScheme: "http" | "https";
+}
+
+export function sandboxServiceRequestToWire(
+  r: SandboxServiceRequest,
+): Record<string, unknown> {
+  return { name: r.name, port: r.port, url_scheme: r.urlScheme };
+}
+
 // ---------- Sandbox snapshots ----------
+
+/**
+ * Provider-specific Daytona detail nested under {@link SandboxSnapshot.daytona}.
+ * Only `name` is required by the schema; wire keys are camelCase here.
+ */
+export interface ExperimentalDaytonaSnapshot {
+  name: string;
+  state?: string;
+  imageName?: string;
+  cpu?: number;
+  memory?: number;
+  disk?: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function experimentalDaytonaSnapshotFromWire(
+  w: Record<string, unknown>,
+): ExperimentalDaytonaSnapshot {
+  return {
+    name: str(w["name"]),
+    state: optionalStr(w["state"]),
+    imageName: optionalStr(w["imageName"]),
+    cpu: optionalNum(w["cpu"]),
+    memory: optionalNum(w["memory"]),
+    disk: optionalNum(w["disk"]),
+    createdAt: optionalStr(w["createdAt"]),
+    updatedAt: optionalStr(w["updatedAt"]),
+  };
+}
 
 /**
  * A snapshot captured from a running sandbox, as returned by the
@@ -328,38 +643,47 @@ export function updateSessionRequestToWire(
  * fork new sandboxes (pass it as {@link CreateSandboxRequest.snapshot}).
  */
 export interface SandboxSnapshot {
+  id: string;
   snapshot: string;
   provider: string;
   description: string | null;
   sourceSandboxId: string | null;
   sourceSandboxName: string | null;
   repositoryId: string | null;
+  repositoryUrl: string | null;
   baseSnapshot: string | null;
   sandboxPreset: string | null;
   sandboxSize: string | null;
+  captureMode: string | null;
   state: string;
   errorMessage: string | null;
   createdAt: string;
   updatedAt: string;
+  daytona: ExperimentalDaytonaSnapshot | null;
 }
 
 export function sandboxSnapshotFromWire(
   w: Record<string, unknown>,
 ): SandboxSnapshot {
   return {
-    snapshot: String(w["snapshot"] ?? ""),
-    provider: String(w["provider"] ?? ""),
-    description: (w["description"] ?? null) as string | null,
-    sourceSandboxId: (w["source_sandbox_id"] ?? null) as string | null,
-    sourceSandboxName: (w["source_sandbox_name"] ?? null) as string | null,
-    repositoryId: (w["repository_id"] ?? null) as string | null,
-    baseSnapshot: (w["base_snapshot"] ?? null) as string | null,
-    sandboxPreset: (w["sandbox_preset"] ?? null) as string | null,
-    sandboxSize: (w["sandbox_size"] ?? null) as string | null,
-    state: String(w["state"] ?? ""),
-    errorMessage: (w["error_message"] ?? null) as string | null,
-    createdAt: String(w["created_at"] ?? ""),
-    updatedAt: String(w["updated_at"] ?? ""),
+    id: str(w["id"]),
+    snapshot: str(w["snapshot"]),
+    provider: str(w["provider"]),
+    description: nullableStr(w["description"]),
+    sourceSandboxId: nullableStr(w["source_sandbox_id"]),
+    sourceSandboxName: nullableStr(w["source_sandbox_name"]),
+    repositoryId: nullableStr(w["repository_id"]),
+    repositoryUrl: nullableStr(w["repository_url"]),
+    baseSnapshot: nullableStr(w["base_snapshot"]),
+    sandboxPreset: nullableStr(w["sandbox_preset"]),
+    sandboxSize: nullableStr(w["sandbox_size"]),
+    captureMode: nullableStr(w["capture_mode"]),
+    state: str(w["state"]),
+    errorMessage: nullableStr(w["error_message"]),
+    createdAt: str(w["created_at"]),
+    updatedAt: str(w["updated_at"]),
+    daytona:
+      optionalObject(w["daytona"], experimentalDaytonaSnapshotFromWire) ?? null,
   };
 }
 
@@ -393,10 +717,13 @@ export function createSandboxSnapshotRequestToWire(
 
 /**
  * The injected secrets a scrub-and-delete snapshot would remove from a
- * sandbox — file paths and env var names only, never values.
+ * sandbox — file paths and env var names only, never values. `restoredFiles`
+ * is a third category: paths reset to a retained clean baseline rather than
+ * deleted outright.
  */
 export interface SandboxScrubPreview {
   files: string[];
+  restoredFiles: string[];
   envVars: string[];
 }
 
@@ -404,12 +731,13 @@ export function sandboxScrubPreviewFromWire(
   w: Record<string, unknown>,
 ): SandboxScrubPreview {
   return {
-    files: (w["files"] ?? []) as string[],
-    envVars: (w["env_vars"] ?? []) as string[],
+    files: strArray(w["files"]),
+    restoredFiles: strArray(w["restored_files"]),
+    envVars: strArray(w["env_vars"]),
   };
 }
 
-// ---------- helpers ----------
+// ---------- wire helpers ----------
 
 function omitUndefined(obj: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
@@ -417,4 +745,74 @@ function omitUndefined(obj: Record<string, unknown>): Record<string, unknown> {
     if (v !== undefined) out[k] = v;
   }
   return out;
+}
+
+/** A schema-required, non-nullable string: null and absent both become "". */
+export function str(v: unknown): string {
+  return v === undefined || v === null ? "" : String(v);
+}
+
+/** A schema-nullable string: null and absent both become null. */
+export function nullableStr(v: unknown): string | null {
+  return v === undefined || v === null ? null : String(v);
+}
+
+/** An optional string: null and absent both become undefined. */
+export function optionalStr(v: unknown): string | undefined {
+  return v === undefined || v === null ? undefined : String(v);
+}
+
+export function num(v: unknown): number {
+  return v === undefined || v === null ? 0 : Number(v);
+}
+
+export function nullableNum(v: unknown): number | null {
+  return v === undefined || v === null ? null : Number(v);
+}
+
+export function optionalNum(v: unknown): number | undefined {
+  return v === undefined || v === null ? undefined : Number(v);
+}
+
+export function bool(v: unknown): boolean {
+  return Boolean(v);
+}
+
+export function optionalBool(v: unknown): boolean | undefined {
+  return v === undefined || v === null ? undefined : Boolean(v);
+}
+
+export function strArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.map((item) => str(item)) : [];
+}
+
+function optionalStrArray(v: unknown): string[] | undefined {
+  return Array.isArray(v) ? v.map((item) => str(item)) : undefined;
+}
+
+export function mapArray<T>(
+  v: unknown,
+  from: (w: Record<string, unknown>) => T,
+): T[] {
+  return Array.isArray(v)
+    ? v.map((item) => from(item as Record<string, unknown>))
+    : [];
+}
+
+function optionalArray<T>(
+  v: unknown,
+  from: (w: Record<string, unknown>) => T,
+): T[] | undefined {
+  return Array.isArray(v)
+    ? v.map((item) => from(item as Record<string, unknown>))
+    : undefined;
+}
+
+function optionalObject<T>(
+  v: unknown,
+  from: (w: Record<string, unknown>) => T,
+): T | undefined {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+    ? from(v as Record<string, unknown>)
+    : undefined;
 }

--- a/sdk/typescript/test/agent-sessions.test.ts
+++ b/sdk/typescript/test/agent-sessions.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+
+import { AmikaClient } from "@/client";
+import { AmikaError, AmikaHTTPError } from "@/errors";
+import { mockFetch } from "./helpers.js";
+
+const BASE = "https://api.example.com";
+
+function makeClient(fetchImpl: typeof fetch): AmikaClient {
+  return new AmikaClient({
+    baseUrl: BASE,
+    accessToken: "tok",
+    fetch: fetchImpl,
+  });
+}
+
+/** Serialize SSE frames the way the server does: one `data:` line per frame. */
+function sse(...frames: [event: string, payload: unknown][]): string {
+  return frames
+    .map(
+      ([event, payload]) =>
+        `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`,
+    )
+    .join("");
+}
+
+const DONE_PAYLOAD = {
+  session_id: "as_1",
+  sandbox_id: "sbx_1",
+  agent: "claude",
+  response: "hello",
+  is_error: false,
+  is_new_session: true,
+  created_sandbox: true,
+};
+
+describe("AmikaClient.sendAgentSession", () => {
+  it("POSTs camelCase → snake_case and maps the response", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: {
+          ...DONE_PAYLOAD,
+          usage: { cost_usd: 0.12, input_tokens: 10, num_turns: 2 },
+        },
+      },
+    ]);
+    const resp = await makeClient(fetch).sendAgentSession({
+      message: "hi",
+      agent: "claude",
+      sessionId: "as_1",
+      sandboxId: "sbx_1",
+      newSession: false,
+      repoUrl: "git@github.com:org/p.git",
+    });
+
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions`);
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({
+      message: "hi",
+      agent: "claude",
+      session_id: "as_1",
+      sandbox_id: "sbx_1",
+      new_session: false,
+      repo_url: "git@github.com:org/p.git",
+    });
+    expect(resp.sessionId).toBe("as_1");
+    expect(resp.createdSandbox).toBe(true);
+    expect(resp.usage).toEqual({
+      costUsd: 0.12,
+      inputTokens: 10,
+      outputTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheCreationTokens: undefined,
+      durationMs: undefined,
+      numTurns: 2,
+    });
+  });
+
+  it("sends only the fields that are set", async () => {
+    const { fetch, calls } = mockFetch([{ status: 200, body: DONE_PAYLOAD }]);
+    await makeClient(fetch).sendAgentSession({ message: "hi" });
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({ message: "hi" });
+  });
+
+  it("leaves usage undefined when the provider reports none", async () => {
+    const { fetch } = mockFetch([{ status: 200, body: DONE_PAYLOAD }]);
+    const resp = await makeClient(fetch).sendAgentSession({ message: "hi" });
+    expect(resp.usage).toBeUndefined();
+  });
+});
+
+describe("AmikaClient.sendAgentSessionStream", () => {
+  it("dispatches status and delta frames, then returns the done result", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: sse(
+          ["status", { phase: "creating_sandbox", sandbox_id: "" }],
+          ["status", { phase: "sandbox_ready", sandbox_id: "sbx_1" }],
+          ["delta", { text: "hel" }],
+          ["delta", { text: "lo" }],
+          ["done", DONE_PAYLOAD],
+        ),
+      },
+    ]);
+
+    const statuses: [string, string][] = [];
+    let text = "";
+    const resp = await makeClient(fetch).sendAgentSessionStream(
+      { message: "hi" },
+      {
+        onStatus: (phase, sandboxId) => statuses.push([phase, sandboxId]),
+        onDelta: (chunk) => {
+          text += chunk;
+        },
+      },
+    );
+
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions/stream`);
+    expect(calls[0]?.headers["Accept"]).toBe("text/event-stream");
+    expect(statuses).toEqual([
+      ["creating_sandbox", ""],
+      ["sandbox_ready", "sbx_1"],
+    ]);
+    expect(text).toBe("hello");
+    expect(resp.response).toBe("hello");
+  });
+
+  it("works without handlers", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: sse(["delta", { text: "x" }], ["done", DONE_PAYLOAD]),
+      },
+    ]);
+    const resp = await makeClient(fetch).sendAgentSessionStream({
+      message: "hi",
+    });
+    expect(resp.sessionId).toBe("as_1");
+  });
+
+  it("prefers a done frame over an error frame", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: sse(["error", { error: "boom" }], ["done", DONE_PAYLOAD]),
+      },
+    ]);
+    const resp = await makeClient(fetch).sendAgentSessionStream({
+      message: "hi",
+    });
+    expect(resp.sessionId).toBe("as_1");
+  });
+
+  it("throws the message from an error frame", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: sse(["error", { error: "agent exploded" }]) },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/agent exploded/);
+  });
+
+  it("points at the session list when the stream ends with no result", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: sse(["delta", { text: "partial" }]) },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/stream ended without a result/);
+  });
+
+  it("fails loudly on an unparseable delta rather than losing output", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: "event: delta\ndata: {not json\n\n" },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(AmikaError);
+  });
+
+  it("surfaces a pre-stream rejection as an HTTP error", async () => {
+    const { fetch } = mockFetch([
+      { status: 401, body: { code: "unauthorized", message: "bad token" } },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(AmikaHTTPError);
+  });
+});
+
+describe("AmikaClient.listAgentSessions", () => {
+  it("GETs the envelope and maps nullable columns", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: {
+          sessions: [
+            {
+              session_id: "as_1",
+              sandbox_id: "sbx_1",
+              sandbox_name: null,
+              agent: "claude",
+              status: "running",
+              preview: "fix the bug",
+              model: null,
+              effort: "high",
+              started_at: "2026-01-01T00:00:00Z",
+              ended_at: null,
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+            },
+          ],
+          total: 12,
+        },
+      },
+    ]);
+    const page = await makeClient(fetch).listAgentSessions();
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions`);
+    expect(page.total).toBe(12);
+    expect(page.sessions[0]?.sandboxName).toBeNull();
+    expect(page.sessions[0]?.model).toBeNull();
+    expect(page.sessions[0]?.effort).toBe("high");
+  });
+
+  it("passes a positive limit as a query param", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 200, body: { sessions: [], total: 0 } },
+    ]);
+    await makeClient(fetch).listAgentSessions(5);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions?limit=5`);
+  });
+
+  it("omits a zero limit and returns [] for an empty page", async () => {
+    const { fetch, calls } = mockFetch([{ status: 200, body: { total: 0 } }]);
+    const page = await makeClient(fetch).listAgentSessions(0);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions`);
+    expect(page.sessions).toEqual([]);
+  });
+});
+
+describe("AmikaClient.getAgentSession", () => {
+  it("GETs one chat with its transcript", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: {
+          session_id: "as/1",
+          sandbox_id: "sbx_1",
+          sandbox_name: "dev",
+          agent: "claude",
+          status: "completed",
+          preview: null,
+          model: "claude-opus-5",
+          effort: null,
+          started_at: "2026-01-01T00:00:00Z",
+          ended_at: "2026-01-01T00:05:00Z",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:05:00Z",
+          messages: [
+            { role: "user", content: "hi", timestamp: "2026-01-01T00:00:00Z" },
+            {
+              role: "assistant",
+              content: "nope",
+              timestamp: "2026-01-01T00:05:00Z",
+              is_error: true,
+            },
+          ],
+        },
+      },
+    ]);
+    const detail = await makeClient(fetch).getAgentSession("as/1");
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions/as%2F1`);
+    expect(detail.model).toBe("claude-opus-5");
+    expect(detail.messages).toHaveLength(2);
+    expect(detail.messages[0]?.isError).toBeUndefined();
+    expect(detail.messages[1]?.isError).toBe(true);
+  });
+});

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -317,7 +317,39 @@ describe("AmikaClient.agentSend", () => {
       session_id: "s1",
       agent: "claude",
     });
-    expect(resp).toEqual({ result: "ok", sessionId: "s1", isError: false });
+    expect(resp).toEqual({
+      result: "ok",
+      sessionId: "s1",
+      isError: false,
+      isNewSession: false,
+      agentSessionId: undefined,
+      costUsd: undefined,
+    });
+  });
+
+  it("decodes the optional accounting fields when the server sends them", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: {
+          response: "ok",
+          session_id: "s1",
+          is_error: false,
+          is_new_session: true,
+          agent_session_id: "as_1",
+          cost_usd: 0.42,
+        },
+      },
+    ]);
+    const resp = await makeClient(fetch).agentSend("dev", { message: "hi" });
+    expect(resp).toEqual({
+      result: "ok",
+      sessionId: "s1",
+      isError: false,
+      isNewSession: true,
+      agentSessionId: "as_1",
+      costUsd: 0.42,
+    });
   });
 
   it("rewrites agent auth-error HTTP failures to a friendly AmikaError", async () => {
@@ -539,6 +571,442 @@ describe("AmikaClient sandbox snapshots", () => {
     expect(calls[0]?.method).toBe("DELETE");
     expect(calls[0]?.url).toBe(
       `${BASE}/api/v0beta1/sandbox-snapshots/org%2Fmy-snap?by=ref`,
+    );
+  });
+});
+
+describe("AmikaClient sandbox decoding", () => {
+  it("keeps every field the API schema defines", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: {
+          id: "sbx_1",
+          user_id: null,
+          org_id: "org_1",
+          name: "dev",
+          provider: "daytona",
+          provider_sandbox_id: "d_1",
+          provider_url: null,
+          amika_opencode_web: null,
+          repo_name: "proj",
+          repo_provider: "github",
+          repo_id: "r_1",
+          repo_url: "git@github.com:org/proj.git",
+          branch: "main",
+          commit_hash: null,
+          snapshot: "proj-base",
+          current_session_id: null,
+          services: [
+            {
+              name: "web",
+              url: "https://web.example",
+              hostPort: 3000,
+              containerPort: 3000,
+              protocol: "tcp",
+            },
+          ],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:01:00Z",
+          sandbox_preset: "coder",
+          github_auth_mode: "app",
+          github_credential_provisioned: true,
+          state: "active",
+          status: "ready",
+          setup_status: "done",
+          secret_names: ["API_KEY"],
+          mounted_secrets: [
+            {
+              name: "ANTHROPIC_API_KEY",
+              scope: "user",
+              managed: true,
+              credential_type: "api_key",
+              provider: "claude",
+            },
+          ],
+          has_workflow: true,
+          created_by: { name: "Jakub", email: null },
+          origin: "cli",
+        },
+      },
+    ]);
+    const sb = await makeClient(fetch).getSandbox("dev");
+
+    expect(sb.orgId).toBe("org_1");
+    expect(sb.providerSandboxId).toBe("d_1");
+    expect(sb.services[0]).toEqual({
+      name: "web",
+      url: "https://web.example",
+      hostPort: 3000,
+      containerPort: 3000,
+      protocol: "tcp",
+    });
+    expect(sb.githubAuthMode).toBe("app");
+    expect(sb.githubCredentialProvisioned).toBe(true);
+    expect(sb.setupStatus).toBe("done");
+    expect(sb.secretNames).toEqual(["API_KEY"]);
+    expect(sb.mountedSecrets?.[0]).toEqual({
+      name: "ANTHROPIC_API_KEY",
+      scope: "user",
+      managed: true,
+      credentialType: "api_key",
+      provider: "claude",
+    });
+    expect(sb.hasWorkflow).toBe(true);
+    expect(sb.createdBy).toEqual({ name: "Jakub", email: null });
+    expect(sb.origin).toBe("cli");
+  });
+
+  it("distinguishes a null nullable field from an absent optional one", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: { id: "sbx_1", name: "dev", repo_url: null } },
+    ]);
+    const sb = await makeClient(fetch).getSandbox("dev");
+    expect(sb.repoUrl).toBeNull();
+    expect(sb.branch).toBeNull();
+    expect(sb.services).toEqual([]);
+    expect(sb.errorMessage).toBeUndefined();
+    expect(sb.mountedSecrets).toBeUndefined();
+    expect(sb.hasWorkflow).toBe(false);
+  });
+
+  it("sends github_auth_mode when createSandbox is given one", async () => {
+    const { fetch, calls } = mockFetch([{ status: 202, body: { id: "1" } }]);
+    await makeClient(fetch).createSandbox({ githubAuthMode: "app" });
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({
+      github_auth_mode: "app",
+    });
+  });
+});
+
+describe("AmikaClient.listRepositories", () => {
+  it("GETs /repositories and maps repo_url", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: [{ id: "r_1", repo_url: "git@github.com:o/p.git" }],
+      },
+    ]);
+    const repos = await makeClient(fetch).listRepositories();
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/repositories`);
+    expect(repos).toEqual([{ id: "r_1", repoUrl: "git@github.com:o/p.git" }]);
+  });
+
+  it("returns [] when the server sends no body", async () => {
+    const { fetch } = mockFetch([{ status: 200, body: "" }]);
+    expect(await makeClient(fetch).listRepositories()).toEqual([]);
+  });
+});
+
+describe("AmikaClient sandbox services", () => {
+  const wireService = {
+    id: "svc_1",
+    sandbox_id: "sbx_1",
+    name: "web",
+    port: 3000,
+    url_scheme: "https",
+    protocol: "tcp",
+    url: "https://web.example",
+    host_port: 3000,
+    source: "table",
+    kind: "user",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+
+  it("listSandboxServices unwraps {items} and filters by sandbox_ref", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 200, body: { items: [wireService] } },
+    ]);
+    const services = await makeClient(fetch).listSandboxServices("org/dev");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandbox-services?sandbox_ref=org%2Fdev`,
+    );
+    expect(services[0]?.urlScheme).toBe("https");
+    expect(services[0]?.hostPort).toBe(3000);
+  });
+
+  it("listSandboxServices omits the filter when no ref is given", async () => {
+    const { fetch, calls } = mockFetch([{ status: 200, body: { items: [] } }]);
+    await makeClient(fetch).listSandboxServices();
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/sandbox-services`);
+  });
+
+  it("keeps a legacy service's null url and id", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: {
+          items: [
+            {
+              ...wireService,
+              id: null,
+              url: null,
+              url_scheme: null,
+              host_port: null,
+            },
+          ],
+        },
+      },
+    ]);
+    const services = await makeClient(fetch).listSandboxServices();
+    expect(services[0]?.id).toBeNull();
+    expect(services[0]?.url).toBeNull();
+    expect(services[0]?.urlScheme).toBeNull();
+    expect(services[0]?.hostPort).toBeNull();
+  });
+
+  it("createSandboxService POSTs url_scheme in snake_case", async () => {
+    const { fetch, calls } = mockFetch([{ status: 201, body: wireService }]);
+    const svc = await makeClient(fetch).createSandboxService("org/dev", {
+      name: "web",
+      port: 3000,
+      urlScheme: "https",
+    });
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/org%2Fdev/services`,
+    );
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({
+      name: "web",
+      port: 3000,
+      url_scheme: "https",
+    });
+    expect(svc.name).toBe("web");
+  });
+
+  it("putSandboxService resolves by name unless told otherwise", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 200, body: wireService },
+      { status: 200, body: wireService },
+    ]);
+    const client = makeClient(fetch);
+    const req = { name: "web", port: 3001, urlScheme: "http" as const };
+    await client.putSandboxService("dev", "web", req);
+    await client.putSandboxService("dev", "svc_1", req, "id");
+    expect(calls[0]?.method).toBe("PUT");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/dev/services/web?by=name`,
+    );
+    expect(calls[1]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/dev/services/svc_1?by=id`,
+    );
+  });
+
+  it("deleteSandboxService DELETEs by name", async () => {
+    const { fetch, calls } = mockFetch([{ status: 204, body: "" }]);
+    await makeClient(fetch).deleteSandboxService("dev", "web");
+    expect(calls[0]?.method).toBe("DELETE");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/dev/services/web?by=name`,
+    );
+  });
+});
+
+describe("AmikaClient SSH public keys", () => {
+  const ED25519_KEY =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4ilkUClOhQyh1hQBSn7N/cMSpX0oqg4P87b21Qqdvt";
+
+  it("createSSHPublicKey POSTs public_key in snake_case", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 201,
+        body: {
+          id: "k_1",
+          name: "laptop",
+          public_key: ED25519_KEY,
+          scope: "user",
+        },
+      },
+    ]);
+    const summary = await makeClient(fetch).createSSHPublicKey({
+      name: "laptop",
+      publicKey: ED25519_KEY,
+    });
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/secrets/ssh-public-keys`);
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({
+      name: "laptop",
+      public_key: ED25519_KEY,
+    });
+    expect(summary.publicKey).toBe(ED25519_KEY);
+  });
+
+  it("listSSHPublicKeys maps each summary", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: [
+          { id: "k_1", name: "laptop", public_key: ED25519_KEY, scope: "user" },
+        ],
+      },
+    ]);
+    const keys = await makeClient(fetch).listSSHPublicKeys();
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/secrets/ssh-public-keys`);
+    expect(keys[0]?.name).toBe("laptop");
+  });
+
+  it("deleteSSHPublicKey URL-encodes the id", async () => {
+    const { fetch, calls } = mockFetch([{ status: 204, body: "" }]);
+    await makeClient(fetch).deleteSSHPublicKey("k/1");
+    expect(calls[0]?.method).toBe("DELETE");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/secrets/ssh-public-keys/k%2F1`,
+    );
+  });
+});
+
+describe("AmikaClient.createSSHSession", () => {
+  const validDescriptor = {
+    session_id: "sshs_abc",
+    transport: "direct_ws",
+    connect_url: "wss://relay.example.com/v1/ssh-sessions",
+    connect_credential: "A".repeat(42) + "Q",
+    sandbox_id: "sbx_1",
+    ssh_user: "amika",
+    host_public_key:
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4ilkUClOhQyh1hQBSn7N/cMSpX0oqg4P87b21Qqdvt",
+  };
+
+  it("POSTs to /ssh-sessions and returns the validated descriptor", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 201, body: validDescriptor },
+    ]);
+    const session = await makeClient(fetch).createSSHSession("sbx_1");
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/sbx_1/ssh-sessions`,
+    );
+    expect(session.sessionId).toBe("sshs_abc");
+    expect(session.transport).toBe("direct_ws");
+  });
+
+  it("rejects a descriptor issued for another sandbox", async () => {
+    const { fetch } = mockFetch([{ status: 201, body: validDescriptor }]);
+    await expect(makeClient(fetch).createSSHSession("sbx_2")).rejects.toThrow(
+      /invalid SSH session descriptor/,
+    );
+  });
+
+  it("rejects a descriptor with a non-wss connect URL", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 201,
+        body: {
+          ...validDescriptor,
+          connect_url: "ws://relay.example.com/v1/ssh-sessions",
+        },
+      },
+    ]);
+    await expect(makeClient(fetch).createSSHSession("sbx_1")).rejects.toThrow(
+      /invalid SSH session descriptor/,
+    );
+  });
+});
+
+describe("AmikaClient snapshot fetch and wait", () => {
+  it("getSandboxSnapshot resolves by ref and decodes every field", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: {
+          id: "snap_1",
+          snapshot: "proj-base",
+          provider: "daytona",
+          description: null,
+          source_sandbox_id: "sbx_1",
+          source_sandbox_name: "dev",
+          repository_id: "r_1",
+          repository_url: "git@github.com:o/p.git",
+          base_snapshot: null,
+          sandbox_preset: "coder",
+          sandbox_size: null,
+          capture_mode: "scrub_and_delete",
+          state: "active",
+          error_message: null,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:01:00Z",
+          daytona: { name: "amika-proj-base", state: "active", cpu: 2 },
+        },
+      },
+    ]);
+    const snap = await makeClient(fetch).getSandboxSnapshot("org/proj-base");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandbox-snapshots/org%2Fproj-base?by=ref`,
+    );
+    expect(snap.id).toBe("snap_1");
+    expect(snap.repositoryUrl).toBe("git@github.com:o/p.git");
+    expect(snap.captureMode).toBe("scrub_and_delete");
+    expect(snap.daytona).toEqual({
+      name: "amika-proj-base",
+      state: "active",
+      imageName: undefined,
+      cpu: 2,
+      memory: undefined,
+      disk: undefined,
+      createdAt: undefined,
+      updatedAt: undefined,
+    });
+  });
+
+  it("leaves daytona null when the provider sends none", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: { snapshot: "s", state: "active" } },
+    ]);
+    const snap = await makeClient(fetch).getSandboxSnapshot("s");
+    expect(snap.daytona).toBeNull();
+  });
+
+  it("getSandboxScrubPreview decodes restored_files", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: {
+          files: ["/home/amika/.claude/.credentials.json"],
+          restored_files: ["/home/amika/.gitconfig"],
+          env_vars: ["ANTHROPIC_API_KEY"],
+        },
+      },
+    ]);
+    const preview = await makeClient(fetch).getSandboxScrubPreview("dev");
+    expect(preview.restoredFiles).toEqual(["/home/amika/.gitconfig"]);
+  });
+
+  it("waitForSandboxSnapshot polls every 3 seconds until active", async () => {
+    vi.useFakeTimers();
+    try {
+      const { fetch } = mockFetch([
+        { status: 200, body: { snapshot: "s", state: "capturing" } },
+        { status: 200, body: { snapshot: "s", state: "capturing" } },
+        { status: 200, body: { snapshot: "s", state: "active" } },
+      ]);
+      const promise = makeClient(fetch).waitForSandboxSnapshot("s");
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(3_000);
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect((await promise).state).toBe("active");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waitForSandboxSnapshot throws the server's message on failure", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: { snapshot: "s", state: "failed", error_message: "disk full" },
+      },
+    ]);
+    await expect(makeClient(fetch).waitForSandboxSnapshot("s")).rejects.toThrow(
+      /disk full/,
+    );
+  });
+
+  it("waitForSandboxSnapshot falls back to a generic message", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: { snapshot: "s", state: "failed" } },
+    ]);
+    await expect(makeClient(fetch).waitForSandboxSnapshot("s")).rejects.toThrow(
+      /sandbox snapshot capture failed/,
     );
   });
 });

--- a/sdk/typescript/test/functional/org-resources.functional.test.ts
+++ b/sdk/typescript/test/functional/org-resources.functional.test.ts
@@ -1,0 +1,88 @@
+// Read-only org-scoped endpoints plus the SSH public key round trip. Nothing
+// here provisions a sandbox, so this suite is cheap enough to run on its own.
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { AmikaClient } from "@/client";
+import { canonicalEd25519PublicKey } from "@/ssh-session";
+
+import {
+  describeFunctional,
+  makeClient,
+  uniqueSuffix,
+} from "@test/functional/helpers";
+
+// Public key material only — the matching private key was discarded.
+const TEST_PUBLIC_KEY =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4ilkUClOhQyh1hQBSn7N/cMSpX0oqg4P87b21Qqdvt";
+
+describeFunctional("org resources functional tests", () => {
+  let client: AmikaClient;
+
+  beforeAll(() => {
+    client = makeClient();
+  });
+
+  describe("read-only listings", () => {
+    it("listRepositories returns the org's repositories", async () => {
+      const repos = await client.listRepositories();
+      expect(Array.isArray(repos)).toBe(true);
+      for (const repo of repos) {
+        expect(typeof repo.id).toBe("string");
+        expect(typeof repo.repoUrl).toBe("string");
+      }
+    });
+
+    it("listSandboxServices returns every service in the org", async () => {
+      const services = await client.listSandboxServices();
+      expect(Array.isArray(services)).toBe(true);
+      for (const service of services) {
+        expect(typeof service.name).toBe("string");
+        expect(typeof service.port).toBe("number");
+        expect(["table", "legacy"]).toContain(service.source);
+      }
+    });
+
+    it("listAgentSessions returns a page and its total", async () => {
+      const page = await client.listAgentSessions(5);
+      expect(Array.isArray(page.sessions)).toBe(true);
+      expect(page.sessions.length).toBeLessThanOrEqual(5);
+      expect(typeof page.total).toBe("number");
+    });
+
+    it("getAgentSession returns the transcript for a listed chat", async () => {
+      const page = await client.listAgentSessions(1);
+      const summary = page.sessions[0];
+      if (!summary) return; // Fresh org with no chats yet.
+
+      const detail = await client.getAgentSession(summary.sessionId);
+      expect(detail.sessionId).toBe(summary.sessionId);
+      expect(Array.isArray(detail.messages)).toBe(true);
+    });
+  });
+
+  describe("ssh public keys", () => {
+    it("create + list + delete round-trips", async () => {
+      const name = `ts-sdk-fn-${uniqueSuffix()}`;
+      const publicKey = canonicalEd25519PublicKey(TEST_PUBLIC_KEY);
+      expect(publicKey).not.toBe("");
+
+      const created = await client.createSSHPublicKey({ name, publicKey });
+      expect(created.name).toBe(name);
+      expect(created.id).not.toBe("");
+
+      try {
+        const keys = await client.listSSHPublicKeys();
+        const found = keys.find((k) => k.id === created.id);
+        expect(found).toBeDefined();
+        // The server canonicalizes the same way the SDK does.
+        expect(found?.publicKey).toBe(publicKey);
+      } finally {
+        await client.deleteSSHPublicKey(created.id);
+      }
+
+      const after = await client.listSSHPublicKeys();
+      expect(after.some((k) => k.id === created.id)).toBe(false);
+    });
+  });
+});

--- a/sdk/typescript/test/functional/sandbox.functional.test.ts
+++ b/sdk/typescript/test/functional/sandbox.functional.test.ts
@@ -73,8 +73,8 @@ describeFunctional("sandbox functional tests", () => {
       expect(sb.name).toBe(sandbox.name);
       expect(sb.id).toBe(sandbox.id);
       expect(["active", "running", "started"]).toContain(sb.state);
-      // String fields are always present, even if empty.
-      expect(typeof sb.repoUrl).toBe("string");
+      // repo_url is nullable in the schema; created_at is required.
+      expect(sb.repoUrl === null || typeof sb.repoUrl === "string").toBe(true);
       expect(typeof sb.createdAt).toBe("string");
     });
 

--- a/sdk/typescript/test/sse.test.ts
+++ b/sdk/typescript/test/sse.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+
+import { readSSEFrames, type SSEFrame } from "@/sse";
+
+/** Build a body stream that delivers `chunks` verbatim, one read at a time. */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function collect(
+  stream: ReadableStream<Uint8Array>,
+): Promise<SSEFrame[]> {
+  const frames: SSEFrame[] = [];
+  for await (const frame of readSSEFrames(stream)) frames.push(frame);
+  return frames;
+}
+
+describe("readSSEFrames", () => {
+  it("parses event/data pairs separated by blank lines", async () => {
+    const frames = await collect(
+      streamOf(
+        'event: delta\ndata: {"text":"hi"}\n\nevent: done\ndata: {}\n\n',
+      ),
+    );
+    expect(frames).toEqual([
+      { event: "delta", data: '{"text":"hi"}' },
+      { event: "done", data: "{}" },
+    ]);
+  });
+
+  it("reassembles frames split across chunk boundaries", async () => {
+    const frames = await collect(
+      streamOf("event: de", "lta\ndat", 'a: {"text":"hi"}', "\n\n"),
+    );
+    expect(frames).toEqual([{ event: "delta", data: '{"text":"hi"}' }]);
+  });
+
+  it("strips exactly one space after the colon", async () => {
+    const frames = await collect(streamOf("event:delta\ndata:  padded\n\n"));
+    expect(frames).toEqual([{ event: "delta", data: " padded" }]);
+  });
+
+  it("joins multiple data lines with a newline", async () => {
+    const frames = await collect(streamOf("event: done\ndata: a\ndata: b\n\n"));
+    expect(frames).toEqual([{ event: "done", data: "a\nb" }]);
+  });
+
+  it("ignores comments and id lines", async () => {
+    const frames = await collect(
+      streamOf(": keep-alive\nid: 7\nevent: delta\ndata: x\n\n"),
+    );
+    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+  });
+
+  it("drops an event-less frame without letting its data bleed into the next", async () => {
+    const frames = await collect(
+      streamOf("data: orphan\n\nevent: delta\ndata: x\n\n"),
+    );
+    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+  });
+
+  it("tolerates CRLF line endings", async () => {
+    const frames = await collect(streamOf("event: delta\r\ndata: x\r\n\r\n"));
+    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+  });
+
+  it("flushes a trailing frame with no blank line and no final newline", async () => {
+    const frames = await collect(streamOf("event: done\ndata: {}"));
+    expect(frames).toEqual([{ event: "done", data: "{}" }]);
+  });
+
+  it("yields nothing for an empty stream", async () => {
+    expect(await collect(streamOf())).toEqual([]);
+  });
+
+  it("decodes a multi-byte character split across chunks", async () => {
+    const encoded = new TextEncoder().encode("event: delta\ndata: né\n\n");
+    // Cut between the two bytes of "é" so the decoder must carry state over.
+    const split = encoded.length - 3;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoded.slice(0, split));
+        controller.enqueue(encoded.slice(split));
+        controller.close();
+      },
+    });
+    expect(await collect(stream)).toEqual([{ event: "delta", data: "né" }]);
+  });
+});

--- a/sdk/typescript/test/ssh-session.test.ts
+++ b/sdk/typescript/test/ssh-session.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  canonicalEd25519PublicKey,
+  isValidSSHSession,
+  type SSHSession,
+} from "@/ssh-session";
+
+const ED25519_KEY =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4ilkUClOhQyh1hQBSn7N/cMSpX0oqg4P87b21Qqdvt";
+const RSA_KEY =
+  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC093npR5HAcy4a1CdTWnMAe5lK3JX6FupbkO8y3qy+2to99D9Y1DhC/CqDAU1GBBD7mKhrg4kb7QZJR+3F";
+
+// 32 zero bytes in unpadded base64url — the canonical shape of a connect token.
+const CONNECT_CREDENTIAL = "A".repeat(42) + "Q";
+
+function validSession(overrides: Partial<SSHSession> = {}): SSHSession {
+  return {
+    sessionId: "sshs_abc123",
+    transport: "direct_ws",
+    connectUrl: "wss://relay.example.com/v1/ssh-sessions",
+    connectCredential: CONNECT_CREDENTIAL,
+    sandboxId: "sbx_1",
+    sshUser: "amika",
+    hostPublicKey: ED25519_KEY,
+    ...overrides,
+  };
+}
+
+describe("canonicalEd25519PublicKey", () => {
+  it("strips the comment and returns the canonical line", () => {
+    expect(canonicalEd25519PublicKey(`${ED25519_KEY} jakub@example.com`)).toBe(
+      ED25519_KEY,
+    );
+  });
+
+  it("tolerates surrounding whitespace and a trailing newline", () => {
+    expect(canonicalEd25519PublicKey(`  ${ED25519_KEY} laptop  \n`)).toBe(
+      ED25519_KEY,
+    );
+  });
+
+  it("rejects a non-ed25519 key", () => {
+    expect(canonicalEd25519PublicKey(RSA_KEY)).toBe("");
+  });
+
+  it("rejects authorized_keys options", () => {
+    expect(canonicalEd25519PublicKey(`no-pty ${ED25519_KEY}`)).toBe("");
+  });
+
+  it("rejects a second key on another line", () => {
+    expect(canonicalEd25519PublicKey(`${ED25519_KEY}\n${ED25519_KEY}`)).toBe(
+      "",
+    );
+  });
+
+  it("rejects a blob whose algorithm name disagrees with the prefix", () => {
+    // An ssh-rsa blob relabelled as ssh-ed25519.
+    const relabelled = `ssh-ed25519 ${RSA_KEY.split(" ")[1]}`;
+    expect(canonicalEd25519PublicKey(relabelled)).toBe("");
+  });
+
+  it("rejects malformed base64 and empty input", () => {
+    expect(canonicalEd25519PublicKey("ssh-ed25519 not!base64")).toBe("");
+    expect(canonicalEd25519PublicKey("ssh-ed25519")).toBe("");
+    expect(canonicalEd25519PublicKey("")).toBe("");
+  });
+});
+
+describe("isValidSSHSession", () => {
+  it("accepts a well-formed descriptor for the expected sandbox", () => {
+    expect(isValidSSHSession(validSession(), "sbx_1")).toBe(true);
+  });
+
+  it("rejects a descriptor for a different sandbox", () => {
+    expect(isValidSSHSession(validSession(), "sbx_2")).toBe(false);
+  });
+
+  it.each([
+    ["a session id without the sshs_ prefix", { sessionId: "abc" }],
+    ["an over-long session id", { sessionId: "sshs_" + "a".repeat(200) }],
+    ["an unknown transport", { transport: "relay_ws" }],
+    ["a non-amika ssh user", { sshUser: "root" }],
+    [
+      "a non-wss connect URL",
+      { connectUrl: "https://r.example/v1/ssh-sessions" },
+    ],
+    [
+      "a connect URL with a query",
+      { connectUrl: "wss://r.example/v1/ssh-sessions?x=1" },
+    ],
+    [
+      "a connect URL with userinfo",
+      { connectUrl: "wss://u:p@r.example/v1/ssh-sessions" },
+    ],
+    [
+      "a connect URL with the wrong path",
+      { connectUrl: "wss://r.example/v1/other" },
+    ],
+    [
+      "a connect credential that is not 32 bytes",
+      { connectCredential: "AAAA" },
+    ],
+    [
+      "a padded connect credential",
+      { connectCredential: CONNECT_CREDENTIAL + "==" },
+    ],
+    ["a host key that is not ed25519", { hostPublicKey: RSA_KEY }],
+  ])("rejects %s", (_label, overrides) => {
+    expect(isValidSSHSession(validSession(overrides), "sbx_1")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

`@amika/sdk` advertises itself as a 1:1 port of `go/internal/apiclient`, but it covered roughly two thirds of that client. Several `amika` commands had no TypeScript equivalent at all, and the shapes the SDK *did* return silently dropped fields the API sends — a caller could not see a sandbox's services, its mounted secrets, or a snapshot's id.

## What's new

| Area | Methods | CLI commands they back |
| ---- | ------- | ---------------------- |
| Repositories | `listRepositories` | `amika snapshot list` (repo resolution) |
| Snapshots | `getSandboxSnapshot`, `waitForSandboxSnapshot` | `amika snapshot create --wait` |
| Services | `listSandboxServices`, `createSandboxService`, `putSandboxService`, `deleteSandboxService` | `amika service create\|list\|delete` |
| SSH keys | `createSSHPublicKey`, `listSSHPublicKeys`, `deleteSSHPublicKey` | `amika secret ssh-key push\|list\|delete` |
| SSH dial | `createSSHSession` | `amika ssh`, `amika code`, `amika scp` |
| Agent sessions | `sendAgentSession`, `sendAgentSessionStream`, `listAgentSessions`, `getAgentSession` | `amika send`, `amika sessions list\|show` |

Two supporting modules come with them, neither adding a runtime dependency:

- `src/sse.ts` — SSE frame parsing for the streaming send, with the same rules as Go's `readAgentSessionStream` (blank-line framing, one optional space after the colon, CRLF tolerance, event-less frames dropped without bleeding into the next).
- `src/ssh-session.ts` — descriptor validation plus `canonicalEd25519PublicKey`, an OpenSSH ed25519 parser written against the wire format rather than pulling in a crypto library.

## Schema fidelity

`RemoteSandbox` gained the ~20 fields it was dropping (`services`, `mountedSecrets`, `setupStatus`, the GitHub auth columns, and the rest); `SandboxSnapshot` gained `id`, `repositoryUrl`, `captureMode`, `daytona`; `Secret` is now the full `SecretSummary`; `SandboxScrubPreview` decodes `restoredFiles`; `AgentSendResponse` decodes `isNewSession`, `agentSessionId`, `costUsd`; `CreateSandboxRequest` accepts `githubAuthMode`.

## Breaking change

Nullability now follows the API schema instead of being flattened. A schema-nullable field is `T | null`; an optional one is `T | undefined`. Readers of `repoUrl`, `provider`, `branch`, `commitHash`, and the other nullable columns previously got `""` where the API said `null` and must now handle `null`. The README documents the rule.

No version bump here — releases land as their own commit via `create-sdk-release-commit`.

## Out of scope

`amikalog`'s storage endpoints (a separately installed CLI), the `auth login` OAuth device flow, and the local Docker commands (`materialize`, `volume`, local `sandbox`). None of those are remote API calls an HTTP client can make.

## Testing

`pnpm run ci` passes: 120 unit tests (up from 52), typecheck, lint, formatcheck, build. New coverage for every added method and mapper, the SSE parser, and the ed25519/descriptor validation.

Functional tests were **not** run against a server. `test/functional/org-resources.functional.test.ts` is new and covers the read-only listings plus an SSH-key round trip; it provisions nothing, so it is cheap to run on staging.