### PR TITLE
Let the SDK open an SSH dial into a sandbox

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -91,6 +91,7 @@ Methods on `AmikaClient` mirror Go's `*apiclient.Client` 1:1:
 | ------------------------- | -------------------------------------- |
 | `getSSH(name)`            | `POST /sandboxes/{name}/ssh`           |
 | `revokeSSH(name, token)`  | `DELETE /sandboxes/{name}/ssh`         |
+| `createSSHSession(id)`    | `POST /sandboxes/{id}/ssh-sessions`    |
 | `createSSHPublicKey(req)` | `POST /secrets/ssh-public-keys`        |
 | `listSSHPublicKeys()`     | `GET /secrets/ssh-public-keys`         |
 | `deleteSSHPublicKey(id)`  | `DELETE /secrets/ssh-public-keys/{id}` |
@@ -150,6 +151,10 @@ Two fields sit outside this rule because they sit outside the schema. `container
 ## Polling behavior
 
 `waitForSandbox`, `waitForSandboxStart`, and `waitForSandboxStop` poll `getSandbox` every **3 seconds** with **no client-side timeout**, matching Go's `WaitForSandbox`. They throw `AmikaError` if the sandbox enters `failed` state, including the server's `errorMessage` when present. `waitForSandboxSnapshot` polls `getSandboxSnapshot` the same way, returning once the snapshot is `active` and throwing if it ends up `failed`.
+
+## SSH helpers
+
+`createSSHSession` returns a one-shot transport descriptor for dialing a sandbox over SSH, and validates it before handing it back — a descriptor for the wrong sandbox, on the wrong transport, or with a malformed connect URL, credential, or host key throws `InvalidSSHSessionError`. `isValidSSHSession` exposes the same check, and `canonicalEd25519PublicKey` validates an OpenSSH ed25519 public key line and returns it in the canonical, comment-stripped form the server stores (`""` if it is not a well-formed ed25519 key). Use it before `createSSHPublicKey` so a typo fails locally.
 
 ## Errors
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,5 +1,11 @@
 import { AmikaError, AmikaHTTPError, extractAgentAuthError } from "@/errors";
 import { HTTPClient } from "@/http";
+import {
+  InvalidSSHSessionError,
+  isValidSSHSession,
+  type SSHSession,
+  sshSessionFromWire,
+} from "@/ssh-session";
 import { StaticTokenSource, type TokenSource } from "@/token";
 import {
   type AgentSendRequest,
@@ -250,6 +256,25 @@ export class AmikaClient {
       "DELETE",
       `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?by=name`,
     );
+  }
+
+  // ---------- SSH sessions ----------
+
+  /**
+   * Create a fresh transport descriptor for one SSH dial into a sandbox, and
+   * validate it. Throws {@link InvalidSSHSessionError} if the server returns a
+   * descriptor that is unsafe or is not for `sandboxId`.
+   */
+  async createSSHSession(sandboxId: string): Promise<SSHSession> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "POST",
+      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxId)}/ssh-sessions`,
+    );
+    const session = sshSessionFromWire(data ?? {});
+    if (!isValidSSHSession(session, sandboxId)) {
+      throw new InvalidSSHSessionError();
+    }
+    return session;
   }
 
   // ---------- SSH public keys ----------

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -12,6 +12,14 @@ export {
 export { StaticTokenSource } from "@/token";
 export type { TokenSource } from "@/token";
 
+export {
+  canonicalEd25519PublicKey,
+  InvalidSSHSessionError,
+  isValidSSHSession,
+  SSH_SESSION_TRANSPORT_DIRECT_WS,
+} from "@/ssh-session";
+export type { SSHSession, SSHSessionTransport } from "@/ssh-session";
+
 export type {
   AgentCredentialRef,
   AgentSendRequest,

--- a/sdk/typescript/src/ssh-session.ts
+++ b/sdk/typescript/src/ssh-session.ts
@@ -1,0 +1,231 @@
+// The SSH transport descriptor behind `amika ssh`, `amika code`, and
+// `amika scp`, plus the key validation those commands rely on. Mirrors
+// go/internal/apiclient/ssh_session.go.
+
+import { AmikaError } from "@/errors";
+import { str } from "@/types";
+
+/** Thrown when an SSH session descriptor is unsafe or internally inconsistent. */
+export class InvalidSSHSessionError extends AmikaError {
+  override name = "InvalidSSHSessionError";
+
+  constructor() {
+    super("invalid SSH session descriptor");
+  }
+}
+
+/** How the stdio proxy reaches the sandbox. Only `direct_ws` exists today. */
+export type SSHSessionTransport = "direct_ws";
+
+/** The provider-exposed no-relay transport. */
+export const SSH_SESSION_TRANSPORT_DIRECT_WS: SSHSessionTransport = "direct_ws";
+
+/** The transport descriptor returned for one SSH dial. */
+export interface SSHSession {
+  sessionId: string;
+  transport: SSHSessionTransport | string;
+  connectUrl: string;
+  connectCredential: string;
+  sandboxId: string;
+  sshUser: string;
+  hostPublicKey: string;
+}
+
+export function sshSessionFromWire(w: Record<string, unknown>): SSHSession {
+  return {
+    sessionId: str(w["session_id"]),
+    transport: str(w["transport"]),
+    connectUrl: str(w["connect_url"]),
+    connectCredential: str(w["connect_credential"]),
+    sandboxId: str(w["sandbox_id"]),
+    sshUser: str(w["ssh_user"]),
+    hostPublicKey: str(w["host_public_key"]),
+  };
+}
+
+/**
+ * Check every field OpenSSH or the WebSocket dialer would act on, and that the
+ * descriptor is for the sandbox that was asked for. Returns true when the
+ * descriptor is safe to dial.
+ */
+export function isValidSSHSession(
+  session: SSHSession,
+  expectedSandboxId: string,
+): boolean {
+  if (
+    session.sessionId === "" ||
+    session.sessionId.length > 128 ||
+    !session.sessionId.startsWith("sshs_")
+  ) {
+    return false;
+  }
+  if (
+    session.transport !== SSH_SESSION_TRANSPORT_DIRECT_WS ||
+    session.sandboxId !== expectedSandboxId ||
+    session.sshUser !== "amika"
+  ) {
+    return false;
+  }
+  if (
+    !isCanonicalConnectToken(session.connectCredential) ||
+    canonicalEd25519PublicKey(session.hostPublicKey) === ""
+  ) {
+    return false;
+  }
+
+  let connectUrl: URL;
+  try {
+    connectUrl = new URL(session.connectUrl);
+  } catch {
+    return false;
+  }
+  if (
+    connectUrl.protocol !== "wss:" ||
+    connectUrl.host === "" ||
+    connectUrl.username !== "" ||
+    connectUrl.password !== "" ||
+    connectUrl.search !== "" ||
+    connectUrl.hash !== ""
+  ) {
+    return false;
+  }
+  return connectUrl.pathname.endsWith("/v1/ssh-sessions");
+}
+
+/**
+ * Validate one OpenSSH ed25519 public key line and return it in canonical form
+ * with any comment stripped, or "" if the value is not a well-formed ed25519
+ * key. The control plane canonicalizes the same way, so uploading this form
+ * keeps a locally read key byte-identical to what the server stores.
+ */
+export function canonicalEd25519PublicKey(value: string): string {
+  const line = value.trim();
+  // A single key line only: authorized_keys options, or a second key, are not
+  // accepted (matching Go's rejection of options and trailing content).
+  if (line === "" || /[\r\n]/.test(line)) return "";
+
+  const fields = line.split(/[ \t]+/);
+  const algorithm = fields[0];
+  const encoded = fields[1];
+  if (algorithm !== ED25519_ALGORITHM || encoded === undefined) return "";
+
+  const blob = decodeBase64(encoded);
+  if (!blob) return "";
+
+  const parsed = parseEd25519Blob(blob);
+  if (!parsed) return "";
+
+  // Re-encode from the parsed key so the canonical form does not inherit any
+  // quirk of the input's base64.
+  return `${ED25519_ALGORITHM} ${encodeBase64(buildEd25519Blob(parsed))}`;
+}
+
+const ED25519_ALGORITHM = "ssh-ed25519";
+const ED25519_KEY_BYTES = 32;
+const CONNECT_TOKEN_BYTES = 32;
+
+/** A connect credential is exactly 32 bytes in canonical unpadded base64url. */
+function isCanonicalConnectToken(value: string): boolean {
+  const decoded = decodeBase64Url(value);
+  if (!decoded || decoded.length !== CONNECT_TOKEN_BYTES) return false;
+  return encodeBase64Url(decoded) === value;
+}
+
+/**
+ * Read the SSH wire encoding of an ed25519 public key: the algorithm name and
+ * the 32 key bytes, each length-prefixed, with nothing trailing. Returns the
+ * key bytes, or null if the blob is not exactly that.
+ */
+function parseEd25519Blob(blob: Uint8Array): Uint8Array | null {
+  const name = readString(blob, 0);
+  if (!name) return null;
+  if (decodeAscii(name.value) !== ED25519_ALGORITHM) return null;
+
+  const key = readString(blob, name.next);
+  if (!key || key.value.length !== ED25519_KEY_BYTES) return null;
+  if (key.next !== blob.length) return null;
+
+  return key.value;
+}
+
+function buildEd25519Blob(key: Uint8Array): Uint8Array {
+  const name = new TextEncoder().encode(ED25519_ALGORITHM);
+  const out = new Uint8Array(4 + name.length + 4 + key.length);
+  writeUint32(out, 0, name.length);
+  out.set(name, 4);
+  writeUint32(out, 4 + name.length, key.length);
+  out.set(key, 8 + name.length);
+  return out;
+}
+
+function readString(
+  buf: Uint8Array,
+  offset: number,
+): { value: Uint8Array; next: number } | null {
+  if (offset + 4 > buf.length) return null;
+  const length = readUint32(buf, offset);
+  const start = offset + 4;
+  const end = start + length;
+  if (end > buf.length) return null;
+  return { value: buf.subarray(start, end), next: end };
+}
+
+function readUint32(buf: Uint8Array, offset: number): number {
+  return (
+    (((buf[offset] as number) << 24) |
+      ((buf[offset + 1] as number) << 16) |
+      ((buf[offset + 2] as number) << 8) |
+      (buf[offset + 3] as number)) >>>
+    0
+  );
+}
+
+function writeUint32(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = (value >>> 24) & 0xff;
+  buf[offset + 1] = (value >>> 16) & 0xff;
+  buf[offset + 2] = (value >>> 8) & 0xff;
+  buf[offset + 3] = value & 0xff;
+}
+
+function decodeAscii(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+/** Strict padded base64, as Go's `base64.StdEncoding` accepts. */
+function decodeBase64(value: string): Uint8Array | null {
+  if (value.length % 4 !== 0) return null;
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null;
+  return atobToBytes(value);
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/** Unpadded base64url, as Go's `base64.RawURLEncoding` accepts. */
+function decodeBase64Url(value: string): Uint8Array | null {
+  if (value === "" || !/^[A-Za-z0-9_-]*$/.test(value)) return null;
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  return atobToBytes(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  return encodeBase64(bytes)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function atobToBytes(value: string): Uint8Array | null {
+  let binary: string;
+  try {
+    binary = atob(value);
+  } catch {
+    return null;
+  }
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -1045,3 +1045,51 @@ describe("AmikaClient SSH public keys", () => {
     );
   });
 });
+
+describe("AmikaClient.createSSHSession", () => {
+  const validDescriptor = {
+    session_id: "sshs_abc",
+    transport: "direct_ws",
+    connect_url: "wss://relay.example.com/v1/ssh-sessions",
+    connect_credential: "A".repeat(42) + "Q",
+    sandbox_id: "sbx_1",
+    ssh_user: "amika",
+    host_public_key:
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4ilkUClOhQyh1hQBSn7N/cMSpX0oqg4P87b21Qqdvt",
+  };
+
+  it("POSTs to /ssh-sessions and returns the validated descriptor", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 201, body: validDescriptor },
+    ]);
+    const session = await makeClient(fetch).createSSHSession("sbx_1");
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.url).toBe(
+      `${BASE}/api/v0beta1/sandboxes/sbx_1/ssh-sessions`,
+    );
+    expect(session.sessionId).toBe("sshs_abc");
+    expect(session.transport).toBe("direct_ws");
+  });
+
+  it("rejects a descriptor issued for another sandbox", async () => {
+    const { fetch } = mockFetch([{ status: 201, body: validDescriptor }]);
+    await expect(makeClient(fetch).createSSHSession("sbx_2")).rejects.toThrow(
+      /invalid SSH session descriptor/,
+    );
+  });
+
+  it("rejects a descriptor with a non-wss connect URL", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 201,
+        body: {
+          ...validDescriptor,
+          connect_url: "ws://relay.example.com/v1/ssh-sessions",
+        },
+      },
+    ]);
+    await expect(makeClient(fetch).createSSHSession("sbx_1")).rejects.toThrow(
+      /invalid SSH session descriptor/,
+    );
+  });
+});

