### PR TITLE
Make `amika send` use the git repo it is run from

### DIFF
--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/gofixpoint/amika/go/internal/apiclient"
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/spf13/cobra"
@@ -50,6 +51,16 @@ scenes and a new chat is started; the returned session id can be passed back as
 --session-id to continue the conversation. The agent (claude or codex) comes
 from --agent, else the organization's default, else claude.
 
+Run from inside a git repo and that repo's "origin" remote is cloned into
+the sandbox, the same way "amika sandbox create" picks up the repo you are
+standing in. Pass --git <path|url> to choose a different repo, or --no-git for
+a sandbox with no repo at all; --repo is accepted as an alias for --git. Only
+the repo's default branch is cloned, whatever branch you have checked out
+locally.
+
+Repo selection only applies to a sandbox this command creates, so it cannot be
+combined with --session-id or --sandbox.
+
 The message can be provided as a positional argument or piped via stdin.
 
 By default the reply streams in as the agent produces it when stdout is a
@@ -84,7 +95,6 @@ func runSend(cmd *cobra.Command, args []string) error {
 	sessionID, _ := cmd.Flags().GetString("session-id")
 	sandboxRef, _ := cmd.Flags().GetString("sandbox")
 	newSession, _ := cmd.Flags().GetBool("new-session")
-	repo, _ := cmd.Flags().GetString("repo")
 
 	format, err := output.FormatFrom(cmd)
 	if err != nil {
@@ -104,11 +114,29 @@ func runSend(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Contradictory repo flags are reported before the auth gate: checking
+	// them costs nothing, so a login should not stand between the caller and
+	// a plain flag conflict. Only the flag-level checks move up — a bad path
+	// needs the filesystem, so it still waits.
+	if err := validateSendRepoFlags(cmd, sessionID, sandboxRef); err != nil {
+		return err
+	}
+
 	// The agent-sessions API is remote-only: it provisions sandboxes in the
 	// control plane, so there is no local equivalent.
 	if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
 		return err
 	}
+
+	// Resolving the repo waits until after the gate: it walks the filesystem
+	// and shells out to git, and login is the precondition for all of it, so
+	// someone not logged in hears that rather than a complaint about their
+	// git remote.
+	repoURL, repoName, err := sendRepo(cmd, sessionID, sandboxRef)
+	if err != nil {
+		return err
+	}
+	printSendRepo(format, os.Stderr, repoName)
 
 	req := apiclient.AgentSessionSendRequest{
 		Message:    message,
@@ -116,7 +144,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 		SessionID:  sessionID,
 		SandboxID:  sandboxRef,
 		NewSession: newSession,
-		RepoURL:    repo,
+		RepoURL:    repoURL,
 	}
 	client := runmode.NewRemoteClient()
 
@@ -154,6 +182,74 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("agent returned an error")
 	}
 	return nil
+}
+
+// printSendRepo reports which repo the sandbox will get, on stderr alongside
+// the other identifying lines so stdout stays the pure agent reply.
+//
+// Suppressed under --output json, per the CLI's rule that human progress goes
+// through format.Progress: a JSON caller gets one object and nothing else,
+// even on the stream stdout does not use.
+func printSendRepo(format output.Format, w io.Writer, name string) {
+	if name == "" {
+		return
+	}
+	fmt.Fprintf(format.Progress(w), "repo: %s\n", name)
+}
+
+// validateSendRepoFlags rejects a repo selection this command cannot honor,
+// using only the flags themselves so it can run before the auth gate.
+//
+// Beyond the contradictions gitrepo knows about, `send` has one of its own:
+// --session-id and --sandbox address a sandbox that already exists, so no
+// repo is created and an explicitly requested one cannot be honored. Refusing
+// beats dropping it from the request, which would show up only in what the
+// agent could see. --no-git needs no such refusal — it asks for exactly what
+// already happens there.
+func validateSendRepoFlags(cmd *cobra.Command, sessionID, sandboxRef string) error {
+	if err := gitrepo.ValidateFlags(cmd); err != nil {
+		return err
+	}
+	if sessionID == "" && sandboxRef == "" {
+		return nil
+	}
+	if flag := gitrepo.RequestedFlag(cmd); flag != "" {
+		return fmt.Errorf(
+			"--%s cannot be combined with --session-id or --sandbox; it only applies to a sandbox this command creates",
+			flag)
+	}
+	return nil
+}
+
+// sendRepo decides which git repo the sandbox created for this message should
+// clone, returning the URL to send and a short name to report (empty when
+// there is no repo to name).
+//
+// A message aimed at an existing chat (--session-id) or an existing sandbox
+// (--sandbox) creates nothing, so there is no repo to choose and the working
+// directory is not consulted at all.
+func sendRepo(cmd *cobra.Command, sessionID, sandboxRef string) (url, name string, err error) {
+	if sessionID != "" || sandboxRef != "" {
+		// validateSendRepoFlags has already refused an explicit repo here, so
+		// this is the "nothing was asked for" case: skip detection entirely.
+		return "", "", nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to determine working directory: %w", err)
+	}
+	identity, err := gitrepo.FromCommand(cmd, cwd)
+	if err != nil {
+		return "", "", err
+	}
+	url, err = identity.RemoteURL()
+	if err != nil {
+		return "", "", err
+	}
+	// Name, not URL: it is what identifies the repo to a reader, it matches
+	// what `sandbox create` reports, and an origin can carry a token in its
+	// userinfo that has no business on a terminal.
+	return url, identity.Name, nil
 }
 
 // mustBool reads a bool flag, ignoring the (impossible for a defined flag)
