### PR TITLE
Report what an agent-send turn actually cost

### DIFF
--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -423,15 +423,21 @@ export interface AgentSendResponse {
   result: string;
   sessionId: string;
   isError: boolean;
+  isNewSession: boolean;
+  agentSessionId?: string;
+  costUsd?: number;
 }
 
 export function agentSendResponseFromWire(
   w: Record<string, unknown>,
 ): AgentSendResponse {
   return {
-    result: String(w["response"] ?? ""),
-    sessionId: String(w["session_id"] ?? ""),
-    isError: Boolean(w["is_error"]),
+    result: str(w["response"]),
+    sessionId: str(w["session_id"]),
+    isError: bool(w["is_error"]),
+    isNewSession: bool(w["is_new_session"]),
+    agentSessionId: optionalStr(w["agent_session_id"]),
+    costUsd: optionalNum(w["cost_usd"]),
   };
 }
 
@@ -446,22 +452,25 @@ export interface Session {
   startedAt: string;
   endedAt: string | null;
   metadata: Record<string, unknown>;
+  /** First user message, capped by the server. List responses only. */
+  preview?: string;
   createdAt: string;
   updatedAt: string;
 }
 
 export function sessionFromWire(w: Record<string, unknown>): Session {
   return {
-    id: String(w["id"] ?? ""),
-    sandboxId: String(w["sandbox_id"] ?? ""),
-    orgId: String(w["org_id"] ?? ""),
-    agentName: String(w["agent_name"] ?? ""),
-    status: String(w["status"] ?? ""),
-    startedAt: String(w["started_at"] ?? ""),
-    endedAt: (w["ended_at"] ?? null) as string | null,
+    id: str(w["id"]),
+    sandboxId: str(w["sandbox_id"]),
+    orgId: str(w["org_id"]),
+    agentName: str(w["agent_name"]),
+    status: str(w["status"]),
+    startedAt: str(w["started_at"]),
+    endedAt: nullableStr(w["ended_at"]),
     metadata: (w["metadata"] ?? {}) as Record<string, unknown>,
-    createdAt: String(w["created_at"] ?? ""),
-    updatedAt: String(w["updated_at"] ?? ""),
+    preview: optionalStr(w["preview"]),
+    createdAt: str(w["created_at"]),
+    updatedAt: str(w["updated_at"]),
   };
 }
 
@@ -609,6 +618,10 @@ export function optionalStr(v: unknown): string | undefined {
 
 export function num(v: unknown): number {
   return v === undefined || v === null ? 0 : Number(v);
+}
+
+export function optionalNum(v: unknown): number | undefined {
+  return v === undefined || v === null ? undefined : Number(v);
 }
 
 export function bool(v: unknown): boolean {

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -363,7 +363,39 @@ describe("AmikaClient.agentSend", () => {
       session_id: "s1",
       agent: "claude",
     });
-    expect(resp).toEqual({ result: "ok", sessionId: "s1", isError: false });
+    expect(resp).toEqual({
+      result: "ok",
+      sessionId: "s1",
+      isError: false,
+      isNewSession: false,
+      agentSessionId: undefined,
+      costUsd: undefined,
+    });
+  });
+
+  it("decodes the optional accounting fields when the server sends them", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: {
+          response: "ok",
+          session_id: "s1",
+          is_error: false,
+          is_new_session: true,
+          agent_session_id: "as_1",
+          cost_usd: 0.42,
+        },
+      },
+    ]);
+    const resp = await makeClient(fetch).agentSend("dev", { message: "hi" });
+    expect(resp).toEqual({
+      result: "ok",
+      sessionId: "s1",
+      isError: false,
+      isNewSession: true,
+      agentSessionId: "as_1",
+      costUsd: 0.42,
+    });
   });
 
   it("rewrites agent auth-error HTTP failures to a friendly AmikaError", async () => {
@@ -413,7 +445,7 @@ describe("AmikaClient sessions", () => {
         status: 200,
         body: {
           sessions: [
-            { id: "s1", agent_name: "claude" },
+            { id: "s1", agent_name: "claude", preview: "fix the bug" },
             { id: "s2", agent_name: "codex" },
           ],
           total: 2,
@@ -424,6 +456,9 @@ describe("AmikaClient sessions", () => {
     const sessions = await client.listSessions("dev");
     expect(sessions).toHaveLength(2);
     expect(sessions[1]?.agentName).toBe("codex");
+    // `preview` is returned on list responses only.
+    expect(sessions[0]?.preview).toBe("fix the bug");
+    expect(sessions[1]?.preview).toBeUndefined();
   });
 
   it("getLatestSession returns null on 404", async () => {


### PR DESCRIPTION
**Stack 3/8** — based on #390.

## Why

`agentSend` dropped three fields the endpoint returns: `is_new_session` (did this turn open a session or continue one), `agent_session_id`, and `cost_usd`. A caller driving a loop of turns had no way to attribute spend, or to notice the server had started a fresh session, short of re-reading the raw HTTP response.

## What

Decode all three. `Session` also gains `preview`, the capped first-user-message the server computes for list responses and the mirror threw away.

Smallest PR in the stack — it is here as its own commit because it is a different command (`amika sandbox agent-send`) from the ones around it.

## Testing

`pnpm run ci` passes locally (58 unit tests).

---

### The stack

Merge front to back. Each PR targets the one above it; GitHub retargets automatically as they land.

| # | PR | Command surface |
| - | -- | --------------- |
| 1 | #389 Decode every sandbox field the API returns | `amika sandbox list\|create\|get` |
| 2 | #390 Return the whole secret summary, not three fields of it | `amika secret list\|push` |
| 3 | #391 Report what an agent-send turn actually cost | `amika sandbox agent-send` |
| 4 | #392 Let the SDK follow a snapshot capture to completion | `amika snapshot` |
| 5 | #393 Expose sandbox services to the TypeScript SDK | `amika service` |
| 6 | #394 Manage SSH public keys from the TypeScript SDK | `amika secret ssh-key` |
| 7 | #395 Let the SDK open an SSH dial into a sandbox | `amika ssh` / `code` / `scp` |
| 8 | #396 Add the agent-session chat surface to the SDK | `amika send`, `amika sessions` |

Together they close the gap between `@amika/sdk` and the network surface of the `amika` CLI. Deliberately out of scope: `amikalog`'s storage endpoints (a separately installed CLI), the `auth login` OAuth device flow, and the local Docker commands (`materialize`, `volume`, local `sandbox`) — none are remote API calls an HTTP client can make.

No version bump in any of these; releases land as their own commit via `create-sdk-release-commit`.


> **On the missing checks:** both `ci.yml` and `sdk-typescript.yml` trigger only on `pull_request: branches: [main]`, so PRs 2–8 show no checks while they target their parent branch. Each picks up CI when GitHub retargets it to `main` as its parent merges.
