### PR TITLE
Infer the git repo for `amika send`, and give it --git/--no-git

### DIFF
--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/spf13/cobra"
@@ -50,6 +51,13 @@ scenes and a new chat is started; the returned session id can be passed back as
 --session-id to continue the conversation. The agent (claude or codex) comes
 from --agent, else the organization's default, else claude.
 
+That new sandbox gets a git repo the same way "amika sandbox create" does: run
+from inside a repo and its "origin" remote is cloned into the sandbox
+automatically. Pass --git <path|url> to choose a different repo, or --no-git
+for a sandbox with no repo at all. (--repo is accepted as an alias for --git.)
+Repo selection only applies when a sandbox is created, so it cannot be
+combined with --session-id or --sandbox.
+
 The message can be provided as a positional argument or piped via stdin.
 
 By default the reply streams in as the agent produces it when stdout is a
@@ -84,7 +92,6 @@ func runSend(cmd *cobra.Command, args []string) error {
 	sessionID, _ := cmd.Flags().GetString("session-id")
 	sandboxRef, _ := cmd.Flags().GetString("sandbox")
 	newSession, _ := cmd.Flags().GetBool("new-session")
-	repo, _ := cmd.Flags().GetString("repo")
 
 	format, err := output.FormatFrom(cmd)
 	if err != nil {
@@ -104,10 +111,30 @@ func runSend(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Resolve the repo selection before the auth gate so a contradictory flag
+	// combination fails on its own terms rather than behind a login error.
+	// Turning the identity into a URL waits until after the gate, since that
+	// shells out to git and is only needed for a request that will be sent.
+	identity, err := sendRepoIdentity(cmd, sessionID, sandboxRef)
+	if err != nil {
+		return err
+	}
+
 	// The agent-sessions API is remote-only: it provisions sandboxes in the
 	// control plane, so there is no local equivalent.
 	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
 		return err
+	}
+
+	repoURL, err := identity.RemoteURL()
+	if err != nil {
+		return err
+	}
+	// Name, not URL: it is what identifies the repo to a reader, and matches
+	// what `sandbox create` reports. A URL would also risk echoing a token,
+	// since an origin can carry one in its userinfo.
+	if identity.Name != "" {
+		fmt.Fprintf(format.Progress(os.Stderr), "repo: %s\n", identity.Name)
 	}
 
 	req := apiclient.AgentSessionSendRequest{
@@ -116,7 +143,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 		SessionID:  sessionID,
 		SandboxID:  sandboxRef,
 		NewSession: newSession,
-		RepoURL:    repo,
+		RepoURL:    repoURL,
 	}
 	client := runmode.NewRemoteClient()
 
@@ -154,6 +181,30 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("agent returned an error")
 	}
 	return nil
+}
+
+// sendRepoIdentity resolves which git repo a sandbox created for this message
+// should clone, from --git / --repo / --no-git and the working directory.
+//
+// A message aimed at an existing chat (--session-id) or an existing sandbox
+// (--sandbox) creates nothing, so there is no repo to choose: auto-detection
+// is skipped rather than silently discarded, and an explicit --git is an error
+// because the server cannot honor it. --no-git needs no such error — it asks
+// for exactly what already happens.
+func sendRepoIdentity(cmd *cobra.Command, sessionID, sandboxRef string) (gitrepo.Identity, error) {
+	if sessionID != "" || sandboxRef != "" {
+		if gitrepo.FlagsChanged(cmd) {
+			return gitrepo.Identity{}, fmt.Errorf(
+				"--%s cannot be combined with --session-id or --sandbox; it only applies to a sandbox this command creates",
+				gitrepo.FlagGit)
+		}
+		return gitrepo.Identity{Source: gitrepo.SourceNone}, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return gitrepo.Identity{}, fmt.Errorf("failed to determine working directory: %w", err)
+	}
+	return gitrepo.FromCommand(cmd, cwd)
 }
 
 // mustBool reads a bool flag, ignoring the (impossible for a defined flag)
