### PR TITLE
Extract the git repo resolution into internal/gitrepo

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -3,6 +3,7 @@ package sandboxcmd
 // command.go assembles the top-level sandbox command and its flags.
 
 import (
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 	"github.com/spf13/cobra"
 )
@@ -47,8 +48,9 @@ func New() *cobra.Command {
 	sandboxCreateCmd.Flags().StringArray("volume", nil, "Mount an existing named volume (name:target[:mode], mode defaults to rw)")
 	sandboxCreateCmd.Flags().StringArray("port", nil, "Publish a container port (hostPort:containerPort[/protocol], protocol defaults to tcp)")
 	sandboxCreateCmd.Flags().String("port-host-ip", "127.0.0.1", "Host IP address to bind published ports")
-	sandboxCreateCmd.Flags().String("git", "", "Mount a git repo into the sandbox. Accepts a local path or a git URL (HTTPS, SSH). If omitted and the cwd is in a git repo, that repo is used automatically.")
-	sandboxCreateCmd.Flags().Bool("no-git", false, "Skip git repo auto-detection; create a sandbox without mounting any repo.")
+	gitrepo.AddFlags(sandboxCreateCmd,
+		"Mount a git repo into the sandbox. Accepts a local path or a git URL (HTTPS, SSH). If omitted and the cwd is in a git repo, that repo is used automatically.",
+		"Skip git repo auto-detection; create a sandbox without mounting any repo.")
 	sandboxCreateCmd.Flags().Bool("no-clean", false, "With a local-path git source, include untracked files from the working tree instead of a clean clone. Local sandboxes only.")
 	sandboxCreateCmd.Flags().String("size", "", "Sandbox size, e.g. \"m\" or \"a1.medium\"; the API validates it and lists what your provider offers (default \"m\", remote only)")
 	sandboxCreateCmd.Flags().String("snapshot", "", "Fork the sandbox from a captured snapshot slug (remote only)")

--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/apiclient"
 	"github.com/gofixpoint/amika/go/internal/config"
 	"github.com/gofixpoint/amika/go/internal/constants"
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
@@ -28,9 +29,6 @@ var sandboxCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		noClean, _ := cmd.Flags().GetBool("no-clean")
 		noSetup, _ := cmd.Flags().GetBool("no-setup")
-		gitFlag, _ := cmd.Flags().GetString("git")
-		gitFlagSet := cmd.Flags().Changed("git")
-		noGit, _ := cmd.Flags().GetBool("no-git")
 		if noSetup && cmd.Flags().Changed("setup-script") {
 			return fmt.Errorf("--no-setup and --setup-script are mutually exclusive")
 		}
@@ -63,7 +61,7 @@ var sandboxCreateCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to determine working directory: %w", err)
 		}
-		identity, err := resolveRepoIdentity(cwd, gitFlag, gitFlagSet, noGit, noClean)
+		identity, err := gitrepo.FromCommand(cmd, cwd)
 		if err != nil {
 			return err
 		}
@@ -325,7 +323,7 @@ var sandboxCreateCmd = &cobra.Command{
 	},
 }
 
