### PR TITLE
Add the agent-session chat surface to the SDK

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -105,14 +105,18 @@ Methods on `AmikaClient` mirror Go's `*apiclient.Client` 1:1:
 
 ### Agents and sessions
 
-| Method                                | Endpoint                                              |
-| ------------------------------------- | ----------------------------------------------------- |
-| `agentSend(name, req)`                | `POST /sandboxes/{name}/agent-send` (10-min timeout)  |
-| `createSession(name, req)`            | `POST /sandboxes/{name}/sessions`                     |
-| `listSessions(name)`                  | `GET /sandboxes/{name}/sessions`                      |
-| `getLatestSession(name)`              | `GET /sandboxes/{name}/sessions/latest` (null on 404) |
-| `getSession(name, sessionId)`         | `GET /sandboxes/{name}/sessions/{sessionId}`          |
-| `updateSession(name, sessionId, req)` | `PATCH /sandboxes/{name}/sessions/{sessionId}`        |
+| Method                                  | Endpoint                                              |
+| --------------------------------------- | ----------------------------------------------------- |
+| `agentSend(name, req)`                  | `POST /sandboxes/{name}/agent-send` (10-min timeout)  |
+| `sendAgentSession(req)`                 | `POST /agent-sessions` (10-min timeout)               |
+| `sendAgentSessionStream(req, handlers)` | `POST /agent-sessions/stream` (SSE)                   |
+| `listAgentSessions(limit?)`             | `GET /agent-sessions`                                 |
+| `getAgentSession(sessionId)`            | `GET /agent-sessions/{sessionId}`                     |
+| `createSession(name, req)`              | `POST /sandboxes/{name}/sessions`                     |
+| `listSessions(name)`                    | `GET /sandboxes/{name}/sessions`                      |
+| `getLatestSession(name)`                | `GET /sandboxes/{name}/sessions/latest` (null on 404) |
+| `getSession(name, sessionId)`           | `GET /sandboxes/{name}/sessions/{sessionId}`          |
+| `updateSession(name, sessionId, req)`   | `PATCH /sandboxes/{name}/sessions/{sessionId}`        |
 
 ### Snapshots
 
@@ -127,7 +131,7 @@ Methods on `AmikaClient` mirror Go's `*apiclient.Client` 1:1:
 
 Fork a new sandbox from a captured snapshot by passing its slug as `snapshot` to `createSandbox({ snapshot })`.
 
-Types are camelCased and translated to/from snake_case on the wire. See `src/types.ts` for the full set: `CreateSandboxRequest`, `RemoteSandbox`, `SSHInfo`, `Secret`, `CreateProviderSecretRequest`, `AgentSendRequest`, `AgentSendResponse`, `Session`, `SandboxSnapshot`, `CreateSandboxSnapshotRequest`, etc.
+Types are camelCased and translated to/from snake_case on the wire. See `src/types.ts` and `src/agent-sessions.ts` for the full set: `CreateSandboxRequest`, `RemoteSandbox`, `SSHInfo`, `Secret`, `CreateProviderSecretRequest`, `AgentSendRequest`, `AgentSendResponse`, `Session`, `SandboxSnapshot`, `SandboxServiceResource`, `AgentSessionSendRequest`, `AgentSessionDetail`, etc.
 
 ### Nullability
 
