### PR TITLE
Bump TypeScript SDK version to 0.11.0

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amika/sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "TypeScript SDK for Amika, derived from the amika CLI",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Release sdk-typescript@v0.11.0.

Changes since sdk-typescript@v0.10.0:

- Drop SSH support from the TypeScript SDK (f4e2a90)
- Add the agent-session chat surface to the SDK (e7e0d7f)
- Expose sandbox services to the TypeScript SDK (2481347)
- Let the SDK follow a snapshot capture to completion (0e7a205)
- Report what an agent-send turn actually cost (e7c86b5)
- Return the whole secret summary, not three fields of it (a400cda)
- Decode every sandbox field the API returns (230bb15)

CI and release tooling:

- Pin pnpm to the exact version in the SDK TypeScript workflows (1f63d63)
- Bump CI node to 22 for pnpm 11 (83c5b3c)