--- a/sdk/typescript/test/ssh-session.test.ts
+++ b/sdk/typescript/test/ssh-session.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  canonicalEd25519PublicKey,
+  isValidSSHSession,
+  type SSHSession,
+} from "@/ssh-session";
+
+const ED25519_KEY =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4ilkUClOhQyh1hQBSn7N/cMSpX0oqg4P87b21Qqdvt";
+const RSA_KEY =
+  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC093npR5HAcy4a1CdTWnMAe5lK3JX6FupbkO8y3qy+2to99D9Y1DhC/CqDAU1GBBD7mKhrg4kb7QZJR+3F";
+
+// 32 zero bytes in unpadded base64url — the canonical shape of a connect token.
+const CONNECT_CREDENTIAL = "A".repeat(42) + "Q";
+
+function validSession(overrides: Partial<SSHSession> = {}): SSHSession {
+  return {
+    sessionId: "sshs_abc123",
+    transport: "direct_ws",
+    connectUrl: "wss://relay.example.com/v1/ssh-sessions",
+    connectCredential: CONNECT_CREDENTIAL,
+    sandboxId: "sbx_1",
+    sshUser: "amika",
+    hostPublicKey: ED25519_KEY,
+    ...overrides,
+  };
+}
+
+describe("canonicalEd25519PublicKey", () => {
+  it("strips the comment and returns the canonical line", () => {
+    expect(canonicalEd25519PublicKey(`${ED25519_KEY} jakub@example.com`)).toBe(
+      ED25519_KEY,
+    );
+  });
+
+  it("tolerates surrounding whitespace and a trailing newline", () => {
+    expect(canonicalEd25519PublicKey(`  ${ED25519_KEY} laptop  \n`)).toBe(
+      ED25519_KEY,
+    );
+  });
+
+  it("rejects a non-ed25519 key", () => {
+    expect(canonicalEd25519PublicKey(RSA_KEY)).toBe("");
+  });
+
+  it("rejects authorized_keys options", () => {
+    expect(canonicalEd25519PublicKey(`no-pty ${ED25519_KEY}`)).toBe("");
+  });
+
+  it("rejects a second key on another line", () => {
+    expect(canonicalEd25519PublicKey(`${ED25519_KEY}\n${ED25519_KEY}`)).toBe(
+      "",
+    );
+  });
+
+  it("rejects a blob whose algorithm name disagrees with the prefix", () => {
+    // An ssh-rsa blob relabelled as ssh-ed25519.
+    const relabelled = `ssh-ed25519 ${RSA_KEY.split(" ")[1]}`;
+    expect(canonicalEd25519PublicKey(relabelled)).toBe("");
+  });
+
+  it("rejects malformed base64 and empty input", () => {
+    expect(canonicalEd25519PublicKey("ssh-ed25519 not!base64")).toBe("");
+    expect(canonicalEd25519PublicKey("ssh-ed25519")).toBe("");
+    expect(canonicalEd25519PublicKey("")).toBe("");
+  });
+});
+
+describe("isValidSSHSession", () => {
+  it("accepts a well-formed descriptor for the expected sandbox", () => {
+    expect(isValidSSHSession(validSession(), "sbx_1")).toBe(true);
+  });
+
+  it("rejects a descriptor for a different sandbox", () => {
+    expect(isValidSSHSession(validSession(), "sbx_2")).toBe(false);
+  });
+
+  it.each([
+    ["a session id without the sshs_ prefix", { sessionId: "abc" }],
+    ["an over-long session id", { sessionId: "sshs_" + "a".repeat(200) }],
+    ["an unknown transport", { transport: "relay_ws" }],
+    ["a non-amika ssh user", { sshUser: "root" }],
+    [
+      "a non-wss connect URL",
+      { connectUrl: "https://r.example/v1/ssh-sessions" },
+    ],
+    [
+      "a connect URL with a query",
+      { connectUrl: "wss://r.example/v1/ssh-sessions?x=1" },
+    ],
+    [
+      "a connect URL with userinfo",
+      { connectUrl: "wss://u:p@r.example/v1/ssh-sessions" },
+    ],
+    [
+      "a connect URL with the wrong path",
+      { connectUrl: "wss://r.example/v1/other" },
+    ],
+    [
+      "a connect credential that is not 32 bytes",
+      { connectCredential: "AAAA" },
+    ],
+    [
+      "a padded connect credential",
+      { connectCredential: CONNECT_CREDENTIAL + "==" },
+    ],
+    ["a host key that is not ed25519", { hostPublicKey: RSA_KEY }],
+  ])("rejects %s", (_label, overrides) => {
+    expect(isValidSSHSession(validSession(overrides), "sbx_1")).toBe(false);
+  });
+});