@@ -147,6 +151,23 @@ Two fields sit outside this rule because they sit outside the schema. `container
 ## Polling behavior
 
 `waitForSandbox`, `waitForSandboxStart`, and `waitForSandboxStop` poll `getSandbox` every **3 seconds** with **no client-side timeout**, matching Go's `WaitForSandbox`. They throw `AmikaError` if the sandbox enters `failed` state, including the server's `errorMessage` when present. `waitForSandboxSnapshot` polls `getSandboxSnapshot` the same way, returning once the snapshot is `active` and throwing if it ends up `failed`.
+
+## Streaming an agent turn
+
+`sendAgentSessionStream` reads the SSE endpoint and resolves with the same response `sendAgentSession` returns, after forwarding progress to your handlers:
+
+```ts
+const result = await amika.sendAgentSessionStream(
+  { message: "Add a CHANGELOG", repoUrl: "git@github.com:org/proj.git" },
+  {
+    onStatus: (phase, sandboxId) => console.error(`[${phase}] ${sandboxId}`),
+    onDelta: (text) => process.stdout.write(text),
+  },
+);
+console.log(`\nsession ${result.sessionId} on sandbox ${result.sandboxId}`);
+```
+
+The server enforces a 300s ceiling on the request, below the client's 10-minute timeout. If it cuts the stream before a terminal frame, the call throws and the turn may still have completed — check `listAgentSessions()` for the session rather than assuming the work was lost.
 
 ## Errors
 
@@ -198,3 +219,5 @@ pnpm test:functional
 Optional env vars: `AMIKA_TEST_REPO_URL`, `AMIKA_TEST_PRESET`, `AMIKA_TEST_AGENT_NAME`, `AMIKA_TEST_AGENT_CREDENTIAL_NAME`, `AMIKA_TEST_AGENT_CREDENTIAL_TYPE`, `AMIKA_TEST_BRANCH`, `AMIKA_TEST_SANDBOX_NAME_PREFIX`, `AMIKA_TEST_PROVIDER`, `AMIKA_TEST_SANDBOX_PROVIDER`. See `test/functional/helpers.ts` for details.
 
 The suite provisions a real sandbox and runs the full lifecycle (create → wait → list → get → SSH → sessions → agentSend → stop → start → delete), so a single run takes several minutes and creates billable resources. Sandboxes are cleaned up in `afterAll`, but the secrets API has no delete endpoint — test-created secrets accumulate.
+
+`org-resources.functional.test.ts` is the exception: it only reads org-scoped listings and round-trips one SSH public key, so it provisions nothing and finishes in seconds. Run it alone with `pnpm test:functional org-resources`.

--- a/sdk/typescript/src/agent-sessions.ts
+++ b/sdk/typescript/src/agent-sessions.ts
@@ -203,14 +203,23 @@ export function listAgentSessionsResponseFromWire(
 
 /**
  * Progress callbacks for {@link AmikaClient.sendAgentSessionStream}. Both are
- * optional and are awaited in order as frames arrive. `onStatus` reports
- * lifecycle milestones (`creating_sandbox` / `sandbox_ready`, the latter
- * carrying the sandbox id); `onDelta` receives agent reply text as it is
- * produced.
+ * optional. `onStatus` reports lifecycle milestones (`creating_sandbox` /
+ * `sandbox_ready`, the latter carrying the sandbox id); `onDelta` receives
+ * agent reply text as it is produced.
+ *
+ * A handler may return a promise, and the reader awaits it before reading the
+ * next frame. Deltas therefore reach an async handler in order, and one that
+ * throws or rejects fails the send instead of becoming an unhandled rejection.
+ * A slow handler backpressures the stream, which is the right trade for output
+ * that must not interleave.
+ *
+ * The return type is `unknown` rather than `void | Promise<void>` so that a
+ * concise arrow body still type-checks: `(text) => process.stdout.write(text)`
+ * returns a boolean, and a union return type would reject it.
  */
 export interface AgentSessionStreamHandlers {
-  onStatus?: (phase: string, sandboxId: string) => void;
-  onDelta?: (text: string) => void;
+  onStatus?: (phase: string, sandboxId: string) => unknown;
+  onDelta?: (text: string) => unknown;
 }
 
 /**
@@ -234,7 +243,10 @@ export async function readAgentSessionStream(
         // Cosmetic progress only, so an unparseable frame is ignored.
         const parsed = tryParse(frame.data);
         if (parsed) {
-          handlers.onStatus(str(parsed["phase"]), str(parsed["sandbox_id"]));
+          await handlers.onStatus(
+            str(parsed["phase"]),
+            str(parsed["sandbox_id"]),
+          );
         }
         break;
       }
@@ -248,7 +260,7 @@ export async function readAgentSessionStream(
           );
         }
         const text = str(parsed["text"]);
-        if (text !== "" && handlers.onDelta) handlers.onDelta(text);
+        if (text !== "" && handlers.onDelta) await handlers.onDelta(text);
         break;
       }
       case "done": {

--- a/sdk/typescript/src/agent-sessions.ts
+++ b/sdk/typescript/src/agent-sessions.ts
@@ -1,0 +1,296 @@
+// Types and stream handling for the `/agent-sessions` endpoints — the chat
+// surface behind `amika send` and `amika sessions list|show`. Mirrors the Go
+// types in go/internal/apiclient/client.go; see src/types.ts for the
+// nullability convention.
+
+import { AmikaError } from "@/errors";
+import { readSSEFrames } from "@/sse";
+import {
+  bool,
+  mapArray,
+  nullableStr,
+  num,
+  optionalBool,
+  optionalNum,
+  optionalStr,
+  str,
+} from "@/types";
+
+/**
+ * Request body for POST /api/v0beta1/agent-sessions. Only `message` is
+ * required: `sessionId` continues an existing chat, `sandboxId` routes into a
+ * specific sandbox, and `repoUrl` is used only when a sandbox has to be
+ * created behind the scenes.
+ */
+export interface AgentSessionSendRequest {
+  message: string;
+  agent?: string;
+  sessionId?: string;
+  sandboxId?: string;
+  newSession?: boolean;
+  repoUrl?: string;
+}
+
+export function agentSessionSendRequestToWire(
+  r: AgentSessionSendRequest,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { message: r.message };
+  if (r.agent !== undefined) out["agent"] = r.agent;
+  if (r.sessionId !== undefined) out["session_id"] = r.sessionId;
+  if (r.sandboxId !== undefined) out["sandbox_id"] = r.sandboxId;
+  if (r.newSession !== undefined) out["new_session"] = r.newSession;
+  if (r.repoUrl !== undefined) out["repo_url"] = r.repoUrl;
+  return out;
+}
+
+/**
+ * Token and cost accounting for one turn. Every field is optional — Claude
+ * reports the full set, Codex currently reports none.
+ */
+export interface AgentSessionUsage {
+  costUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  durationMs?: number;
+  numTurns?: number;
+}
+
+function agentSessionUsageFromWire(
+  w: Record<string, unknown>,
+): AgentSessionUsage {
+  return {
+    costUsd: optionalNum(w["cost_usd"]),
+    inputTokens: optionalNum(w["input_tokens"]),
+    outputTokens: optionalNum(w["output_tokens"]),
+    cacheReadTokens: optionalNum(w["cache_read_tokens"]),
+    cacheCreationTokens: optionalNum(w["cache_creation_tokens"]),
+    durationMs: optionalNum(w["duration_ms"]),
+    numTurns: optionalNum(w["num_turns"]),
+  };
+}
+
+/**
+ * Response of POST /api/v0beta1/agent-sessions. `sessionId` is the durable
+ * chat id to pass back as `sessionId` to continue the chat.
+ */
+export interface AgentSessionSendResponse {
+  sessionId: string;
+  sandboxId: string;
+  agent: string;
+  response: string;
+  isError: boolean;
+  isNewSession: boolean;
+  createdSandbox: boolean;
+  usage?: AgentSessionUsage;
+}
+
+export function agentSessionSendResponseFromWire(
+  w: Record<string, unknown>,
+): AgentSessionSendResponse {
+  const usage = w["usage"];
+  return {
+    sessionId: str(w["session_id"]),
+    sandboxId: str(w["sandbox_id"]),
+    agent: str(w["agent"]),
+    response: str(w["response"]),
+    isError: bool(w["is_error"]),
+    isNewSession: bool(w["is_new_session"]),
+    createdSandbox: bool(w["created_sandbox"]),
+    usage:
+      typeof usage === "object" && usage !== null
+        ? agentSessionUsageFromWire(usage as Record<string, unknown>)
+        : undefined,
+  };
+}
+
+/**
+ * One row of the agent-sessions list. `sandboxName`, `preview`, `model`,
+ * `effort`, and `endedAt` are nullable: a chat can outlive the sandbox whose
+ * name it shows, carry no user message to preview, run at the agent CLI's own
+ * model and effort, and still be running.
+ */
+export interface AgentSessionSummary {
+  sessionId: string;
+  sandboxId: string;
+  sandboxName: string | null;
+  agent: string;
+  status: string;
+  preview: string | null;
+  model: string | null;
+  effort: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function agentSessionSummaryFromWire(
+  w: Record<string, unknown>,
+): AgentSessionSummary {
+  return {
+    sessionId: str(w["session_id"]),
+    sandboxId: str(w["sandbox_id"]),
+    sandboxName: nullableStr(w["sandbox_name"]),
+    agent: str(w["agent"]),
+    status: str(w["status"]),
+    preview: nullableStr(w["preview"]),
+    model: nullableStr(w["model"]),
+    effort: nullableStr(w["effort"]),
+    startedAt: str(w["started_at"]),
+    endedAt: nullableStr(w["ended_at"]),
+    createdAt: str(w["created_at"]),
+    updatedAt: str(w["updated_at"]),
+  };
+}
+
+/**
+ * One turn in a chat transcript. `isError` marks an assistant turn the agent
+ * reported as failed; it is absent on user turns and on transcripts that
+ * predate per-turn error tracking.
+ */
+export interface AgentSessionMessage {
+  role: string;
+  content: string;
+  timestamp: string;
+  isError?: boolean;
+}
+
+function agentSessionMessageFromWire(
+  w: Record<string, unknown>,
+): AgentSessionMessage {
+  return {
+    role: str(w["role"]),
+    content: str(w["content"]),
+    timestamp: str(w["timestamp"]),
+    isError: optionalBool(w["is_error"]),
+  };
+}
+
+/** An {@link AgentSessionSummary} plus the chat's full transcript. */
+export interface AgentSessionDetail extends AgentSessionSummary {
+  messages: AgentSessionMessage[];
+}
+
+export function agentSessionDetailFromWire(
+  w: Record<string, unknown>,
+): AgentSessionDetail {
+  return {
+    ...agentSessionSummaryFromWire(w),
+    messages: mapArray(w["messages"], agentSessionMessageFromWire),
+  };
+}
+
+/**
+ * One page of chats plus the total matching the query. `total` exceeds
+ * `sessions.length` when the page cuts the list short; report that rather than
+ * presenting a truncated list as the whole of it.
+ */
+export interface ListAgentSessionsResponse {
+  sessions: AgentSessionSummary[];
+  total: number;
+}
+
+export function listAgentSessionsResponseFromWire(
+  w: Record<string, unknown>,
+): ListAgentSessionsResponse {
+  return {
+    sessions: mapArray(w["sessions"], agentSessionSummaryFromWire),
+    total: num(w["total"]),
+  };
+}
+
+/**
+ * Progress callbacks for {@link AmikaClient.sendAgentSessionStream}. Both are
+ * optional and are awaited in order as frames arrive. `onStatus` reports
+ * lifecycle milestones (`creating_sandbox` / `sandbox_ready`, the latter
+ * carrying the sandbox id); `onDelta` receives agent reply text as it is
+ * produced.
+ */
+export interface AgentSessionStreamHandlers {
+  onStatus?: (phase: string, sandboxId: string) => void;
+  onDelta?: (text: string) => void;
+}
+
+/**
+ * Consume the send SSE stream, dispatching `status`/`delta` frames to the
+ * handlers and returning the terminal `done` result.
+ *
+ * A completed turn wins over an `error` frame: `done` carries the persisted
+ * result, so if both somehow arrive the send succeeded and reporting the error
+ * would discard a real session id.
+ */
+export async function readAgentSessionStream(
+  body: ReadableStream<Uint8Array>,
+  handlers: AgentSessionStreamHandlers,
+): Promise<AgentSessionSendResponse> {
+  let streamError = "";
+
+  for await (const frame of readSSEFrames(body)) {
+    switch (frame.event) {
+      case "status": {
+        if (!handlers.onStatus) break;
+        // Cosmetic progress only, so an unparseable frame is ignored.
+        const parsed = tryParse(frame.data);
+        if (parsed) {
+          handlers.onStatus(str(parsed["phase"]), str(parsed["sandbox_id"]));
+        }
+        break;
+      }
+      case "delta": {
+        // A delta carries reply text, so an unparseable one is lost output.
+        // Fail loudly rather than silently returning a truncated reply.
+        const parsed = tryParse(frame.data);
+        if (!parsed) {
+          throw new AmikaError(
+            "remote agent-session send: parsing delta frame failed",
+          );
+        }
+        const text = str(parsed["text"]);
+        if (text !== "" && handlers.onDelta) handlers.onDelta(text);
+        break;
+      }
+      case "done": {
+        const parsed = tryParse(frame.data);
+        if (!parsed) {
+          throw new AmikaError(
+            "remote agent-session send: parsing done frame failed",
+          );
+        }
+        // `done` is terminal: stop reading so a later frame cannot discard a
+        // completed turn's result.
+        return agentSessionSendResponseFromWire(parsed);
+      }
+      case "error": {
+        const parsed = tryParse(frame.data);
+        streamError = optionalStr(parsed?.["error"]) || "stream error";
+        break;
+      }
+    }
+  }
+
+  if (streamError !== "") {
+    throw new AmikaError(`remote agent-session send: ${streamError}`);
+  }
+  // No terminal frame. The most likely cause is the server's own request
+  // ceiling (300s) cutting the stream mid-turn — the turn may well have
+  // completed and persisted, so point at the session list rather than
+  // implying the work was lost.
+  throw new AmikaError(
+    "remote agent-session send: stream ended without a result " +
+      "(the server may have hit its request time limit; " +
+      "check listAgentSessions() for the session)",
+  );
+}
+
+function tryParse(data: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/sdk/typescript/src/agent-sessions.ts
+++ b/sdk/typescript/src/agent-sessions.ts
@@ -12,6 +12,7 @@ import {
   num,
   optionalBool,
   optionalNum,
+  optionalObject,
   optionalStr,
   str,
 } from "@/types";
@@ -89,7 +90,6 @@ export interface AgentSessionSendResponse {
 export function agentSessionSendResponseFromWire(
   w: Record<string, unknown>,
 ): AgentSessionSendResponse {
-  const usage = w["usage"];
   return {
     sessionId: str(w["session_id"]),
     sandboxId: str(w["sandbox_id"]),
@@ -98,10 +98,9 @@ export function agentSessionSendResponseFromWire(
     isError: bool(w["is_error"]),
     isNewSession: bool(w["is_new_session"]),
     createdSandbox: bool(w["created_sandbox"]),
-    usage:
-      typeof usage === "object" && usage !== null
-        ? agentSessionUsageFromWire(usage as Record<string, unknown>)
-        : undefined,
+    // optionalObject rather than a bare typeof check: an array is also
+    // `typeof "object"`, and would decode to an all-undefined usage object.
+    usage: optionalObject(w["usage"], agentSessionUsageFromWire),
   };
 }
 
@@ -280,6 +279,10 @@ export async function readAgentSessionStream(
       }
       case "error": {
         const parsed = tryParse(frame.data);
+        // Same reasoning as delta/done: a cut mid-frame is a lost stream, not
+        // a new error. Without this, a truncated error frame overwrites an
+        // earlier real message with the generic fallback.
+        if (!parsed && !frame.terminated) break stream;
         streamError = optionalStr(parsed?.["error"]) || "stream error";
         break;
       }
@@ -289,14 +292,15 @@ export async function readAgentSessionStream(
   if (streamError !== "") {
     throw new AmikaError(`remote agent-session send: ${streamError}`);
   }
-  // No terminal frame. The most likely cause is the server's own request
-  // ceiling (300s) cutting the stream mid-turn — the turn may well have
-  // completed and persisted, so point at the session list rather than
-  // implying the work was lost.
+  // No terminal frame. The likeliest cause is the server's own request ceiling
+  // (300s) cutting the stream mid-turn, but a clean close with a malformed
+  // final frame lands here too and the two are indistinguishable from here, so
+  // name both. Either way the turn may have completed and persisted, so point
+  // at the session list rather than implying the work was lost.
   throw new AmikaError(
     "remote agent-session send: stream ended without a result " +
-      "(the server may have hit its request time limit; " +
-      "check listAgentSessions() for the session)",
+      "(the server may have hit its request time limit, or the final frame " +
+      "was truncated or malformed; check listAgentSessions() for the session)",
   );
 }
 

--- a/sdk/typescript/src/agent-sessions.ts
+++ b/sdk/typescript/src/agent-sessions.ts
@@ -236,7 +236,7 @@ export async function readAgentSessionStream(
 ): Promise<AgentSessionSendResponse> {
   let streamError = "";
 
-  for await (const frame of readSSEFrames(body)) {
+  stream: for await (const frame of readSSEFrames(body)) {
     switch (frame.event) {
       case "status": {
         if (!handlers.onStatus) break;
@@ -255,6 +255,9 @@ export async function readAgentSessionStream(
         // Fail loudly rather than silently returning a truncated reply.
         const parsed = tryParse(frame.data);
         if (!parsed) {
+          // Truncated trailing frame: the connection was cut mid-delta, which
+          // is a lost stream, not corrupt output. Stop and report it as such.
+          if (!frame.terminated) break stream;
           throw new AmikaError(
             "remote agent-session send: parsing delta frame failed",
           );
@@ -266,6 +269,7 @@ export async function readAgentSessionStream(
       case "done": {
         const parsed = tryParse(frame.data);
         if (!parsed) {
+          if (!frame.terminated) break stream;
           throw new AmikaError(
             "remote agent-session send: parsing done frame failed",
           );
@@ -299,7 +303,9 @@ export async function readAgentSessionStream(
 function tryParse(data: string): Record<string, unknown> | undefined {
   try {
     const parsed: unknown = JSON.parse(data);
-    return typeof parsed === "object" && parsed !== null
+    return typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : undefined;
   } catch {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,3 +1,15 @@
+import {
+  type AgentSessionDetail,
+  agentSessionDetailFromWire,
+  type AgentSessionSendRequest,
+  type AgentSessionSendResponse,
+  agentSessionSendRequestToWire,
+  agentSessionSendResponseFromWire,
+  type AgentSessionStreamHandlers,
+  type ListAgentSessionsResponse,
+  listAgentSessionsResponseFromWire,
+  readAgentSessionStream,
+} from "@/agent-sessions";
 import { AmikaError, AmikaHTTPError, extractAgentAuthError } from "@/errors";
 import { HTTPClient } from "@/http";
 import { StaticTokenSource, type TokenSource } from "@/token";
@@ -484,6 +496,80 @@ export class AmikaClient {
       "DELETE",
       `${API_BASE_PATH}/sandbox-snapshots/${encodeURIComponent(ref)}?by=ref`,
     );
+  }
+
+  // ---------- Agent sessions ----------
+
+  /**
+   * Send a message to a coding agent, creating a sandbox behind the scenes
+   * when the chat has none, or routing to an existing sandbox or session. The
+   * endpoint is synchronous, so it uses the same 10-minute timeout as
+   * {@link agentSend}.
+   *
+   * Unlike {@link agentSend}, a provider auth failure comes back as a normal
+   * response with `isError` set and the agent CLI's own message in `response`,
+   * not as an HTTP error.
+   */
+  async sendAgentSession(
+    req: AgentSessionSendRequest,
+  ): Promise<AgentSessionSendResponse> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "POST",
+      `${API_BASE_PATH}/agent-sessions`,
+      agentSessionSendRequestToWire(req),
+      { timeoutMs: AGENT_SEND_TIMEOUT_MS },
+    );
+    return agentSessionSendResponseFromWire(data ?? {});
+  }
+
+  /**
+   * The streaming counterpart to {@link sendAgentSession}: forwards `status`
+   * and `delta` frames to `handlers` as they arrive and resolves with the same
+   * response the buffered endpoint returns.
+   *
+   * The effective time limit is the server's (a 300s request ceiling), which
+   * is lower than the client's 10 minutes: it ends the stream first, without a
+   * terminal frame, and the client timeout only guards a connection that hangs
+   * past even that.
+   */
+  async sendAgentSessionStream(
+    req: AgentSessionSendRequest,
+    handlers: AgentSessionStreamHandlers = {},
+  ): Promise<AgentSessionSendResponse> {
+    const { body, release } = await this.http.openStream(
+      "POST",
+      `${API_BASE_PATH}/agent-sessions/stream`,
+      agentSessionSendRequestToWire(req),
+      { timeoutMs: AGENT_SEND_TIMEOUT_MS },
+    );
+    try {
+      return await readAgentSessionStream(body, handlers);
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * List the org's agent-session chats, newest first. Omitting `limit` leaves
+   * the server's default page size (50) in place. The response's `total`
+   * exceeds `sessions.length` when the page cuts the list short.
+   */
+  async listAgentSessions(limit?: number): Promise<ListAgentSessionsResponse> {
+    const qs = limit && limit > 0 ? `?limit=${limit}` : "";
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "GET",
+      `${API_BASE_PATH}/agent-sessions${qs}`,
+    );
+    return listAgentSessionsResponseFromWire(data ?? {});
+  }
+
+  /** Fetch one agent-session chat with its message history. */
+  async getAgentSession(sessionId: string): Promise<AgentSessionDetail> {
+    const data = await this.http.doJSON<Record<string, unknown>>(
+      "GET",
+      `${API_BASE_PATH}/agent-sessions/${encodeURIComponent(sessionId)}`,
+    );
+    return agentSessionDetailFromWire(data ?? {});
   }
 }
 

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -1,4 +1,4 @@
-import { AmikaHTTPError } from "@/errors";
+import { AmikaError, AmikaHTTPError } from "@/errors";
 import type { TokenSource } from "@/token";
 
 export interface HTTPClientOptions {
@@ -13,6 +13,17 @@ export interface HTTPClientOptions {
 export interface RequestOptions {
   /** Override the default timeout for a single request. */
   timeoutMs?: number;
+}
+
+/**
+ * A streaming response body plus the cleanup its caller owes. `release` clears
+ * the request's timeout, so it must be called once the body is fully consumed
+ * (or abandoned) — until then the timeout still applies to the whole stream,
+ * not just the response headers.
+ */
+export interface StreamHandle {
+  body: ReadableStream<Uint8Array>;
+  release: () => void;
 }
 
 /**
@@ -44,10 +55,82 @@ export class HTTPClient {
     body?: unknown,
     requestOptions?: RequestOptions,
   ): Promise<T | null> {
-    const url = this.baseUrl + path;
+    const { response, release } = await this.send(
+      method,
+      path,
+      body,
+      undefined,
+      requestOptions,
+    );
+
+    let text: string;
+    try {
+      text = await response.text();
+    } finally {
+      release();
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new AmikaHTTPError(response.status, text);
+    }
+
+    if (text.length === 0) return null;
+    return JSON.parse(text) as T;
+  }
+
+  /**
+   * Open a Server-Sent Events response and hand back its body unread. A
+   * rejection (auth, validation) arrives as a normal JSON error before the
+   * stream opens and is surfaced as `AmikaHTTPError`, exactly as it would be
+   * on the buffered path.
+   */
+  async openStream(
+    method: string,
+    path: string,
+    body?: unknown,
+    requestOptions?: RequestOptions,
+  ): Promise<StreamHandle> {
+    const { response, release } = await this.send(
+      method,
+      path,
+      body,
+      "text/event-stream",
+      requestOptions,
+    );
+
+    if (response.status < 200 || response.status >= 300) {
+      let text: string;
+      try {
+        text = await response.text();
+      } finally {
+        release();
+      }
+      throw new AmikaHTTPError(response.status, text);
+    }
+
+    if (!response.body) {
+      release();
+      throw new AmikaError("stream response has no body");
+    }
+    return { body: response.body, release };
+  }
+
+  /**
+   * Issue one authenticated request and return the response with the timeout
+   * still armed. The caller must invoke `release` once it is done with the
+   * body; nothing else here clears the timer.
+   */
+  private async send(
+    method: string,
+    path: string,
+    body: unknown,
+    accept: string | undefined,
+    requestOptions: RequestOptions | undefined,
+  ): Promise<{ response: Response; release: () => void }> {
     const headers: Record<string, string> = {};
     const token = await this.tokenSource.token();
     headers["Authorization"] = `Bearer ${token}`;
+    if (accept) headers["Accept"] = accept;
 
     let serialized: string | undefined;
     if (body !== undefined && body !== null) {
@@ -58,26 +141,20 @@ export class HTTPClient {
     const timeoutMs = requestOptions?.timeoutMs ?? this.defaultTimeoutMs;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const release = () => clearTimeout(timer);
 
     let response: Response;
     try {
-      response = await this.fetchImpl(url, {
+      response = await this.fetchImpl(this.baseUrl + path, {
         method,
         headers,
         body: serialized,
         signal: controller.signal,
       });
-    } finally {
-      clearTimeout(timer);
+    } catch (err) {
+      release();
+      throw err;
     }
-
-    const text = await response.text();
-
-    if (response.status < 200 || response.status >= 300) {
-      throw new AmikaHTTPError(response.status, text);
-    }
-
-    if (text.length === 0) return null;
-    return JSON.parse(text) as T;
+    return { response, release };
   }
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -13,6 +13,17 @@ export { StaticTokenSource } from "@/token";
 export type { TokenSource } from "@/token";
 
 export type {
+  AgentSessionDetail,
+  AgentSessionMessage,
+  AgentSessionSendRequest,
+  AgentSessionSendResponse,
+  AgentSessionStreamHandlers,
+  AgentSessionSummary,
+  AgentSessionUsage,
+  ListAgentSessionsResponse,
+} from "@/agent-sessions";
+
+export type {
   AgentCredentialRef,
   AgentSendRequest,
   AgentSendResponse,

--- a/sdk/typescript/src/sse.ts
+++ b/sdk/typescript/src/sse.ts
@@ -11,6 +11,13 @@
 export interface SSEFrame {
   event: string;
   data: string;
+  /**
+   * False when the stream ended before this frame's terminating blank line,
+   * i.e. the connection was cut mid-frame and `data` is truncated. A consumer
+   * should treat an unparseable unterminated frame as a lost stream rather
+   * than as corrupt content.
+   */
+  terminated: boolean;
 }
 
 /**
@@ -32,7 +39,8 @@ export async function* readSSEFrames(
   const consumeLine = (raw: string): SSEFrame | undefined => {
     const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
     if (line === "") {
-      const frame = event === "" ? undefined : { event, data };
+      const frame =
+        event === "" ? undefined : { event, data, terminated: true };
       event = "";
       data = "";
       return frame;
@@ -50,33 +58,53 @@ export async function* readSSEFrames(
     return undefined;
   };
 
-  let buffer = "";
+  // Unconsumed input, kept as chunks rather than one accumulating string.
+  // `buffer += chunk` builds a rope that `indexOf` must flatten, so appending
+  // and scanning per chunk costs O(n) each time and O(n^2) over a line as long
+  // as a whole agent turn (the `done` frame is exactly that). Joining only when
+  // a newline actually arrives keeps the whole read linear.
+  let parts: string[] = [];
   try {
     for (;;) {
       const { done, value } = await reader.read();
-      buffer += value
+      const chunk = value
         ? decoder.decode(value, { stream: true })
         : decoder.decode();
 
+      if (chunk !== "") parts.push(chunk);
+      // No line to emit yet: hold the chunk and read more.
+      if (!done && !chunk.includes("\n")) continue;
+
+      let buffer = parts.length === 1 ? parts[0]! : parts.join("");
+      parts = [];
+
+      let consumed = 0;
       let newline = buffer.indexOf("\n");
       while (newline !== -1) {
-        const line = buffer.slice(0, newline);
-        buffer = buffer.slice(newline + 1);
-        const frame = consumeLine(line);
+        const frame = consumeLine(buffer.slice(consumed, newline));
+        consumed = newline + 1;
         if (frame) yield frame;
-        newline = buffer.indexOf("\n");
+        newline = buffer.indexOf("\n", consumed);
       }
+      if (consumed > 0) buffer = buffer.slice(consumed);
+      if (buffer !== "") parts.push(buffer);
 
       if (done) break;
     }
 
     // A final line need not be newline-terminated.
-    if (buffer.length > 0) {
-      const frame = consumeLine(buffer);
+    const tail = parts.join("");
+    if (tail !== "") {
+      const frame = consumeLine(tail);
       if (frame) yield frame;
     }
-    // Flush a trailing frame that never saw its blank line (defensive).
-    if (event !== "") yield { event, data };
+
+    // A frame that never saw its blank line is one the connection was cut in
+    // the middle of, so its `data` may be truncated. Yield it anyway, marked
+    // unterminated, and let the consumer decide: a complete final frame from a
+    // server that omitted the trailing blank line is still usable, while a
+    // genuinely truncated one is a lost stream rather than corrupt content.
+    if (event !== "") yield { event, data, terminated: false };
   } finally {
     await reader.cancel().catch(() => {});
   }

--- a/sdk/typescript/src/sse.ts
+++ b/sdk/typescript/src/sse.ts
@@ -1,0 +1,87 @@
+/**
+ * Minimal Server-Sent Events frame reader, matching the parser Go's
+ * `readAgentSessionStream` uses so both transports accept the same streams.
+ *
+ * Only the subset the Amika API emits is handled: `event:` and `data:` lines
+ * terminated by a blank line. Comments (`:`), `id:`, and `retry:` are ignored,
+ * and a frame with no `event:` line is dropped (the protocol never sends the
+ * default `message` event) — but its buffered data is still discarded, so it
+ * cannot bleed into the next frame.
+ */
+export interface SSEFrame {
+  event: string;
+  data: string;
+}
+
+/**
+ * Yield each complete frame from an SSE response body. A trailing frame not
+ * followed by a blank line is flushed at end of stream, and a final line
+ * without a newline is parsed. Cancels the underlying reader when the consumer
+ * stops early.
+ */
+export async function* readSSEFrames(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<SSEFrame> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+
+  let event = "";
+  let data = "";
+
+  // Returns the completed frame when `line` terminates one, else undefined.
+  const consumeLine = (raw: string): SSEFrame | undefined => {
+    const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+    if (line === "") {
+      const frame = event === "" ? undefined : { event, data };
+      event = "";
+      data = "";
+      return frame;
+    }
+    if (line.startsWith("event:")) {
+      // The space after the colon is optional in SSE; strip exactly one.
+      event = stripOneSpace(line.slice("event:".length));
+      return undefined;
+    }
+    if (line.startsWith("data:")) {
+      // SSE joins multiple data lines with \n; the server emits one line.
+      if (data.length > 0) data += "\n";
+      data += stripOneSpace(line.slice("data:".length));
+    }
+    return undefined;
+  };
+
+  let buffer = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      buffer += value
+        ? decoder.decode(value, { stream: true })
+        : decoder.decode();
+
+      let newline = buffer.indexOf("\n");
+      while (newline !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        const frame = consumeLine(line);
+        if (frame) yield frame;
+        newline = buffer.indexOf("\n");
+      }
+
+      if (done) break;
+    }
+
+    // A final line need not be newline-terminated.
+    if (buffer.length > 0) {
+      const frame = consumeLine(buffer);
+      if (frame) yield frame;
+    }
+    // Flush a trailing frame that never saw its blank line (defensive).
+    if (event !== "") yield { event, data };
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+}
+
+function stripOneSpace(value: string): string {
+  return value.startsWith(" ") ? value.slice(1) : value;
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -820,7 +820,7 @@ function optionalArray<T>(
     : undefined;
 }
 
-function optionalObject<T>(
+export function optionalObject<T>(
   v: unknown,
   from: (w: Record<string, unknown>) => T,
 ): T | undefined {

--- a/sdk/typescript/test/agent-sessions.test.ts
+++ b/sdk/typescript/test/agent-sessions.test.ts
@@ -419,3 +419,51 @@ describe("AmikaClient.sendAgentSessionStream truncated streams", () => {
     ).rejects.toThrow(/parsing done frame failed/);
   });
 });
+
+describe("AmikaClient agent-session malformed payloads", () => {
+  it("treats a non-object usage as absent rather than an empty object", async () => {
+    for (const usage of [[1], "x", 3]) {
+      const { fetch } = mockFetch([
+        { status: 200, body: { ...DONE_PAYLOAD, usage } },
+      ]);
+      const resp = await makeClient(fetch).sendAgentSession({ message: "hi" });
+      expect(resp.usage, `usage=${JSON.stringify(usage)}`).toBeUndefined();
+    }
+  });
+
+  // A cut mid-error-frame is a lost stream, not a new error, so it must not
+  // overwrite a message an earlier error frame already delivered.
+  it("keeps an earlier error message when a later error frame is cut", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body:
+          'event: error\ndata: {"error":"boom"}\n\n' +
+          'event: error\ndata: {"error":"tru',
+      },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/boom/);
+  });
+
+  it("reports a lone truncated error frame as a lost stream", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: 'event: error\ndata: {"error":"boom bec' },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/stream ended without a result/);
+  });
+
+  // The SDK cannot tell a cut connection from a clean close with a corrupt
+  // final frame, so the message must not assert only the former.
+  it("does not blame the time limit alone for a corrupt final frame", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: "event: delta\ndata: <html>oops</html>" },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/truncated or malformed/);
+  });
+});

--- a/sdk/typescript/test/agent-sessions.test.ts
+++ b/sdk/typescript/test/agent-sessions.test.ts
@@ -356,3 +356,66 @@ describe("AmikaClient.sendAgentSessionStream async handlers", () => {
     ).rejects.toThrow(/writer closed/);
   });
 });
+
+describe("AmikaClient.sendAgentSessionStream truncated streams", () => {
+  // The server's 300s ceiling cuts the connection at an arbitrary byte
+  // offset, and the `data:` line is most of every frame's bytes, so a cut
+  // lands mid-frame far more often than on a frame boundary. That must read
+  // as a lost stream, not as corrupt output.
+  it("reports a mid-delta cut as a lost stream, not a parse failure", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: 'event: delta\ndata: {"text":"hello "}\n\nevent: delta\ndata: {"tex',
+      },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/stream ended without a result/);
+  });
+
+  it("reports a mid-done cut as a lost stream", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: 'event: done\ndata: {"session_id":"as' },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/stream ended without a result/);
+  });
+
+  it("keeps an earlier error frame's message when the stream is then cut", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: 'event: error\ndata: {"error":"boom"}\n\nevent: delta\ndata: {"tex',
+      },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/boom/);
+  });
+
+  // A complete final frame from a server that omitted the trailing blank line
+  // is still usable, so the unterminated flag must not discard it outright.
+  it("still accepts a complete done frame with no trailing blank line", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: `event: done\ndata: ${JSON.stringify(DONE_PAYLOAD)}`,
+      },
+    ]);
+    const resp = await makeClient(fetch).sendAgentSessionStream({
+      message: "hi",
+    });
+    expect(resp.sessionId).toBe("as_1");
+  });
+
+  it("rejects a JSON array in a done frame instead of resolving empty", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: "event: done\ndata: [1,2]\n\n" },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/parsing done frame failed/);
+  });
+});

--- a/sdk/typescript/test/agent-sessions.test.ts
+++ b/sdk/typescript/test/agent-sessions.test.ts
@@ -278,3 +278,81 @@ describe("AmikaClient.getAgentSession", () => {
     expect(detail.messages[1]?.isError).toBe(true);
   });
 });
+
+describe("AmikaClient.sendAgentSessionStream async handlers", () => {
+  it("awaits an async onDelta so text arrives in order", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: sse(
+          ["delta", { text: "first" }],
+          ["delta", { text: "second" }],
+          ["delta", { text: "third" }],
+          ["done", DONE_PAYLOAD],
+        ),
+      },
+    ]);
+
+    const written: string[] = [];
+    // The first chunk takes the longest to write. Without an await the
+    // reader would race ahead and the writes would land out of order.
+    const delays: Record<string, number> = { first: 30, second: 10, third: 0 };
+    await makeClient(fetch).sendAgentSessionStream(
+      { message: "hi" },
+      {
+        onDelta: async (text) => {
+          await new Promise((r) => setTimeout(r, delays[text] ?? 0));
+          written.push(text);
+        },
+      },
+    );
+
+    expect(written).toEqual(["first", "second", "third"]);
+  });
+
+  it("awaits an async onStatus before the next frame", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: sse(
+          ["status", { phase: "creating_sandbox", sandbox_id: "" }],
+          ["delta", { text: "x" }],
+          ["done", DONE_PAYLOAD],
+        ),
+      },
+    ]);
+
+    const order: string[] = [];
+    await makeClient(fetch).sendAgentSessionStream(
+      { message: "hi" },
+      {
+        onStatus: async (phase) => {
+          await new Promise((r) => setTimeout(r, 20));
+          order.push(`status:${phase}`);
+        },
+        onDelta: (text) => {
+          order.push(`delta:${text}`);
+        },
+      },
+    );
+
+    expect(order).toEqual(["status:creating_sandbox", "delta:x"]);
+  });
+
+  it("fails the send when a handler rejects", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: sse(["delta", { text: "x" }], ["done", DONE_PAYLOAD]),
+      },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream(
+        { message: "hi" },
+        {
+          onDelta: () => Promise.reject(new Error("writer closed")),
+        },
+      ),
+    ).rejects.toThrow(/writer closed/);
+  });
+});

--- a/sdk/typescript/test/agent-sessions.test.ts
+++ b/sdk/typescript/test/agent-sessions.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+
+import { AmikaClient } from "@/client";
+import { AmikaError, AmikaHTTPError } from "@/errors";
+import { mockFetch } from "./helpers.js";
+
+const BASE = "https://api.example.com";
+
+function makeClient(fetchImpl: typeof fetch): AmikaClient {
+  return new AmikaClient({
+    baseUrl: BASE,
+    accessToken: "tok",
+    fetch: fetchImpl,
+  });
+}
+
+/** Serialize SSE frames the way the server does: one `data:` line per frame. */
+function sse(...frames: [event: string, payload: unknown][]): string {
+  return frames
+    .map(
+      ([event, payload]) =>
+        `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`,
+    )
+    .join("");
+}
+
+const DONE_PAYLOAD = {
+  session_id: "as_1",
+  sandbox_id: "sbx_1",
+  agent: "claude",
+  response: "hello",
+  is_error: false,
+  is_new_session: true,
+  created_sandbox: true,
+};
+
+describe("AmikaClient.sendAgentSession", () => {
+  it("POSTs camelCase → snake_case and maps the response", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: {
+          ...DONE_PAYLOAD,
+          usage: { cost_usd: 0.12, input_tokens: 10, num_turns: 2 },
+        },
+      },
+    ]);
+    const resp = await makeClient(fetch).sendAgentSession({
+      message: "hi",
+      agent: "claude",
+      sessionId: "as_1",
+      sandboxId: "sbx_1",
+      newSession: false,
+      repoUrl: "git@github.com:org/p.git",
+    });
+
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions`);
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({
+      message: "hi",
+      agent: "claude",
+      session_id: "as_1",
+      sandbox_id: "sbx_1",
+      new_session: false,
+      repo_url: "git@github.com:org/p.git",
+    });
+    expect(resp.sessionId).toBe("as_1");
+    expect(resp.createdSandbox).toBe(true);
+    expect(resp.usage).toEqual({
+      costUsd: 0.12,
+      inputTokens: 10,
+      outputTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheCreationTokens: undefined,
+      durationMs: undefined,
+      numTurns: 2,
+    });
+  });
+
+  it("sends only the fields that are set", async () => {
+    const { fetch, calls } = mockFetch([{ status: 200, body: DONE_PAYLOAD }]);
+    await makeClient(fetch).sendAgentSession({ message: "hi" });
+    expect(JSON.parse(calls[0]?.body ?? "")).toEqual({ message: "hi" });
+  });
+
+  it("leaves usage undefined when the provider reports none", async () => {
+    const { fetch } = mockFetch([{ status: 200, body: DONE_PAYLOAD }]);
+    const resp = await makeClient(fetch).sendAgentSession({ message: "hi" });
+    expect(resp.usage).toBeUndefined();
+  });
+});
+
+describe("AmikaClient.sendAgentSessionStream", () => {
+  it("dispatches status and delta frames, then returns the done result", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: sse(
+          ["status", { phase: "creating_sandbox", sandbox_id: "" }],
+          ["status", { phase: "sandbox_ready", sandbox_id: "sbx_1" }],
+          ["delta", { text: "hel" }],
+          ["delta", { text: "lo" }],
+          ["done", DONE_PAYLOAD],
+        ),
+      },
+    ]);
+
+    const statuses: [string, string][] = [];
+    let text = "";
+    const resp = await makeClient(fetch).sendAgentSessionStream(
+      { message: "hi" },
+      {
+        onStatus: (phase, sandboxId) => statuses.push([phase, sandboxId]),
+        onDelta: (chunk) => {
+          text += chunk;
+        },
+      },
+    );
+
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions/stream`);
+    expect(calls[0]?.headers["Accept"]).toBe("text/event-stream");
+    expect(statuses).toEqual([
+      ["creating_sandbox", ""],
+      ["sandbox_ready", "sbx_1"],
+    ]);
+    expect(text).toBe("hello");
+    expect(resp.response).toBe("hello");
+  });
+
+  it("works without handlers", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: sse(["delta", { text: "x" }], ["done", DONE_PAYLOAD]),
+      },
+    ]);
+    const resp = await makeClient(fetch).sendAgentSessionStream({
+      message: "hi",
+    });
+    expect(resp.sessionId).toBe("as_1");
+  });
+
+  it("prefers a done frame over an error frame", async () => {
+    const { fetch } = mockFetch([
+      {
+        status: 200,
+        body: sse(["error", { error: "boom" }], ["done", DONE_PAYLOAD]),
+      },
+    ]);
+    const resp = await makeClient(fetch).sendAgentSessionStream({
+      message: "hi",
+    });
+    expect(resp.sessionId).toBe("as_1");
+  });
+
+  it("throws the message from an error frame", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: sse(["error", { error: "agent exploded" }]) },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/agent exploded/);
+  });
+
+  it("points at the session list when the stream ends with no result", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: sse(["delta", { text: "partial" }]) },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(/stream ended without a result/);
+  });
+
+  it("fails loudly on an unparseable delta rather than losing output", async () => {
+    const { fetch } = mockFetch([
+      { status: 200, body: "event: delta\ndata: {not json\n\n" },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(AmikaError);
+  });
+
+  it("surfaces a pre-stream rejection as an HTTP error", async () => {
+    const { fetch } = mockFetch([
+      { status: 401, body: { code: "unauthorized", message: "bad token" } },
+    ]);
+    await expect(
+      makeClient(fetch).sendAgentSessionStream({ message: "hi" }),
+    ).rejects.toThrow(AmikaHTTPError);
+  });
+});
+
+describe("AmikaClient.listAgentSessions", () => {
+  it("GETs the envelope and maps nullable columns", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: {
+          sessions: [
+            {
+              session_id: "as_1",
+              sandbox_id: "sbx_1",
+              sandbox_name: null,
+              agent: "claude",
+              status: "running",
+              preview: "fix the bug",
+              model: null,
+              effort: "high",
+              started_at: "2026-01-01T00:00:00Z",
+              ended_at: null,
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+            },
+          ],
+          total: 12,
+        },
+      },
+    ]);
+    const page = await makeClient(fetch).listAgentSessions();
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions`);
+    expect(page.total).toBe(12);
+    expect(page.sessions[0]?.sandboxName).toBeNull();
+    expect(page.sessions[0]?.model).toBeNull();
+    expect(page.sessions[0]?.effort).toBe("high");
+  });
+
+  it("passes a positive limit as a query param", async () => {
+    const { fetch, calls } = mockFetch([
+      { status: 200, body: { sessions: [], total: 0 } },
+    ]);
+    await makeClient(fetch).listAgentSessions(5);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions?limit=5`);
+  });
+
+  it("omits a zero limit and returns [] for an empty page", async () => {
+    const { fetch, calls } = mockFetch([{ status: 200, body: { total: 0 } }]);
+    const page = await makeClient(fetch).listAgentSessions(0);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions`);
+    expect(page.sessions).toEqual([]);
+  });
+});
+
+describe("AmikaClient.getAgentSession", () => {
+  it("GETs one chat with its transcript", async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        status: 200,
+        body: {
+          session_id: "as/1",
+          sandbox_id: "sbx_1",
+          sandbox_name: "dev",
+          agent: "claude",
+          status: "completed",
+          preview: null,
+          model: "claude-opus-5",
+          effort: null,
+          started_at: "2026-01-01T00:00:00Z",
+          ended_at: "2026-01-01T00:05:00Z",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:05:00Z",
+          messages: [
+            { role: "user", content: "hi", timestamp: "2026-01-01T00:00:00Z" },
+            {
+              role: "assistant",
+              content: "nope",
+              timestamp: "2026-01-01T00:05:00Z",
+              is_error: true,
+            },
+          ],
+        },
+      },
+    ]);
+    const detail = await makeClient(fetch).getAgentSession("as/1");
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/agent-sessions/as%2F1`);
+    expect(detail.model).toBe("claude-opus-5");
+    expect(detail.messages).toHaveLength(2);
+    expect(detail.messages[0]?.isError).toBeUndefined();
+    expect(detail.messages[1]?.isError).toBe(true);
+  });
+});

--- a/sdk/typescript/test/functional/org-resources.functional.test.ts
+++ b/sdk/typescript/test/functional/org-resources.functional.test.ts
@@ -33,5 +33,22 @@ describeFunctional("org resources functional tests", () => {
         expect(["table", "legacy"]).toContain(service.source);
       }
     });
+
+    it("listAgentSessions returns a page and its total", async () => {
+      const page = await client.listAgentSessions(5);
+      expect(Array.isArray(page.sessions)).toBe(true);
+      expect(page.sessions.length).toBeLessThanOrEqual(5);
+      expect(typeof page.total).toBe("number");
+    });
+
+    it("getAgentSession returns the transcript for a listed chat", async () => {
+      const page = await client.listAgentSessions(1);
+      const summary = page.sessions[0];
+      if (!summary) return; // Fresh org with no chats yet.
+
+      const detail = await client.getAgentSession(summary.sessionId);
+      expect(detail.sessionId).toBe(summary.sessionId);
+      expect(Array.isArray(detail.messages)).toBe(true);
+    });
   });
 });

--- a/sdk/typescript/test/sse.test.ts
+++ b/sdk/typescript/test/sse.test.ts
@@ -29,8 +29,8 @@ describe("readSSEFrames", () => {
       ),
     );
     expect(frames).toEqual([
-      { event: "delta", data: '{"text":"hi"}' },
-      { event: "done", data: "{}" },
+      { event: "delta", data: '{"text":"hi"}', terminated: true },
+      { event: "done", data: "{}", terminated: true },
     ]);
   });
 
@@ -38,41 +38,52 @@ describe("readSSEFrames", () => {
     const frames = await collect(
       streamOf("event: de", "lta\ndat", 'a: {"text":"hi"}', "\n\n"),
     );
-    expect(frames).toEqual([{ event: "delta", data: '{"text":"hi"}' }]);
+    expect(frames).toEqual([
+      { event: "delta", data: '{"text":"hi"}', terminated: true },
+    ]);
   });
 
   it("strips exactly one space after the colon", async () => {
     const frames = await collect(streamOf("event:delta\ndata:  padded\n\n"));
-    expect(frames).toEqual([{ event: "delta", data: " padded" }]);
+    expect(frames).toEqual([
+      { event: "delta", data: " padded", terminated: true },
+    ]);
   });
 
   it("joins multiple data lines with a newline", async () => {
     const frames = await collect(streamOf("event: done\ndata: a\ndata: b\n\n"));
-    expect(frames).toEqual([{ event: "done", data: "a\nb" }]);
+    expect(frames).toEqual([{ event: "done", data: "a\nb", terminated: true }]);
   });
 
   it("ignores comments and id lines", async () => {
     const frames = await collect(
       streamOf(": keep-alive\nid: 7\nevent: delta\ndata: x\n\n"),
     );
-    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+    expect(frames).toEqual([{ event: "delta", data: "x", terminated: true }]);
   });
 
   it("drops an event-less frame without letting its data bleed into the next", async () => {
     const frames = await collect(
       streamOf("data: orphan\n\nevent: delta\ndata: x\n\n"),
     );
-    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+    expect(frames).toEqual([{ event: "delta", data: "x", terminated: true }]);
   });
 
   it("tolerates CRLF line endings", async () => {
     const frames = await collect(streamOf("event: delta\r\ndata: x\r\n\r\n"));
-    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+    expect(frames).toEqual([{ event: "delta", data: "x", terminated: true }]);
   });
 
-  it("flushes a trailing frame with no blank line and no final newline", async () => {
+  it("flushes a trailing frame with no blank line, marked unterminated", async () => {
     const frames = await collect(streamOf("event: done\ndata: {}"));
-    expect(frames).toEqual([{ event: "done", data: "{}" }]);
+    expect(frames).toEqual([{ event: "done", data: "{}", terminated: false }]);
+  });
+
+  it("marks a frame cut mid-data as unterminated", async () => {
+    const frames = await collect(streamOf('event: delta\ndata: {"tex'));
+    expect(frames).toEqual([
+      { event: "delta", data: '{"tex', terminated: false },
+    ]);
   });
 
   it("yields nothing for an empty stream", async () => {
@@ -90,6 +101,8 @@ describe("readSSEFrames", () => {
         controller.close();
       },
     });
-    expect(await collect(stream)).toEqual([{ event: "delta", data: "né" }]);
+    expect(await collect(stream)).toEqual([
+      { event: "delta", data: "né", terminated: true },
+    ]);
   });
 });

--- a/sdk/typescript/test/sse.test.ts
+++ b/sdk/typescript/test/sse.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+
+import { readSSEFrames, type SSEFrame } from "@/sse";
+
+/** Build a body stream that delivers `chunks` verbatim, one read at a time. */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function collect(
+  stream: ReadableStream<Uint8Array>,
+): Promise<SSEFrame[]> {
+  const frames: SSEFrame[] = [];
+  for await (const frame of readSSEFrames(stream)) frames.push(frame);
+  return frames;
+}
+
+describe("readSSEFrames", () => {
+  it("parses event/data pairs separated by blank lines", async () => {
+    const frames = await collect(
+      streamOf(
+        'event: delta\ndata: {"text":"hi"}\n\nevent: done\ndata: {}\n\n',
+      ),
+    );
+    expect(frames).toEqual([
+      { event: "delta", data: '{"text":"hi"}' },
+      { event: "done", data: "{}" },
+    ]);
+  });
+
+  it("reassembles frames split across chunk boundaries", async () => {
+    const frames = await collect(
+      streamOf("event: de", "lta\ndat", 'a: {"text":"hi"}', "\n\n"),
+    );
+    expect(frames).toEqual([{ event: "delta", data: '{"text":"hi"}' }]);
+  });
+
+  it("strips exactly one space after the colon", async () => {
+    const frames = await collect(streamOf("event:delta\ndata:  padded\n\n"));
+    expect(frames).toEqual([{ event: "delta", data: " padded" }]);
+  });
+
+  it("joins multiple data lines with a newline", async () => {
+    const frames = await collect(streamOf("event: done\ndata: a\ndata: b\n\n"));
+    expect(frames).toEqual([{ event: "done", data: "a\nb" }]);
+  });
+
+  it("ignores comments and id lines", async () => {
+    const frames = await collect(
+      streamOf(": keep-alive\nid: 7\nevent: delta\ndata: x\n\n"),
+    );
+    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+  });
+
+  it("drops an event-less frame without letting its data bleed into the next", async () => {
+    const frames = await collect(
+      streamOf("data: orphan\n\nevent: delta\ndata: x\n\n"),
+    );
+    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+  });
+
+  it("tolerates CRLF line endings", async () => {
+    const frames = await collect(streamOf("event: delta\r\ndata: x\r\n\r\n"));
+    expect(frames).toEqual([{ event: "delta", data: "x" }]);
+  });
+
+  it("flushes a trailing frame with no blank line and no final newline", async () => {
+    const frames = await collect(streamOf("event: done\ndata: {}"));
+    expect(frames).toEqual([{ event: "done", data: "{}" }]);
+  });
+
+  it("yields nothing for an empty stream", async () => {
+    expect(await collect(streamOf())).toEqual([]);
+  });
+
+  it("decodes a multi-byte character split across chunks", async () => {
+    const encoded = new TextEncoder().encode("event: delta\ndata: né\n\n");
+    // Cut between the two bytes of "é" so the decoder must carry state over.
+    const split = encoded.length - 3;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoded.slice(0, split));
+        controller.enqueue(encoded.slice(split));
+        controller.close();
+      },
+    });
+    expect(await collect(stream)).toEqual([{ event: "delta", data: "né" }]);
+  });
+});


### PR DESCRIPTION
**Stack 8/8** — based on #395. Last one.

## Why

`amika send` and `amika sessions list|show` sit on the `/agent-sessions` endpoints, which the SDK did not reach at all. Unlike `agentSend`, these route by durable chat id and will create a sandbox behind the scenes when a chat has none — so they are the entry point for a caller that just wants to talk to an agent about a repo.

## What

| Method | Endpoint |
| --- | --- |
| `sendAgentSession(req)` | `POST /agent-sessions` |
| `sendAgentSessionStream(req, handlers)` | `POST /agent-sessions/stream` (SSE) |
| `listAgentSessions(limit?)` | `GET /agent-sessions` |
| `getAgentSession(sessionId)` | `GET /agent-sessions/{id}` |

### Two things worth a reviewer's attention

**`HTTPClient.openStream`.** `sendAgentSessionStream` needs the response body unread, which `doJSON` cannot give. The timeout now spans the whole body rather than being cleared once the headers arrive — closer to Go, where `http.Client.Timeout` covers reading the body too. The caller releases the timer when it is done with the stream.

**`sse.ts`.** Frame parsing is separated out so it can be tested without a socket. It follows the same rules as Go's reader, including the two that are easy to get wrong:

- a frame with no `event:` line is dropped but *still clears its buffered data*, so an orphan payload cannot glue itself onto the front of the next frame;
- a `done` frame wins over an `error` frame, because `done` carries a persisted session id that reporting the error would discard.

## Testing

`pnpm run ci` passes locally (122 unit tests). `sse.test.ts` covers chunk-boundary splits, CRLF, multi-line `data:`, comments, orphan frames, a trailing frame with no blank line, and a multi-byte character split across two reads.

---

### The stack

Merge front to back. Each PR targets the one above it; GitHub retargets automatically as they land.

| # | PR | Command surface |
| - | -- | --------------- |
| 1 | #389 Decode every sandbox field the API returns | `amika sandbox list\|create\|get` |
| 2 | #390 Return the whole secret summary, not three fields of it | `amika secret list\|push` |
| 3 | #391 Report what an agent-send turn actually cost | `amika sandbox agent-send` |
| 4 | #392 Let the SDK follow a snapshot capture to completion | `amika snapshot` |
| 5 | #393 Expose sandbox services to the TypeScript SDK | `amika service` |
| 6 | #394 Manage SSH public keys from the TypeScript SDK | `amika secret ssh-key` |
| 7 | #395 Let the SDK open an SSH dial into a sandbox | `amika ssh` / `code` / `scp` |
| 8 | #396 Add the agent-session chat surface to the SDK | `amika send`, `amika sessions` |

Together they close the gap between `@amika/sdk` and the network surface of the `amika` CLI. Deliberately out of scope: `amikalog`'s storage endpoints (a separately installed CLI), the `auth login` OAuth device flow, and the local Docker commands (`materialize`, `volume`, local `sandbox`) — none are remote API calls an HTTP client can make.

No version bump in any of these; releases land as their own commit via `create-sdk-release-commit`.


> **On the missing checks:** both `ci.yml` and `sdk-typescript.yml` trigger only on `pull_request: branches: [main]`, so PRs 2–8 show no checks while they target their parent branch. Each picks up CI when GitHub retargets it to `main` as its parent merges.
