### PR TITLE
Align the root pnpm pin with the SDK's

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,5 @@
 {
   "name": "amika-workspace",
   "private": true,
-  "packageManager": "pnpm@10.18.2",
-  "pnpm": {
-    "overrides": {
-      "@bufbuild/protobuf": "2.13.0"
-    }
-  }
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,5 +7,15 @@ packages:
 # own `packageManager` pin, and both `sdk-typescript.yml` and the OIDC publish
 # workflow install from that lockfile. Absorbing it here would orphan it.
 
-onlyBuiltDependencies:
-  - esbuild
+# pnpm 11 replaced `onlyBuiltDependencies` with an explicit per-package map.
+# These values preserve pnpm 10's behavior exactly: esbuild's install scripts
+# ran, everything else's did not. protobufjs is new to the list only because
+# pnpm 11 now names every package it skips.
+allowBuilds:
+  esbuild: true
+  protobufjs: false
+
+# Moved from the root package.json's `pnpm` field, which pnpm 11 no longer
+# reads. Pins a transitive dep below the 7-day package-age gate in CI.
+overrides:
+  "@bufbuild/protobuf": "2.13.0"


### PR DESCRIPTION
## Why

The root workspace pins `pnpm@10.18.2`; `sdk/typescript` pins `pnpm@11.1.3`. Two versions in one repo, and the mismatch is not harmless.

A job running in `sdk/typescript` installs pnpm 10 and then self-delegates to 11.1.3, because pnpm reads the nearest `packageManager` field. That part works. What breaks is the cache:

```
pnpm 10.18.2 store path: ~/.local/share/pnpm/store/v10
pnpm 11.1.3  store path: ~/.local/share/pnpm/store/v11
```

`actions/setup-node` with `cache: pnpm` asks the pnpm on `PATH` where the store is, gets `v10`, and caches that. The install then delegates to 11.1.3 and writes `v11`. The action caches and restores an empty directory. No error, no hit, permanently cold.

## What moved, and why it isn't a one-line bump

pnpm 11 reads neither of the repo's two pnpm settings where they currently live:

| Setting | Was | Now |
| ------- | --- | --- |
| `overrides` | `pnpm.overrides` in root `package.json` | top-level `overrides` in `pnpm-workspace.yaml` |
| build scripts | `onlyBuiltDependencies: [esbuild]` | `allowBuilds:` map, explicit per package |

**`overrides`** is ignored outright by pnpm 11, which fails a frozen install with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. It pins `@bufbuild/protobuf` to `2.13.0` under the 7-day package-age gate, so dropping it would have silently unpinned a dep that is pinned on purpose.

**`allowBuilds`** needs a true/false decision per package rather than an allowlist. The values here preserve pnpm 10's behavior exactly: esbuild's install scripts ran, nothing else's did.

```yaml
allowBuilds:
  esbuild: true
  protobufjs: false
```

`protobufjs` is new to the list only because pnpm 11 names every package whose scripts it skips; under pnpm 10 it was skipped silently. It stays skipped, so this PR changes no behavior. **If protobufjs is supposed to run its build, that is a separate deliberate decision** and I have not made it here.

## Testing

The lockfile is unchanged. From a clean clone with the root pinned to 11.1.3:

- `pnpm install --frozen-lockfile` succeeds
- `js/sandbox`: formatcheck, typecheck, lint, test all pass
- `eslint-rules`: test passes

## Relationship to the SDK CI fix

Independent, and both are needed. The SDK workflow passes `version: 11` explicitly, and `pnpm/action-setup` compares that string against the `packageManager` pin, so `11` still will not equal `11.1.3` after this PR. Dropping that input is a separate change to `.github/workflows/`, which I cannot push from here.