### PR TITLE
Return the whole secret summary, not three fields of it

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -25,6 +25,7 @@ import {
   type SandboxSnapshot,
   sandboxSnapshotFromWire,
   type Secret,
+  secretFromWire,
   type Session,
   sessionFromWire,
   type SSHInfo,
@@ -168,10 +169,11 @@ export class AmikaClient {
   // ---------- Secrets ----------
 
   async listSecrets(): Promise<Secret[]> {
-    const data =
-      (await this.http.doJSON<Secret[]>("GET", `${API_BASE_PATH}/secrets`)) ??
-      [];
-    return data;
+    const data = await this.http.doJSON<unknown[]>(
+      "GET",
+      `${API_BASE_PATH}/secrets`,
+    );
+    return mapArray(data, secretFromWire);
   }
 
   async createSecret(req: CreateSecretRequest): Promise<void> {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -334,10 +334,33 @@ export interface RevokeSSHRequest {
 
 // ---------- Secrets ----------
 
+/**
+ * Mirrors the API's SecretSummary schema, returned by the /secrets endpoints.
+ * Never carries the secret's value.
+ */
 export interface Secret {
   id: string;
+  orgId: string;
+  userId: string;
   name: string;
+  description: string | null;
+  /** "user" or "org". */
   scope: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function secretFromWire(w: Record<string, unknown>): Secret {
+  return {
+    id: str(w["id"]),
+    orgId: str(w["org_id"]),
+    userId: str(w["user_id"]),
+    name: str(w["name"]),
+    description: nullableStr(w["description"]),
+    scope: str(w["scope"]),
+    createdAt: str(w["created_at"]),
+    updatedAt: str(w["updated_at"]),
+  };
 }
 
 export interface CreateSecretRequest {
@@ -357,6 +380,8 @@ export interface CreateProviderSecretRequest {
   value: string;
   /** "oauth" or "api_key" — required by the server. */
   type: "oauth" | "api_key";
+  /** "user" (default) or "org"; omit to take the server default. */
+  scope?: "user" | "org";
 }
 
 export interface ProviderSecretSummary {
@@ -369,6 +394,8 @@ export interface ProviderSecretListItem {
   id: string;
   name: string;
   type: string;
+  /** "user" or "org". */
+  scope: string;
 }
 
 // ---------- Agent send ----------

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -243,14 +243,60 @@ describe("AmikaClient.waitForSandbox", () => {
 });
 
 describe("AmikaClient secrets", () => {
-  it("listSecrets returns the array as-is", async () => {
+  it("listSecrets decodes the full summary", async () => {
     const { fetch, calls } = mockFetch([
-      { status: 200, body: [{ id: "1", name: "API_KEY", scope: "user" }] },
+      {
+        status: 200,
+        body: [
+          {
+            id: "1",
+            org_id: "org_1",
+            user_id: "usr_1",
+            name: "API_KEY",
+            description: null,
+            scope: "user",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-02T00:00:00Z",
+          },
+        ],
+      },
     ]);
     const client = makeClient(fetch);
     const secrets = await client.listSecrets();
     expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/secrets`);
-    expect(secrets[0]?.name).toBe("API_KEY");
+    expect(secrets[0]).toEqual({
+      id: "1",
+      orgId: "org_1",
+      userId: "usr_1",
+      name: "API_KEY",
+      description: null,
+      scope: "user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+    });
+  });
+
+  it("listSecrets returns [] when the server sends no body", async () => {
+    const { fetch } = mockFetch([{ status: 200, body: "" }]);
+    expect(await makeClient(fetch).listSecrets()).toEqual([]);
+  });
+
+  it("createProviderSecret forwards an explicit scope", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 201, body: { id: "1", name: "work", scope: "org" } },
+    ]);
+    await makeClient(fetch).createProviderSecret("claude", {
+      name: "work",
+      value: "sk-…",
+      type: "api_key",
+      scope: "org",
+    });
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({
+      name: "work",
+      value: "sk-…",
+      type: "api_key",
+      scope: "org",
+    });
   });
 
   it("createSecret POSTs the request body", async () => {


### PR DESCRIPTION
**Stack 2/8** — based on #389.

## Why

`listSecrets` typed its rows as `{id, name, scope}` and passed the server's JSON straight through, so `orgId`, `userId`, `description`, `createdAt`, and `updatedAt` were present at runtime but invisible to the type system. A caller could not tell when a secret was last rotated without casting.

## What

Decode the full `SecretSummary` the way every other response is decoded.

Provider secrets pick up the `scope` they were also dropping: `createProviderSecret` can now ask for an org-scoped credential rather than always taking the server default, and `listProviderSecrets` rows report which scope they came back from.

## Testing

`pnpm run ci` passes locally (57 unit tests).

---

### The stack

Merge front to back. Each PR targets the one above it; GitHub retargets automatically as they land.

| # | PR | Command surface |
| - | -- | --------------- |
| 1 | #389 Decode every sandbox field the API returns | `amika sandbox list\|create\|get` |
| 2 | #390 Return the whole secret summary, not three fields of it | `amika secret list\|push` |
| 3 | #391 Report what an agent-send turn actually cost | `amika sandbox agent-send` |
| 4 | #392 Let the SDK follow a snapshot capture to completion | `amika snapshot` |
| 5 | #393 Expose sandbox services to the TypeScript SDK | `amika service` |
| 6 | #394 Manage SSH public keys from the TypeScript SDK | `amika secret ssh-key` |
| 7 | #395 Let the SDK open an SSH dial into a sandbox | `amika ssh` / `code` / `scp` |
| 8 | #396 Add the agent-session chat surface to the SDK | `amika send`, `amika sessions` |

Together they close the gap between `@amika/sdk` and the network surface of the `amika` CLI. Deliberately out of scope: `amikalog`'s storage endpoints (a separately installed CLI), the `auth login` OAuth device flow, and the local Docker commands (`materialize`, `volume`, local `sandbox`) — none are remote API calls an HTTP client can make.

No version bump in any of these; releases land as their own commit via `create-sdk-release-commit`.


> **On the missing checks:** both `ci.yml` and `sdk-typescript.yml` trigger only on `pull_request: branches: [main]`, so PRs 2–8 show no checks while they target their parent branch. Each picks up CI when GitHub retargets it to `main` as its parent merges.