### PR DESCRIPTION
**Stack 7/8** — based on #394.

## Why

`amika ssh`, `amika code`, and `amika scp` all begin by asking the API for a one-shot transport descriptor, then hand it to OpenSSH or a WebSocket dialer. Without `createSSHSession` a TypeScript caller could provision a sandbox but not reach into it.

## What

`createSSHSession(sandboxId)`, plus `src/ssh-session.ts`.

The descriptor is validated before it is returned, because acting on a bad one is exactly what the check guards against: a wrong `sandboxId` would dial someone else's sandbox, and a malformed connect URL, credential, or host key would weaken the dial. The rules mirror Go's `SSHSession.Validate` field for field.

Validating the host key means parsing an OpenSSH ed25519 line. `canonicalEd25519PublicKey` does that against the SSH wire format rather than by pulling in a crypto library, so the SDK still has zero runtime dependencies. It is exported too — run a key through it before `createSSHPublicKey` and a typo fails locally, in the same canonical comment-stripped form the server stores.

## Testing

`pnpm run ci` passes locally (98 unit tests). 20 of them are new: the ed25519 parser against a real key, an RSA key, authorized_keys options, a relabelled blob, and a table of 11 rejection cases for the descriptor validator.

---

### The stack

Merge front to back. Each PR targets the one above it; GitHub retargets automatically as they land.

