### PR TITLE
Bump CI node to 22 for pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # pnpm 11 requires node >=22.13; it aborts on 20 with
+          # ERR_UNKNOWN_BUILTIN_MODULE before it can even print its version.
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -78,7 +80,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # pnpm 11 requires node >=22.13; it aborts on 20 with
+          # ERR_UNKNOWN_BUILTIN_MODULE before it can even print its version.
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The check-js-sandbox and check-eslint-rules jobs pinned node 20, but pnpm 11 requires node >=22.13 and aborts with ERR_UNKNOWN_BUILTIN_MODULE before it can even print its version. Bump both jobs to node 22.