### PR TITLE
Warn when `amika send` will not have the branch you are on

### DIFF
--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -54,9 +54,11 @@ from --agent, else the organization's default, else claude.
 Run from inside a git repo and that repo's "origin" remote is cloned into
 the sandbox, the same way "amika sandbox create" picks up the repo you are
 standing in. Pass --git <path|url> to choose a different repo, or --no-git for
-a sandbox with no repo at all; --repo is accepted as an alias for --git. Only
-the repo's default branch is cloned, whatever branch you have checked out
-locally.
+a sandbox with no repo at all; --repo is accepted as an alias for --git.
+
+Only the repo's default branch is cloned, whatever branch you have checked out
+locally; a warning says so when the two differ. To work on a specific branch,
+use "amika sandbox create --branch" and send into that sandbox with --sandbox.
 
 Repo selection only applies to a sandbox this command creates, so it cannot be
 combined with --session-id or --sandbox.
@@ -132,11 +134,14 @@ func runSend(cmd *cobra.Command, args []string) error {
 	// and shells out to git, and login is the precondition for all of it, so
 	// someone not logged in hears that rather than a complaint about their
 	// git remote.
-	repoURL, repoName, err := sendRepo(cmd, sessionID, sandboxRef)
+	repoURL, identity, err := sendRepo(cmd, sessionID, sandboxRef)
 	if err != nil {
 		return err
 	}
-	printSendRepo(format, os.Stderr, repoName)
+	printSendRepo(format, os.Stderr, identity.Name)
+	if w := sendBranchWarning(identity); w != "" {
+		fmt.Fprintln(format.Progress(os.Stderr), w)
+	}
 
 	req := apiclient.AgentSessionSendRequest{
 		Message:    message,
@@ -228,28 +233,58 @@ func validateSendRepoFlags(cmd *cobra.Command, sessionID, sandboxRef string) err
 // A message aimed at an existing chat (--session-id) or an existing sandbox
 // (--sandbox) creates nothing, so there is no repo to choose and the working
 // directory is not consulted at all.
-func sendRepo(cmd *cobra.Command, sessionID, sandboxRef string) (url, name string, err error) {
+func sendRepo(cmd *cobra.Command, sessionID, sandboxRef string) (url string, identity gitrepo.Identity, err error) {
 	if sessionID != "" || sandboxRef != "" {
 		// validateSendRepoFlags has already refused an explicit repo here, so
 		// this is the "nothing was asked for" case: skip detection entirely.
-		return "", "", nil
+		return "", gitrepo.Identity{}, nil
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to determine working directory: %w", err)
+		return "", gitrepo.Identity{}, fmt.Errorf("failed to determine working directory: %w", err)
 	}
-	identity, err := gitrepo.FromCommand(cmd, cwd)
+	identity, err = gitrepo.FromCommand(cmd, cwd)
 	if err != nil {
-		return "", "", err
+		return "", gitrepo.Identity{}, err
 	}
 	url, err = identity.RemoteURL()
 	if err != nil {
-		return "", "", err
+		return "", gitrepo.Identity{}, err
 	}
-	// Name, not URL: it is what identifies the repo to a reader, it matches
-	// what `sandbox create` reports, and an origin can carry a token in its
-	// userinfo that has no business on a terminal.
-	return url, identity.Name, nil
+	return url, identity, nil
+}
+
+// sendBranchWarning returns the warning to print when the sandbox will not
+// have the branch the caller is standing on, or "" when there is nothing to
+// say.
+//
+// The agent-sessions API accepts no branch, so a sandbox always gets the
+// repo's default branch. Asking an agent about work in progress therefore
+// gets an answer about different code, and without this the only clue is the
+// repo name — which looks exactly right. The warning cannot fix that; it
+// makes it visible.
+//
+// Silence is the answer whenever the comparison cannot be made confidently:
+// a URL source has no local checkout to compare, a detached HEAD has no
+// branch name, and a repo with no recorded origin HEAD has no default branch
+// to compare against. Guessing would put a wrong warning in front of people
+// who are on the default branch already.
+func sendBranchWarning(identity gitrepo.Identity) string {
+	if !identity.IsLocalPath() {
+		return ""
+	}
+	current, err := gitrepo.CurrentBranch(identity.Path)
+	if err != nil {
+		return ""
+	}
+	defaultBranch, err := gitrepo.DefaultBranch(identity.Path)
+	if err != nil || defaultBranch == current {
+		return ""
+	}
+	return fmt.Sprintf(
+		"warning: you are on %q but the sandbox will get %q — the agent-sessions API cannot select a branch yet.\n"+
+			"         Push %q and mention it in your message, or use \"amika sandbox create --branch %s\" instead.",
+		current, defaultBranch, current, current)
 }
 
 // mustBool reads a bool flag, ignoring the (impossible for a defined flag)

--- a/go/cmd/amika/send_test.go
+++ b/go/cmd/amika/send_test.go
@@ -125,15 +125,15 @@ func TestSendRepo(t *testing.T) {
 
 	t.Run("infers the origin of the repo containing the cwd", func(t *testing.T) {
 		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
-		url, name, err := sendRepo(newCmd(t), "", "")
+		url, identity, err := sendRepo(newCmd(t), "", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if url != origin {
 			t.Fatalf("url = %q, want %q", url, origin)
 		}
-		if name != "myrepo" {
-			t.Fatalf("name = %q, want %q", name, "myrepo")
+		if identity.Name != "myrepo" {
+			t.Fatalf("name = %q, want %q", identity.Name, "myrepo")
 		}
 	})
 
@@ -155,23 +155,23 @@ func TestSendRepo(t *testing.T) {
 
 	t.Run("outside a repo sends no repo", func(t *testing.T) {
 		chdir(t, t.TempDir())
-		url, name, err := sendRepo(newCmd(t), "", "")
+		url, identity, err := sendRepo(newCmd(t), "", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if url != "" || name != "" {
-			t.Fatalf("url = %q, name = %q, want both empty", url, name)
+		if url != "" || identity.Name != "" {
+			t.Fatalf("url = %q, name = %q, want both empty", url, identity.Name)
 		}
 	})
 
 	t.Run("--no-git skips detection inside a repo", func(t *testing.T) {
 		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
-		url, name, err := sendRepo(newCmd(t, "--no-git"), "", "")
+		url, identity, err := sendRepo(newCmd(t, "--no-git"), "", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if url != "" || name != "" {
-			t.Fatalf("url = %q, name = %q, want both empty", url, name)
+		if url != "" || identity.Name != "" {
+			t.Fatalf("url = %q, name = %q, want both empty", url, identity.Name)
 		}
 	})
 
@@ -188,12 +188,12 @@ func TestSendRepo(t *testing.T) {
 
 	t.Run("--git overrides the detected repo", func(t *testing.T) {
 		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
-		url, name, err := sendRepo(newCmd(t, "--git", "https://github.com/other/thing.git"), "", "")
+		url, identity, err := sendRepo(newCmd(t, "--git", "https://github.com/other/thing.git"), "", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if url != "https://github.com/other/thing.git" || name != "thing" {
-			t.Fatalf("url = %q, name = %q, want the --git repo", url, name)
+		if url != "https://github.com/other/thing.git" || identity.Name != "thing" {
+			t.Fatalf("url = %q, name = %q, want the --git repo", url, identity.Name)
 		}
 	})
 
@@ -202,12 +202,12 @@ func TestSendRepo(t *testing.T) {
 		// support rather than staying URL-only.
 		other := initRepo(t, "otherrepo", map[string]string{"origin": "https://github.com/example/other.git"})
 		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
-		url, name, err := sendRepo(newCmd(t, "--repo", other), "", "")
+		url, identity, err := sendRepo(newCmd(t, "--repo", other), "", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if url != "https://github.com/example/other.git" || name != "otherrepo" {
-			t.Fatalf("url = %q, name = %q, want the --repo path's origin", url, name)
+		if url != "https://github.com/example/other.git" || identity.Name != "otherrepo" {
+			t.Fatalf("url = %q, name = %q, want the --repo path's origin", url, identity.Name)
 		}
 	})
 
@@ -227,12 +227,12 @@ func TestSendRepo(t *testing.T) {
 	t.Run("an existing target accepts --no-git", func(t *testing.T) {
 		// --no-git asks for what already happens there, so it is no conflict.
 		chdir(t, initRepo(t, "myrepo", map[string]string{"origin": origin}))
-		url, name, err := sendRepo(newCmd(t, "--no-git"), "sess-1", "")
+		url, identity, err := sendRepo(newCmd(t, "--no-git"), "sess-1", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if url != "" || name != "" {
-			t.Fatalf("url = %q, name = %q, want both empty", url, name)
+		if url != "" || identity.Name != "" {
+			t.Fatalf("url = %q, name = %q, want both empty", url, identity.Name)
 		}
 	})
 
@@ -256,12 +256,12 @@ func TestSendRepo(t *testing.T) {
 			{sessionID: "sess-1"},
 			{sandboxRef: "my-sandbox"},
 		} {
-			url, name, err := sendRepo(newCmd(t), tc.sessionID, tc.sandboxRef)
+			url, identity, err := sendRepo(newCmd(t), tc.sessionID, tc.sandboxRef)
 			if err != nil {
 				t.Fatalf("unexpected error for %+v: %v", tc, err)
 			}
-			if url != "" || name != "" {
-				t.Fatalf("url = %q, name = %q for %+v, want both empty", url, name, tc)
+			if url != "" || identity.Name != "" {
+				t.Fatalf("url = %q, name = %q for %+v, want both empty", url, identity.Name, tc)
 			}
 		}
 	})
@@ -422,4 +422,98 @@ func TestPrintSendRepo(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSendBranchWarning covers when the user is told that the sandbox will not
+// have their branch — and, just as importantly, when they are not, since a
+// warning shown to someone already on the default branch is pure noise.
+func TestSendBranchWarning(t *testing.T) {
+	// recordDefault is separate from defaultBranch because a repo can have a
+	// branch checked out and still have no origin HEAD recorded — the `git
+	// init` plus manual remote case — and that is one of the cases under test.
+	newRepo := func(t *testing.T, name, current, defaultBranch string, recordDefault bool) string {
+		t.Helper()
+		repo := filepath.Join(t.TempDir(), name)
+		run := func(args ...string) {
+			t.Helper()
+			cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %s", args, out)
+			}
+		}
+		if out, err := exec.Command("git", "init", "-q", "-b", defaultBranch, repo).CombinedOutput(); err != nil {
+			t.Fatalf("git init: %s", out)
+		}
+		run("config", "user.email", "t@example.com")
+		run("config", "user.name", "T")
+		run("commit", "--allow-empty", "-m", "c1")
+		run("remote", "add", "origin", "https://github.com/example/"+name+".git")
+		if recordDefault {
+			run("update-ref", "refs/remotes/origin/"+defaultBranch, "HEAD")
+			run("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/"+defaultBranch)
+		}
+		if current != defaultBranch {
+			run("checkout", "-q", "-b", current)
+		}
+		return repo
+	}
+
+	t.Run("warns when the checked-out branch is not the default", func(t *testing.T) {
+		repo := newRepo(t, "r1", "fix-parser", "main", true)
+		got := sendBranchWarning(gitrepo.Identity{Name: "r1", Source: gitrepo.SourceAutoDetect, Path: repo})
+		if got == "" {
+			t.Fatal("expected a warning on a non-default branch")
+		}
+		for _, want := range []string{"fix-parser", "main", "cannot select a branch"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("warning = %q, want it to mention %q", got, want)
+			}
+		}
+	})
+
+	t.Run("silent on the default branch", func(t *testing.T) {
+		repo := newRepo(t, "r2", "main", "main", true)
+		if got := sendBranchWarning(gitrepo.Identity{Source: gitrepo.SourceAutoDetect, Path: repo}); got != "" {
+			t.Fatalf("warning = %q, want silence on the default branch", got)
+		}
+	})
+
+	t.Run("silent when the default branch is not main", func(t *testing.T) {
+		// The comparison is against what origin actually records, not a guess
+		// at "main" — someone whose default is "develop" must not be warned
+		// while sitting on it.
+		repo := newRepo(t, "r3", "develop", "develop", true)
+		if got := sendBranchWarning(gitrepo.Identity{Source: gitrepo.SourceAutoDetect, Path: repo}); got != "" {
+			t.Fatalf("warning = %q, want silence", got)
+		}
+	})
+
+	t.Run("silent when origin records no default branch", func(t *testing.T) {
+		repo := newRepo(t, "r4", "feature", "main", false)
+		if got := sendBranchWarning(gitrepo.Identity{Source: gitrepo.SourceAutoDetect, Path: repo}); got != "" {
+			t.Fatalf("warning = %q, want silence when there is nothing to compare", got)
+		}
+	})
+
+	t.Run("silent for a URL source and for no repo", func(t *testing.T) {
+		for _, id := range []gitrepo.Identity{
+			{Name: "x", Source: gitrepo.SourceFlagURL, URL: "https://github.com/a/b.git"},
+			{Source: gitrepo.SourceNone},
+		} {
+			if got := sendBranchWarning(id); got != "" {
+				t.Fatalf("warning = %q for %+v, want silence", got, id)
+			}
+		}
+	})
+
+	t.Run("silent on a detached HEAD", func(t *testing.T) {
+		repo := newRepo(t, "r5", "main", "main", true)
+		cmd := exec.Command("git", "-C", repo, "checkout", "-q", "--detach")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("detach: %s", out)
+		}
+		if got := sendBranchWarning(gitrepo.Identity{Source: gitrepo.SourceAutoDetect, Path: repo}); got != "" {
+			t.Fatalf("warning = %q, want silence with no branch name", got)
+		}
+	})
 }

--- a/go/internal/gitrepo/gitrepo.go
+++ b/go/internal/gitrepo/gitrepo.go
@@ -340,3 +340,29 @@ func Output(repo string, args ...string) (string, error) {
 	}
 	return string(out), nil
 }
+
+// DefaultBranch returns the branch a fresh clone of the repo's origin would
+// check out, read from the local `refs/remotes/origin/HEAD` symref that git
+// records at clone time.
+//
+// Deliberately local-only: no ls-remote, so this costs nothing on a command
+// that runs it every invocation. A repo created with `git init` and a manually
+// added remote has no such symref, and rather than guess at "main" or "master"
+// it returns an error — a caller comparing branches is better off staying
+// quiet than reporting a default it invented.
+func DefaultBranch(repoPath string) (string, error) {
+	out, err := Output(repoPath, "symbolic-ref", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return "", fmt.Errorf("no recorded default branch for origin in %q: %w", repoPath, err)
+	}
+	ref := strings.TrimSpace(out)
+	const prefix = "refs/remotes/origin/"
+	if !strings.HasPrefix(ref, prefix) {
+		return "", fmt.Errorf("unexpected origin HEAD ref %q in %q", ref, repoPath)
+	}
+	name := strings.TrimPrefix(ref, prefix)
+	if name == "" {
+		return "", fmt.Errorf("empty default branch in %q", repoPath)
+	}
+	return name, nil
+}

--- a/go/internal/gitrepo/remoteurl_test.go
+++ b/go/internal/gitrepo/remoteurl_test.go
@@ -151,3 +151,44 @@ func TestIdentityIsLocalPath(t *testing.T) {
 		}
 	}
 }
+
+func TestDefaultBranch(t *testing.T) {
+	t.Run("reads the recorded origin HEAD", func(t *testing.T) {
+		repo := initRepo(t, map[string]string{"origin": "https://github.com/example/upstream.git"})
+		runGit(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+		got, err := DefaultBranch(repo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "develop" {
+			t.Fatalf("DefaultBranch = %q, want %q", got, "develop")
+		}
+	})
+
+	t.Run("a branch name containing slashes survives", func(t *testing.T) {
+		repo := initRepo(t, map[string]string{"origin": "https://github.com/example/upstream.git"})
+		runGit(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/release/v2")
+		got, err := DefaultBranch(repo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "release/v2" {
+			t.Fatalf("DefaultBranch = %q, want %q", got, "release/v2")
+		}
+	})
+
+	t.Run("no recorded HEAD is an error, not a guess", func(t *testing.T) {
+		// `git init` plus a manually added remote records no origin HEAD.
+		// Returning "main" here would put a wrong branch in a warning.
+		repo := initRepo(t, map[string]string{"origin": "https://github.com/example/upstream.git"})
+		if _, err := DefaultBranch(repo); err == nil {
+			t.Fatal("expected an error when origin HEAD is unrecorded")
+		}
+	})
+
+	t.Run("not a repo is an error", func(t *testing.T) {
+		if _, err := DefaultBranch(t.TempDir()); err == nil {
+			t.Fatal("expected an error outside a repo")
+		}
+	})
+}


### PR DESCRIPTION
`amika send` clones the repo's default branch, because the agent-sessions
API accepts no branch. Asking about work in progress therefore gets an
answer about different code, and the only clue was the repo name, which
looks exactly right. This cannot be fixed in the CLI, so it is at least
made visible:

    $ amika send "why does the parser drop escapes?"
    repo: amika
    warning: you are on "fix-parser" but the sandbox will get "main" — the
             agent-sessions API cannot select a branch yet.
             Push "fix-parser" and mention it in your message, or use
             "amika sandbox create --branch fix-parser" instead.

## Staying quiet when unsure

A warning shown to someone already on the default branch is pure noise,
so the comparison is only made when it can be made confidently. Nothing
is printed for a `--git <url>` source (no local checkout), a detached
HEAD (no branch name), or a repo whose origin records no default branch.

`gitrepo.DefaultBranch` reads the local `refs/remotes/origin/HEAD` symref
that git writes at clone time, so it costs no network round trip on a
command that would pay it every invocation. A `git init` repo with a
manually added remote has no such symref and returns an error rather than
guessing at "main" — guessing would put a wrong branch name in front of
someone whose default is "develop".

Suppressed under `--output json` like the other progress output.