@@ -384,7 +480,10 @@ func init() {
 	sendCmd.Flags().String("session-id", "", "Continue an existing chat by its session id")
 	sendCmd.Flags().String("sandbox", "", "Send into a specific sandbox (id or name)")
 	sendCmd.Flags().Bool("new-session", false, "Start a brand-new chat")
-	sendCmd.Flags().String("repo", "", "Repository URL to clone when a sandbox is created")
+	gitrepo.AddFlags(sendCmd,
+		"Clone a git repo into the sandbox this command creates. Accepts a local path or a git URL (HTTPS, SSH). If omitted and the cwd is in a git repo, that repo is used automatically",
+		"Skip git repo auto-detection; create a sandbox without any repo")
+	gitrepo.AddRepoAlias(sendCmd)
 	sendCmd.Flags().Bool("stream", false, "Stream the reply as it is produced (default: on for a terminal, off when piped; always off with --output json)")
 	rootCmd.AddCommand(sendCmd)
 

--- a/go/cmd/amika/send_test.go
+++ b/go/cmd/amika/send_test.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/gofixpoint/amika/go/internal/gitrepo"
+	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +26,7 @@ func TestSendAndSessionsCommandsRegistered(t *testing.T) {
 	if send == nil {
 		t.Fatal("send command not registered on rootCmd")
 	}
-	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "repo", "stream"} {
+	for _, name := range []string{"agent", "session-id", "sandbox", "new-session", "git", "repo", "no-git", "stream"} {
 		if send.Flags().Lookup(name) == nil {
 			t.Errorf("send is missing --%s flag", name)
 		}
@@ -71,6 +75,275 @@ func TestSendRejectsInvalidOutput(t *testing.T) {
 	}
 }
 
+// TestSendRepo covers which repo the sandbox created for a message clones,
+// and when the working directory is not consulted at all.
+func TestSendRepo(t *testing.T) {
+	// initRepo builds a real repo, since resolving a repo to its "origin"
+	// shells out to git.
+	initRepo := func(t *testing.T, name string, remotes map[string]string) string {
+		t.Helper()
+		repo := filepath.Join(t.TempDir(), name)
+		run := func(dir string, args ...string) {
+			t.Helper()
+			cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v failed: %s", args, out)
+			}
+		}
+		run(filepath.Dir(repo), "init", repo)
+		for n, url := range remotes {
+			run(repo, "remote", "add", n, url)
+		}
+		return repo
+	}
+	// chdir runs the resolution from inside dir, since auto-detection walks up
+	// from the process's working directory.
+	chdir := func(t *testing.T, dir string) {
+		t.Helper()
+		old, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(old) })
+	}
+	const origin = "https://github.com/example/upstream.git"
+	// sendRepo reads the repo flags off the command, so tests need one
+	// registering the same set `send` does.
+	newCmd := func(t *testing.T, args ...string) *cobra.Command {
+		t.Helper()
+		cmd := &cobra.Command{Use: "send"}
+		gitrepo.AddFlags(cmd, "git", "no-git")
+		gitrepo.AddRepoAlias(cmd)
+		if err := cmd.ParseFlags(args); err != nil {
+			t.Fatal(err)
+		}
+		return cmd
+	}
+
+	t.Run("infers the origin of the repo containing the cwd", func(t *testing.T) {
+		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
+		url, name, err := sendRepo(newCmd(t), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != origin {
+			t.Fatalf("url = %q, want %q", url, origin)
+		}
+		if name != "myrepo" {
+			t.Fatalf("name = %q, want %q", name, "myrepo")
+		}
+	})
+
+	t.Run("infers from a nested directory", func(t *testing.T) {
+		repo := initRepo(t, "myrepo", map[string]string{"origin": origin})
+		nested := filepath.Join(repo, "a", "b")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		chdir(t, nested)
+		url, _, err := sendRepo(newCmd(t), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != origin {
+			t.Fatalf("url = %q, want %q", url, origin)
+		}
+	})
+
+	t.Run("outside a repo sends no repo", func(t *testing.T) {
+		chdir(t, t.TempDir())
+		url, name, err := sendRepo(newCmd(t), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != "" || name != "" {
+			t.Fatalf("url = %q, name = %q, want both empty", url, name)
+		}
+	})
+
+	t.Run("--no-git skips detection inside a repo", func(t *testing.T) {
+		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
+		url, name, err := sendRepo(newCmd(t, "--no-git"), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != "" || name != "" {
+			t.Fatalf("url = %q, name = %q, want both empty", url, name)
+		}
+	})
+
+	t.Run("--repo overrides the detected repo", func(t *testing.T) {
+		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
+		url, _, err := sendRepo(newCmd(t, "--repo", "https://github.com/other/thing.git"), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != "https://github.com/other/thing.git" {
+			t.Fatalf("url = %q, want the --repo value", url)
+		}
+	})
+
+	t.Run("--git overrides the detected repo", func(t *testing.T) {
+		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
+		url, name, err := sendRepo(newCmd(t, "--git", "https://github.com/other/thing.git"), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != "https://github.com/other/thing.git" || name != "thing" {
+			t.Fatalf("url = %q, name = %q, want the --git repo", url, name)
+		}
+	})
+
+	t.Run("--repo resolves a local path, like --git", func(t *testing.T) {
+		// The alias is the same input under an older name, so it gained path
+		// support rather than staying URL-only.
+		other := initRepo(t, "otherrepo", map[string]string{"origin": "https://github.com/example/other.git"})
+		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
+		url, name, err := sendRepo(newCmd(t, "--repo", other), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != "https://github.com/example/other.git" || name != "otherrepo" {
+			t.Fatalf("url = %q, name = %q, want the --repo path's origin", url, name)
+		}
+	})
+
+	t.Run("--git and --repo agreeing is accepted", func(t *testing.T) {
+		chdir(t, t.TempDir())
+		url, _, err := sendRepo(newCmd(t,
+			"--git", "https://github.com/a/b.git",
+			"--repo", "https://github.com/a/b.git"), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != "https://github.com/a/b.git" {
+			t.Fatalf("url = %q", url)
+		}
+	})
+
+	t.Run("an existing target accepts --no-git", func(t *testing.T) {
+		// --no-git asks for what already happens there, so it is no conflict.
+		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
+		url, name, err := sendRepo(newCmd(t, "--no-git"), "sess-1", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != "" || name != "" {
+			t.Fatalf("url = %q, name = %q, want both empty", url, name)
+		}
+	})
+
+	t.Run("a repo with no origin is an error naming the way out", func(t *testing.T) {
+		chdir(t, initRepo(t, "myrepo", nil))
+		_, _, err := sendRepo(newCmd(t), "", "")
+		if err == nil || !strings.Contains(err.Error(), "no origin remote found") {
+			t.Fatalf("err = %v, want a missing-origin error", err)
+		}
+		if !strings.Contains(err.Error(), "--no-git") {
+			t.Fatalf("err = %v, want it to mention --no-git", err)
+		}
+	})
+
+	t.Run("an existing target never consults the cwd", func(t *testing.T) {
+		// Not merely "sends no repo": a repo with no origin would error if the
+		// working directory were consulted at all, so this also pins that the
+		// detection is skipped rather than attempted and discarded.
+		chdir(t, initRepo(t, "myrepo", nil))
+		for _, tc := range []struct{ sessionID, sandboxRef string }{
+			{sessionID: "sess-1"},
+			{sandboxRef: "my-sandbox"},
+		} {
+			url, name, err := sendRepo(newCmd(t), tc.sessionID, tc.sandboxRef)
+			if err != nil {
+				t.Fatalf("unexpected error for %+v: %v", tc, err)
+			}
+			if url != "" || name != "" {
+				t.Fatalf("url = %q, name = %q for %+v, want both empty", url, name, tc)
+			}
+		}
+	})
+}
+
+// TestValidateSendRepoFlags covers the checks that run before the auth gate,
+// so a mistyped invocation is reported without needing credentials.
+func TestValidateSendRepoFlags(t *testing.T) {
+	newCmd := func(t *testing.T, args ...string) *cobra.Command {
+		t.Helper()
+		cmd := &cobra.Command{Use: "send"}
+		gitrepo.AddFlags(cmd, "git", "no-git")
+		gitrepo.AddRepoAlias(cmd)
+		if err := cmd.ParseFlags(args); err != nil {
+			t.Fatal(err)
+		}
+		return cmd
+	}
+
+	t.Run("a repo flag with --no-git is refused, naming the flag typed", func(t *testing.T) {
+		for _, flag := range []string{"--git", "--repo"} {
+			err := validateSendRepoFlags(newCmd(t, flag, "https://github.com/a/b.git", "--no-git"), "", "")
+			if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+				t.Fatalf("err = %v for %s, want a mutual-exclusion error", err, flag)
+			}
+			if !strings.Contains(err.Error(), flag) {
+				t.Fatalf("err = %v, want it to name %s", err, flag)
+			}
+		}
+	})
+
+	t.Run("--git and --repo disagreeing is ambiguous", func(t *testing.T) {
+		err := validateSendRepoFlags(newCmd(t,
+			"--git", "https://github.com/a/b.git",
+			"--repo", "https://github.com/c/d.git"), "", "")
+		if err == nil || !strings.Contains(err.Error(), "same flag under two names") {
+			t.Fatalf("err = %v, want an ambiguity error", err)
+		}
+	})
+
+	t.Run("--git with an empty value is refused", func(t *testing.T) {
+		err := validateSendRepoFlags(newCmd(t, "--git", "  "), "", "")
+		if err == nil || !strings.Contains(err.Error(), "requires a non-empty value") {
+			t.Fatalf("err = %v, want an empty-value error", err)
+		}
+	})
+
+	t.Run("an existing target refuses an explicit repo rather than dropping it", func(t *testing.T) {
+		// Before inference existed, --repo with --sandbox reached the API as-is.
+		// Silently discarding it would be a regression visible only in what the
+		// agent could see, so it is an error.
+		for _, flag := range []string{"--git", "--repo"} {
+			for _, tc := range []struct{ sessionID, sandboxRef string }{
+				{sessionID: "sess-1"},
+				{sandboxRef: "my-sandbox"},
+			} {
+				err := validateSendRepoFlags(newCmd(t, flag, "https://github.com/a/b.git"), tc.sessionID, tc.sandboxRef)
+				if err == nil || !strings.Contains(err.Error(), "cannot be combined with --session-id or --sandbox") {
+					t.Fatalf("err = %v for %s %+v, want a refusal", err, flag, tc)
+				}
+				if !strings.Contains(err.Error(), flag) {
+					t.Fatalf("err = %v, want it to name %s", err, flag)
+				}
+			}
+		}
+	})
+
+	t.Run("an existing target with no repo flag, or --no-git, is fine", func(t *testing.T) {
+		for _, args := range [][]string{nil, {"--no-git"}} {
+			if err := validateSendRepoFlags(newCmd(t, args...), "sess-1", ""); err != nil {
+				t.Fatalf("unexpected error for %v: %v", args, err)
+			}
+		}
+	})
+
+	t.Run("a plain invocation passes", func(t *testing.T) {
+		if err := validateSendRepoFlags(newCmd(t), "", ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 // TestUnstreamedRemainder covers what `amika send --stream` still has to print
 // after the deltas, given that the streamed text and the authoritative
 // `response` come from two different server-side parsers and need not agree.
@@ -115,6 +388,37 @@ func TestUnstreamedRemainder(t *testing.T) {
 			if extra != tc.extra || continuation != tc.continuation {
 				t.Errorf("unstreamedRemainder(%q, %q) = (%q, %v), want (%q, %v)",
 					tc.streamed, tc.response, extra, continuation, tc.extra, tc.continuation)
+			}
+		})
+	}
+}
+
+// TestPrintSendRepo pins the output contract for the repo line: stderr in text
+// mode, nothing at all in JSON mode. Getting this wrong by writing to stdout
+// would put a bare "repo: x" ahead of the JSON object and break every scripted
+// consumer, so it is worth a test of its own.
+func TestPrintSendRepo(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		repo   string
+		want   string
+	}{
+		{name: "text mode names the repo", format: "text", repo: "myrepo", want: "repo: myrepo\n"},
+		{name: "text mode with no repo says nothing", format: "text", repo: "", want: ""},
+		{name: "json mode is silent", format: "json", repo: "myrepo", want: ""},
+		{name: "json-pretty mode is silent", format: "json-pretty", repo: "myrepo", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, err := output.ParseFormat(tt.format)
+			if err != nil {
+				t.Fatalf("ParseFormat(%q): %v", tt.format, err)
+			}
+			var buf strings.Builder
+			printSendRepo(format, &buf, tt.repo)
+			if got := buf.String(); got != tt.want {
+				t.Fatalf("output = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/go/internal/gitrepo/flags.go
+++ b/go/internal/gitrepo/flags.go
@@ -4,6 +4,9 @@ package gitrepo
 // can put a repo in a sandbox spells them the same way.
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +16,8 @@ const (
 	FlagGit = "git"
 	// FlagNoGit skips auto-detection so no repo is used.
 	FlagNoGit = "no-git"
+	// FlagRepo is a legacy alias for FlagGit that a command may register.
+	FlagRepo = "repo"
 	// FlagNoClean includes the working tree's untracked files instead of a
 	// clean clone. Only local sandboxes offer it.
 	FlagNoClean = "no-clean"
@@ -27,19 +32,95 @@ func AddFlags(cmd *cobra.Command, gitUsage, noGitUsage string) {
 	cmd.Flags().Bool(FlagNoGit, false, noGitUsage)
 }
 
-// FromCommand reads the repo-selection flags off cmd and resolves them
-// against cwd.
+// AddRepoAlias registers --repo as a deprecated alias for --git. `amika send`
+// shipped with --repo before --git existed, so the old spelling keeps working
+// and resolves identically — including accepting a local path, which it did
+// not before.
 //
-// --no-clean is read only when the command registers it, so a command that
-// does not offer it resolves as if it were unset rather than tripping over a
-// flag it never exposed.
-func FromCommand(cmd *cobra.Command, cwd string) (Identity, error) {
-	git, _ := cmd.Flags().GetString(FlagGit)
-	gitSet := cmd.Flags().Changed(FlagGit)
+// MarkDeprecated rather than MarkHidden: both keep the flag out of --help, but
+// only this one prints a notice when it is used. Since the alias also tightened
+// what it accepts, a script that breaks after upgrading needs to be told where
+// the flag went — and --help can no longer be the place it finds out.
+func AddRepoAlias(cmd *cobra.Command) {
+	cmd.Flags().String(FlagRepo, "", "Deprecated alias for --"+FlagGit)
+	_ = cmd.Flags().MarkDeprecated(FlagRepo, "use --"+FlagGit)
+}
+
+// RequestedFlag returns the flag through which the caller explicitly asked for
+// a repo — FlagGit or its FlagRepo alias — or "" if neither was passed. A
+// command that cannot honor repo selection in some mode uses it both to tell
+// an unused default from a real request and to name the right flag when
+// refusing.
+func RequestedFlag(cmd *cobra.Command) string {
+	for _, name := range []string{FlagGit, FlagRepo} {
+		if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+			return name
+		}
+	}
+	return ""
+}
+
+// readFlags translates cmd's repo-selection flags into Options, leaving Cwd
+// unset.
+//
+// Only --no-git is required of a caller. --git, --repo, and --no-clean are
+// read when the command registers them and treated as unset otherwise, so a
+// command offering some of the set resolves the same way as one offering all
+// of it rather than tripping over a flag it never exposed.
+func readFlags(cmd *cobra.Command) (Options, error) {
+	git, gitSet, gitFlagName := "", false, FlagGit
+	if f := cmd.Flags().Lookup(FlagGit); f != nil {
+		git, gitSet = f.Value.String(), f.Changed
+	}
+	// --repo is the same input under an older name, so it feeds the same
+	// field. Both set to different values is ambiguous rather than a
+	// last-one-wins guess.
+	if f := cmd.Flags().Lookup(FlagRepo); f != nil && f.Changed {
+		alias := f.Value.String()
+		if gitSet && strings.TrimSpace(git) != strings.TrimSpace(alias) {
+			return Options{}, fmt.Errorf(
+				"--%s and --%s are the same flag under two names; pass one, not both with different values",
+				FlagGit, FlagRepo)
+		}
+		// Name the alias only when it is the sole spelling used, so one
+		// invocation is never reported under two different flag names
+		// depending on which check happens to fire. RequestedFlag prefers
+		// --git for the same reason.
+		if !gitSet {
+			gitFlagName = FlagRepo
+		}
+		git, gitSet = alias, true
+	}
 	noGit, _ := cmd.Flags().GetBool(FlagNoGit)
 	noClean := false
 	if f := cmd.Flags().Lookup(FlagNoClean); f != nil {
 		noClean, _ = cmd.Flags().GetBool(FlagNoClean)
 	}
-	return Resolve(Options{Cwd: cwd, Git: git, GitSet: gitSet, NoGit: noGit, NoClean: noClean})
+	return Options{
+		Git: git, GitSet: gitSet, GitFlagName: gitFlagName,
+		NoGit: noGit, NoClean: noClean,
+	}, nil
+}
+
+// ValidateFlags rejects a contradictory combination of cmd's repo-selection
+// flags without touching the filesystem. A command whose resolution happens
+// late — after an auth gate, say — calls this early so a mistyped invocation
+// is reported on its own terms rather than behind an unrelated error.
+func ValidateFlags(cmd *cobra.Command) error {
+	opts, err := readFlags(cmd)
+	if err != nil {
+		return err
+	}
+	return opts.Validate()
+}
+
+// FromCommand reads the repo-selection flags off cmd and resolves them
+// against cwd. See readFlags for which flags a caller must register.
+func FromCommand(cmd *cobra.Command, cwd string) (Identity, error) {
+	opts, err := readFlags(cmd)
+	if err != nil {
+		return Identity{}, err
+	}
+	opts.Cwd = cwd
+	return Resolve(opts)
 }

--- a/go/internal/gitrepo/flags_test.go
+++ b/go/internal/gitrepo/flags_test.go
@@ -3,17 +3,22 @@ package gitrepo
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
 
 // newTestCmd builds a command carrying the flags a caller opts into: always
-// --git/--no-git, plus --no-clean when asked, since only local sandboxes
-// offer that one.
-func newTestCmd(withNoClean bool) *cobra.Command {
+// --git/--no-git, plus the --repo alias and --no-clean when asked. That mirrors
+// the real split — `amika send` registers the alias, `amika sandbox create`
+// registers --no-clean, and neither registers the other's.
+func newTestCmd(withRepoAlias, withNoClean bool) *cobra.Command {
 	cmd := &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
 	AddFlags(cmd, "git usage", "no-git usage")
+	if withRepoAlias {
+		AddRepoAlias(cmd)
+	}
 	if withNoClean {
 		cmd.Flags().Bool(FlagNoClean, false, "no-clean usage")
 	}
@@ -39,7 +44,7 @@ func makeFakeRepo(t *testing.T, name string) string {
 func TestFromCommand(t *testing.T) {
 	t.Run("no flags auto-detects from cwd", func(t *testing.T) {
 		repo := makeFakeRepo(t, "myrepo")
-		cmd := newTestCmd(true)
+		cmd := newTestCmd(false, true)
 		got, err := FromCommand(cmd, repo)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -52,7 +57,7 @@ func TestFromCommand(t *testing.T) {
 	t.Run("--git wins over auto-detection", func(t *testing.T) {
 		cwdRepo := makeFakeRepo(t, "cwdrepo")
 		flagRepo := makeFakeRepo(t, "flagrepo")
-		cmd := newTestCmd(true)
+		cmd := newTestCmd(false, true)
 		parseFlags(t, cmd, "--git", flagRepo)
 		got, err := FromCommand(cmd, cwdRepo)
 		if err != nil {
@@ -65,7 +70,7 @@ func TestFromCommand(t *testing.T) {
 
 	t.Run("--no-git skips auto-detection", func(t *testing.T) {
 		repo := makeFakeRepo(t, "myrepo")
-		cmd := newTestCmd(true)
+		cmd := newTestCmd(false, true)
 		parseFlags(t, cmd, "--no-git")
 		got, err := FromCommand(cmd, repo)
 		if err != nil {
@@ -78,14 +83,14 @@ func TestFromCommand(t *testing.T) {
 
 	t.Run("--no-clean is read only where it is registered", func(t *testing.T) {
 		// The command that offers --no-clean must see it enforced...
-		withFlag := newTestCmd(true)
+		withFlag := newTestCmd(false, true)
 		parseFlags(t, withFlag, "--no-clean")
 		if _, err := FromCommand(withFlag, t.TempDir()); err == nil {
 			t.Fatal("expected --no-clean outside a repo to error")
 		}
 		// ...and one that does not offer it must resolve as if unset, rather
 		// than tripping over a flag it never exposed.
-		withoutFlag := newTestCmd(false)
+		withoutFlag := newTestCmd(false, false)
 		got, err := FromCommand(withoutFlag, t.TempDir())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -94,4 +99,197 @@ func TestFromCommand(t *testing.T) {
 			t.Fatalf("Source = %v, want none", got.Source)
 		}
 	})
+}
+
+func TestFromCommandWithoutGitFlag(t *testing.T) {
+	// `amika send` registers --no-git without --git, so the reader has to treat
+	// the missing flag as unset rather than depending on pflag's forgiving
+	// lookups.
+	cmd := &cobra.Command{Use: "sendlike"}
+	cmd.Flags().Bool(FlagNoGit, false, "no-git usage")
+
+	repo := makeFakeRepo(t, "myrepo")
+	got, err := FromCommand(cmd, repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Source != SourceAutoDetect || got.Name != "myrepo" {
+		t.Fatalf("identity = %+v, want the auto-detected repo", got)
+	}
+
+	parseFlags(t, cmd, "--no-git")
+	got, err = FromCommand(cmd, repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Source != SourceNone {
+		t.Fatalf("Source = %v, want none", got.Source)
+	}
+}
+
+func TestOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+		want string // substring, or "" for no error
+	}{{
+		name: "nothing set",
+		opts: Options{},
+	}, {
+		name: "git alone",
+		opts: Options{Git: "https://github.com/a/b.git", GitSet: true},
+	}, {
+		// GitFlagName defaults to --git, which is what keeps `sandbox create`'s
+		// messages stable: it never sets the field, and must never be told
+		// about an alias it does not register.
+		name: "git with no-git names --git when GitFlagName is unset",
+		opts: Options{Git: "x", GitSet: true, NoGit: true},
+		want: "--git and --no-git are mutually exclusive",
+	}, {
+		name: "git with no-git names the alias when GitFlagName says so",
+		opts: Options{Git: "x", GitSet: true, NoGit: true, GitFlagName: FlagRepo},
+		want: "--repo and --no-git are mutually exclusive",
+	}, {
+		name: "empty value names --git",
+		opts: Options{Git: "   ", GitSet: true},
+		want: "--git requires a non-empty value",
+	}, {
+		name: "empty value names the alias",
+		opts: Options{Git: "", GitSet: true, GitFlagName: FlagRepo},
+		want: "--repo requires a non-empty value",
+	}, {
+		name: "no-clean with no-git",
+		opts: Options{NoClean: true, NoGit: true},
+		want: "--no-clean and --no-git are mutually exclusive",
+	}, {
+		name: "no-clean with a URL",
+		opts: Options{Git: "https://github.com/a/b.git", GitSet: true, NoClean: true},
+		want: "--no-clean cannot be used with a git URL",
+	}, {
+		// A path is fine with --no-clean; only a URL is not.
+		name: "no-clean with a path",
+		opts: Options{Git: "/some/path", GitSet: true, NoClean: true},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("err = %v, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateFlags(t *testing.T) {
+	t.Run("a command without the alias reports --git", func(t *testing.T) {
+		// This is `sandbox create`'s shape. Its error wording is pinned here
+		// so a change to how readFlags picks GitFlagName cannot make create
+		// advise a flag it does not accept.
+		cmd := newTestCmd(false, true)
+		parseFlags(t, cmd, "--git", "x", "--no-git")
+		err := ValidateFlags(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--git and --no-git") {
+			t.Fatalf("err = %v, want it to name --git", err)
+		}
+		if strings.Contains(err.Error(), "--"+FlagRepo) {
+			t.Fatalf("err = %v, must not mention a flag this command lacks", err)
+		}
+	})
+
+	t.Run("the alias alone reports --repo", func(t *testing.T) {
+		cmd := newTestCmd(true, false)
+		parseFlags(t, cmd, "--repo", "x", "--no-git")
+		err := ValidateFlags(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--repo and --no-git") {
+			t.Fatalf("err = %v, want it to name --repo", err)
+		}
+	})
+
+	t.Run("both spellings agreeing reports --git, matching RequestedFlag", func(t *testing.T) {
+		cmd := newTestCmd(true, false)
+		parseFlags(t, cmd, "--git", "x", "--repo", "x", "--no-git")
+		err := ValidateFlags(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--git and --no-git") {
+			t.Fatalf("err = %v, want it to name --git", err)
+		}
+		if got := RequestedFlag(cmd); got != FlagGit {
+			t.Fatalf("RequestedFlag() = %q, want %q — the two must agree", got, FlagGit)
+		}
+	})
+
+	t.Run("a valid invocation passes without touching the filesystem", func(t *testing.T) {
+		// A path that does not exist must still validate: ValidateFlags is the
+		// pure half, and resolution is what rejects a bad path.
+		cmd := newTestCmd(true, true)
+		parseFlags(t, cmd, "--git", "/no/such/path/anywhere")
+		if err := ValidateFlags(cmd); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestRequestedFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "nothing set", args: nil, want: ""},
+		{name: "--git", args: []string{"--git", "x"}, want: FlagGit},
+		{name: "--repo", args: []string{"--repo", "x"}, want: FlagRepo},
+		{name: "both prefers --git", args: []string{"--git", "x", "--repo", "x"}, want: FlagGit},
+		// --no-git asks for the default outcome, so it is not a repo request.
+		{name: "--no-git", args: []string{"--no-git"}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newTestCmd(true, false)
+			parseFlags(t, cmd, tt.args...)
+			if got := RequestedFlag(cmd); got != tt.want {
+				t.Fatalf("RequestedFlag() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestedFlagWithoutAlias(t *testing.T) {
+	// A command that never registered --repo must not panic looking for it.
+	cmd := newTestCmd(false, true)
+	if got := RequestedFlag(cmd); got != "" {
+		t.Fatalf("RequestedFlag() = %q, want empty", got)
+	}
+}
+
+func TestResolveRejectsANonexistentExplicitPath(t *testing.T) {
+	// ResolveRoot walks up, so without a guard an explicit value that does not
+	// exist — a typo, or GitHub shorthand like "acme/billing" — would resolve
+	// to whatever repo encloses the caller.
+	repo := makeFakeRepo(t, "enclosing")
+	nested := filepath.Join(repo, "sub")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range []string{"acme/billing", "totally/bogus/path", "no-such-dir"} {
+		_, err := Resolve(Options{Cwd: nested, Git: v, GitSet: true})
+		if err == nil {
+			t.Fatalf("Resolve(%q) succeeded, want an error rather than the enclosing repo", v)
+		}
+		if !strings.Contains(err.Error(), "could not find git repo") {
+			t.Fatalf("Resolve(%q) err = %v, want a missing-repo error", v, err)
+		}
+	}
+	// A path that does exist still resolves by walking up to the repo root.
+	got, err := Resolve(Options{Cwd: "/", Git: nested, GitSet: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Source != SourceFlagPath || got.Path != repo {
+		t.Fatalf("identity = %+v, want the repo containing %q", got, nested)
+	}
 }

--- a/go/internal/gitrepo/gitrepo.go
+++ b/go/internal/gitrepo/gitrepo.go
@@ -76,45 +76,73 @@ type Options struct {
 	GitSet bool
 	// NoGit is the --no-git flag: skip auto-detection entirely.
 	NoGit bool
+	// GitFlagName is the flag that supplied Git, so an error names what the
+	// caller actually typed. Empty means "git"; `amika send` sets "repo" when
+	// the value arrived through that alias.
+	GitFlagName string
 	// NoClean is the local-sandbox --no-clean flag. It only makes sense with a
 	// local-path repo, so it constrains which sources are acceptable.
 	// Commands that do not offer --no-clean leave it false.
 	NoClean bool
 }
 
+// Validate reports contradictions between the flags without touching the
+// filesystem, so a command can reject a bad invocation before doing any work
+// — or before requiring credentials. Resolve applies it too, so a caller that
+// skips it still cannot resolve an invalid combination.
+func (o Options) Validate() error {
+	gitFlag := "--" + FlagGit
+	if o.GitFlagName != "" {
+		gitFlag = "--" + o.GitFlagName
+	}
+	if o.GitSet && o.NoGit {
+		return fmt.Errorf("%s and --%s are mutually exclusive", gitFlag, FlagNoGit)
+	}
+	if o.NoClean && o.NoGit {
+		return fmt.Errorf("--%s and --%s are mutually exclusive", FlagNoClean, FlagNoGit)
+	}
+	if o.GitSet {
+		v := strings.TrimSpace(o.Git)
+		if v == "" {
+			return fmt.Errorf("%s requires a non-empty value", gitFlag)
+		}
+		if o.NoClean && IsNetworkURL(v) {
+			return fmt.Errorf("--%s cannot be used with a git URL", FlagNoClean)
+		}
+	}
+	return nil
+}
+
 // Resolve decides which git repo (if any) should back a sandbox based on the
 // user's flag input and the working directory.
 //
-//   - --git and --no-git are mutually exclusive.
-//   - --no-clean and --no-git are mutually exclusive.
-//   - --no-clean is only meaningful when a local-path repo is sourced
-//     (auto-detect or --git <path>).
+//   - Contradictory combinations are rejected by Options.Validate, which this
+//     applies first.
 //   - When neither --git nor --no-git is set, the function walks up from Cwd
 //     to detect a repo; if none is found, the identity is SourceNone.
 func Resolve(opts Options) (Identity, error) {
-	if opts.GitSet && opts.NoGit {
-		return Identity{}, fmt.Errorf("--git and --no-git are mutually exclusive")
-	}
-	if opts.NoClean && opts.NoGit {
-		return Identity{}, fmt.Errorf("--no-clean and --no-git are mutually exclusive")
+	if err := opts.Validate(); err != nil {
+		return Identity{}, err
 	}
 	if opts.NoGit {
 		return Identity{Source: SourceNone}, nil
 	}
 	if opts.GitSet {
+		// Validate already rejected an empty value.
 		v := strings.TrimSpace(opts.Git)
-		if v == "" {
-			return Identity{}, fmt.Errorf("--git requires a non-empty value")
-		}
 		if IsNetworkURL(v) {
-			if opts.NoClean {
-				return Identity{}, fmt.Errorf("--no-clean cannot be used with a git URL")
-			}
 			name, err := NameFromURL(v)
 			if err != nil {
 				return Identity{}, err
 			}
 			return Identity{Name: name, Source: SourceFlagURL, URL: v}, nil
+		}
+		// An explicitly named path has to exist. ResolveRoot walks *up*, which
+		// is what auto-detection wants but would quietly promote a typo — or
+		// GitHub shorthand like "acme/billing", which reads as a repo but is
+		// not a URL — into whatever repo happens to enclose the caller.
+		if _, statErr := os.Stat(v); statErr != nil {
+			return Identity{}, fmt.Errorf("could not find git repo at %q: %w", v, statErr)
 		}
 		repoRoot, err := ResolveRoot(v)
 		if err != nil {

--- a/go/test/e2e/cases/offline-send-sessions.yaml
+++ b/go/test/e2e/cases/offline-send-sessions.yaml
@@ -58,6 +58,67 @@ steps:
       exit: 1
       stderr_contains: 'not logged in; run "amika auth login" or use --local'
 
+  - name: send --no-git skips repo detection and reaches the auth check
+    # Nothing is inferred from the working directory, so the next thing that
+    # can fail is the auth gate. The runner executes cases from inside this
+    # repo, so without --no-git the cwd's repo would be resolved first.
+    cmd: [send, hello, --no-git]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: send --repo reaches the auth check with a repo given
+    # --repo is an alias for --git, so it resolves the same way; with valid
+    # flags the next thing that can fail is the auth gate.
+    cmd: [send, hello, --repo, "https://github.com/gofixpoint/example-repo"]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: 'not logged in; run "amika auth login" or use --local'
+
+  - name: send rejects --git with --no-git before asking for credentials
+    # Flag contradictions are checked ahead of the auth gate: needing a login
+    # to be told about a typo would be absurd, and it keeps these assertable
+    # without credentials.
+    cmd: [send, hello, --git, ".", --no-git]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: "--git and --no-git are mutually exclusive"
+
+  - name: send names the alias when --repo is the flag that conflicts
+    # The message has to name what the caller typed, not the canonical spelling
+    # of the flag it aliases.
+    cmd: [send, hello, --repo, "https://github.com/gofixpoint/example-repo", --no-git]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: "--repo and --no-git are mutually exclusive"
+
+  - name: send rejects --git and --repo set to different values
+    cmd: [send, hello, --git, "https://github.com/gofixpoint/example-repo", --repo, "https://github.com/gofixpoint/amika"]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: "are the same flag under two names"
+
+  - name: send refuses a repo flag aimed at an existing sandbox
+    # No sandbox is created, so an explicit repo cannot be honored. Before
+    # inference existed this reached the API and was ignored; dropping it
+    # silently would be a regression visible only in the sandbox contents.
+    cmd: [send, hello, --sandbox, some-sandbox, --repo, "https://github.com/gofixpoint/example-repo"]
+    env:
+      AMIKA_API_KEY: ""
+    expect:
+      exit: 1
+      stderr_contains: "--repo cannot be combined with --session-id or --sandbox"
+
   - name: send --stream reaches the same auth check as the buffered path
     # --stream selects the SSE transport, but only after auth. Asserting the
     # same failure here proves the flag is registered and does not change the


### PR DESCRIPTION
`amika send` created a sandbox with no repo in it, so the agent had
nothing to look at. It now uses the repo containing the working
directory, sending that repo's `origin` as `repo_url` — the same
inference `amika sandbox create` performs.

## Flags

- `--git <path|url>` selects a repo explicitly.
- `--no-git` skips detection, for a sandbox with no repo. This is the
  opt-out for the new default; without it there would be no way to ask
  for a bare sandbox.
- `--repo` becomes a deprecated alias for `--git`. It now accepts a local
  path as well as a URL, and prints a deprecation notice when used.

Contradictions are refused rather than resolved by precedence, and the
message names the flag that was passed:

| Invocation | Result |
| --- | --- |
| `--git X --no-git` | `--git and --no-git are mutually exclusive` |
| `--repo X --no-git` | same, naming `--repo` |
| `--git X --repo Y` | refused as two names for one flag |
| `--git ""` | `--git requires a non-empty value` |
| `--git X --sandbox B` | refused: no sandbox is created, so the repo cannot be honored |
| `--no-git --sandbox B` | accepted |

## Implementation

Resolution comes from `internal/gitrepo`; this adds no new git logic.
Flag validation (`Options.Validate`) runs before the auth gate, since a
flag conflict is cheap to detect and should not require a login to
report. Resolution runs after, as it touches the filesystem.

One fix reaches `sandbox create` as well: an explicitly named
`--git`/`--repo` path must now exist. `ResolveRoot` walks up looking for
`.git`, so a value that matched nothing — a typo, or GitHub shorthand
like `acme/billing` — previously resolved to whatever repo enclosed the
caller and was used without warning.

## Known limitations

- Only the repo's default branch is cloned, whatever is checked out
  locally: the agent-sessions API accepts no branch, unlike
  `POST /sandboxes`. Stated in `--help` and tracked separately.
- A repo URL is forwarded as `git` reports it, including any credential
  embedded in its userinfo, matching `sandbox create`. Tracked
  separately.

