### PR TITLE
Expose sandbox services to the TypeScript SDK

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -76,6 +76,15 @@ Methods on `AmikaClient` mirror Go's `*apiclient.Client` 1:1:
 | `deleteSandbox(name)`       | `DELETE /sandboxes/{name}`                |
 | `listRepositories()`        | `GET /repositories`                       |
 
+### Services
+
+| Method                                           | Endpoint                                        |
+| ------------------------------------------------ | ----------------------------------------------- |
+| `listSandboxServices(sandboxRef?)`               | `GET /sandbox-services`                         |
+| `createSandboxService(sandboxRef, req)`          | `POST /sandboxes/{ref}/services`                |
+| `putSandboxService(sandboxRef, serviceRef, req)` | `PUT /sandboxes/{ref}/services/{serviceRef}`    |
+| `deleteSandboxService(sandboxRef, serviceRef)`   | `DELETE /sandboxes/{ref}/services/{serviceRef}` |
+
 ### SSH
 
 | Method                   | Endpoint                       |

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -24,6 +24,10 @@ import {
   type RevokeSSHRequest,
   type SandboxScrubPreview,
   sandboxScrubPreviewFromWire,
+  type SandboxServiceRequest,
+  type SandboxServiceResource,
+  sandboxServiceRequestToWire,
+  sandboxServiceResourceFromWire,
   type SandboxSnapshot,
   sandboxSnapshotFromWire,
   type Secret,
@@ -177,6 +181,71 @@ export class AmikaClient {
       `${API_BASE_PATH}/repositories`,
     );
     return mapArray(data, remoteRepositoryFromWire);
+  }
+
+  // ---------- Sandbox services ----------
+
+  /**
+   * List live services for the caller's org. `sandboxRef` is an optional
+   * name-or-id filter; omit it to list every service in the org.
+   */
+  async listSandboxServices(
+    sandboxRef?: string,
+  ): Promise<SandboxServiceResource[]> {
+    const params = new URLSearchParams();
+    if (sandboxRef) params.set("sandbox_ref", sandboxRef);
+    const qs = params.toString();
+    const envelope = await this.http.doJSON<{ items?: unknown[] }>(
+      "GET",
+      `${API_BASE_PATH}/sandbox-services${qs ? `?${qs}` : ""}`,
+    );
+    return mapArray(envelope?.items, sandboxServiceResourceFromWire);
+  }
+
+  /**
+   * Create a service on the sandbox referenced by name or id (the server
+   * resolves id first, then name).
+   */
+  async createSandboxService(
+    sandboxRef: string,
+    req: SandboxServiceRequest,
+  ): Promise<SandboxServiceResource> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "POST",
+      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services`,
+      sandboxServiceRequestToWire(req),
+    );
+    return sandboxServiceResourceFromWire(data ?? {});
+  }
+
+  /**
+   * Fully replace the service identified by `serviceRef` within a sandbox.
+   * `by` selects how `serviceRef` is resolved and defaults to `name`.
+   */
+  async putSandboxService(
+    sandboxRef: string,
+    serviceRef: string,
+    req: SandboxServiceRequest,
+    by: "name" | "id" | "ref" = "name",
+  ): Promise<SandboxServiceResource> {
+    const params = new URLSearchParams({ by });
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "PUT",
+      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?${params.toString()}`,
+      sandboxServiceRequestToWire(req),
+    );
+    return sandboxServiceResourceFromWire(data ?? {});
+  }
+
+  /** Delete the service with the given name within a sandbox. */
+  async deleteSandboxService(
+    sandboxRef: string,
+    serviceRef: string,
+  ): Promise<void> {
+    await this.http.doJSON(
+      "DELETE",
+      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?by=name`,
+    );
   }
 
   // ---------- Secrets ----------

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -3,6 +3,12 @@ export type { AmikaClientOptions } from "@/client";
 
 export { AmikaError, AmikaHTTPError, extractAgentAuthError } from "@/errors";
 
+export {
+  RESERVED_PORT_MAX,
+  RESERVED_PORT_MIN,
+  validateServicePort,
+} from "@/types";
+
 export { StaticTokenSource } from "@/token";
 export type { TokenSource } from "@/token";
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -26,6 +26,8 @@ export type {
   ResolvedAgentCredential,
   RevokeSSHRequest,
   SandboxScrubPreview,
+  SandboxServiceRequest,
+  SandboxServiceResource,
   SandboxSnapshot,
   SSHInfo,
   Secret,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -519,6 +519,64 @@ export function updateSessionRequestToWire(
   });
 }
 
+// ---------- Sandbox services ----------
+
+/**
+ * One service on a sandbox, as returned by the /sandbox-services endpoints.
+ * It unifies rows from the `sandbox_services` table with legacy jsonb entries:
+ * `source` discriminates ("table" or "legacy") and `kind` is "system" or
+ * "user". A legacy or not-yet-provisioned service has a null `url`/`urlScheme`.
+ *
+ * Distinct from {@link RemoteSandboxService}, the abbreviated form nested in a
+ * sandbox resource.
+ */
+export interface SandboxServiceResource {
+  id: string | null;
+  sandboxId: string;
+  name: string;
+  port: number;
+  urlScheme: string | null;
+  protocol: string;
+  url: string | null;
+  hostPort: number | null;
+  source: string;
+  kind: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export function sandboxServiceResourceFromWire(
+  w: Record<string, unknown>,
+): SandboxServiceResource {
+  return {
+    id: nullableStr(w["id"]),
+    sandboxId: str(w["sandbox_id"]),
+    name: str(w["name"]),
+    port: num(w["port"]),
+    urlScheme: nullableStr(w["url_scheme"]),
+    protocol: str(w["protocol"]),
+    url: nullableStr(w["url"]),
+    hostPort: nullableNum(w["host_port"]),
+    source: str(w["source"]),
+    kind: str(w["kind"]),
+    createdAt: nullableStr(w["created_at"]),
+    updatedAt: nullableStr(w["updated_at"]),
+  };
+}
+
+/** Request body for creating (POST) or replacing (PUT) a sandbox service. */
+export interface SandboxServiceRequest {
+  name: string;
+  port: number;
+  urlScheme: "http" | "https";
+}
+
+export function sandboxServiceRequestToWire(
+  r: SandboxServiceRequest,
+): Record<string, unknown> {
+  return { name: r.name, port: r.port, url_scheme: r.urlScheme };
+}
+
 // ---------- Sandbox snapshots ----------
 
 /**
@@ -678,6 +736,10 @@ export function optionalStr(v: unknown): string | undefined {
 
 export function num(v: unknown): number {
   return v === undefined || v === null ? 0 : Number(v);
+}
+
+export function nullableNum(v: unknown): number | null {
+  return v === undefined || v === null ? null : Number(v);
 }
 
 export function optionalNum(v: unknown): number | undefined {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -15,6 +15,8 @@
 // on a pointer encodes nil as an omitted key, so the server never distinguishes
 // the two either.
 
+import { AmikaError } from "@/errors";
+
 // ---------- Sandboxes ----------
 
 /**
@@ -567,13 +569,51 @@ export function sandboxServiceResourceFromWire(
 /** Request body for creating (POST) or replacing (PUT) a sandbox service. */
 export interface SandboxServiceRequest {
   name: string;
+  /** A user-assignable container port. See {@link validateServicePort}. */
   port: number;
   urlScheme: "http" | "https";
 }
 
+/**
+ * Inclusive lower bound of the container port range Amika reserves for its own
+ * sandbox services.
+ */
+export const RESERVED_PORT_MIN = 60899;
+/**
+ * Inclusive upper bound of the reserved range (the OpenCode web UI runs on
+ * 60998 and the amikad daemon on 60999). See `docs/sandbox-configuration.md`
+ * for the full allocation table.
+ */
+export const RESERVED_PORT_MAX = 60999;
+
+/**
+ * Throw unless `port` is a legal, user-assignable container port: within
+ * 1-65535 and outside the reserved Amika range. Mirrors Go's
+ * `services.ValidatePort`, including its messages, so the same bad port fails
+ * the same way whether it goes through the CLI or the SDK.
+ *
+ * The server enforces this too. Checking here turns a round trip into an
+ * immediate error, which is the point of keeping the two in sync.
+ */
+export function validateServicePort(port: number): void {
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new AmikaError(`invalid port ${port}: must be between 1 and 65535`);
+  }
+  if (port >= RESERVED_PORT_MIN && port <= RESERVED_PORT_MAX) {
+    throw new AmikaError(
+      `invalid port ${port}: ports ${RESERVED_PORT_MIN}-${RESERVED_PORT_MAX} are reserved for internal Amika services`,
+    );
+  }
+}
+
+/**
+ * Validation lives here rather than in the two client methods so that every
+ * path to the wire goes through it, including any future one.
+ */
 export function sandboxServiceRequestToWire(
   r: SandboxServiceRequest,
 ): Record<string, unknown> {
+  validateServicePort(r.port);
   return { name: r.name, port: r.port, url_scheme: r.urlScheme };
 }
 

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -854,3 +854,108 @@ describe("AmikaClient snapshot fetch and wait", () => {
     );
   });
 });
+
+describe("AmikaClient sandbox services", () => {
+  const wireService = {
+    id: "svc_1",
+    sandbox_id: "sbx_1",
+    name: "web",
+    port: 3000,
+    url_scheme: "https",
+    protocol: "tcp",
+    url: "https://web.example",
+    host_port: 3000,
+    source: "table",
+    kind: "user",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+
+  it("listSandboxServices unwraps {items} and filters by sandbox_ref", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 200, body: { items: [wireService] } },
+    ]);
+    const services = await makeClient(fetch).listSandboxServices("org/dev");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandbox-services?sandbox_ref=org%2Fdev`,
+    );
+    expect(services[0]?.urlScheme).toBe("https");
+    expect(services[0]?.hostPort).toBe(3000);
+  });
+
+  it("listSandboxServices omits the filter when no ref is given", async () => {
+    const { fetch, calls } = mockFetch([{ status: 200, body: { items: [] } }]);
+    await makeClient(fetch).listSandboxServices();
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/sandbox-services`);
+  });
+
+  it("keeps a legacy service's null url and id", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: {
+          items: [
+            {
+              ...wireService,
+              id: null,
+              url: null,
+              url_scheme: null,
+              host_port: null,
+            },
+          ],
+        },
+      },
+    ]);
+    const services = await makeClient(fetch).listSandboxServices();
+    expect(services[0]?.id).toBeNull();
+    expect(services[0]?.url).toBeNull();
+    expect(services[0]?.urlScheme).toBeNull();
+    expect(services[0]?.hostPort).toBeNull();
+  });
+
+  it("createSandboxService POSTs url_scheme in snake_case", async () => {
+    const { fetch, calls } = mockFetch([{ status: 201, body: wireService }]);
+    const svc = await makeClient(fetch).createSandboxService("org/dev", {
+      name: "web",
+      port: 3000,
+      urlScheme: "https",
+    });
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/org%2Fdev/services`,
+    );
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({
+      name: "web",
+      port: 3000,
+      url_scheme: "https",
+    });
+    expect(svc.name).toBe("web");
+  });
+
+  it("putSandboxService resolves by name unless told otherwise", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 200, body: wireService },
+      { status: 200, body: wireService },
+    ]);
+    const client = makeClient(fetch);
+    const req = { name: "web", port: 3001, urlScheme: "http" as const };
+    await client.putSandboxService("dev", "web", req);
+    await client.putSandboxService("dev", "svc_1", req, "id");
+    expect(calls[0]?.method).toBe("PUT");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/dev/services/web?by=name`,
+    );
+    expect(calls[1]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/dev/services/svc_1?by=id`,
+    );
+  });
+
+  it("deleteSandboxService DELETEs by name", async () => {
+    const { fetch, calls } = mockFetch([{ status: 204, body: "" }]);
+    await makeClient(fetch).deleteSandboxService("dev", "web");
+    expect(calls[0]?.method).toBe("DELETE");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/dev/services/web?by=name`,
+    );
+  });
+});

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -959,3 +959,37 @@ describe("AmikaClient sandbox services", () => {
     );
   });
 });
+
+describe("sandbox service port validation", () => {
+  // Mirrors go/internal/services.TestValidatePort so the two stay in step.
+  it.each([3000, 1, 65535, 60898, 61000])("accepts port %i", async (port) => {
+    const { fetch, calls } = mockFetch([{ status: 201, body: {} }]);
+    await makeClient(fetch).createSandboxService("dev", {
+      name: "web",
+      port,
+      urlScheme: "http",
+    });
+    expect(JSON.parse(calls[0]?.body ?? "").port).toBe(port);
+  });
+
+  it.each([
+    [0, /must be between 1 and 65535/],
+    [-1, /must be between 1 and 65535/],
+    [70000, /must be between 1 and 65535/],
+    [3000.5, /must be between 1 and 65535/],
+    [60899, /reserved for internal Amika services/],
+    [60999, /reserved for internal Amika services/],
+    [60950, /reserved for internal Amika services/],
+  ])("rejects port %i without issuing a request", async (port, message) => {
+    const { fetch, calls } = mockFetch([]);
+    const client = makeClient(fetch);
+    const req = { name: "web", port, urlScheme: "http" as const };
+    await expect(client.createSandboxService("dev", req)).rejects.toThrow(
+      message,
+    );
+    await expect(client.putSandboxService("dev", "web", req)).rejects.toThrow(
+      message,
+    );
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/sdk/typescript/test/functional/org-resources.functional.test.ts
+++ b/sdk/typescript/test/functional/org-resources.functional.test.ts
@@ -23,5 +23,15 @@ describeFunctional("org resources functional tests", () => {
         expect(typeof repo.repoUrl).toBe("string");
       }
     });
+
+    it("listSandboxServices returns every service in the org", async () => {
+      const services = await client.listSandboxServices();
+      expect(Array.isArray(services)).toBe(true);
+      for (const service of services) {
+        expect(typeof service.name).toBe("string");
+        expect(typeof service.port).toBe("number");
+        expect(["table", "legacy"]).toContain(service.source);
+      }
+    });
   });
 });


### PR DESCRIPTION
**Stack 5/8** — based on #392.

## Why

`amika service create|list|delete` had no SDK equivalent, so a caller that provisioned a sandbox could not publish a port on it or discover what was already published.

## What

The four endpoints behind that command group.

`SandboxServiceResource` is deliberately separate from the `RemoteSandboxService` nested inside a sandbox resource: the standalone endpoints return a fuller row that also covers legacy jsonb entries — whose `id`, `url`, `urlScheme`, and `hostPort` are null — and carries the `source`/`kind` discriminators that say so. A test pins that null-preserving behavior.

`putSandboxService` has no CLI caller yet; it is included because it is part of the Go client's surface.

## Testing

`pnpm run ci` passes locally (72 unit tests).

---

### The stack

Merge front to back. Each PR targets the one above it; GitHub retargets automatically as they land.

| # | PR | Command surface |
| - | -- | --------------- |
| 1 | #389 Decode every sandbox field the API returns | `amika sandbox list\|create\|get` |
| 2 | #390 Return the whole secret summary, not three fields of it | `amika secret list\|push` |
| 3 | #391 Report what an agent-send turn actually cost | `amika sandbox agent-send` |
| 4 | #392 Let the SDK follow a snapshot capture to completion | `amika snapshot` |
| 5 | #393 Expose sandbox services to the TypeScript SDK | `amika service` |
| 6 | #394 Manage SSH public keys from the TypeScript SDK | `amika secret ssh-key` |
| 7 | #395 Let the SDK open an SSH dial into a sandbox | `amika ssh` / `code` / `scp` |
| 8 | #396 Add the agent-session chat surface to the SDK | `amika send`, `amika sessions` |

Together they close the gap between `@amika/sdk` and the network surface of the `amika` CLI. Deliberately out of scope: `amikalog`'s storage endpoints (a separately installed CLI), the `auth login` OAuth device flow, and the local Docker commands (`materialize`, `volume`, local `sandbox`) — none are remote API calls an HTTP client can make.

No version bump in any of these; releases land as their own commit via `create-sdk-release-commit`.


> **On the missing checks:** both `ci.yml` and `sdk-typescript.yml` trigger only on `pull_request: branches: [main]`, so PRs 2–8 show no checks while they target their parent branch. Each picks up CI when GitHub retargets it to `main` as its parent merges.
