### PR TITLE
Cut --new-branch from the branch you are on, not the default

### DIFF
--- a/go/cmd/amika/sandbox/sandbox_create.go
+++ b/go/cmd/amika/sandbox/sandbox_create.go
@@ -355,9 +355,8 @@ func createRemoteSandbox(cmd *cobra.Command, target string, identity gitrepo.Ide
 	}
 
 	branches, err := gitrepo.ResolveBranch(identity, gitrepo.BranchRequest{
-		Branch:        branch,
-		NewBranch:     newBranch,
-		BranchFlagSet: cmd.Flags().Changed("branch"),
+		Branch:    branch,
+		NewBranch: newBranch,
 	})
 	if err != nil {
 		return err

--- a/go/cmd/amika/send.go
+++ b/go/cmd/amika/send.go
@@ -294,9 +294,8 @@ func sendBranches(cmd *cobra.Command, identity gitrepo.Identity) (gitrepo.Branch
 	branch, _ := cmd.Flags().GetString(flagBranch)
 	newBranch, _ := cmd.Flags().GetString(flagNewBranch)
 	return gitrepo.ResolveBranch(identity, gitrepo.BranchRequest{
-		Branch:        branch,
-		NewBranch:     newBranch,
-		BranchFlagSet: cmd.Flags().Changed(flagBranch),
+		Branch:    branch,
+		NewBranch: newBranch,
 	})
 }
 

--- a/go/internal/gitrepo/branch.go
+++ b/go/internal/gitrepo/branch.go
@@ -13,53 +13,48 @@ import (
 // Both empty means "decide from the working directory".
 type BranchRequest struct {
 	// Branch is --branch: check out this branch, creating it if the remote
-	// has none.
+	// has none. It is also the base --new-branch is cut from.
 	Branch string
-	// NewBranch is --new-branch: cut a new branch, from Branch when both are
-	// given.
+	// NewBranch is --new-branch: cut a new branch from Branch.
 	NewBranch string
-	// BranchFlagSet reports whether --branch was passed explicitly, which
-	// suppresses the unpushed-branch refusal: someone naming a branch has
-	// said what they want, even if the remote does not have it yet.
-	BranchFlagSet bool
 }
 
 // ResolveBranch fills in the branch a remote sandbox should be cut from and
 // refuses the case where the caller would silently get different code.
 //
-// With neither flag given and a local checkout to read, the current branch is
-// carried over — a sandbox for "the thing I am working on" should hold that
-// thing. But a branch the remote does not have cannot be cloned, and the
-// sandbox would quietly come up on the default branch instead; since only the
-// caller can fix that, it is an error rather than a warning.
+// Whenever --branch is absent, the checked-out branch becomes the base: a
+// sandbox for "the thing I am working on" should hold that thing, and a new
+// branch should be cut from it. Leaving the base empty would hand the server
+// nothing to start from, so it would use its default branch instead — the
+// same code the caller is not looking at.
 //
-// A URL source has no local checkout to read, so its pair passes through
-// untouched and the server applies its own default.
+// An inferred base must exist on the remote, since that is where the sandbox
+// clones from. If it does not, the sandbox would quietly come up on the
+// default branch, so this is an error rather than a warning. A base named
+// explicitly with --branch is the caller's stated intent and is passed
+// through: the server creates it when the remote has none.
+//
+// A URL source has no local checkout to read, so its pair passes through and
+// the server applies its own default.
 func ResolveBranch(identity Identity, req BranchRequest) (BranchRequest, error) {
-	if !identity.IsLocalPath() {
+	if !identity.IsLocalPath() || req.Branch != "" {
 		return req, nil
 	}
-	if req.Branch == "" && req.NewBranch == "" {
-		// A detached HEAD has no branch to carry over; the server's default
-		// is the only sensible answer, so leave the pair empty.
-		if current, err := CurrentBranch(identity.Path); err == nil {
-			req.Branch = current
-		}
-	}
-	// Only an inferred base branch is checked. --new-branch cuts a fresh
-	// branch, so the remote is not expected to have it, and an explicit
-	// --branch is the caller's stated intent.
-	if req.Branch == "" || req.NewBranch != "" || req.BranchFlagSet {
+	// A detached HEAD has no branch name to carry over; the server's default
+	// is then the only answer available, so leave the pair as it is.
+	current, err := CurrentBranch(identity.Path)
+	if err != nil {
 		return req, nil
 	}
-	if !BranchReachableFromRemote(identity.Path, req.Branch) {
+	if !BranchReachableFromRemote(identity.Path, current) {
 		return BranchRequest{}, fmt.Errorf(
 			"current branch %q has not been pushed or is not up-to-date with the remote\n\n"+
-				"The sandbox will either start from an older version of this branch or\n"+
-				"create it fresh from the default branch.\n\n"+
-				"Push your branch first, or use --branch to specify your branch explicitly.",
-			req.Branch)
+				"The sandbox clones from the remote, so it would start from an older\n"+
+				"version of this branch or from the default branch instead.\n\n"+
+				"Push your branch first, or use --branch to name the branch to start from.",
+			current)
 	}
+	req.Branch = current
 	return req, nil
 }
 

--- a/go/internal/gitrepo/branch_test.go
+++ b/go/internal/gitrepo/branch_test.go
@@ -225,7 +225,7 @@ func TestResolveBranch(t *testing.T) {
 		repo := pushedRepo(t)
 		runGitIn(t, repo, "checkout", "-q", "-b", "unpushed")
 		runGitIn(t, repo, "commit", "--allow-empty", "-m", "local only")
-		got, err := ResolveBranch(local(repo), BranchRequest{Branch: "unpushed", BranchFlagSet: true})
+		got, err := ResolveBranch(local(repo), BranchRequest{Branch: "unpushed"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -234,11 +234,12 @@ func TestResolveBranch(t *testing.T) {
 		}
 	})
 
-	t.Run("--new-branch skips the reachability check", func(t *testing.T) {
-		// A new branch is not expected to exist on the remote.
+	t.Run("--new-branch is cut from the current branch", func(t *testing.T) {
+		// The base has to be sent explicitly: with no branch in the request the
+		// server cuts from its default, which is not the code the caller is
+		// looking at.
 		repo := pushedRepo(t)
-		runGitIn(t, repo, "checkout", "-q", "-b", "unpushed")
-		runGitIn(t, repo, "commit", "--allow-empty", "-m", "local only")
+		want := currentBranchOf(t, repo)
 		got, err := ResolveBranch(local(repo), BranchRequest{NewBranch: "feature/x"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -246,15 +247,41 @@ func TestResolveBranch(t *testing.T) {
 		if got.NewBranch != "feature/x" {
 			t.Fatalf("NewBranch = %q", got.NewBranch)
 		}
-		if got.Branch != "" {
-			t.Fatalf("Branch = %q, want it left empty so the server picks the base", got.Branch)
+		if got.Branch != want {
+			t.Fatalf("Branch = %q, want the current branch %q as the base", got.Branch, want)
+		}
+	})
+
+	t.Run("--new-branch from an unpushed branch is refused", func(t *testing.T) {
+		// The remote has no such base to cut from, so the server would fall
+		// back to its default branch without saying so.
+		repo := pushedRepo(t)
+		runGitIn(t, repo, "checkout", "-q", "-b", "unpushed")
+		runGitIn(t, repo, "commit", "--allow-empty", "-m", "local only")
+		_, err := ResolveBranch(local(repo), BranchRequest{NewBranch: "feature/x"})
+		if err == nil || !strings.Contains(err.Error(), "has not been pushed") {
+			t.Fatalf("err = %v, want an unpushed-base refusal", err)
+		}
+	})
+
+	t.Run("an explicit --branch base is honored with --new-branch", func(t *testing.T) {
+		// Naming the base is intent, so no reachability check applies.
+		repo := pushedRepo(t)
+		runGitIn(t, repo, "checkout", "-q", "-b", "unpushed")
+		runGitIn(t, repo, "commit", "--allow-empty", "-m", "local only")
+		got, err := ResolveBranch(local(repo), BranchRequest{Branch: "unpushed", NewBranch: "feature/x"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Branch != "unpushed" || got.NewBranch != "feature/x" {
+			t.Fatalf("pair = %+v, want both forwarded", got)
 		}
 	})
 
 	t.Run("both flags pass through together", func(t *testing.T) {
 		repo := pushedRepo(t)
 		got, err := ResolveBranch(local(repo), BranchRequest{
-			Branch: "release/2.0", NewBranch: "feature/from-release", BranchFlagSet: true,
+			Branch: "release/2.0", NewBranch: "feature/from-release",
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -275,7 +302,7 @@ func TestResolveBranch(t *testing.T) {
 		if got.Branch != "" || got.NewBranch != "" {
 			t.Fatalf("pair = %+v, want empty", got)
 		}
-		got, err = ResolveBranch(id, BranchRequest{Branch: "develop", BranchFlagSet: true})
+		got, err = ResolveBranch(id, BranchRequest{Branch: "develop"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
`--new-branch` promises "starts from the current checkout", and for a
remote sandbox it did not. With no `--branch` alongside it, the request
carried `new_branch_name` and no base, so the server cut the new branch
from its own default. A branch made for the work in progress therefore
started from `main`, and the agent saw code the caller was not looking
at.

The base is now inferred whenever `--branch` is absent, so the pair sent
is `{branch: <current>, new_branch_name: <new>}`:

    on branch feature/pushed, --new-branch agent-work
      before:  branch=None                 (server default)
      after:   branch="feature/pushed"     (the checkout)

Both `amika sandbox create` and `amika send` change, since both resolve
through `gitrepo.ResolveBranch`. Verified by capturing each command's
request body from the same checkout: they now send identical pairs.

## Why remote diverged from the help

Local sandboxes always honored it, which is why the promise looked true.
There the repo is cloned from the working copy, so `git clone --local`
lands on the source's HEAD and `git checkout -b` cuts from the current
branch by construction. The remote path shares the flags but not that
mechanism: it sends the pair to the API and the server clones from
`origin`, so a base it is not given is a base it has to invent. Only
remote sandboxes are in use, so the promise was false in practice.

## The unpushed-branch refusal now covers this case

An inferred base has to exist on the remote, since that is where the
sandbox clones from — and that is as true for cutting a new branch as
for checking one out. Previously `--new-branch` skipped the check, on
the reasoning that a new branch is not expected on the remote; that
holds for the branch being created, not for the base it comes from. So
`--new-branch` from an unpushed branch is now refused with the same
message.

Naming a base explicitly with `--branch` still skips the check: that is
the caller's stated intent, and the server creates the branch when the
remote has none. It is also the way out of the refusal.

`BranchRequest.BranchFlagSet` is gone. It meant "was --branch passed",
which is now exactly "is Branch non-empty", so the field was a second
way to say the same thing.

