### PR TITLE
Pin pnpm to the exact version in the SDK TypeScript workflows

### DIFF
--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -80,7 +80,9 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11
+          # Exact version, matching the sdk/typescript `packageManager` pin.
+          # See sdk-typescript.yml.
+          version: 11.1.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -23,7 +23,11 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11
+          # Must match sdk/typescript/package.json's `packageManager` pin
+          # exactly:
+          # pnpm/action-setup compares the two strings and fails the job if
+          # they differ. A floating major does not satisfy that comparison.
+          version: 11.1.3
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
pnpm/action-setup compares its `version` input against the `packageManager` pin and fails the job when the two strings differ, so the floating `version: 11` does not satisfy the pnpm@11.1.3 pin in sdk/typescript/package.json, the workspace both jobs run in. Pin both workflows to 11.1.3.