@@ -384,7 +435,10 @@ func init() {
 	sendCmd.Flags().String("session-id", "", "Continue an existing chat by its session id")
 	sendCmd.Flags().String("sandbox", "", "Send into a specific sandbox (id or name)")
 	sendCmd.Flags().Bool("new-session", false, "Start a brand-new chat")
-	sendCmd.Flags().String("repo", "", "Repository URL to clone when a sandbox is created")
+	gitrepo.AddFlags(sendCmd,
+		"Clone a git repo into the sandbox this command creates. Accepts a local path or a git URL (HTTPS, SSH). If omitted and the cwd is in a git repo, that repo is used automatically.",
+		"Skip git repo auto-detection; create a sandbox without any repo.")
+	gitrepo.AddRepoAlias(sendCmd)
 	sendCmd.Flags().Bool("stream", false, "Stream the reply as it is produced (default: on for a terminal, off when piped; always off with --output json)")
 	rootCmd.AddCommand(sendCmd)
 

--- a/go/cmd/amika/send_test.go
+++ b/go/cmd/amika/send_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +24,7 @@ func TestSendAndSessionsCommandsRegistered(t *testing.T) {
 	if send == nil {
 		t.Fatal("send command not registered on rootCmd")
 	}
-	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "repo", "stream"} {
+	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "git", "no-git", "repo", "stream"} {
 		if send.Flags().Lookup(name) == nil {
 			t.Errorf("send is missing --%s flag", name)
 		}
@@ -69,6 +71,142 @@ func TestSendRejectsInvalidOutput(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "invalid --output") {
 		t.Fatalf("err = %v, want an invalid --output error", err)
 	}
+}
+
+// TestSendRepoIdentity covers which repo a `amika send` message puts in the
+// sandbox it creates, and when that question does not apply at all.
+func TestSendRepoIdentity(t *testing.T) {
+	newSendCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "send"}
+		gitrepo.AddFlags(cmd, "git usage", "no-git usage")
+		gitrepo.AddRepoAlias(cmd)
+		return cmd
+	}
+	fakeRepo := func(t *testing.T, name string) string {
+		t.Helper()
+		repo := filepath.Join(t.TempDir(), name)
+		if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+			t.Fatalf("failed to create fake repo: %v", err)
+		}
+		return repo
+	}
+	// chdirTo runs the resolution from inside dir, since auto-detection walks
+	// up from the process's working directory.
+	chdirTo := func(t *testing.T, dir string) {
+		t.Helper()
+		old, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(old) })
+	}
+
+	t.Run("auto-detects the repo containing the cwd", func(t *testing.T) {
+		repo := fakeRepo(t, "myrepo")
+		chdirTo(t, repo)
+		got, err := sendRepoIdentity(newSendCmd(), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != gitrepo.SourceAutoDetect || got.Name != "myrepo" {
+			t.Fatalf("identity = %+v, want the auto-detected repo", got)
+		}
+	})
+
+	t.Run("outside a repo resolves to no repo", func(t *testing.T) {
+		chdirTo(t, t.TempDir())
+		got, err := sendRepoIdentity(newSendCmd(), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != gitrepo.SourceNone {
+			t.Fatalf("Source = %v, want none", got.Source)
+		}
+	})
+
+	t.Run("--no-git skips auto-detection", func(t *testing.T) {
+		repo := fakeRepo(t, "myrepo")
+		chdirTo(t, repo)
+		cmd := newSendCmd()
+		if err := cmd.ParseFlags([]string{"--no-git"}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := sendRepoIdentity(cmd, "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != gitrepo.SourceNone {
+			t.Fatalf("Source = %v, want none", got.Source)
+		}
+	})
+
+	t.Run("--git overrides the cwd repo", func(t *testing.T) {
+		chdirTo(t, fakeRepo(t, "cwdrepo"))
+		cmd := newSendCmd()
+		if err := cmd.ParseFlags([]string{"--git", "https://github.com/foo/bar.git"}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := sendRepoIdentity(cmd, "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != gitrepo.SourceFlagURL || got.URL != "https://github.com/foo/bar.git" {
+			t.Fatalf("identity = %+v, want the --git URL", got)
+		}
+	})
+
+	t.Run("an existing target skips auto-detection", func(t *testing.T) {
+		// No sandbox is created for these, so the cwd repo is not a silently
+		// dropped part of the request.
+		repo := fakeRepo(t, "myrepo")
+		chdirTo(t, repo)
+		for _, tc := range []struct{ sessionID, sandboxRef string }{
+			{sessionID: "sess-1"},
+			{sandboxRef: "my-sandbox"},
+		} {
+			got, err := sendRepoIdentity(newSendCmd(), tc.sessionID, tc.sandboxRef)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Source != gitrepo.SourceNone {
+				t.Fatalf("Source = %v for %+v, want none", got.Source, tc)
+			}
+		}
+	})
+
+	t.Run("an existing target rejects an explicit repo", func(t *testing.T) {
+		chdirTo(t, t.TempDir())
+		for _, flag := range []string{"--git", "--repo"} {
+			cmd := newSendCmd()
+			if err := cmd.ParseFlags([]string{flag, "https://github.com/foo/bar.git"}); err != nil {
+				t.Fatal(err)
+			}
+			_, err := sendRepoIdentity(cmd, "sess-1", "")
+			if err == nil || !strings.Contains(err.Error(), "cannot be combined with --session-id") {
+				t.Fatalf("err = %v for %s, want a conflict error", err, flag)
+			}
+		}
+	})
+
+	t.Run("an existing target accepts --no-git", func(t *testing.T) {
+		// --no-git asks for exactly what already happens, so it is not a
+		// contradiction worth failing on.
+		chdirTo(t, fakeRepo(t, "myrepo"))
+		cmd := newSendCmd()
+		if err := cmd.ParseFlags([]string{"--no-git"}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := sendRepoIdentity(cmd, "sess-1", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != gitrepo.SourceNone {
+			t.Fatalf("Source = %v, want none", got.Source)
+		}
+	})
 }
 
 // TestUnstreamedRemainder covers what `amika send --stream` still has to print

--- a/go/internal/gitrepo/flags.go
+++ b/go/internal/gitrepo/flags.go
@@ -4,15 +4,21 @@ package gitrepo
 // can put a repo in a sandbox spells them the same way.
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
-// Flag names for repo selection.
+// Flag names for repo selection. FlagRepo is an optional alias for FlagGit
+// that a command may register for backward compatibility.
 const (
 	// FlagGit names the repo to use: a local path or a git URL.
 	FlagGit = "git"
 	// FlagNoGit skips auto-detection so no repo is used.
 	FlagNoGit = "no-git"
+	// FlagRepo is the legacy alias for FlagGit.
+	FlagRepo = "repo"
 	// FlagNoClean includes the working tree's untracked files instead of a
 	// clean clone. Only local sandboxes offer it.
 	FlagNoClean = "no-clean"
@@ -27,19 +33,45 @@ func AddFlags(cmd *cobra.Command, gitUsage, noGitUsage string) {
 	cmd.Flags().Bool(FlagNoGit, false, noGitUsage)
 }
 
+// AddRepoAlias registers --repo as a hidden alias for --git. `amika send`
+// shipped with --repo before --git existed, so the old name keeps working.
+func AddRepoAlias(cmd *cobra.Command) {
+	cmd.Flags().String(FlagRepo, "", "Deprecated alias for --git")
+	_ = cmd.Flags().MarkHidden(FlagRepo)
+}
+
 // FromCommand reads the repo-selection flags off cmd and resolves them
 // against cwd.
 //
-// --no-clean is read only when the command registers it, so a command that
-// does not offer it resolves as if it were unset rather than tripping over a
-// flag it never exposed.
+// The optional flags are read only when the command registers them: --repo
+// stands in for --git where AddRepoAlias was called, and --no-clean applies
+// where the command offers it. That keeps a command's call site a single line
+// regardless of which of the trio it exposes.
 func FromCommand(cmd *cobra.Command, cwd string) (Identity, error) {
 	git, _ := cmd.Flags().GetString(FlagGit)
 	gitSet := cmd.Flags().Changed(FlagGit)
+	if alias := cmd.Flags().Lookup(FlagRepo); alias != nil && alias.Changed {
+		aliasValue := alias.Value.String()
+		if gitSet && strings.TrimSpace(git) != strings.TrimSpace(aliasValue) {
+			return Identity{}, fmt.Errorf("--repo is an alias for --git; pass only one")
+		}
+		git, gitSet = aliasValue, true
+	}
 	noGit, _ := cmd.Flags().GetBool(FlagNoGit)
 	noClean := false
 	if f := cmd.Flags().Lookup(FlagNoClean); f != nil {
 		noClean, _ = cmd.Flags().GetBool(FlagNoClean)
 	}
 	return Resolve(Options{Cwd: cwd, Git: git, GitSet: gitSet, NoGit: noGit, NoClean: noClean})
+}
+
+// FlagsChanged reports whether the user explicitly asked for a repo with
+// --git or its --repo alias. Commands that can skip repo resolution entirely
+// use it to tell an ignored default from an ignored request.
+func FlagsChanged(cmd *cobra.Command) bool {
+	if cmd.Flags().Changed(FlagGit) {
+		return true
+	}
+	alias := cmd.Flags().Lookup(FlagRepo)
+	return alias != nil && alias.Changed
 }

--- a/go/internal/gitrepo/flags_test.go
+++ b/go/internal/gitrepo/flags_test.go
@@ -3,17 +3,21 @@ package gitrepo
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
 
 // newTestCmd builds a command carrying the flags a caller opts into: always
-// --git/--no-git, plus --no-clean when asked, since only local sandboxes
-// offer that one.
-func newTestCmd(withNoClean bool) *cobra.Command {
+// --git/--no-git, plus --repo and --no-clean when asked, mirroring how
+// `amika send` and `amika sandbox create` differ.
+func newTestCmd(withRepoAlias, withNoClean bool) *cobra.Command {
 	cmd := &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
 	AddFlags(cmd, "git usage", "no-git usage")
+	if withRepoAlias {
+		AddRepoAlias(cmd)
+	}
 	if withNoClean {
 		cmd.Flags().Bool(FlagNoClean, false, "no-clean usage")
 	}
@@ -39,7 +43,7 @@ func makeFakeRepo(t *testing.T, name string) string {
 func TestFromCommand(t *testing.T) {
 	t.Run("no flags auto-detects from cwd", func(t *testing.T) {
 		repo := makeFakeRepo(t, "myrepo")
-		cmd := newTestCmd(true)
+		cmd := newTestCmd(true, true)
 		got, err := FromCommand(cmd, repo)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -52,7 +56,7 @@ func TestFromCommand(t *testing.T) {
 	t.Run("--git wins over auto-detection", func(t *testing.T) {
 		cwdRepo := makeFakeRepo(t, "cwdrepo")
 		flagRepo := makeFakeRepo(t, "flagrepo")
-		cmd := newTestCmd(true)
+		cmd := newTestCmd(true, true)
 		parseFlags(t, cmd, "--git", flagRepo)
 		got, err := FromCommand(cmd, cwdRepo)
 		if err != nil {
@@ -63,9 +67,57 @@ func TestFromCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("--repo is an alias for --git", func(t *testing.T) {
+		cwdRepo := makeFakeRepo(t, "cwdrepo")
+		cmd := newTestCmd(true, false)
+		parseFlags(t, cmd, "--repo", "https://github.com/foo/bar.git")
+		got, err := FromCommand(cmd, cwdRepo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceFlagURL || got.URL != "https://github.com/foo/bar.git" {
+			t.Fatalf("identity = %+v, want the --repo URL", got)
+		}
+	})
+
+	t.Run("--repo forwards a user-less scp URL as a URL", func(t *testing.T) {
+		// `send --repo` used to reach the API without any classification, so
+		// this form has to stay a URL rather than be read as a local path.
+		cmd := newTestCmd(true, false)
+		parseFlags(t, cmd, "--repo", "build-host:org/repo.git")
+		got, err := FromCommand(cmd, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceFlagURL || got.URL != "build-host:org/repo.git" {
+			t.Fatalf("identity = %+v, want the scp-style URL", got)
+		}
+	})
+
+	t.Run("--git and --repo disagreeing is an error", func(t *testing.T) {
+		cmd := newTestCmd(true, false)
+		parseFlags(t, cmd, "--git", "https://github.com/foo/bar.git", "--repo", "https://github.com/foo/other.git")
+		_, err := FromCommand(cmd, t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "alias") {
+			t.Fatalf("err = %v, want an alias conflict error", err)
+		}
+	})
+
+	t.Run("--git and --repo agreeing is accepted", func(t *testing.T) {
+		cmd := newTestCmd(true, false)
+		parseFlags(t, cmd, "--git", "https://github.com/foo/bar.git", "--repo", "https://github.com/foo/bar.git")
+		got, err := FromCommand(cmd, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != "bar" {
+			t.Fatalf("Name = %q, want %q", got.Name, "bar")
+		}
+	})
+
 	t.Run("--no-git skips auto-detection", func(t *testing.T) {
 		repo := makeFakeRepo(t, "myrepo")
-		cmd := newTestCmd(true)
+		cmd := newTestCmd(true, true)
 		parseFlags(t, cmd, "--no-git")
 		got, err := FromCommand(cmd, repo)
 		if err != nil {
@@ -78,14 +130,14 @@ func TestFromCommand(t *testing.T) {
 
 	t.Run("--no-clean is read only where it is registered", func(t *testing.T) {
 		// The command that offers --no-clean must see it enforced...
-		withFlag := newTestCmd(true)
+		withFlag := newTestCmd(false, true)
 		parseFlags(t, withFlag, "--no-clean")
 		if _, err := FromCommand(withFlag, t.TempDir()); err == nil {
 			t.Fatal("expected --no-clean outside a repo to error")
 		}
 		// ...and one that does not offer it must resolve as if unset, rather
 		// than tripping over a flag it never exposed.
-		withoutFlag := newTestCmd(false)
+		withoutFlag := newTestCmd(true, false)
 		got, err := FromCommand(withoutFlag, t.TempDir())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -94,4 +146,35 @@ func TestFromCommand(t *testing.T) {
 			t.Fatalf("Source = %v, want none", got.Source)
 		}
 	})
+}
+
+func TestFlagsChanged(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "nothing set", args: nil, want: false},
+		{name: "--git set", args: []string{"--git", "https://github.com/foo/bar.git"}, want: true},
+		{name: "--repo set", args: []string{"--repo", "https://github.com/foo/bar.git"}, want: true},
+		// --no-git asks for the default outcome, so it is not a repo request.
+		{name: "--no-git set", args: []string{"--no-git"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newTestCmd(true, false)
+			parseFlags(t, cmd, tt.args...)
+			if got := FlagsChanged(cmd); got != tt.want {
+				t.Fatalf("FlagsChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagsChangedWithoutRepoAlias(t *testing.T) {
+	// A command that never registered --repo must not panic looking for it.
+	cmd := newTestCmd(false, true)
+	if FlagsChanged(cmd) {
+		t.Fatal("FlagsChanged() = true with no flags set")
+	}
 }

--- a/go/test/e2e/cases/offline-send-sessions.yaml
+++ b/go/test/e2e/cases/offline-send-sessions.yaml
@@ -58,6 +58,47 @@ steps:
       exit: 1
       stderr_contains: 'not logged in; run "amika auth login" or use --local'
 
+  - name: send rejects --git together with --no-git
+    # The repo selection is resolved before the auth check, so a
+    # contradictory pair fails on its own terms rather than behind a login
+    # error — the same ordering `amika sandbox create` uses.
+    cmd: [send, hello, --git, "https://github.com/example/repo.git", --no-git]
+    expect:
+      exit: 1
+      stderr_contains: "--git and --no-git are mutually exclusive"
+
+  - name: send rejects a --git path that is not a git repo
+    cmd: [send, hello, --git, /nonexistent-amika-e2e-path]
+    expect:
+      exit: 1
+      stderr_contains: "could not find git repo"
+
+  - name: send --no-git skips repo detection and reaches the auth check
+    # Nothing is inferred from the working directory, so the next thing that
+    # can fail is the auth gate.
+    cmd: [send, hello, --no-git]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: send rejects --git alongside --session-id
+    # A continued chat already has a sandbox, so there is no repo to choose;
+    # an explicit request the server cannot honor is an error, not a no-op.
+    cmd: [send, hello, --session-id, some-session-id, --git, "https://github.com/example/repo.git"]
+    expect:
+      exit: 1
+      stderr_contains: "--git cannot be combined with --session-id or --sandbox"
+
+  - name: send rejects the legacy --repo alias alongside --sandbox
+    # Same rule through the --repo spelling, which proves the alias feeds the
+    # same resolution as --git.
+    cmd: [send, hello, --sandbox, some-sandbox, --repo, "https://github.com/example/repo.git"]
+    expect:
+      exit: 1
+      stderr_contains: "--git cannot be combined with --session-id or --sandbox"
+
   - name: send --stream reaches the same auth check as the buffered path
     # --stream selects the SSE transport, but only after auth. Asserting the
     # same failure here proves the flag is registered and does not change the


### PR DESCRIPTION
`amika send "What does this repo do?"` from inside a git repo created a
sandbox with no repo in it, so the agent had nothing to look at. It now
resolves a repo through `internal/gitrepo`, the same path `amika sandbox
create` takes, and accepts the same --git / --no-git pair.

Closes KAPRO-879, KAPRO-880.

## What `send` does now

- Run it inside a repo and the repo's `origin` is sent as `repo_url`, so
  the sandbox the API creates clones it. Detection walks up from the cwd,
  as create's does.
- `--git <path|url>` picks a different repo and `--no-git` sends no repo
  at all.
- `--repo` becomes a hidden alias for `--git`, so existing callers keep
  working. Passing both with different values is an error.
- Repo selection only applies to a sandbox this command creates, so with
  `--session-id` or `--sandbox` auto-detection is skipped rather than
  silently discarded, and an explicit `--git`/`--repo` is rejected with a
  message saying why. `--no-git` is accepted there — it asks for exactly
  what already happens.
- Resolution runs before the auth gate (matching create) so a
  contradictory flag pair fails on its own terms instead of behind a
  login error; the git subprocess that resolves the URL runs after it.
- In text mode the repo is named on stderr as `repo: <name>`, next to
  `session_id:`; `-o json` suppresses it so stdout stays one valid
  object. The name rather than the URL, matching what `sandbox create`
  reports — it is what identifies the repo to a reader, and a URL would
  risk echoing a token, since an origin can carry one in its userinfo.

`AddRepoAlias` and `FlagsChanged` join `internal/gitrepo` here rather
than in the extraction commit, since the alias and the
"was a repo actually requested?" question exist only for this command.

