### PR TITLE
Strip embedded credentials from the repo URL sent to the API

### DIFF
--- a/go/internal/gitrepo/gitrepo.go
+++ b/go/internal/gitrepo/gitrepo.go
@@ -53,15 +53,66 @@ func (i Identity) IsLocalPath() bool {
 // RemoteURL returns the git URL a remote sandbox should clone: the URL from
 // --git as given, or the "origin" remote of a local-path repo. An identity
 // with no repo returns an empty string and no error.
+//
+// Any embedded credential is stripped. The server clones with the GitHub auth
+// the user configured there and never uses one supplied in the URL, so sending
+// it would leak a secret to no purpose — and origins written by Amika's own
+// sandbox provisioning carry a live token. Local cloning reads Identity.URL
+// directly and so keeps whatever credential it needs.
 func (i Identity) RemoteURL() (string, error) {
 	switch i.Source {
 	case SourceFlagURL:
-		return i.URL, nil
+		return StripCredentials(i.URL), nil
 	case SourceAutoDetect, SourceFlagPath:
-		return ResolveURL(i.Path)
+		url, err := ResolveURL(i.Path)
+		if err != nil {
+			return "", err
+		}
+		return StripCredentials(url), nil
 	default:
 		return "", nil
 	}
+}
+
+// StripCredentials removes a credential embedded in a git URL, leaving an ssh
+// username in place.
+//
+// For http(s) the whole userinfo is a credential — a GitHub App token arrives
+// as `https://x-access-token:<token>@…` and a PAT is often pasted as
+// `https://<pat>@…`, so the secret can be on either side of the colon and both
+// halves go. For ssh:// and the scp-like `user@host:path`, the username is how
+// ssh picks an account (`git@github.com` will not authenticate as anything
+// else), so only a password half is dropped.
+func StripCredentials(rawURL string) string {
+	if i := strings.Index(rawURL, "://"); i >= 0 {
+		scheme, rest := rawURL[:i+3], rawURL[i+3:]
+		at := strings.Index(rest, "@")
+		slash := strings.Index(rest, "/")
+		// An "@" after the first "/" belongs to the path, not the authority.
+		if at < 0 || (slash >= 0 && at > slash) {
+			return rawURL
+		}
+		userinfo, host := rest[:at], rest[at+1:]
+		if strings.HasPrefix(scheme, "ssh") {
+			if name, _, ok := strings.Cut(userinfo, ":"); ok && name != "" {
+				return scheme + name + "@" + host
+			}
+			return rawURL
+		}
+		return scheme + host
+	}
+	// scp-like [user@]host:path.
+	at := strings.Index(rawURL, "@")
+	if at < 0 {
+		return rawURL
+	}
+	if name, _, ok := strings.Cut(rawURL[:at], ":"); ok {
+		if name == "" {
+			return rawURL[at+1:]
+		}
+		return name + "@" + rawURL[at+1:]
+	}
+	return rawURL
 }
 
 // Options is the flag input to Resolve.

--- a/go/internal/gitrepo/remoteurl_test.go
+++ b/go/internal/gitrepo/remoteurl_test.go
@@ -151,3 +151,109 @@ func TestIdentityIsLocalPath(t *testing.T) {
 		}
 	}
 }
