### PR TITLE
Pin the sandbox host key on every SSH proxy dial

### DIFF
--- a/go/cmd/amika/plumbing.go
+++ b/go/cmd/amika/plumbing.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/runmode"
 	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/spf13/cobra"
@@ -17,10 +18,15 @@ var sshStdioProxyCmd = &cobra.Command{
 	Short: "Proxy standard IO to one SSH transport",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		pins, err := ssh.SessionPinStore(basedir.New(""))
+		if err != nil {
+			return err
+		}
 		return ssh.ProxySession(
 			cmd.Context(),
 			runmode.NewRemoteClient(),
 			ssh.WebSocketDialer{},
+			pins,
 			args[0],
 			cmd.InOrStdin(),
 			cmd.OutOrStdout(),

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -294,36 +294,18 @@ func ProxySession(
 	if err := session.Validate(parsed.ID); err != nil {
 		return err
 	}
-	// Pin here, and not only in PrepareSessionHost, because this is the one
-	// step every connection goes through: OpenSSH runs it as the ProxyCommand
-	// on every dial of a managed alias, and the descriptor it just validated
-	// carries the same API-issued host key `sandbox code` would have pinned.
+	// Pin here, not only in PrepareSessionHost: this runs as the ProxyCommand on
+	// every dial, so an alias never opened through `sandbox ssh`/`code` still
+	// gets the API-issued key pinned. Without it the managed block's
+	// StrictHostKeyChecking refuses every other route to an alias — a bare
+	// `ssh`, an editor's Remote-SSH entry, a cmux deep link.
 	//
-	// Without it the pin exists only for sandboxes opened at least once through
-	// `sandbox ssh`, `sandbox code` or `scp`. The managed block is
-	// StrictHostKeyChecking yes against a dedicated known-hosts file, so any
-	// other way of naming the alias — cmux's ssh deep link, an editor's own
-	// Remote-SSH entry, a bare `ssh <alias>` — met an empty file and failed
-	// verification, for a host this command was in the middle of authenticating.
+	// Before the dial: no byte crosses until the stream exists, so the line is
+	// always on disk before OpenSSH reads it. Pin still returns
+	// ErrHostKeyMismatch for a changed key, so this cannot loosen the check.
 	//
-	// Before the dial, which is what makes the ordering sound rather than
-	// lucky: no SSH byte can cross until the stream exists, and OpenSSH cannot
-	// reach host-key verification without those bytes, so the line is always on
-	// disk before it is read. Pinning afterwards would race the handshake it
-	// exists to satisfy.
-	//
-	// This cannot loosen the check. Pin accepts an identical key and returns
-	// ErrHostKeyMismatch for a changed one, so a rotated host key still fails
-	// closed — with this command's error rather than OpenSSH's, and on exactly
-	// the terms `sandbox code` already fails on.
-	//
-	// TODO(KAPRO-911): reaches the Linux known-hosts file only, so this does
-	// nothing for a WSL setup, where the Windows session block reads a mirrored
-	// copy (wslmirror.go) that only MirrorToWindows refreshes. `sandbox code`
-	// is unaffected — it pins before it mirrors — but every other route to an
-	// alias still fails verification from the Windows side. Mirroring here has
-	// to wait on Pin reporting whether it wrote: wslbridge.ResolveTarget spawns
-	// two Windows interop processes, which does not belong on every dial.
+	// TODO(KAPRO-911): writes the Linux file only. Under WSL the Windows client
+	// reads a mirrored copy that only MirrorToWindows refreshes.
 	if err := pins.Pin(alias, session.HostPublicKey); err != nil {
 		return err
 	}
@@ -452,14 +434,10 @@ func PrepareSessionTarget(
 	return alias, nil
 }
 
-// SessionPinStore returns the pin store backing the shared session known-hosts
-// file.
-//
-// It resolves that path the same way every other session caller does, which is
-// the whole point of it existing: `ssh-keygen --import` persists a session
-// config naming its own known-hosts file, and a caller that reached for the
-// default path instead would pin into a file the generated SSH block does not
-// name — pins written where OpenSSH will never look for them.
+// SessionPinStore returns the pin store for the session known-hosts file,
+// resolved the way every other session caller resolves it: `ssh-keygen
+// --import` persists its own path, and reaching for the default instead would
+// write pins where OpenSSH never looks.
 func SessionPinStore(paths basedir.Paths) (HostKeyPinStore, error) {
 	sessionConfig, err := resolveSessionConfig(paths)
 	if err != nil {

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -316,6 +316,14 @@ func ProxySession(
 	// ErrHostKeyMismatch for a changed one, so a rotated host key still fails
 	// closed — with this command's error rather than OpenSSH's, and on exactly
 	// the terms `sandbox code` already fails on.
+	//
+	// TODO(KAPRO-911): reaches the Linux known-hosts file only, so this does
+	// nothing for a WSL setup, where the Windows session block reads a mirrored
+	// copy (wslmirror.go) that only MirrorToWindows refreshes. `sandbox code`
+	// is unaffected — it pins before it mirrors — but every other route to an
+	// alias still fails verification from the Windows side. Mirroring here has
+	// to wait on Pin reporting whether it wrote: wslbridge.ResolveTarget spawns
+	// two Windows interop processes, which does not belong on every dial.
 	if err := pins.Pin(alias, session.HostPublicKey); err != nil {
 		return err
 	}

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -271,12 +271,14 @@ func PrepareSessionHost(
 	return session, nil
 }
 
-// ProxySession creates a fresh descriptor, dials it with header credentials,
-// and copies opaque bytes between OpenSSH standard I/O and the WebSocket.
+// ProxySession creates a fresh descriptor, pins its host key, dials it with
+// header credentials, and copies opaque bytes between OpenSSH standard I/O and
+// the WebSocket.
 func ProxySession(
 	ctx context.Context,
 	creator SessionCreator,
 	dialer SessionDialer,
+	pins HostKeyPinStore,
 	alias string,
 	stdin io.Reader,
 	stdout io.Writer,
@@ -290,6 +292,31 @@ func ProxySession(
 		return err
 	}
 	if err := session.Validate(parsed.ID); err != nil {
+		return err
+	}
+	// Pin here, and not only in PrepareSessionHost, because this is the one
+	// step every connection goes through: OpenSSH runs it as the ProxyCommand
+	// on every dial of a managed alias, and the descriptor it just validated
+	// carries the same API-issued host key `sandbox code` would have pinned.
+	//
+	// Without it the pin exists only for sandboxes opened at least once through
+	// `sandbox ssh`, `sandbox code` or `scp`. The managed block is
+	// StrictHostKeyChecking yes against a dedicated known-hosts file, so any
+	// other way of naming the alias — cmux's ssh deep link, an editor's own
+	// Remote-SSH entry, a bare `ssh <alias>` — met an empty file and failed
+	// verification, for a host this command was in the middle of authenticating.
+	//
+	// Before the dial, which is what makes the ordering sound rather than
+	// lucky: no SSH byte can cross until the stream exists, and OpenSSH cannot
+	// reach host-key verification without those bytes, so the line is always on
+	// disk before it is read. Pinning afterwards would race the handshake it
+	// exists to satisfy.
+	//
+	// This cannot loosen the check. Pin accepts an identical key and returns
+	// ErrHostKeyMismatch for a changed one, so a rotated host key still fails
+	// closed — with this command's error rather than OpenSSH's, and on exactly
+	// the terms `sandbox code` already fails on.
+	if err := pins.Pin(alias, session.HostPublicKey); err != nil {
 		return err
 	}
 	stream, err := dialer.Dial(ctx, session.ConnectURL, session.ConnectCredential)
@@ -415,6 +442,22 @@ func PrepareSessionTarget(
 		return "", err
 	}
 	return alias, nil
+}
+
+// SessionPinStore returns the pin store backing the shared session known-hosts
+// file.
+//
+// It resolves that path the same way every other session caller does, which is
+// the whole point of it existing: `ssh-keygen --import` persists a session
+// config naming its own known-hosts file, and a caller that reached for the
+// default path instead would pin into a file the generated SSH block does not
+// name — pins written where OpenSSH will never look for them.
+func SessionPinStore(paths basedir.Paths) (HostKeyPinStore, error) {
+	sessionConfig, err := resolveSessionConfig(paths)
+	if err != nil {
+		return nil, err
+	}
+	return FileHostKeyPinStore{Path: sessionConfig.KnownHostsFile}, nil
 }
 
 // resolveSessionConfig returns the persisted session identity, or the default

--- a/go/internal/ssh/session_test.go
+++ b/go/internal/ssh/session_test.go
@@ -210,8 +210,7 @@ type fakeSessionDialer struct {
 	url        string
 	credential string
 	calls      int
-	// pins, and the count read from it on dial, are how the ordering assertion
-	// is made: the pin has to be on disk before any byte can reach OpenSSH.
+	// Pin count as of the dial, for the ordering assertion.
 	pins       *fakePinStore
 	pinsAtDial int
 }
@@ -248,14 +247,12 @@ func TestProxySessionCreatesSessionAndCopiesBytes(t *testing.T) {
 	if creator.calls != 1 || dialer.calls != 1 {
 		t.Fatalf("creator calls = %d, dialer calls = %d", creator.calls, dialer.calls)
 	}
-	// The alias OpenSSH was invoked with, keyed to the host key the API just
-	// issued: this is what lets a sandbox never opened through `sandbox code`
-	// pass StrictHostKeyChecking.
+	// The dialled alias, keyed to the host key the API just issued.
 	if pins.calls != 1 || pins.alias != "my.team.sbx_123.localhost-3011.amika" || pins.key != creator.hostKey {
 		t.Fatalf("pin calls = %d alias = %q key = %q", pins.calls, pins.alias, pins.key)
 	}
-	// Before the dial, not merely somewhere in the run. Pinned afterwards, the
-	// write would race the handshake it exists to satisfy.
+	// Before the dial, not merely somewhere in the run: pinned afterwards, the
+	// write would race the handshake.
 	if dialer.pinsAtDial != 1 {
 		t.Fatalf("pins at dial = %d, want the host key pinned before the transport opens", dialer.pinsAtDial)
 	}
@@ -291,10 +288,8 @@ func TestProxySessionAcceptsNormalWebSocketClosure(t *testing.T) {
 	}
 }
 
-// A host key that no longer matches the pin must stop the connection here,
-// rather than being written over. Pinning on every dial is only safe because
-// this direction still fails closed: the store refuses the change, and the
-// transport is never opened.
+// Pinning on every dial is only safe because a changed key still fails closed:
+// the store refuses it and the transport is never opened.
 func TestProxySessionRefusesChangedHostKeyBeforeDialing(t *testing.T) {
 	creator := &fakeCreator{hostKey: testHostKey(t)}
 	dialer := &fakeSessionDialer{stream: &proxyStream{read: bytes.NewReader(nil)}}

--- a/go/internal/ssh/session_test.go
+++ b/go/internal/ssh/session_test.go
@@ -146,13 +146,14 @@ type fakePinStore struct {
 	alias string
 	key   string
 	calls int
+	err   error
 }
 
 func (s *fakePinStore) Pin(alias, key string) error {
 	s.calls++
 	s.alias = alias
 	s.key = key
-	return nil
+	return s.err
 }
 
 func TestPrepareSessionHostPinsAPIHostKeyBeforeOpenSSH(t *testing.T) {
@@ -209,25 +210,34 @@ type fakeSessionDialer struct {
 	url        string
 	credential string
 	calls      int
+	// pins, and the count read from it on dial, are how the ordering assertion
+	// is made: the pin has to be on disk before any byte can reach OpenSSH.
+	pins       *fakePinStore
+	pinsAtDial int
 }
 
 func (d *fakeSessionDialer) Dial(_ context.Context, url, credential string) (Stream, error) {
 	d.calls++
 	d.url = url
 	d.credential = credential
+	if d.pins != nil {
+		d.pinsAtDial = d.pins.calls
+	}
 	return d.stream, nil
 }
 
 func TestProxySessionCreatesSessionAndCopiesBytes(t *testing.T) {
 	creator := &fakeCreator{hostKey: testHostKey(t)}
 	stream := &proxyStream{read: bytes.NewReader([]byte("from-sshd"))}
-	dialer := &fakeSessionDialer{stream: stream}
+	pins := &fakePinStore{}
+	dialer := &fakeSessionDialer{stream: stream, pins: pins}
 	var stdout bytes.Buffer
 
 	err := ProxySession(
 		context.Background(),
 		creator,
 		dialer,
+		pins,
 		"my.team.sbx_123.localhost-3011.amika",
 		strings.NewReader("from-openssh"),
 		&stdout,
@@ -237,6 +247,17 @@ func TestProxySessionCreatesSessionAndCopiesBytes(t *testing.T) {
 	}
 	if creator.calls != 1 || dialer.calls != 1 {
 		t.Fatalf("creator calls = %d, dialer calls = %d", creator.calls, dialer.calls)
+	}
+	// The alias OpenSSH was invoked with, keyed to the host key the API just
+	// issued: this is what lets a sandbox never opened through `sandbox code`
+	// pass StrictHostKeyChecking.
+	if pins.calls != 1 || pins.alias != "my.team.sbx_123.localhost-3011.amika" || pins.key != creator.hostKey {
+		t.Fatalf("pin calls = %d alias = %q key = %q", pins.calls, pins.alias, pins.key)
+	}
+	// Before the dial, not merely somewhere in the run. Pinned afterwards, the
+	// write would race the handshake it exists to satisfy.
+	if dialer.pinsAtDial != 1 {
+		t.Fatalf("pins at dial = %d, want the host key pinned before the transport opens", dialer.pinsAtDial)
 	}
 	if dialer.url != "wss://sandbox.example/v1/ssh-sessions" || dialer.credential != testConnectToken() {
 		t.Fatalf("dial = %q credential %q", dialer.url, dialer.credential)
@@ -261,11 +282,37 @@ func TestProxySessionAcceptsNormalWebSocketClosure(t *testing.T) {
 		context.Background(),
 		creator,
 		dialer,
+		&fakePinStore{},
 		"my.team.sbx_123.localhost-3011.amika",
 		strings.NewReader(""),
 		io.Discard,
 	); err != nil {
 		t.Fatalf("ProxySession normal close: %v", err)
+	}
+}
+
+// A host key that no longer matches the pin must stop the connection here,
+// rather than being written over. Pinning on every dial is only safe because
+// this direction still fails closed: the store refuses the change, and the
+// transport is never opened.
+func TestProxySessionRefusesChangedHostKeyBeforeDialing(t *testing.T) {
+	creator := &fakeCreator{hostKey: testHostKey(t)}
+	dialer := &fakeSessionDialer{stream: &proxyStream{read: bytes.NewReader(nil)}}
+
+	err := ProxySession(
+		context.Background(),
+		creator,
+		dialer,
+		&fakePinStore{err: ErrHostKeyMismatch},
+		"my.team.sbx_123.localhost-3011.amika",
+		strings.NewReader(""),
+		io.Discard,
+	)
+	if !errors.Is(err, ErrHostKeyMismatch) {
+		t.Fatalf("ProxySession err = %v, want ErrHostKeyMismatch", err)
+	}
+	if dialer.calls != 0 {
+		t.Fatalf("dialer calls = %d, want the transport left unopened", dialer.calls)
 	}
 }
 


### PR DESCRIPTION
## What

`plumbing ssh-stdio-proxy` — the `ProxyCommand` behind every managed `*.<env>.amika` alias — already creates a session descriptor and validates its `HostPublicKey` against the sandbox id, then discards that key. This pins it instead, so the managed known-hosts file fills itself in on first use.

## Why

The pin was written only by `PrepareSessionHost`, which runs inside `sandbox ssh`, `sandbox code` and `scp`. The generated block is `StrictHostKeyChecking yes` against a dedicated `UserKnownHostsFile`, so a sandbox created outside the CLI has no line in that file and **any other way of naming its alias fails host-key verification** — a bare `ssh <alias>`, an editor's own Remote-SSH entry, or a `cmux://ssh?host=` deep link. The awkward part is that the connection failing verification is served by a `ProxyCommand` that is authenticating the very same host at the very same moment.

This came out of wiring the sandbox page's "Open with … CMUX" item to cmux's native SSH deep link, which hands OpenSSH an alias and nothing else. That work is a separate PR in `amika-mono` and depends on this one.

## Ordering

The pin goes in **before the dial**, which is what makes it sound rather than lucky: no SSH byte can cross until the stream exists, and OpenSSH cannot reach host-key verification without those bytes, so the line is always on disk before it is read. Pinning afterwards would race the handshake it exists to satisfy. `TestProxySessionCreatesSessionAndCopiesBytes` asserts the ordering, not just the call.

## This does not loosen the check

`Pin` accepts an identical key and returns `ErrHostKeyMismatch` for a changed one. A rotated host key therefore still fails closed — on exactly the terms `sandbox code` already fails on, with this command's error rather than OpenSSH's, and with the transport never opened. `TestProxySessionRefusesChangedHostKeyBeforeDialing` covers that direction. The alternative I explicitly did not take was relaxing the client to `accept-new`, which would trust whatever answered first.

`SessionPinStore` resolves the known-hosts path the same way every other session caller does, rather than reaching for the default: `ssh-keygen --import` persists a session config naming its own file, and pinning into the default path would write pins where OpenSSH is never going to look.

## Testing

`make fmtcheck`, `make vet`, `make lint` all clean. `go test ./...` passes except `internal/materialize`, which shells out to `rsync` — not installed in my environment, and unrelated to this change.

Not exercised against a live control plane — I have no sandbox to dial from here, so the end-to-end claim (fresh sandbox, `ssh <alias>` with no prior CLI run) is reasoned from the config the CLI generates rather than observed. Worth one manual check before merge.