| # | PR | Command surface |
| - | -- | --------------- |
| 1 | #389 Decode every sandbox field the API returns | `amika sandbox list\|create\|get` |
| 2 | #390 Return the whole secret summary, not three fields of it | `amika secret list\|push` |
| 3 | #391 Report what an agent-send turn actually cost | `amika sandbox agent-send` |
| 4 | #392 Let the SDK follow a snapshot capture to completion | `amika snapshot` |
| 5 | #393 Expose sandbox services to the TypeScript SDK | `amika service` |
| 6 | #394 Manage SSH public keys from the TypeScript SDK | `amika secret ssh-key` |
| 7 | #395 Let the SDK open an SSH dial into a sandbox | `amika ssh` / `code` / `scp` |
| 8 | #396 Add the agent-session chat surface to the SDK | `amika send`, `amika sessions` |

Together they close the gap between `@amika/sdk` and the network surface of the `amika` CLI. Deliberately out of scope: `amikalog`'s storage endpoints (a separately installed CLI), the `auth login` OAuth device flow, and the local Docker commands (`materialize`, `volume`, local `sandbox`) — none are remote API calls an HTTP client can make.

No version bump in any of these; releases land as their own commit via `create-sdk-release-commit`.


> **On the missing checks:** both `ci.yml` and `sdk-typescript.yml` trigger only on `pull_request: branches: [main]`, so PRs 2–8 show no checks while they target their parent branch. Each picks up CI when GitHub retargets it to `main` as its parent merges.