-func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentity) error {
+func createRemoteSandbox(cmd *cobra.Command, target string, identity gitrepo.Identity) error {
 	name, _ := cmd.Flags().GetString("name")
 	provider := requestedRemoteProvider(cmd)
 	secretFlags, _ := cmd.Flags().GetStringArray("secret")
@@ -351,21 +349,14 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity repoIdentit
 		name = sandbox.GenerateName()
 	}
 
-	var gitURL string
-	gitIsLocalPath := identity.Source == repoSourceAutoDetect || identity.Source == repoSourceFlagPath
-	switch identity.Source {
-	case repoSourceFlagURL:
-		gitURL = identity.URL
-	case repoSourceAutoDetect, repoSourceFlagPath:
-		resolved, err := resolveGitURL(identity.Path)
-		if err != nil {
-			return err
-		}
-		gitURL = resolved
+	gitIsLocalPath := identity.IsLocalPath()
+	gitURL, err := identity.RemoteURL()
+	if err != nil {
+		return err
 	}
 
 	if branch == "" && newBranch == "" && gitIsLocalPath {
-		if hostBranch, err := detectHostCurrentBranch(identity.Path); err == nil {
+		if hostBranch, err := gitrepo.CurrentBranch(identity.Path); err == nil {
 			branch = hostBranch
 		}
 	}

--- a/go/cmd/amika/sandbox/sandbox_create_git.go
+++ b/go/cmd/amika/sandbox/sandbox_create_git.go
@@ -4,7 +4,6 @@ package sandboxcmd
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -12,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 )
 
@@ -23,7 +23,7 @@ type gitMountInfo struct {
 }
 
 func prepareGitMount(startPath string, noClean bool, cloneFn func(src, dst string) error, branch, newBranch string) (gitMountInfo, func(), error) {
-	repoRoot, err := resolveGitRoot(startPath)
+	repoRoot, err := gitrepo.ResolveRoot(startPath)
 	if err != nil {
 		return gitMountInfo{}, func() {}, err
 	}
@@ -70,36 +70,6 @@ func prepareGitMount(startPath string, noClean bool, cloneFn func(src, dst strin
 	}, cleanup, nil
 }
 
-func resolveGitRoot(startPath string) (string, error) {
-	if startPath == "" {
-		startPath = "."
-	}
-	absPath, err := filepath.Abs(startPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve git start path %q: %w", startPath, err)
-	}
-
-	current := absPath
-	if stat, err := os.Stat(absPath); err == nil && !stat.IsDir() {
-		current = filepath.Dir(absPath)
-	}
-
-	for {
-		gitMarker := filepath.Join(current, ".git")
-		if _, err := os.Stat(gitMarker); err == nil {
-			return current, nil
-		}
-
-		parent := filepath.Dir(current)
-		if parent == current {
-			break
-		}
-		current = parent
-	}
-
-	return "", fmt.Errorf("no git repository root found from %q", absPath)
-}
-
 func cloneGitRepo(src, dst string) error {
 	args := []string{"clone", "--local", "--no-hardlinks", src, dst}
 	cmd := exec.Command("git", args...)
@@ -127,7 +97,7 @@ func cloneGitURL(src, dst string) error {
 // path delegates to "git clone <url>", which already configures origin
 // pointing at rawURL. No additional remote sync is needed.
 func prepareGitMountFromURL(rawURL string, cloneFn func(src, dst string) error, branch, newBranch string) (gitMountInfo, func(), error) {
-	name, err := repoNameFromURL(rawURL)
+	name, err := gitrepo.NameFromURL(rawURL)
 	if err != nil {
 		return gitMountInfo{}, func() {}, err
 	}
@@ -243,23 +213,6 @@ func applyBranchCheckout(repoDir, branch, newBranch string) error {
 	return nil
 }
 
-func detectHostCurrentBranch(startPath string) (string, error) {
-	repoRoot, err := resolveGitRoot(startPath)
-	if err != nil {
-		return "", err
-	}
-	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to detect current host branch: %w", err)
-	}
-	name := strings.TrimSpace(string(out))
-	if name == "" || name == "HEAD" {
-		return "", fmt.Errorf("detached HEAD; specify --branch explicitly")
-	}
-	return name, nil
-}
-
 // isLocalBranchReachableFromRemote returns true when the local branch tip
 // is an ancestor of (or equal to) the corresponding branch on the "origin"
 // remote. This means the remote already contains every commit on the local
@@ -340,63 +293,32 @@ func copyRepoWorkingTree(src, dst string) error {
 }
 
 func syncGitRemotes(srcRepo, dstRepo string) error {
-	srcRemotes, err := listGitRemotes(srcRepo)
+	srcRemotes, err := gitrepo.ListRemotes(srcRepo)
 	if err != nil {
 		return fmt.Errorf("failed to read remotes from source repo %q: %w", srcRepo, err)
 	}
 	filtered := make(map[string]string)
 	for name, url := range srcRemotes {
-		if isNetworkRemoteURL(url) {
+		if gitrepo.IsNetworkURL(url) {
 			filtered[name] = url
 		}
 	}
 
-	dstRemotes, err := listGitRemotes(dstRepo)
+	dstRemotes, err := gitrepo.ListRemotes(dstRepo)
 	if err != nil {
 		return fmt.Errorf("failed to read remotes from prepared repo %q: %w", dstRepo, err)
 	}
 	for _, name := range sortedRemoteNames(dstRemotes) {
-		if err := runGit(dstRepo, "remote", "remove", name); err != nil {
+		if err := gitrepo.Run(dstRepo, "remote", "remove", name); err != nil {
 			return fmt.Errorf("failed to remove remote %q from prepared repo %q: %w", name, dstRepo, err)
 		}
 	}
 	for _, name := range sortedRemoteNames(filtered) {
-		if err := runGit(dstRepo, "remote", "add", name, filtered[name]); err != nil {
+		if err := gitrepo.Run(dstRepo, "remote", "add", name, filtered[name]); err != nil {
 			return fmt.Errorf("failed to add remote %q to prepared repo %q: %w", name, dstRepo, err)
 		}
 	}
 	return nil
-}
-
-func listGitRemotes(repo string) (map[string]string, error) {
-	out, err := runGitOutput(repo, "remote")
-	if err != nil {
-		return nil, err
-	}
-	names := strings.Fields(strings.TrimSpace(out))
-	remotes := make(map[string]string, len(names))
-	for _, name := range names {
-		url, err := runGitOutput(repo, "remote", "get-url", name)
-		if err != nil {
-			return nil, err
-		}
-		remotes[name] = strings.TrimSpace(url)
-	}
-	return remotes, nil
-}
-
-func isNetworkRemoteURL(url string) bool {
-	switch {
-	case strings.HasPrefix(url, "http://"),
-		strings.HasPrefix(url, "https://"),
-		strings.HasPrefix(url, "ssh://"):
-		return true
-	case strings.HasPrefix(url, "file://"):
-		return false
-	}
-	at := strings.Index(url, "@")
-	colon := strings.Index(url, ":")
-	return at > 0 && colon > at+1
 }
 
 func sortedRemoteNames(m map[string]string) []string {
@@ -406,149 +328,4 @@ func sortedRemoteNames(m map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
-}
-
-func runGit(repo string, args ...string) error {
-	_, err := runGitOutput(repo, args...)
-	return err
-}
-
-func runGitOutput(repo string, args ...string) (string, error) {
-	cmdArgs := append([]string{"-C", repo}, args...)
-	cmd := exec.Command("git", cmdArgs...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("git %s failed: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
-	}
-	return string(out), nil
-}
-
-type repoSource int
-
-const (
-	repoSourceNone repoSource = iota
-	repoSourceAutoDetect
-	repoSourceFlagPath
-	repoSourceFlagURL
-)
-
-type repoIdentity struct {
-	Name   string
-	Source repoSource
-	Path   string
-	URL    string
-}
-
-// resolveRepoIdentity decides which git repo (if any) should back a sandbox
-// based on the user's flag input and the working directory.
-//
-//   - --git and --no-git are mutually exclusive.
-//   - --no-clean and --no-git are mutually exclusive.
-//   - --no-clean is only meaningful when a local-path repo is sourced
-//     (auto-detect or --git <path>).
-//   - When neither --git nor --no-git is set, the function walks up from cwd
-//     to detect a repo; if none is found, identity is repoSourceNone.
-func resolveRepoIdentity(cwd, gitFlag string, gitFlagSet, noGit, noClean bool) (repoIdentity, error) {
-	if gitFlagSet && noGit {
-		return repoIdentity{}, fmt.Errorf("--git and --no-git are mutually exclusive")
-	}
-	if noClean && noGit {
-		return repoIdentity{}, fmt.Errorf("--no-clean and --no-git are mutually exclusive")
-	}
-	if noGit {
-		return repoIdentity{Source: repoSourceNone}, nil
-	}
-	if gitFlagSet {
-		v := strings.TrimSpace(gitFlag)
-		if v == "" {
-			return repoIdentity{}, fmt.Errorf("--git requires a non-empty value")
-		}
-		if isNetworkRemoteURL(v) {
-			if noClean {
-				return repoIdentity{}, fmt.Errorf("--no-clean cannot be used with a git URL")
-			}
-			name, err := repoNameFromURL(v)
-			if err != nil {
-				return repoIdentity{}, err
-			}
-			return repoIdentity{Name: name, Source: repoSourceFlagURL, URL: v}, nil
-		}
-		repoRoot, err := resolveGitRoot(v)
-		if err != nil {
-			return repoIdentity{}, fmt.Errorf("could not find git repo at %q: %w", v, err)
-		}
-		return repoIdentity{Name: filepath.Base(repoRoot), Source: repoSourceFlagPath, Path: repoRoot}, nil
-	}
-	repoRoot, err := resolveGitRoot(cwd)
-	if err != nil {
-		if noClean {
-			return repoIdentity{}, fmt.Errorf("--no-clean requires a git repo, but none was detected from %q", cwd)
-		}
-		return repoIdentity{Source: repoSourceNone}, nil
-	}
-	return repoIdentity{Name: filepath.Base(repoRoot), Source: repoSourceAutoDetect, Path: repoRoot}, nil
-}
-
-// repoNameFromURL extracts the repo name from a git URL.
-// Examples:
-//
-//	https://github.com/foo/bar       -> bar
-//	https://github.com/foo/bar.git   -> bar
-//	git@github.com:foo/bar.git       -> bar
-//	ssh://git@github.com/foo/bar.git -> bar
-func repoNameFromURL(rawURL string) (string, error) {
-	s := strings.TrimSpace(rawURL)
-	if s == "" {
-		return "", fmt.Errorf("empty git URL")
-	}
-	var pathPart string
-	if strings.Contains(s, "://") {
-		u, err := url.Parse(s)
-		if err != nil {
-			return "", fmt.Errorf("parsing git URL %q: %w", rawURL, err)
-		}
-		pathPart = u.Path
-	} else if i := strings.Index(s, ":"); i >= 0 {
-		pathPart = s[i+1:]
-	} else {
-		return "", fmt.Errorf("not a git URL: %q", rawURL)
-	}
-	pathPart = strings.TrimSuffix(strings.TrimSpace(pathPart), "/")
-	if pathPart == "" {
-		return "", fmt.Errorf("git URL %q has no repo path", rawURL)
-	}
-	if i := strings.LastIndex(pathPart, "/"); i >= 0 {
-		pathPart = pathPart[i+1:]
-	}
-	pathPart = strings.TrimSuffix(pathPart, ".git")
-	if pathPart == "" {
-		return "", fmt.Errorf("could not extract repo name from %q", rawURL)
-	}
-	if pathPart == "." || pathPart == ".." || strings.ContainsAny(pathPart, "/\\") {
-		return "", fmt.Errorf("invalid repo name %q extracted from %q", pathPart, rawURL)
-	}
-	return pathPart, nil
-}
-
-func resolveGitURL(value string) (string, error) {
-	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "git@") {
-		return value, nil
-	}
-
-	repoRoot, err := resolveGitRoot(value)
-	if err != nil {
-		return "", fmt.Errorf("could not find git repo at %q: %w", value, err)
-	}
-	remotes, err := listGitRemotes(repoRoot)
-	if err != nil {
-		return "", err
-	}
-	origin, ok := remotes["origin"]
-	if !ok {
-		return "", fmt.Errorf("no origin remote found in %q; specify a git HTTP(S) or SSH URL directly with --git <url>, or pass --no-git to create a sandbox without a repo", repoRoot)
-	}
-	if !isNetworkRemoteURL(origin) {
-		return "", fmt.Errorf("origin remote %q is a local path; specify a git HTTP(S) or SSH URL directly with --git <url>, or pass --no-git to create a sandbox without a repo", origin)
-	}
-	return origin, nil
 }

--- a/go/cmd/amika/sandbox/sandbox_create_materialize.go
+++ b/go/cmd/amika/sandbox/sandbox_create_materialize.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gofixpoint/amika/go/internal/agentconfig"
 	"github.com/gofixpoint/amika/go/internal/amikaconfig"
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 	"github.com/gofixpoint/amika/go/internal/txn"
 	"github.com/gofixpoint/amika/go/pkg/amika"
@@ -88,7 +89,7 @@ type collectedMounts struct {
 func collectMounts(
 	mountStrs, volumeStrs, portStrs []string,
 	portHostIP string,
-	identity repoIdentity,
+	identity gitrepo.Identity,
 	noClean bool,
 	setupScript string,
 	setupScriptFlagChanged bool,
@@ -112,7 +113,7 @@ func collectMounts(
 	cleanup := func() {}
 	var gmi *gitMountInfo
 	switch identity.Source {
-	case repoSourceAutoDetect, repoSourceFlagPath:
+	case gitrepo.SourceAutoDetect, gitrepo.SourceFlagPath:
 		info, cleanupGitMount, err := prepareGitMount(identity.Path, noClean, cloneGitRepo, branch, newBranch)
 		if err != nil {
 			return collectedMounts{}, err
@@ -120,7 +121,7 @@ func collectMounts(
 		cleanup = cleanupGitMount
 		gmi = &info
 		mounts = append(mounts, info.Mount)
-	case repoSourceFlagURL:
+	case gitrepo.SourceFlagURL:
 		info, cleanupGitMount, err := prepareGitMountFromURL(identity.URL, cloneGitURL, branch, newBranch)
 		if err != nil {
 			return collectedMounts{}, err

--- a/go/cmd/amika/sandbox/sandbox_create_mounts.go
+++ b/go/cmd/amika/sandbox/sandbox_create_mounts.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
 	"github.com/gofixpoint/amika/go/pkg/amika"
 )
@@ -282,8 +283,8 @@ func validateMountTargets(bindMounts, volumeMounts []sandbox.MountBinding) error
 	return nil
 }
 
-func formatRepoBanner(identity repoIdentity) string {
-	if identity.Source == repoSourceNone {
+func formatRepoBanner(identity gitrepo.Identity) string {
+	if identity.Source == gitrepo.SourceNone {
 		return "Creating a bare sandbox with no repos."
 	}
 	return fmt.Sprintf("Creating sandbox with repo %s.", identity.Name)

--- a/go/cmd/amika/sandbox/sandbox_git_test.go
+++ b/go/cmd/amika/sandbox/sandbox_git_test.go
@@ -11,80 +11,8 @@ import (
 	"testing"
 
 	"github.com/gofixpoint/amika/go/internal/amikaconfig"
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 )
-
-func TestResolveGitRoot(t *testing.T) {
-	t.Run("finds from nested directory", func(t *testing.T) {
-		root := t.TempDir()
-		if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
-			t.Fatalf("failed to create .git directory: %v", err)
-		}
-		nested := filepath.Join(root, "a", "b")
-		if err := os.MkdirAll(nested, 0o755); err != nil {
-			t.Fatalf("failed to create nested dir: %v", err)
-		}
-
-		got, err := resolveGitRoot(nested)
-		if err != nil {
-			t.Fatalf("resolveGitRoot failed: %v", err)
-		}
-		if got != root {
-			t.Fatalf("got %q, want %q", got, root)
-		}
-	})
-
-	t.Run("accepts .git file", func(t *testing.T) {
-		root := t.TempDir()
-		if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: /tmp/worktree"), 0o644); err != nil {
-			t.Fatalf("failed to create .git file: %v", err)
-		}
-		nested := filepath.Join(root, "nested")
-		if err := os.MkdirAll(nested, 0o755); err != nil {
-			t.Fatalf("failed to create nested dir: %v", err)
-		}
-
-		got, err := resolveGitRoot(nested)
-		if err != nil {
-			t.Fatalf("resolveGitRoot failed: %v", err)
-		}
-		if got != root {
-			t.Fatalf("got %q, want %q", got, root)
-		}
-	})
-
-	t.Run("handles file path input", func(t *testing.T) {
-		root := t.TempDir()
-		if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
-			t.Fatalf("failed to create .git directory: %v", err)
-		}
-		filePath := filepath.Join(root, "nested", "file.txt")
-		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
-			t.Fatalf("failed to create nested dir: %v", err)
-		}
-		if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
-			t.Fatalf("failed to write file: %v", err)
-		}
-
-		got, err := resolveGitRoot(filePath)
-		if err != nil {
-			t.Fatalf("resolveGitRoot failed: %v", err)
-		}
-		if got != root {
-			t.Fatalf("got %q, want %q", got, root)
-		}
-	})
-
-	t.Run("errors when repo is not found", func(t *testing.T) {
-		dir := t.TempDir()
-		_, err := resolveGitRoot(dir)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-		if !strings.Contains(err.Error(), "no git repository root found") {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-}
 
 func TestPrepareGitMount_NoClean(t *testing.T) {
 	root := createGitRepo(t, map[string]string{"origin": "https://github.com/example/upstream.git"})
@@ -487,200 +415,30 @@ func TestSyncGitRemotes(t *testing.T) {
 	}
 }
 
-func TestIsNetworkRemoteURL(t *testing.T) {
-	tests := []struct {
-		url  string
-		want bool
-	}{
-		{url: "https://github.com/org/repo.git", want: true},
-		{url: "http://github.com/org/repo.git", want: true},
-		{url: "ssh://git@github.com/org/repo.git", want: true},
-		{url: "git@github.com:org/repo.git", want: true},
-		{url: "/Users/me/repo", want: false},
-		{url: "../repo", want: false},
-		{url: "file:///Users/me/repo", want: false},
-	}
-	for _, tt := range tests {
-		if got := isNetworkRemoteURL(tt.url); got != tt.want {
-			t.Fatalf("isNetworkRemoteURL(%q) = %v, want %v", tt.url, got, tt.want)
-		}
-	}
-}
-
-func TestResolveRepoIdentity(t *testing.T) {
-	makeRepo := func(t *testing.T, name string) string {
-		t.Helper()
-		root := t.TempDir()
-		repo := filepath.Join(root, name)
-		if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
-			t.Fatalf("failed to create fake repo: %v", err)
-		}
-		return repo
-	}
-
-	t.Run("auto-detect from in-repo cwd", func(t *testing.T) {
-		repo := makeRepo(t, "myrepo")
-		nested := filepath.Join(repo, "sub", "dir")
-		if err := os.MkdirAll(nested, 0o755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-		got, err := resolveRepoIdentity(nested, "", false, false, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got.Source != repoSourceAutoDetect {
-			t.Fatalf("Source = %v, want autoDetect", got.Source)
-		}
-		if got.Name != "myrepo" {
-			t.Fatalf("Name = %q, want %q", got.Name, "myrepo")
-		}
-		if got.Path != repo {
-			t.Fatalf("Path = %q, want %q", got.Path, repo)
-		}
-	})
-
-	t.Run("auto-detect outside repo returns none", func(t *testing.T) {
-		dir := t.TempDir()
-		got, err := resolveRepoIdentity(dir, "", false, false, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got.Source != repoSourceNone {
-			t.Fatalf("Source = %v, want none", got.Source)
-		}
-	})
-
-	t.Run("auto-detect + --no-clean uses repo", func(t *testing.T) {
-		repo := makeRepo(t, "myrepo")
-		got, err := resolveRepoIdentity(repo, "", false, false, true)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got.Source != repoSourceAutoDetect {
-			t.Fatalf("Source = %v, want autoDetect", got.Source)
-		}
-		if got.Path != repo {
-			t.Fatalf("Path = %q, want %q", got.Path, repo)
-		}
-	})
-
-	t.Run("--no-git in repo returns none", func(t *testing.T) {
-		repo := makeRepo(t, "myrepo")
-		got, err := resolveRepoIdentity(repo, "", false, true, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got.Source != repoSourceNone {
-			t.Fatalf("Source = %v, want none", got.Source)
-		}
-	})
-
-	t.Run("--git <path>", func(t *testing.T) {
-		repo := makeRepo(t, "fromflag")
-		got, err := resolveRepoIdentity("/tmp", repo, true, false, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got.Source != repoSourceFlagPath {
-			t.Fatalf("Source = %v, want flagPath", got.Source)
-		}
-		if got.Name != "fromflag" {
-			t.Fatalf("Name = %q, want %q", got.Name, "fromflag")
-		}
-	})
-
-	t.Run("--git <https url>", func(t *testing.T) {
-		got, err := resolveRepoIdentity("/tmp", "https://github.com/foo/bar.git", true, false, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got.Source != repoSourceFlagURL {
-			t.Fatalf("Source = %v, want flagURL", got.Source)
-		}
-		if got.Name != "bar" {
-			t.Fatalf("Name = %q, want %q", got.Name, "bar")
-		}
-		if got.URL != "https://github.com/foo/bar.git" {
-			t.Fatalf("URL = %q", got.URL)
-		}
-	})
-
-	t.Run("--git <ssh url>", func(t *testing.T) {
-		got, err := resolveRepoIdentity("/tmp", "git@github.com:foo/baz.git", true, false, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got.Source != repoSourceFlagURL {
-			t.Fatalf("Source = %v, want flagURL", got.Source)
-		}
-		if got.Name != "baz" {
-			t.Fatalf("Name = %q, want %q", got.Name, "baz")
-		}
-	})
-
-	t.Run("--git + --no-git is an error", func(t *testing.T) {
-		if _, err := resolveRepoIdentity("/tmp", "https://x/y.git", true, true, false); err == nil {
-			t.Fatal("expected error")
-		}
-	})
-
-	t.Run("--no-clean + --no-git is an error", func(t *testing.T) {
-		if _, err := resolveRepoIdentity("/tmp", "", false, true, true); err == nil {
-			t.Fatal("expected error")
-		}
-	})
-
-	t.Run("--no-clean + --git <url> is an error", func(t *testing.T) {
-		if _, err := resolveRepoIdentity("/tmp", "https://x/y.git", true, false, true); err == nil {
-			t.Fatal("expected error")
-		}
-	})
-
-	t.Run("--no-clean without a repo is an error", func(t *testing.T) {
-		dir := t.TempDir()
-		if _, err := resolveRepoIdentity(dir, "", false, false, true); err == nil {
-			t.Fatal("expected error")
-		}
-	})
-
-	t.Run("--git with empty value is an error", func(t *testing.T) {
-		if _, err := resolveRepoIdentity("/tmp", "  ", true, false, false); err == nil {
-			t.Fatal("expected error")
-		}
-	})
-
-	t.Run("--git <bad path> is an error", func(t *testing.T) {
-		bogus := filepath.Join(t.TempDir(), "no-such-dir")
-		if _, err := resolveRepoIdentity("/tmp", bogus, true, false, false); err == nil {
-			t.Fatal("expected error")
-		}
-	})
-}
-
 func TestFormatRepoBanner(t *testing.T) {
 	tests := []struct {
 		name     string
-		identity repoIdentity
+		identity gitrepo.Identity
 		want     string
 	}{
 		{
 			name:     "none",
-			identity: repoIdentity{Source: repoSourceNone},
+			identity: gitrepo.Identity{Source: gitrepo.SourceNone},
 			want:     "Creating a bare sandbox with no repos.",
 		},
 		{
 			name:     "auto-detect",
-			identity: repoIdentity{Source: repoSourceAutoDetect, Name: "myrepo"},
+			identity: gitrepo.Identity{Source: gitrepo.SourceAutoDetect, Name: "myrepo"},
 			want:     "Creating sandbox with repo myrepo.",
 		},
 		{
 			name:     "flag-path",
-			identity: repoIdentity{Source: repoSourceFlagPath, Name: "frompath"},
+			identity: gitrepo.Identity{Source: gitrepo.SourceFlagPath, Name: "frompath"},
 			want:     "Creating sandbox with repo frompath.",
 		},
 		{
 			name:     "flag-url",
-			identity: repoIdentity{Source: repoSourceFlagURL, Name: "fromurl"},
+			identity: gitrepo.Identity{Source: gitrepo.SourceFlagURL, Name: "fromurl"},
 			want:     "Creating sandbox with repo fromurl.",
 		},
 	}
@@ -688,51 +446,6 @@ func TestFormatRepoBanner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := formatRepoBanner(tt.identity); got != tt.want {
 				t.Fatalf("formatRepoBanner = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestRepoNameFromURL(t *testing.T) {
-	tests := []struct {
-		url     string
-		want    string
-		wantErr bool
-	}{
-		{url: "https://github.com/foo/bar", want: "bar"},
-		{url: "https://github.com/foo/bar.git", want: "bar"},
-		{url: "https://github.com/foo/bar/", want: "bar"},
-		{url: "http://example.com/foo/bar.git", want: "bar"},
-		{url: "git@github.com:foo/bar.git", want: "bar"},
-		{url: "git@github.com:foo/bar", want: "bar"},
-		{url: "ssh://git@github.com/foo/bar.git", want: "bar"},
-		{url: "ssh://git@github.com:22/foo/bar.git", want: "bar"},
-		{url: "https://gitlab.com/group/subgroup/repo.git", want: "repo"},
-		{url: "  https://github.com/foo/bar.git  ", want: "bar"},
-		{url: "", wantErr: true},
-		{url: "   ", wantErr: true},
-		{url: "https://github.com/", wantErr: true},
-		{url: "https://github.com", wantErr: true},
-		{url: "just-a-name", wantErr: true},
-		{url: "https://example.com/foo/.", wantErr: true},
-		{url: "https://example.com/foo/..", wantErr: true},
-		{url: "https://example.com/foo/..git", wantErr: true},
-		{url: "git@example.com:foo/.", wantErr: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.url, func(t *testing.T) {
-			got, err := repoNameFromURL(tt.url)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("repoNameFromURL(%q) = %q, want error", tt.url, got)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("repoNameFromURL(%q) unexpected error: %v", tt.url, err)
-			}
-			if got != tt.want {
-				t.Fatalf("repoNameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
 			}
 		})
 	}
@@ -896,9 +609,9 @@ func createGitRepo(t *testing.T, remotes map[string]string) string {
 
 func readGitRemotes(t *testing.T, repo string) map[string]string {
 	t.Helper()
-	remotes, err := listGitRemotes(repo)
+	remotes, err := gitrepo.ListRemotes(repo)
 	if err != nil {
-		t.Fatalf("listGitRemotes(%q) failed: %v", repo, err)
+		t.Fatalf("gitrepo.ListRemotes(%q) failed: %v", repo, err)
 	}
 	return remotes
 }

--- a/go/internal/gitrepo/flags.go
+++ b/go/internal/gitrepo/flags.go
@@ -1,0 +1,45 @@
+package gitrepo
+
+// flags.go registers and reads the repo-selection flags, so every command that
+// can put a repo in a sandbox spells them the same way.
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Flag names for repo selection.
+const (
+	// FlagGit names the repo to use: a local path or a git URL.
+	FlagGit = "git"
+	// FlagNoGit skips auto-detection so no repo is used.
+	FlagNoGit = "no-git"
+	// FlagNoClean includes the working tree's untracked files instead of a
+	// clean clone. Only local sandboxes offer it.
+	FlagNoClean = "no-clean"
+)
+
+// AddFlags registers --git and --no-git on cmd. The usage strings stay
+// per-command because a local sandbox mounts the repo while a remote one
+// clones it, but the names, types, and defaults live here so every command
+// accepts exactly the same input.
+func AddFlags(cmd *cobra.Command, gitUsage, noGitUsage string) {
+	cmd.Flags().String(FlagGit, "", gitUsage)
+	cmd.Flags().Bool(FlagNoGit, false, noGitUsage)
+}
+
+// FromCommand reads the repo-selection flags off cmd and resolves them
+// against cwd.
+//
+// --no-clean is read only when the command registers it, so a command that
+// does not offer it resolves as if it were unset rather than tripping over a
+// flag it never exposed.
+func FromCommand(cmd *cobra.Command, cwd string) (Identity, error) {
+	git, _ := cmd.Flags().GetString(FlagGit)
+	gitSet := cmd.Flags().Changed(FlagGit)
+	noGit, _ := cmd.Flags().GetBool(FlagNoGit)
+	noClean := false
+	if f := cmd.Flags().Lookup(FlagNoClean); f != nil {
+		noClean, _ = cmd.Flags().GetBool(FlagNoClean)
+	}
+	return Resolve(Options{Cwd: cwd, Git: git, GitSet: gitSet, NoGit: noGit, NoClean: noClean})
+}

--- a/go/internal/gitrepo/flags_test.go
+++ b/go/internal/gitrepo/flags_test.go
@@ -1,0 +1,97 @@
+package gitrepo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestCmd builds a command carrying the flags a caller opts into: always
+// --git/--no-git, plus --no-clean when asked, since only local sandboxes
+// offer that one.
+func newTestCmd(withNoClean bool) *cobra.Command {
+	cmd := &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
+	AddFlags(cmd, "git usage", "no-git usage")
+	if withNoClean {
+		cmd.Flags().Bool(FlagNoClean, false, "no-clean usage")
+	}
+	return cmd
+}
+
+func parseFlags(t *testing.T, cmd *cobra.Command, args ...string) {
+	t.Helper()
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags(%v) failed: %v", args, err)
+	}
+}
+
+func makeFakeRepo(t *testing.T, name string) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatalf("failed to create fake repo: %v", err)
+	}
+	return repo
+}
+
+func TestFromCommand(t *testing.T) {
+	t.Run("no flags auto-detects from cwd", func(t *testing.T) {
+		repo := makeFakeRepo(t, "myrepo")
+		cmd := newTestCmd(true)
+		got, err := FromCommand(cmd, repo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceAutoDetect || got.Path != repo {
+			t.Fatalf("identity = %+v, want auto-detected %q", got, repo)
+		}
+	})
+
+	t.Run("--git wins over auto-detection", func(t *testing.T) {
+		cwdRepo := makeFakeRepo(t, "cwdrepo")
+		flagRepo := makeFakeRepo(t, "flagrepo")
+		cmd := newTestCmd(true)
+		parseFlags(t, cmd, "--git", flagRepo)
+		got, err := FromCommand(cmd, cwdRepo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceFlagPath || got.Path != flagRepo {
+			t.Fatalf("identity = %+v, want --git path %q", got, flagRepo)
+		}
+	})
+
+	t.Run("--no-git skips auto-detection", func(t *testing.T) {
+		repo := makeFakeRepo(t, "myrepo")
+		cmd := newTestCmd(true)
+		parseFlags(t, cmd, "--no-git")
+		got, err := FromCommand(cmd, repo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceNone {
+			t.Fatalf("Source = %v, want none", got.Source)
+		}
+	})
+
+	t.Run("--no-clean is read only where it is registered", func(t *testing.T) {
+		// The command that offers --no-clean must see it enforced...
+		withFlag := newTestCmd(true)
+		parseFlags(t, withFlag, "--no-clean")
+		if _, err := FromCommand(withFlag, t.TempDir()); err == nil {
+			t.Fatal("expected --no-clean outside a repo to error")
+		}
+		// ...and one that does not offer it must resolve as if unset, rather
+		// than tripping over a flag it never exposed.
+		withoutFlag := newTestCmd(false)
+		got, err := FromCommand(withoutFlag, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceNone {
+			t.Fatalf("Source = %v, want none", got.Source)
+		}
+	})
+}

--- a/go/internal/gitrepo/gitrepo.go
+++ b/go/internal/gitrepo/gitrepo.go
@@ -1,0 +1,304 @@
+// Package gitrepo resolves which git repo (if any) should back a sandbox: the
+// shared --git / --no-git flag pair, auto-detection from the working
+// directory, and the "origin" URL a remote sandbox has to clone.
+//
+// It is shared by `amika sandbox create` and `amika send` so that running
+// either from inside a repo picks up the same repo, with the same flags and
+// the same error messages.
+package gitrepo
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Source records where a resolved repo came from, which decides how it is
+// handed to the sandbox: a local path is copied or cloned locally, a URL is
+// cloned from the network, and SourceNone means no repo at all.
+type Source int
+
+const (
+	// SourceNone means no repo backs the sandbox, either because --no-git was
+	// passed or because no repo was found from the working directory.
+	SourceNone Source = iota
+	// SourceAutoDetect means the repo was found by walking up from the
+	// working directory.
+	SourceAutoDetect
+	// SourceFlagPath means --git named a local path.
+	SourceFlagPath
+	// SourceFlagURL means --git named a git URL (HTTPS or SSH).
+	SourceFlagURL
+)
+
+// Identity is the repo a command resolved from its flags and working
+// directory. Path is set for the local-path sources, URL for a URL source,
+// and Name is the repo's short name in both cases.
+type Identity struct {
+	Name   string
+	Source Source
+	Path   string
+	URL    string
+}
+
+// IsLocalPath reports whether the identity names a repo on this machine,
+// as opposed to a URL or no repo at all.
+func (i Identity) IsLocalPath() bool {
+	return i.Source == SourceAutoDetect || i.Source == SourceFlagPath
+}
+
+// RemoteURL returns the git URL a remote sandbox should clone: the URL from
+// --git as given, or the "origin" remote of a local-path repo. An identity
+// with no repo returns an empty string and no error.
+func (i Identity) RemoteURL() (string, error) {
+	switch i.Source {
+	case SourceFlagURL:
+		return i.URL, nil
+	case SourceAutoDetect, SourceFlagPath:
+		return ResolveURL(i.Path)
+	default:
+		return "", nil
+	}
+}
+
+// Options is the flag input to Resolve.
+type Options struct {
+	// Cwd is the directory auto-detection walks up from when neither --git
+	// nor --no-git is set.
+	Cwd string
+	// Git is the --git value and GitSet reports whether the flag was passed,
+	// so an explicit empty value can be rejected rather than silently
+	// falling back to auto-detection.
+	Git    string
+	GitSet bool
+	// NoGit is the --no-git flag: skip auto-detection entirely.
+	NoGit bool
+	// NoClean is the local-sandbox --no-clean flag. It only makes sense with a
+	// local-path repo, so it constrains which sources are acceptable.
+	// Commands that do not offer --no-clean leave it false.
+	NoClean bool
+}
+
+// Resolve decides which git repo (if any) should back a sandbox based on the
+// user's flag input and the working directory.
+//
+//   - --git and --no-git are mutually exclusive.
+//   - --no-clean and --no-git are mutually exclusive.
+//   - --no-clean is only meaningful when a local-path repo is sourced
+//     (auto-detect or --git <path>).
+//   - When neither --git nor --no-git is set, the function walks up from Cwd
+//     to detect a repo; if none is found, the identity is SourceNone.
+func Resolve(opts Options) (Identity, error) {
+	if opts.GitSet && opts.NoGit {
+		return Identity{}, fmt.Errorf("--git and --no-git are mutually exclusive")
+	}
+	if opts.NoClean && opts.NoGit {
+		return Identity{}, fmt.Errorf("--no-clean and --no-git are mutually exclusive")
+	}
+	if opts.NoGit {
+		return Identity{Source: SourceNone}, nil
+	}
+	if opts.GitSet {
+		v := strings.TrimSpace(opts.Git)
+		if v == "" {
+			return Identity{}, fmt.Errorf("--git requires a non-empty value")
+		}
+		if IsNetworkURL(v) {
+			if opts.NoClean {
+				return Identity{}, fmt.Errorf("--no-clean cannot be used with a git URL")
+			}
+			name, err := NameFromURL(v)
+			if err != nil {
+				return Identity{}, err
+			}
+			return Identity{Name: name, Source: SourceFlagURL, URL: v}, nil
+		}
+		repoRoot, err := ResolveRoot(v)
+		if err != nil {
+			return Identity{}, fmt.Errorf("could not find git repo at %q: %w", v, err)
+		}
+		return Identity{Name: filepath.Base(repoRoot), Source: SourceFlagPath, Path: repoRoot}, nil
+	}
+	repoRoot, err := ResolveRoot(opts.Cwd)
+	if err != nil {
+		if opts.NoClean {
+			return Identity{}, fmt.Errorf("--no-clean requires a git repo, but none was detected from %q", opts.Cwd)
+		}
+		return Identity{Source: SourceNone}, nil
+	}
+	return Identity{Name: filepath.Base(repoRoot), Source: SourceAutoDetect, Path: repoRoot}, nil
+}
+
+// ResolveRoot walks up from startPath and returns the first directory holding
+// a .git entry. A file path is resolved from its containing directory.
+func ResolveRoot(startPath string) (string, error) {
+	if startPath == "" {
+		startPath = "."
+	}
+	absPath, err := filepath.Abs(startPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve git start path %q: %w", startPath, err)
+	}
+
+	current := absPath
+	if stat, err := os.Stat(absPath); err == nil && !stat.IsDir() {
+		current = filepath.Dir(absPath)
+	}
+
+	for {
+		gitMarker := filepath.Join(current, ".git")
+		if _, err := os.Stat(gitMarker); err == nil {
+			return current, nil
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+
+	return "", fmt.Errorf("no git repository root found from %q", absPath)
+}
+
+// ResolveURL turns a --git value into a git URL a remote sandbox can clone:
+// a URL passes through, and a local path resolves to that repo's "origin"
+// remote.
+func ResolveURL(value string) (string, error) {
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "git@") {
+		return value, nil
+	}
+
+	repoRoot, err := ResolveRoot(value)
+	if err != nil {
+		return "", fmt.Errorf("could not find git repo at %q: %w", value, err)
+	}
+	remotes, err := ListRemotes(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	origin, ok := remotes["origin"]
+	if !ok {
+		return "", fmt.Errorf("no origin remote found in %q; specify a git HTTP(S) or SSH URL directly with --git <url>, or pass --no-git to create a sandbox without a repo", repoRoot)
+	}
+	if !IsNetworkURL(origin) {
+		return "", fmt.Errorf("origin remote %q is a local path; specify a git HTTP(S) or SSH URL directly with --git <url>, or pass --no-git to create a sandbox without a repo", origin)
+	}
+	return origin, nil
+}
+
+// ListRemotes returns the repo's remotes as a name-to-URL map.
+func ListRemotes(repo string) (map[string]string, error) {
+	out, err := Output(repo, "remote")
+	if err != nil {
+		return nil, err
+	}
+	names := strings.Fields(strings.TrimSpace(out))
+	remotes := make(map[string]string, len(names))
+	for _, name := range names {
+		url, err := Output(repo, "remote", "get-url", name)
+		if err != nil {
+			return nil, err
+		}
+		remotes[name] = strings.TrimSpace(url)
+	}
+	return remotes, nil
+}
+
+// IsNetworkURL reports whether a remote URL points at a network host, as
+// opposed to a local path (which a sandbox on another machine cannot reach).
+// It recognizes http(s)://, ssh://, and the scp-like user@host:path form.
+func IsNetworkURL(url string) bool {
+	switch {
+	case strings.HasPrefix(url, "http://"),
+		strings.HasPrefix(url, "https://"),
+		strings.HasPrefix(url, "ssh://"):
+		return true
+	case strings.HasPrefix(url, "file://"):
+		return false
+	}
+	at := strings.Index(url, "@")
+	colon := strings.Index(url, ":")
+	return at > 0 && colon > at+1
+}
+
+// NameFromURL extracts the repo name from a git URL.
+// Examples:
+//
+//	https://github.com/foo/bar       -> bar
+//	https://github.com/foo/bar.git   -> bar
+//	git@github.com:foo/bar.git       -> bar
+//	ssh://git@github.com/foo/bar.git -> bar
+func NameFromURL(rawURL string) (string, error) {
+	s := strings.TrimSpace(rawURL)
+	if s == "" {
+		return "", fmt.Errorf("empty git URL")
+	}
+	var pathPart string
+	if strings.Contains(s, "://") {
+		u, err := url.Parse(s)
+		if err != nil {
+			return "", fmt.Errorf("parsing git URL %q: %w", rawURL, err)
+		}
+		pathPart = u.Path
+	} else if i := strings.Index(s, ":"); i >= 0 {
+		pathPart = s[i+1:]
+	} else {
+		return "", fmt.Errorf("not a git URL: %q", rawURL)
+	}
+	pathPart = strings.TrimSuffix(strings.TrimSpace(pathPart), "/")
+	if pathPart == "" {
+		return "", fmt.Errorf("git URL %q has no repo path", rawURL)
+	}
+	if i := strings.LastIndex(pathPart, "/"); i >= 0 {
+		pathPart = pathPart[i+1:]
+	}
+	pathPart = strings.TrimSuffix(pathPart, ".git")
+	if pathPart == "" {
+		return "", fmt.Errorf("could not extract repo name from %q", rawURL)
+	}
+	if pathPart == "." || pathPart == ".." || strings.ContainsAny(pathPart, "/\\") {
+		return "", fmt.Errorf("invalid repo name %q extracted from %q", pathPart, rawURL)
+	}
+	return pathPart, nil
+}
+
+// CurrentBranch returns the branch checked out in the repo containing
+// startPath. A detached HEAD is an error, since there is no branch name to
+// carry into a sandbox.
+func CurrentBranch(startPath string) (string, error) {
+	repoRoot, err := ResolveRoot(startPath)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to detect current host branch: %w", err)
+	}
+	name := strings.TrimSpace(string(out))
+	if name == "" || name == "HEAD" {
+		return "", fmt.Errorf("detached HEAD; specify --branch explicitly")
+	}
+	return name, nil
+}
+
+// Run runs a git command in repo and discards its output.
+func Run(repo string, args ...string) error {
+	_, err := Output(repo, args...)
+	return err
+}
+
+// Output runs a git command in repo and returns its combined output.
+func Output(repo string, args ...string) (string, error) {
+	cmdArgs := append([]string{"-C", repo}, args...)
+	cmd := exec.Command("git", cmdArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s failed: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}

--- a/go/internal/gitrepo/gitrepo_test.go
+++ b/go/internal/gitrepo/gitrepo_test.go
@@ -1,0 +1,296 @@
+package gitrepo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveGitRoot(t *testing.T) {
+	t.Run("finds from nested directory", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+			t.Fatalf("failed to create .git directory: %v", err)
+		}
+		nested := filepath.Join(root, "a", "b")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatalf("failed to create nested dir: %v", err)
+		}
+
+		got, err := ResolveRoot(nested)
+		if err != nil {
+			t.Fatalf("ResolveRoot failed: %v", err)
+		}
+		if got != root {
+			t.Fatalf("got %q, want %q", got, root)
+		}
+	})
+
+	t.Run("accepts .git file", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: /tmp/worktree"), 0o644); err != nil {
+			t.Fatalf("failed to create .git file: %v", err)
+		}
+		nested := filepath.Join(root, "nested")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatalf("failed to create nested dir: %v", err)
+		}
+
+		got, err := ResolveRoot(nested)
+		if err != nil {
+			t.Fatalf("ResolveRoot failed: %v", err)
+		}
+		if got != root {
+			t.Fatalf("got %q, want %q", got, root)
+		}
+	})
+
+	t.Run("handles file path input", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+			t.Fatalf("failed to create .git directory: %v", err)
+		}
+		filePath := filepath.Join(root, "nested", "file.txt")
+		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+			t.Fatalf("failed to create nested dir: %v", err)
+		}
+		if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+
+		got, err := ResolveRoot(filePath)
+		if err != nil {
+			t.Fatalf("ResolveRoot failed: %v", err)
+		}
+		if got != root {
+			t.Fatalf("got %q, want %q", got, root)
+		}
+	})
+
+	t.Run("errors when repo is not found", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := ResolveRoot(dir)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "no git repository root found") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestIsNetworkURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{url: "https://github.com/org/repo.git", want: true},
+		{url: "http://github.com/org/repo.git", want: true},
+		{url: "ssh://git@github.com/org/repo.git", want: true},
+		{url: "git@github.com:org/repo.git", want: true},
+		{url: "/Users/me/repo", want: false},
+		{url: "../repo", want: false},
+		{url: "file:///Users/me/repo", want: false},
+	}
+	for _, tt := range tests {
+		if got := IsNetworkURL(tt.url); got != tt.want {
+			t.Fatalf("IsNetworkURL(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestResolve(t *testing.T) {
+	makeRepo := func(t *testing.T, name string) string {
+		t.Helper()
+		root := t.TempDir()
+		repo := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+			t.Fatalf("failed to create fake repo: %v", err)
+		}
+		return repo
+	}
+
+	t.Run("auto-detect from in-repo cwd", func(t *testing.T) {
+		repo := makeRepo(t, "myrepo")
+		nested := filepath.Join(repo, "sub", "dir")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		got, err := Resolve(Options{Cwd: nested})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceAutoDetect {
+			t.Fatalf("Source = %v, want autoDetect", got.Source)
+		}
+		if got.Name != "myrepo" {
+			t.Fatalf("Name = %q, want %q", got.Name, "myrepo")
+		}
+		if got.Path != repo {
+			t.Fatalf("Path = %q, want %q", got.Path, repo)
+		}
+	})
+
+	t.Run("auto-detect outside repo returns none", func(t *testing.T) {
+		dir := t.TempDir()
+		got, err := Resolve(Options{Cwd: dir})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceNone {
+			t.Fatalf("Source = %v, want none", got.Source)
+		}
+	})
+
+	t.Run("auto-detect + --no-clean uses repo", func(t *testing.T) {
+		repo := makeRepo(t, "myrepo")
+		got, err := Resolve(Options{Cwd: repo, NoClean: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceAutoDetect {
+			t.Fatalf("Source = %v, want autoDetect", got.Source)
+		}
+		if got.Path != repo {
+			t.Fatalf("Path = %q, want %q", got.Path, repo)
+		}
+	})
+
+	t.Run("--no-git in repo returns none", func(t *testing.T) {
+		repo := makeRepo(t, "myrepo")
+		got, err := Resolve(Options{Cwd: repo, NoGit: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceNone {
+			t.Fatalf("Source = %v, want none", got.Source)
+		}
+	})
+
+	t.Run("--git <path>", func(t *testing.T) {
+		repo := makeRepo(t, "fromflag")
+		got, err := Resolve(Options{Cwd: "/tmp", Git: repo, GitSet: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceFlagPath {
+			t.Fatalf("Source = %v, want flagPath", got.Source)
+		}
+		if got.Name != "fromflag" {
+			t.Fatalf("Name = %q, want %q", got.Name, "fromflag")
+		}
+	})
+
+	t.Run("--git <https url>", func(t *testing.T) {
+		got, err := Resolve(Options{Cwd: "/tmp", Git: "https://github.com/foo/bar.git", GitSet: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceFlagURL {
+			t.Fatalf("Source = %v, want flagURL", got.Source)
+		}
+		if got.Name != "bar" {
+			t.Fatalf("Name = %q, want %q", got.Name, "bar")
+		}
+		if got.URL != "https://github.com/foo/bar.git" {
+			t.Fatalf("URL = %q", got.URL)
+		}
+	})
+
+	t.Run("--git <ssh url>", func(t *testing.T) {
+		got, err := Resolve(Options{Cwd: "/tmp", Git: "git@github.com:foo/baz.git", GitSet: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Source != SourceFlagURL {
+			t.Fatalf("Source = %v, want flagURL", got.Source)
+		}
+		if got.Name != "baz" {
+			t.Fatalf("Name = %q, want %q", got.Name, "baz")
+		}
+	})
+
+	t.Run("--git + --no-git is an error", func(t *testing.T) {
+		if _, err := Resolve(Options{Cwd: "/tmp", Git: "https://x/y.git", GitSet: true, NoGit: true}); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("--no-clean + --no-git is an error", func(t *testing.T) {
+		if _, err := Resolve(Options{Cwd: "/tmp", NoGit: true, NoClean: true}); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("--no-clean + --git <url> is an error", func(t *testing.T) {
+		if _, err := Resolve(Options{Cwd: "/tmp", Git: "https://x/y.git", GitSet: true, NoClean: true}); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("--no-clean without a repo is an error", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := Resolve(Options{Cwd: dir, NoClean: true}); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("--git with empty value is an error", func(t *testing.T) {
+		if _, err := Resolve(Options{Cwd: "/tmp", Git: "  ", GitSet: true}); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("--git <bad path> is an error", func(t *testing.T) {
+		bogus := filepath.Join(t.TempDir(), "no-such-dir")
+		if _, err := Resolve(Options{Cwd: "/tmp", Git: bogus, GitSet: true}); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestNameFromURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{url: "https://github.com/foo/bar", want: "bar"},
+		{url: "https://github.com/foo/bar.git", want: "bar"},
+		{url: "https://github.com/foo/bar/", want: "bar"},
+		{url: "http://example.com/foo/bar.git", want: "bar"},
+		{url: "git@github.com:foo/bar.git", want: "bar"},
+		{url: "git@github.com:foo/bar", want: "bar"},
+		{url: "ssh://git@github.com/foo/bar.git", want: "bar"},
+		{url: "ssh://git@github.com:22/foo/bar.git", want: "bar"},
+		{url: "https://gitlab.com/group/subgroup/repo.git", want: "repo"},
+		{url: "  https://github.com/foo/bar.git  ", want: "bar"},
+		{url: "", wantErr: true},
+		{url: "   ", wantErr: true},
+		{url: "https://github.com/", wantErr: true},
+		{url: "https://github.com", wantErr: true},
+		{url: "just-a-name", wantErr: true},
+		{url: "https://example.com/foo/.", wantErr: true},
+		{url: "https://example.com/foo/..", wantErr: true},
+		{url: "https://example.com/foo/..git", wantErr: true},
+		{url: "git@example.com:foo/.", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			got, err := NameFromURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NameFromURL(%q) = %q, want error", tt.url, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NameFromURL(%q) unexpected error: %v", tt.url, err)
+			}
+			if got != tt.want {
+				t.Fatalf("NameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/gitrepo/remoteurl_test.go
+++ b/go/internal/gitrepo/remoteurl_test.go
@@ -1,0 +1,153 @@
+package gitrepo
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initRepo creates a real git repo with the given remotes, so the origin
+// lookup exercises git itself rather than a stub.
+func initRepo(t *testing.T, remotes map[string]string) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	runGit(t, filepath.Dir(repo), "init", repo)
+	for name, url := range remotes {
+		runGit(t, repo, "remote", "add", name, url)
+	}
+	return repo
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %s", strings.Join(args, " "), out)
+	}
+}
+
+func TestResolveURL(t *testing.T) {
+	t.Run("a URL passes through", func(t *testing.T) {
+		for _, url := range []string{
+			"https://github.com/foo/bar.git",
+			"http://example.com/foo/bar.git",
+			"git@github.com:foo/bar.git",
+		} {
+			got, err := ResolveURL(url)
+			if err != nil {
+				t.Fatalf("ResolveURL(%q) failed: %v", url, err)
+			}
+			if got != url {
+				t.Fatalf("ResolveURL(%q) = %q, want it unchanged", url, got)
+			}
+		}
+	})
+
+	t.Run("a local path resolves to its origin remote", func(t *testing.T) {
+		repo := initRepo(t, map[string]string{
+			"origin":   "https://github.com/example/upstream.git",
+			"upstream": "git@github.com:example/other.git",
+		})
+		got, err := ResolveURL(repo)
+		if err != nil {
+			t.Fatalf("ResolveURL failed: %v", err)
+		}
+		if got != "https://github.com/example/upstream.git" {
+			t.Fatalf("ResolveURL = %q, want the origin remote", got)
+		}
+	})
+
+	t.Run("a nested path resolves from the repo root", func(t *testing.T) {
+		repo := initRepo(t, map[string]string{"origin": "https://github.com/example/upstream.git"})
+		got, err := ResolveURL(filepath.Join(repo, "does", "not", "exist"))
+		if err != nil {
+			t.Fatalf("ResolveURL failed: %v", err)
+		}
+		if got != "https://github.com/example/upstream.git" {
+			t.Fatalf("ResolveURL = %q, want the origin remote", got)
+		}
+	})
+
+	t.Run("no origin remote is an error naming --no-git", func(t *testing.T) {
+		repo := initRepo(t, map[string]string{"upstream": "https://github.com/example/upstream.git"})
+		_, err := ResolveURL(repo)
+		if err == nil || !strings.Contains(err.Error(), "no origin remote found") {
+			t.Fatalf("err = %v, want a missing-origin error", err)
+		}
+		if !strings.Contains(err.Error(), "--no-git") {
+			t.Fatalf("err = %v, want it to mention --no-git", err)
+		}
+	})
+
+	t.Run("a local origin is an error", func(t *testing.T) {
+		// A path on this machine is unreachable from a remote sandbox, so it
+		// must be rejected rather than sent to the API.
+		repo := initRepo(t, map[string]string{"origin": "/srv/git/upstream.git"})
+		_, err := ResolveURL(repo)
+		if err == nil || !strings.Contains(err.Error(), "is a local path") {
+			t.Fatalf("err = %v, want a local-origin error", err)
+		}
+	})
+
+	t.Run("not a repo is an error", func(t *testing.T) {
+		_, err := ResolveURL(t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "could not find git repo") {
+			t.Fatalf("err = %v, want a missing-repo error", err)
+		}
+	})
+}
+
+func TestIdentityRemoteURL(t *testing.T) {
+	t.Run("a URL identity returns its URL verbatim", func(t *testing.T) {
+		id := Identity{Name: "bar", Source: SourceFlagURL, URL: "git@github.com:foo/bar.git"}
+		got, err := id.RemoteURL()
+		if err != nil {
+			t.Fatalf("RemoteURL failed: %v", err)
+		}
+		if got != "git@github.com:foo/bar.git" {
+			t.Fatalf("RemoteURL = %q", got)
+		}
+	})
+
+	t.Run("a local identity resolves its origin", func(t *testing.T) {
+		repo := initRepo(t, map[string]string{"origin": "https://github.com/example/upstream.git"})
+		for _, source := range []Source{SourceAutoDetect, SourceFlagPath} {
+			id := Identity{Name: "repo", Source: source, Path: repo}
+			got, err := id.RemoteURL()
+			if err != nil {
+				t.Fatalf("RemoteURL failed: %v", err)
+			}
+			if got != "https://github.com/example/upstream.git" {
+				t.Fatalf("RemoteURL = %q, want the origin remote", got)
+			}
+		}
+	})
+
+	t.Run("no repo returns an empty URL and no error", func(t *testing.T) {
+		got, err := Identity{Source: SourceNone}.RemoteURL()
+		if err != nil {
+			t.Fatalf("RemoteURL failed: %v", err)
+		}
+		if got != "" {
+			t.Fatalf("RemoteURL = %q, want empty", got)
+		}
+	})
+}
+
+func TestIdentityIsLocalPath(t *testing.T) {
+	tests := []struct {
+		source Source
+		want   bool
+	}{
+		{source: SourceAutoDetect, want: true},
+		{source: SourceFlagPath, want: true},
+		{source: SourceFlagURL, want: false},
+		{source: SourceNone, want: false},
+	}
+	for _, tt := range tests {
+		if got := (Identity{Source: tt.source}).IsLocalPath(); got != tt.want {
+			t.Fatalf("IsLocalPath() for source %v = %v, want %v", tt.source, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Pure refactor, no behavior change. `amika sandbox create` is still the
only caller; the point is to make the resolution reachable from other
commands, since `amika send` needs the same answers and today cannot get
them (KAPRO-879, KAPRO-880).

The logic lived in package-private helpers under `go/cmd/amika/sandbox/`.
Anything outside `package sandboxcmd` — `amika send` is in `package
main` — could only duplicate it. It moves to `go/internal/gitrepo`, with
bodies unchanged:

| Was (sandboxcmd) | Now (gitrepo) |
| --- | --- |
| `resolveRepoIdentity(cwd, git, gitSet, noGit, noClean)` | `Resolve(Options{...})` |
| `repoIdentity`, `repoSource*` | `Identity`, `Source*` |
| `resolveGitRoot` | `ResolveRoot` |
| `resolveGitURL` | `ResolveURL` |
| `repoNameFromURL` | `NameFromURL` |
| `isNetworkRemoteURL` | `IsNetworkURL` |
| `listGitRemotes`, `runGit`, `runGitOutput` | `ListRemotes`, `Run`, `Output` |
| `detectHostCurrentBranch` | `CurrentBranch` |

Every one of those is the same code with a new name — worth checking by
diffing the bodies rather than reading them fresh.

Three things are genuinely new:

- `Options`, replacing the five positional parameters of
  `resolveRepoIdentity`. Its `NoClean` field carries the local-sandbox
  `--no-clean` rules, which is why the doc comment spells out that only
  commands offering that flag set it.
- `Identity.IsLocalPath()` and `Identity.RemoteURL()`, both lifted from
  inline code in `createRemoteSandbox` — the second is the
  identity-to-clone-URL switch that sat in the middle of that function.
- `AddFlags` / `FromCommand`, which register and read --git/--no-git so a
  second command cannot drift from the first. The usage strings stay at
  the call site, since a local sandbox mounts the repo while a remote one
  clones it.

What stays in `sandboxcmd`: mount preparation, branch checkout, and the
unpushed-branch warning. Those are local-sandbox and create-specific, not
shared vocabulary.

Tests move with the code — `TestResolveGitRoot`, `TestIsNetworkURL`,
`TestResolve`, `TestNameFromURL` — and `ResolveURL`, `RemoteURL`, and
`FromCommand` gain the coverage they had none of, since they are now a
public surface.

