### PR TITLE
Classify user-less scp git URLs as remote, not as local paths

### DIFF
--- a/go/internal/gitrepo/gitrepo.go
+++ b/go/internal/gitrepo/gitrepo.go
@@ -210,7 +210,7 @@ func ListRemotes(repo string) (map[string]string, error) {
 
 // IsNetworkURL reports whether a remote URL points at a network host, as
 // opposed to a local path (which a sandbox on another machine cannot reach).
-// It recognizes http(s)://, ssh://, and the scp-like user@host:path form.
+// It recognizes http(s)://, ssh://, and the scp-like [user@]host:path form.
 func IsNetworkURL(url string) bool {
 	switch {
 	case strings.HasPrefix(url, "http://"),
@@ -220,9 +220,19 @@ func IsNetworkURL(url string) bool {
 	case strings.HasPrefix(url, "file://"):
 		return false
 	}
-	at := strings.Index(url, "@")
+	// scp-like syntax, which git resolves over ssh. Git's own rule is that a
+	// colon with no slash before it makes this an ssh URL, so the user half is
+	// optional: "build-host:org/repo.git" is as valid as
+	// "git@build-host:org/repo.git".
 	colon := strings.Index(url, ":")
-	return at > 0 && colon > at+1
+	// A one-character host is a Windows drive letter ("C:\repo"), not a host.
+	if colon < 2 {
+		return false
+	}
+	if strings.ContainsAny(url[:colon], `/\`) {
+		return false
+	}
+	return url[colon+1:] != ""
 }
 
 // NameFromURL extracts the repo name from a git URL.

--- a/go/internal/gitrepo/gitrepo_test.go
+++ b/go/internal/gitrepo/gitrepo_test.go
@@ -89,9 +89,19 @@ func TestIsNetworkURL(t *testing.T) {
 		{url: "http://github.com/org/repo.git", want: true},
 		{url: "ssh://git@github.com/org/repo.git", want: true},
 		{url: "git@github.com:org/repo.git", want: true},
+		// scp-like syntax with the optional user half omitted, which git
+		// still resolves over ssh.
+		{url: "build-host:org/repo.git", want: true},
 		{url: "/Users/me/repo", want: false},
 		{url: "../repo", want: false},
 		{url: "file:///Users/me/repo", want: false},
+		// A colon that follows a path separator belongs to the path.
+		{url: "/srv/git:mirror/repo", want: false},
+		{url: "./weird:name", want: false},
+		// A Windows drive letter is a path, not a one-character host.
+		{url: `C:\Users\me\repo`, want: false},
+		// A host with nothing after the colon names no repo.
+		{url: "build-host:", want: false},
 	}
 	for _, tt := range tests {
 		if got := IsNetworkURL(tt.url); got != tt.want {


### PR DESCRIPTION
`--git build-host:org/repo.git` silently used the wrong repo.

`IsNetworkURL` required an `@` to recognize scp-like syntax, so a valid
ssh remote with the optional user half omitted was classified as a local
path. Git itself needs no user: `git ls-remote build-host:org/repo.git`
resolves over ssh.

Misclassifying it does not merely fail. `Resolve` hands a path to
`ResolveRoot`, which walks *up* from it — and from inside any repo that
walk lands on the cwd's own `.git`, so the flag quietly selects a
different repo than the one asked for:

```
$ amika sandbox create --git build-host:org/repo.git   # in the amika checkout
Creating sandbox with repo amika.                      # before — wrong repo, no warning
Creating sandbox with repo repo.                       # after
```

Outside a repo it merely failed (`could not find git repo at
"build-host:org/repo.git"`), which is how the problem stayed hidden.

The classifier now follows git's own rule — a colon with no slash before
it makes this an ssh URL — with two guards: a one-character host is a
Windows drive letter (`C:\repo`), not a host, and a colon that follows a
path separator (`/srv/git:mirror/repo`) belongs to the path.

The same classifier decides which of a repo's remotes get copied into a
local sandbox (`syncGitRemotes`), so a user-less ssh remote now survives
that copy too instead of being dropped as a local path.