+
+func TestStripCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{{
+		name: "GitHub App token in the password half",
+		url:  "https://x-access-token:ghs_SECRET@github.com/org/repo.git",
+		want: "https://github.com/org/repo.git",
+	}, {
+		name: "PAT in the username half",
+		url:  "https://ghp_SECRET@github.com/org/repo.git",
+		want: "https://github.com/org/repo.git",
+	}, {
+		name: "user and password",
+		url:  "http://user:SECRET@example.com/org/repo.git",
+		want: "http://example.com/org/repo.git",
+	}, {
+		name: "no userinfo is untouched",
+		url:  "https://github.com/org/repo.git",
+		want: "https://github.com/org/repo.git",
+	}, {
+		name: "an @ in the path is not userinfo",
+		url:  "https://example.com/org/repo@v2.git",
+		want: "https://example.com/org/repo@v2.git",
+	}, {
+		// The ssh username selects the account; dropping it would authenticate
+		// as the wrong user, or fail outright.
+		name: "scp-style ssh username is kept",
+		url:  "git@github.com:org/repo.git",
+		want: "git@github.com:org/repo.git",
+	}, {
+		name: "ssh:// username is kept",
+		url:  "ssh://git@github.com/org/repo.git",
+		want: "ssh://git@github.com/org/repo.git",
+	}, {
+		name: "ssh:// password half is dropped, username kept",
+		url:  "ssh://git:SECRET@github.com/org/repo.git",
+		want: "ssh://git@github.com/org/repo.git",
+	}, {
+		name: "scp-style password half is dropped, username kept",
+		url:  "git:SECRET@build-host:org/repo.git",
+		want: "git@build-host:org/repo.git",
+	}, {
+		name: "user-less scp URL is untouched",
+		url:  "build-host:org/repo.git",
+		want: "build-host:org/repo.git",
+	}, {
+		name: "a local path is untouched",
+		url:  "/srv/git/repo.git",
+		want: "/srv/git/repo.git",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripCredentials(tt.url)
+			if got != tt.want {
+				t.Fatalf("StripCredentials(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+			if strings.Contains(got, "SECRET") {
+				t.Fatalf("StripCredentials(%q) leaked the secret", tt.url)
+			}
+		})
+	}
+}
+
+func TestRemoteURLStripsCredentials(t *testing.T) {
+	// The whole point: what reaches the API carries no credential, whether the
+	// URL was typed or read out of a checkout's origin.
+	t.Run("from an explicit URL", func(t *testing.T) {
+		id := Identity{Name: "repo", Source: SourceFlagURL, URL: "https://x-access-token:ghs_SECRET@github.com/org/repo.git"}
+		got, err := id.RemoteURL()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "https://github.com/org/repo.git" {
+			t.Fatalf("RemoteURL = %q", got)
+		}
+	})
+
+	t.Run("from a checkout whose origin carries a token", func(t *testing.T) {
+		// Amika's own sandboxes have exactly this shape of origin.
+		repo := initRepo(t, map[string]string{
+			"origin": "https://x-access-token:ghs_SECRET@github.com/gofixpoint/amika",
+		})
+		for _, source := range []Source{SourceAutoDetect, SourceFlagPath} {
+			got, err := Identity{Source: source, Path: repo}.RemoteURL()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != "https://github.com/gofixpoint/amika" {
+				t.Fatalf("RemoteURL = %q, want the credential stripped", got)
+			}
+		}
+	})
+
+	t.Run("local cloning still sees the credential", func(t *testing.T) {
+		// Identity.URL is what the local-sandbox clone path uses, and it has
+		// to keep working auth — only the API-bound value is sanitized.
+		const withToken = "https://x-access-token:ghs_SECRET@github.com/org/repo.git"
+		id := Identity{Source: SourceFlagURL, URL: withToken}
+		if id.URL != withToken {
+			t.Fatalf("Identity.URL = %q, want it untouched", id.URL)
+		}
+	})
+}


### PR DESCRIPTION
Running `amika send` or `amika sandbox create` from inside a sandbox
failed with a 400. Sandbox provisioning writes an origin of the form
`https://x-access-token:<token>@github.com/...`, so a checkout inside a
sandbox has a token in `.git/config`. With repo auto-detection the CLI
read that origin and forwarded it as `repo_url`, and the API rejects any
userinfo on http(s):

    http 400  repo_url must be an HTTP(S), SSH, or SCP-style SSH
              repository location

The credential was never usable anyway. The server clones with the GitHub
auth configured there — an org PAT or a GitHub App token it mints itself
— and overwrites any userinfo in the URL, so nothing was gained by
sending one. It is now stripped before the request, which both fixes the
400 and keeps a secret that serves no purpose off the wire.

`Identity.RemoteURL` does the stripping, which covers both commands since
that method is the single place either one obtains an API-bound URL.

## What is kept

An ssh username is not a credential — it selects the account, and
`git@github.com` will not authenticate as anything else — so for `ssh://`
and the scp-like `user@host:path` only a password half is dropped. For
http(s) the whole userinfo goes, since the secret can be on either side
of the colon: `x-access-token:<token>@` and `<pat>@` are both common.

Every shape this can emit was checked against the API's schema, so
stripping cannot turn an accepted URL into a rejected one:
`https://host/p`, `http://host/p`, `git@host:p`, `ssh://git@host/p`,
`host:p`, `git@host:p`.

Local sandbox cloning is unaffected. It reads `Identity.URL` directly and
runs a real `git clone` on this machine, so it keeps whatever credential
it needs.

