### PR TITLE
Register the managed SSH entry when a key is pushed

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -654,6 +654,8 @@ amika secret ssh-key push --name laptop --force
 
 Re-pushing the *same* key material under an existing name is a no-op. Pushing *different* material under an existing name fails unless `--force` is passed. Only ed25519 keys are accepted, and the key's trailing comment is stripped before upload.
 
+A successful push also registers the key locally, the same way `ssh-keygen` does: the Amika-managed SSH host entry in `~/.ssh/amika.conf` is regenerated to authenticate with the private key sitting beside the `.pub` file, and `~/.ssh/config` is given the `Include` that pulls it in. That is what lets `amika sandbox ssh` and `amika sandbox code` reach a sandbox straight after the push. A `.pub` whose matching private key is missing, encrypted, not ed25519, or readable by others is still uploaded; only the local registration is skipped, and the command says so.
+
 With `-o json` this emits the API's `SshPublicKeySummary` response unchanged (`id`, `name`, `public_key`, `scope`). Whether the push created or replaced a key is reported only in the text output.
 
 #### `amika secret ssh-key list`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -654,7 +654,15 @@ amika secret ssh-key push --name laptop --force
 
 Re-pushing the *same* key material under an existing name is a no-op. Pushing *different* material under an existing name fails unless `--force` is passed. Only ed25519 keys are accepted, and the key's trailing comment is stripped before upload.
 
-A successful push also registers the key locally, the same way `ssh-keygen` does: the Amika-managed SSH host entry in `~/.ssh/amika.conf` is regenerated to authenticate with the private key sitting beside the `.pub` file, and `~/.ssh/config` is given the `Include` that pulls it in. That is what lets `amika sandbox ssh` and `amika sandbox code` reach a sandbox straight after the push. A `.pub` whose matching private key is missing, encrypted, not ed25519, or readable by others is still uploaded; only the local registration is skipped, and the command says so.
+**The first push on a machine also registers the key locally**, the way `ssh-keygen` does: the Amika-managed SSH host entry in `~/.ssh/amika.conf` is written to authenticate with the private key sitting beside the `.pub` file, and `~/.ssh/config` is given the `Include` that pulls it in.
+
+That matters for anything that hands an `amika` host alias straight to OpenSSH without going through the CLI first, such as the `cmux://` and `cursor://` links the web app offers. `amika sandbox ssh` and `sandbox code` do not depend on it: they write the same entry themselves on their way through.
+
+**Later pushes leave the entry alone.** Uploaded keys are a set, so pushing a second key authorizes it alongside the first, while the entry names the one identity every connection authenticates with — and it is rendered with `IdentitiesOnly yes`, so re-pointing it would offer OpenSSH only the newest key and cut off sandboxes provisioned against the previous one. Use `amika secret ssh-key create` to change which identity is in effect. A repeat push rewrites the same entry from the same identity, so re-running it changes nothing.
+
+A `.pub` whose matching private key is missing, encrypted, not ed25519, readable by others, or at a path OpenSSH cannot express is still uploaded; only the local registration is skipped, and the command says so. A push that is not registering anything needs no private key at all.
+
+Either way the command's last line names the identity the entry holds, which after a later push is not the key just uploaded.
 
 With `-o json` this emits the API's `SshPublicKeySummary` response unchanged (`id`, `name`, `public_key`, `scope`). Whether the push created or replaced a key is reported only in the text output.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -658,7 +658,11 @@ Re-pushing the *same* key material under an existing name is a no-op. Pushing *d
 
 That matters for anything that hands an `amika` host alias straight to OpenSSH without going through the CLI first, such as the `cmux://` and `cursor://` links the web app offers. `amika sandbox ssh` and `sandbox code` do not depend on it: they write the same entry themselves on their way through.
 
-**Later pushes leave the entry alone.** Uploaded keys are a set, so pushing a second key authorizes it alongside the first, while the entry names the one identity every connection authenticates with — and it is rendered with `IdentitiesOnly yes`, so re-pointing it would offer OpenSSH only the newest key and cut off sandboxes provisioned against the previous one. Use `amika secret ssh-key create` to change which identity is in effect. A repeat push rewrites the same entry from the same identity, so re-running it changes nothing.
+**The entry is one of two prerequisites, not the whole of one.** The generated block sets `StrictHostKeyChecking yes` against a dedicated known-hosts file, and that file is filled in by `sandbox ssh`, `sandbox code` and `scp` alone. So on a machine that has only ever pushed a key, another client can now resolve the alias but will still be refused for want of a host-key pin, until the sandbox has been reached from the CLI once.
+
+**Later pushes leave the identity alone.** Uploaded keys are a set, so pushing a second key authorizes it alongside the first, while the entry names the one identity every connection authenticates with. It is rendered with `IdentitiesOnly yes`, so re-pointing it would offer OpenSSH only the newest key and cut off sandboxes provisioned against the previous one. Use `amika secret ssh-key create` to change which identity is in effect.
+
+Such a push still regenerates the config from that identity, which is deliberate: a deleted `amika.conf` or a stripped `Include` is restored. Two things about it are not fixed, and neither is a bug: pushing while pointed at a different control plane adds that environment's block alongside the existing ones, and pushing from a different `amika` binary rewrites the `ProxyCommand` line to name it, exactly as a sandbox command would.
 
 A `.pub` whose matching private key is missing, encrypted, not ed25519, readable by others, or at a path OpenSSH cannot express is still uploaded; only the local registration is skipped, and the command says so. A push that is not registering anything needs no private key at all.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -135,6 +135,11 @@ Keys are named, and a name is unique per user. Re-pushing the same key material
 under an existing name is a no-op; replacing a name with different material
 requires `--force`.
 
+Like `create`, this also points the Amika-managed SSH config at the private key
+beside the `.pub` file, so the sandbox commands work straight after the push. A
+`.pub` with no usable private key beside it is still uploaded; only that local
+step is skipped.
+
 3. **List your keys:**
 
 ```bash

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -138,10 +138,13 @@ requires `--force`.
 The first push on a machine also points the Amika-managed SSH config at the
 private key beside the `.pub` file, the way `create` does, so an app handed an
 `amika` host alias can resolve it without a sandbox command having run first.
-Later pushes add an authorized key and leave that choice alone; use `create` to
-change which identity is in effect. A `.pub` with no usable private key beside
-it is still uploaded, and only a push that would have registered one needs a
-private key at all.
+Resolving it is not the whole of connecting: the generated block pins host keys
+strictly, and only `sandbox ssh`, `sandbox code` and `scp` write those pins.
+
+Later pushes add an authorized key and leave that identity alone; use `create`
+to change which identity is in effect. A `.pub` with no usable private key
+beside it is still uploaded, and only a push that would have registered one
+needs a private key at all.
 
 3. **List your keys:**
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -135,10 +135,13 @@ Keys are named, and a name is unique per user. Re-pushing the same key material
 under an existing name is a no-op; replacing a name with different material
 requires `--force`.
 
-Like `create`, this also points the Amika-managed SSH config at the private key
-beside the `.pub` file, so the sandbox commands work straight after the push. A
-`.pub` with no usable private key beside it is still uploaded; only that local
-step is skipped.
+The first push on a machine also points the Amika-managed SSH config at the
+private key beside the `.pub` file, the way `create` does, so an app handed an
+`amika` host alias can resolve it without a sandbox command having run first.
+Later pushes add an authorized key and leave that choice alone; use `create` to
+change which identity is in effect. A `.pub` with no usable private key beside
+it is still uploaded, and only a push that would have registered one needs a
+private key at all.
 
 3. **List your keys:**
 

--- a/go/cmd/amika/ssh_key.go
+++ b/go/cmd/amika/ssh_key.go
@@ -66,11 +66,19 @@ func newSSHKeyPushCmd() *cobra.Command {
 Reads ~/.ssh/amika_id_ed25519.pub unless --from-file names another file. Use
 "amika secret ssh-key create" to generate a new keypair instead.
 
-The uploaded key is also registered locally, exactly as "ssh-key create" does:
-the managed SSH entry in ~/.ssh/amika.conf is regenerated to authenticate with
-the private half beside the .pub file, so a sandbox can be reached over SSH
-straight after the push. A .pub with no usable private key beside it is still
-uploaded; only the local registration is skipped.
+The first push on a machine also registers the key locally, the way
+"ssh-key create" does: the managed SSH entry in ~/.ssh/amika.conf is written to
+authenticate with the private half beside the .pub file, and ~/.ssh/config is
+given the Include that pulls it in. That is what lets an app resolve an
+"amika" host alias on a machine where no sandbox command has run yet.
+
+Later pushes leave that entry alone. Uploaded keys are a set, so pushing a
+second key authorizes it alongside the first; the entry names the one identity
+every connection authenticates with, and re-pointing it would cut off sandboxes
+provisioned against the previous key. Use "ssh-key create" to change it.
+
+A .pub with no usable private key beside it is still uploaded; only the local
+registration is skipped.
 
 A key is identified by its name. Re-uploading the same key material under an
 existing name is a no-op; replacing an existing name with different material
@@ -118,14 +126,14 @@ Examples:
 				return fmt.Errorf("%s is not a valid ed25519 public key", fromFile)
 			}
 
-			// Resolve the local SSH entry before uploading, for the reason
-			// `ssh-keygen` validates before it uploads: a config that cannot
-			// be written must be known while the stored key is still the one
-			// the current config selects. Unlike keygen, a failure here is not
-			// fatal — the upload is what this command is for, and a public key
-			// whose private half is elsewhere is a legitimate thing to push —
-			// so the reason is carried and reported instead.
-			session, sessionErr := localSSHEntryFor(paths, fromFile)
+			// Decide the entry before uploading, for the reason `ssh-keygen`
+			// validates before it uploads: a config that cannot be written
+			// must be known while the stored key is still the one the current
+			// config selects. Unlike keygen, a failure here is not fatal — the
+			// upload is what this command is for, and a public key whose
+			// private half is elsewhere is a legitimate thing to push — so the
+			// reason is carried and reported instead.
+			plan, planErr := planSSHEntry(paths, fromFile)
 
 			force, _ := cmd.Flags().GetBool("force")
 			summary, status, err := uploadSSHPublicKey(name, publicKey, force)
@@ -136,30 +144,31 @@ Examples:
 			// The same writer `secret ssh-keygen` uses, so a key that arrives
 			// by push leaves the machine in the state a generated one does:
 			// there is one managed SSH entry, written in one place.
-			if sessionErr == nil {
-				if err := ssh.ConfigureSession(paths, session); err != nil {
-					return fmt.Errorf("registering the managed SSH host entry: %w", err)
-				}
+			//
+			// Not fatal, though the resolution above already caught the
+			// foreseeable refusals: past this point the key is stored, and
+			// exiting non-zero would tell a caller its upload had failed when
+			// it had not. What is left to go wrong here is a filesystem the
+			// command cannot repair anyway.
+			writeErr := error(nil)
+			if planErr == nil {
+				writeErr = ssh.ConfigureSession(paths, plan.session)
 			}
 
 			if format.IsJSON() {
 				// Remote-backed commands emit the API's response schema
 				// unchanged (AGENTS.md "CLI Output Format"), so the
-				// created/updated distinction — and the two lines below —
-				// stay in the text output only.
+				// created/updated distinction — and every line below — stay in
+				// the text output only. The JSON models the stored key, which
+				// is what a scripted caller asked for and what did happen.
 				return format.JSON(cmd.OutOrStdout(), summary)
 			}
 			out := cmd.OutOrStdout()
 			fmt.Fprintf(out, "%s SSH public key %q from %s\n",
 				uploadVerb(status), summary.Name, fromFile)
-			if sessionErr != nil {
-				// Said after the upload it qualifies, because the upload is
-				// what the reader asked for and it did happen.
-				fmt.Fprintf(out, "Left the managed SSH host entry alone: %v\n", sessionErr)
-				return nil
-			}
-			fmt.Fprintf(out, "Registered the managed SSH host entry; it authenticates with %s.\n",
-				session.IdentityFile)
+			// Said after the upload it qualifies, because the upload is what
+			// the reader asked for and it did happen.
+			fmt.Fprintln(out, sshEntryNotice(plan, planErr, writeErr))
 			return nil
 		},
 	}
@@ -169,6 +178,72 @@ Examples:
 	return cmd
 }
 
+// sshEntryPlan is what a push intends to do about the managed SSH entry: the
+// identity the entry will authenticate with once written, and whether this
+// push is what chose it.
+type sshEntryPlan struct {
+	session ssh.SessionConfig
+	// adopted is true when the machine had no managed identity and the pushed
+	// key becomes it. False means one was already registered and this push
+	// leaves it selecting whatever it selected before.
+	adopted bool
+}
+
+// planSSHEntry decides what a push should register.
+//
+// The first push on a machine adopts its key. Nothing has yet said which
+// private key the managed config authenticates with, the key being uploaded is
+// the only sensible answer, and writing it is what lets the deep-link
+// launchers (cmux, Cursor) resolve an alias on a machine where no sandbox
+// command has run.
+//
+// Every later push leaves that choice alone, so repeat pushes are idempotent.
+// This is the asymmetry that makes it necessary: uploaded keys are a *set*,
+// keyed by name, so `push --name work` adds an authorized key rather than
+// replacing one — while the session identity is a single value shared by every
+// environment, rendered under `IdentitiesOnly yes`. Adopting each new key would
+// silently re-point every sandbox connection at the newest one and lock the
+// user out of sandboxes provisioned against the previous. `secret ssh-keygen`
+// remains the command for deliberately changing which identity is in effect.
+//
+// A push that adopts nothing needs no private key at all, which is why the
+// resolution is behind the check rather than in front of it.
+func planSSHEntry(paths basedir.Paths, publicKeyPath string) (sshEntryPlan, error) {
+	state, err := ssh.LoadState(paths)
+	if err != nil {
+		return sshEntryPlan{}, err
+	}
+	if state.SessionConfig != nil {
+		return sshEntryPlan{session: *state.SessionConfig}, nil
+	}
+	session, err := localSSHEntryFor(paths, publicKeyPath)
+	if err != nil {
+		return sshEntryPlan{}, err
+	}
+	return sshEntryPlan{session: session, adopted: true}, nil
+}
+
+// sshEntryNotice is the one line a push says about the managed SSH entry.
+//
+// A push that changed nothing still says which identity the entry holds. The
+// reader has just uploaded a key and the honest answer is often "not that one"
+// — a `--force` replace can even leave the entry selecting material the server
+// no longer stores — and naming the file is what lets them see it.
+func sshEntryNotice(plan sshEntryPlan, planErr, writeErr error) string {
+	switch {
+	case planErr != nil:
+		return fmt.Sprintf("Left the managed SSH host entry alone: %v", planErr)
+	case writeErr != nil:
+		return fmt.Sprintf("Could not write the managed SSH host entry: %v", writeErr)
+	case plan.adopted:
+		return fmt.Sprintf("Registered the managed SSH host entry; it authenticates with %s.",
+			plan.session.IdentityFile)
+	default:
+		return fmt.Sprintf("The managed SSH host entry is unchanged; it authenticates with %s.",
+			plan.session.IdentityFile)
+	}
+}
+
 // localSSHEntryFor resolves the managed SSH entry an uploaded public key
 // implies on this machine: the private half beside the .pub is the identity
 // the entry authenticates with. `ImportIdentity` is what establishes that the
@@ -176,12 +251,21 @@ Examples:
 // Ed25519 key, and matches the public half — so a push whose .pub has no
 // usable partner is told apart from one that does, rather than registering an
 // entry that selects a key OpenSSH cannot use.
+//
+// Both errors are wrapped with the path they are about, because unwrapped they
+// name neither: `ImportIdentity` speaks of an "imported" key, which is keygen's
+// vocabulary rather than push's, and a path OpenSSH cannot express comes back
+// as "invalid Amika SSH host alias", naming an alias no one asked for.
 func localSSHEntryFor(paths basedir.Paths, publicKeyPath string) (ssh.SessionConfig, error) {
 	identityPath, _, err := ssh.ImportIdentity(publicKeyPath)
 	if err != nil {
-		return ssh.SessionConfig{}, err
+		return ssh.SessionConfig{}, fmt.Errorf("no usable private key beside %s: %w", publicKeyPath, err)
 	}
-	return sshSessionFor(paths, identityPath)
+	session, err := sshSessionFor(paths, identityPath)
+	if err != nil {
+		return ssh.SessionConfig{}, fmt.Errorf("cannot build an SSH config for %s: %w", identityPath, err)
+	}
+	return session, nil
 }
 
 // sshSessionFor builds the session config for a private key and checks that

--- a/go/cmd/amika/ssh_key.go
+++ b/go/cmd/amika/ssh_key.go
@@ -69,16 +69,19 @@ Reads ~/.ssh/amika_id_ed25519.pub unless --from-file names another file. Use
 The first push on a machine also registers the key locally, the way
 "ssh-key create" does: the managed SSH entry in ~/.ssh/amika.conf is written to
 authenticate with the private half beside the .pub file, and ~/.ssh/config is
-given the Include that pulls it in. That is what lets an app resolve an
-"amika" host alias on a machine where no sandbox command has run yet.
+given the Include that pulls it in. That is one of the two things an app needs
+before it can resolve an "amika" host alias on its own; the other is a
+host-key pin, which only "sandbox ssh", "sandbox code" and "scp" write today.
 
-Later pushes leave that entry alone. Uploaded keys are a set, so pushing a
+Later pushes leave the identity alone. Uploaded keys are a set, so pushing a
 second key authorizes it alongside the first; the entry names the one identity
 every connection authenticates with, and re-pointing it would cut off sandboxes
-provisioned against the previous key. Use "ssh-key create" to change it.
+provisioned against the previous key. Use "ssh-key create" to change it. Such a
+push still refreshes the generated config, so a deleted amika.conf or a stripped
+Include is restored.
 
 A .pub with no usable private key beside it is still uploaded; only the local
-registration is skipped.
+registration is skipped. A push that registers nothing needs no private key.
 
 A key is identified by its name. Re-uploading the same key material under an
 existing name is a no-op; replacing an existing name with different material
@@ -152,7 +155,20 @@ Examples:
 			// command cannot repair anyway.
 			writeErr := error(nil)
 			if planErr == nil {
-				writeErr = ssh.ConfigureSession(paths, plan.session)
+				if err := ssh.ConfigureSession(paths, plan.session); err != nil {
+					// Wrapped for the same reason the resolve errors are: the
+					// bare error can be `invalid Amika SSH host alias`, which
+					// names an alias nobody asked for.
+					writeErr = fmt.Errorf("regenerating the managed SSH config: %w", err)
+				}
+			}
+			if writeErr != nil {
+				// Stderr, and in JSON mode too, unlike every other line here.
+				// This one says the command wrote to the user's ~/.ssh and
+				// failed — a thing the response schema has no field for, and
+				// that a script should not have to infer from silence. AGENTS.md
+				// keeps stdout for the JSON value alone, not stderr.
+				fmt.Fprintln(cmd.ErrOrStderr(), writeErr)
 			}
 
 			if format.IsJSON() {
@@ -167,8 +183,11 @@ Examples:
 			fmt.Fprintf(out, "%s SSH public key %q from %s\n",
 				uploadVerb(status), summary.Name, fromFile)
 			// Said after the upload it qualifies, because the upload is what
-			// the reader asked for and it did happen.
-			fmt.Fprintln(out, sshEntryNotice(plan, planErr, writeErr))
+			// the reader asked for and it did happen. Empty when the write
+			// failed, which stderr has already reported.
+			if notice := sshEntryNotice(plan, planErr, writeErr); notice != "" {
+				fmt.Fprintln(out, notice)
+			}
 			return nil
 		},
 	}
@@ -187,6 +206,12 @@ type sshEntryPlan struct {
 	// key becomes it. False means one was already registered and this push
 	// leaves it selecting whatever it selected before.
 	adopted bool
+	// deadIdentity is set when an already-registered identity is no longer a
+	// key OpenSSH will use — deleted, or readable by anyone but its owner.
+	// Refusing to silently re-point is the rule; saying nothing while
+	// re-rendering a config that selects a missing file is not part of it, and
+	// this notice is the one place the reader could find out.
+	deadIdentity bool
 }
 
 // planSSHEntry decides what a push should register.
@@ -214,7 +239,10 @@ func planSSHEntry(paths basedir.Paths, publicKeyPath string) (sshEntryPlan, erro
 		return sshEntryPlan{}, err
 	}
 	if state.SessionConfig != nil {
-		return sshEntryPlan{session: *state.SessionConfig}, nil
+		return sshEntryPlan{
+			session:      *state.SessionConfig,
+			deadIdentity: !usableIdentity(state.SessionConfig.IdentityFile),
+		}, nil
 	}
 	session, err := localSSHEntryFor(paths, publicKeyPath)
 	if err != nil {
@@ -234,14 +262,33 @@ func sshEntryNotice(plan sshEntryPlan, planErr, writeErr error) string {
 	case planErr != nil:
 		return fmt.Sprintf("Left the managed SSH host entry alone: %v", planErr)
 	case writeErr != nil:
-		return fmt.Sprintf("Could not write the managed SSH host entry: %v", writeErr)
+		// Already reported on stderr, where a JSON caller can see it too.
+		return ""
 	case plan.adopted:
 		return fmt.Sprintf("Registered the managed SSH host entry; it authenticates with %s.",
 			plan.session.IdentityFile)
+	case plan.deadIdentity:
+		return fmt.Sprintf(
+			"The managed SSH host entry still names %s, which is missing or not owner-only; "+
+				"run \"amika secret ssh-key create\" to point it at a usable key.",
+			plan.session.IdentityFile)
 	default:
-		return fmt.Sprintf("The managed SSH host entry is unchanged; it authenticates with %s.",
+		// "Identity" rather than "entry": the generated config *is* rewritten,
+		// and a push against another control plane or from another binary
+		// legitimately changes what it holds. What this push did not touch is
+		// which private key it authenticates with.
+		return fmt.Sprintf("The managed SSH host entry still authenticates with %s.",
 			plan.session.IdentityFile)
 	}
+}
+
+// usableIdentity reports whether a private key path is one OpenSSH would
+// accept: a regular file, readable by nobody but its owner. The same test
+// `PrepareSessionTarget` applies before it dials, so a push cannot call an
+// identity fine that a later `sandbox ssh` will refuse.
+func usableIdentity(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o077 == 0
 }
 
 // localSSHEntryFor resolves the managed SSH entry an uploaded public key

--- a/go/cmd/amika/ssh_key.go
+++ b/go/cmd/amika/ssh_key.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/output"
 	"github.com/gofixpoint/amika/go/internal/runmode"
+	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,12 @@ func newSSHKeyPushCmd() *cobra.Command {
 Reads ~/.ssh/amika_id_ed25519.pub unless --from-file names another file. Use
 "amika secret ssh-key create" to generate a new keypair instead.
 
+The uploaded key is also registered locally, exactly as "ssh-key create" does:
+the managed SSH entry in ~/.ssh/amika.conf is regenerated to authenticate with
+the private half beside the .pub file, so a sandbox can be reached over SSH
+straight after the push. A .pub with no usable private key beside it is still
+uploaded; only the local registration is skipped.
+
 A key is identified by its name. Re-uploading the same key material under an
 existing name is a no-op; replacing an existing name with different material
 requires --force.
@@ -88,10 +95,10 @@ Examples:
 				return fmt.Errorf("--name must not be empty")
 			}
 
+			paths := basedir.New("")
 			fromFile, _ := cmd.Flags().GetString("from-file")
 			fromFile = strings.TrimSpace(fromFile)
 			if fromFile == "" {
-				paths := basedir.New("")
 				identityPath, err := paths.SSHIdentityFile()
 				if err != nil {
 					return err
@@ -111,19 +118,48 @@ Examples:
 				return fmt.Errorf("%s is not a valid ed25519 public key", fromFile)
 			}
 
+			// Resolve the local SSH entry before uploading, for the reason
+			// `ssh-keygen` validates before it uploads: a config that cannot
+			// be written must be known while the stored key is still the one
+			// the current config selects. Unlike keygen, a failure here is not
+			// fatal — the upload is what this command is for, and a public key
+			// whose private half is elsewhere is a legitimate thing to push —
+			// so the reason is carried and reported instead.
+			session, sessionErr := localSSHEntryFor(paths, fromFile)
+
 			force, _ := cmd.Flags().GetBool("force")
 			summary, status, err := uploadSSHPublicKey(name, publicKey, force)
 			if err != nil {
 				return err
 			}
+
+			// The same writer `secret ssh-keygen` uses, so a key that arrives
+			// by push leaves the machine in the state a generated one does:
+			// there is one managed SSH entry, written in one place.
+			if sessionErr == nil {
+				if err := ssh.ConfigureSession(paths, session); err != nil {
+					return fmt.Errorf("registering the managed SSH host entry: %w", err)
+				}
+			}
+
 			if format.IsJSON() {
 				// Remote-backed commands emit the API's response schema
 				// unchanged (AGENTS.md "CLI Output Format"), so the
-				// created/updated distinction stays in the text output only.
+				// created/updated distinction — and the two lines below —
+				// stay in the text output only.
 				return format.JSON(cmd.OutOrStdout(), summary)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "%s SSH public key %q from %s\n",
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "%s SSH public key %q from %s\n",
 				uploadVerb(status), summary.Name, fromFile)
+			if sessionErr != nil {
+				// Said after the upload it qualifies, because the upload is
+				// what the reader asked for and it did happen.
+				fmt.Fprintf(out, "Left the managed SSH host entry alone: %v\n", sessionErr)
+				return nil
+			}
+			fmt.Fprintf(out, "Registered the managed SSH host entry; it authenticates with %s.\n",
+				session.IdentityFile)
 			return nil
 		},
 	}
@@ -131,6 +167,41 @@ Examples:
 	cmd.Flags().String("from-file", "", "Public key file to upload (default ~/.ssh/amika_id_ed25519.pub)")
 	cmd.Flags().Bool("force", false, "Replace an existing SSH key with the same name")
 	return cmd
+}
+
+// localSSHEntryFor resolves the managed SSH entry an uploaded public key
+// implies on this machine: the private half beside the .pub is the identity
+// the entry authenticates with. `ImportIdentity` is what establishes that the
+// pair is real — the private key exists, is owner-only, is an unencrypted
+// Ed25519 key, and matches the public half — so a push whose .pub has no
+// usable partner is told apart from one that does, rather than registering an
+// entry that selects a key OpenSSH cannot use.
+func localSSHEntryFor(paths basedir.Paths, publicKeyPath string) (ssh.SessionConfig, error) {
+	identityPath, _, err := ssh.ImportIdentity(publicKeyPath)
+	if err != nil {
+		return ssh.SessionConfig{}, err
+	}
+	return sshSessionFor(paths, identityPath)
+}
+
+// sshSessionFor builds the session config for a private key and checks that
+// ConfigureSession would accept it, without writing anything. Both commands
+// that upload a key — `ssh-key push` and `ssh-keygen` — go through it, so they
+// cannot disagree about what an uploaded key implies locally, and both learn of
+// a config OpenSSH cannot express before the remote key changes.
+func sshSessionFor(paths basedir.Paths, identityPath string) (ssh.SessionConfig, error) {
+	knownHostsPath, err := paths.SSHKnownHostsFile()
+	if err != nil {
+		return ssh.SessionConfig{}, err
+	}
+	session := ssh.SessionConfig{
+		IdentityFile:   identityPath,
+		KnownHostsFile: knownHostsPath,
+	}
+	if err := ssh.ValidateSessionConfig(session); err != nil {
+		return ssh.SessionConfig{}, err
+	}
+	return session, nil
 }
 
 // uploadSSHPublicKey stores one public key under a name, refusing to replace

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -754,6 +754,137 @@ func TestSSHKeyPushInProcess_JSONIsTheAPIResponse(t *testing.T) {
 	}
 }
 
+// writeTestKeypair generates a real ed25519 keypair in dir and returns the
+// private key path. Unlike writeTestPubKey it produces both halves, which is
+// what a push needs before it can register a managed SSH entry for the key.
+func writeTestKeypair(t *testing.T, dir string) string {
+	t.Helper()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	if out, err := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-C", "me@host",
+		"-f", keyPath).CombinedOutput(); err != nil {
+		t.Fatalf("ssh-keygen: %v\n%s", err, out)
+	}
+	return keyPath
+}
+
+// isolateSSHHome points HOME and the state dir at fresh directories, so a test
+// that writes SSH config cannot touch the developer's own. Returns the home.
+func isolateSSHHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Set explicitly rather than relying on the HOME fallback: an inherited
+	// XDG_STATE_HOME would otherwise put ssh-hosts.json outside the temp home.
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, "state"))
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func TestSSHKeyPushInProcess_RegistersManagedSSHEntry(t *testing.T) {
+	home := isolateSSHHome(t)
+	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
+
+	api := &sshKeyAPI{}
+	setupInProcessSSHKeyAPI(t, api)
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", keyPath+".pub")
+	if err != nil {
+		t.Fatalf("push failed: %v\n%s", err, out)
+	}
+	if len(api.created) != 1 {
+		t.Fatalf("expected the key to be uploaded, got %+v", api.created)
+	}
+
+	// A push must leave behind exactly what `ssh-keygen` leaves behind: the
+	// JSON state naming the identity, the config rendered from it, and the
+	// Include that makes OpenSSH read that config.
+	state, err := os.ReadFile(filepath.Join(home, "state", "amika", "ssh-hosts.json"))
+	if err != nil {
+		t.Fatalf("ssh-hosts.json was not written: %v", err)
+	}
+	if !strings.Contains(string(state), keyPath) {
+		t.Errorf("ssh-hosts.json does not record the pushed identity:\n%s", state)
+	}
+	conf, err := os.ReadFile(filepath.Join(home, ".ssh", "amika.conf"))
+	if err != nil {
+		t.Fatalf("~/.ssh/amika.conf was not written: %v", err)
+	}
+	if !strings.Contains(string(conf), "IdentityFile "+keyPath) {
+		t.Errorf("the managed config does not select the pushed key:\n%s", conf)
+	}
+	config, err := os.ReadFile(filepath.Join(home, ".ssh", "config"))
+	if err != nil {
+		t.Fatalf("~/.ssh/config was not written: %v", err)
+	}
+	if !strings.Contains(string(config), "Include amika.conf") {
+		t.Errorf("~/.ssh/config does not include the managed config:\n%s", config)
+	}
+	if !strings.Contains(out, "Registered the managed SSH host entry") {
+		t.Errorf("output should say the entry was registered: %s", out)
+	}
+}
+
+func TestSSHKeyPushInProcess_UploadsWithoutRegisteringWhenPrivateKeyIsMissing(t *testing.T) {
+	home := isolateSSHHome(t)
+	// A .pub with no private half beside it: a legitimate thing to push (the
+	// private key may live on another machine), and nothing a usable local
+	// config can be written from.
+	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
+
+	api := &sshKeyAPI{}
+	setupInProcessSSHKeyAPI(t, api)
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", pubPath)
+	if err != nil {
+		t.Fatalf("push failed: %v\n%s", err, out)
+	}
+	// The upload is the command's job and must still happen.
+	if len(api.created) != 1 || api.created[0]["public_key"] != canonical {
+		t.Errorf("expected the key to be uploaded, got %+v", api.created)
+	}
+	if !strings.Contains(out, "Left the managed SSH host entry alone") {
+		t.Errorf("output should say the entry was skipped, and why: %s", out)
+	}
+	// No half-written config selecting a key OpenSSH cannot use.
+	for _, name := range []string{"amika.conf", "config"} {
+		if _, statErr := os.Stat(filepath.Join(home, ".ssh", name)); statErr == nil {
+			t.Errorf("~/.ssh/%s was written for a key with no private half", name)
+		}
+	}
+}
+
+func TestSSHKeyPushInProcess_DoesNotRegisterWhenUploadRefused(t *testing.T) {
+	home := isolateSSHHome(t)
+	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
+
+	// A different key already stored under this name, so the upload is
+	// refused without --force.
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "laptop",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
+	}}
+	setupInProcessSSHKeyAPI(t, api)
+
+	_, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", keyPath+".pub")
+	if err == nil {
+		t.Fatal("expected the upload to be refused")
+	}
+
+	// Same rule as `ssh-keygen`: the config must not end up pointing at a
+	// private key whose public half was never stored.
+	for _, name := range []string{"amika.conf", "config"} {
+		if _, statErr := os.Stat(filepath.Join(home, ".ssh", name)); statErr == nil {
+			t.Errorf("~/.ssh/%s was written despite the upload being refused", name)
+		}
+	}
+}
+
 func TestSSHKeygenInProcess_DoesNotPersistSessionWhenUploadRefused(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -31,9 +31,22 @@ type sshKeyAPI struct {
 }
 
 // setupMockSSHKeyAPI stands up a stub control plane for the ssh-key endpoints
-// and returns the env that points the CLI at it.
+// and returns the env that points the CLI at it, pointed at an isolated HOME.
+//
+// The isolation is here rather than in the tests that obviously need it,
+// because `ssh-key push` writes SSH config on a path no test opts into: a push
+// that is not adopting an identity registers the entry without ever touching a
+// private key, so on a machine that has run `secret ssh-keygen` — which every
+// developer's does — the plain push tests rewrite the real ~/.ssh/amika.conf
+// and ~/.ssh/config. Isolation that each test remembers to ask for is
+// isolation the next test forgets; this is the one door they all come through.
+//
+// XDG_STATE_HOME is set explicitly rather than left to the HOME fallback: an
+// inherited value would put ssh-hosts.json outside the temp home, which is
+// what decides whether a push adopts.
 func setupMockSSHKeyAPI(t *testing.T, api *sshKeyAPI) []string {
 	t.Helper()
+	home := isolateSSHHome(t)
 	if api.deleteStatus == 0 {
 		api.deleteStatus = http.StatusNoContent
 	}
@@ -102,10 +115,28 @@ func setupMockSSHKeyAPI(t *testing.T, api *sshKeyAPI) []string {
 		}
 	}))
 	t.Cleanup(srv.Close)
+	// HOME and XDG_STATE_HOME travel in the env too, so a subprocess test's
+	// child gets the same isolated home the parent was just given.
 	return withEnv(os.Environ(),
 		"AMIKA_API_URL="+srv.URL,
 		"AMIKA_API_KEY=test-bearer-token",
+		"HOME="+home,
+		"XDG_STATE_HOME="+filepath.Join(home, "state"),
 	)
+}
+
+// isolateSSHHome points HOME and the state dir at fresh directories, so a test
+// that writes SSH config cannot touch the developer's own. Returns the home.
+func isolateSSHHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, "state"))
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return home
 }
 
 // writeTestPubKey writes a valid ed25519 .pub file and returns its path plus
@@ -389,11 +420,15 @@ func TestSecretSSHKeyDelete_NotFound(t *testing.T) {
 // subprocess. Subprocess tests assert the real end-to-end behavior but record
 // no coverage for this package, so the RunE bodies are exercised here too.
 
-// setupInProcessSSHKeyAPI points the in-process command tree at a stub API.
-func setupInProcessSSHKeyAPI(t *testing.T, api *sshKeyAPI) {
+// setupInProcessSSHKeyAPI points the in-process command tree at a stub API and
+// returns the isolated HOME it will read and write, which a test asserting on
+// SSH config needs to look inside. HOME itself is already set by
+// setupMockSSHKeyAPI; only the API variables have to be copied into this
+// process, since it does not go through the returned env.
+func setupInProcessSSHKeyAPI(t *testing.T, api *sshKeyAPI) string {
 	t.Helper()
-	env := setupMockSSHKeyAPI(t, api)
-	for _, entry := range env {
+	home := ""
+	for _, entry := range setupMockSSHKeyAPI(t, api) {
 		key, value, found := strings.Cut(entry, "=")
 		if !found {
 			continue
@@ -401,8 +436,11 @@ func setupInProcessSSHKeyAPI(t *testing.T, api *sshKeyAPI) {
 		switch key {
 		case "AMIKA_API_URL", "AMIKA_API_KEY":
 			t.Setenv(key, value)
+		case "HOME":
+			home = value
 		}
 	}
+	return home
 }
 
 func TestSSHKeyListInProcess(t *testing.T) {
@@ -627,10 +665,8 @@ func TestSSHKeyPushInProcess_SameMaterialIsNoOpWithoutForce(t *testing.T) {
 }
 
 func TestSSHKeyPushInProcess_DefaultFromFile(t *testing.T) {
-	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
-		t.Fatal(err)
-	}
+	api := &sshKeyAPI{}
+	home := setupInProcessSSHKeyAPI(t, api)
 	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
 	raw, err := os.ReadFile(pubPath)
 	if err != nil {
@@ -641,10 +677,6 @@ func TestSSHKeyPushInProcess_DefaultFromFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(home, ".ssh", "amika_id_ed25519.pub"), raw, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", home)
-
-	api := &sshKeyAPI{}
-	setupInProcessSSHKeyAPI(t, api)
 
 	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push", "--name", "laptop")
 	if err != nil {
@@ -767,28 +799,10 @@ func writeTestKeypair(t *testing.T, dir string) string {
 	return keyPath
 }
 
-// isolateSSHHome points HOME and the state dir at fresh directories, so a test
-// that writes SSH config cannot touch the developer's own. Returns the home.
-func isolateSSHHome(t *testing.T) string {
-	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	// Set explicitly rather than relying on the HOME fallback: an inherited
-	// XDG_STATE_HOME would otherwise put ssh-hosts.json outside the temp home.
-	t.Setenv("XDG_STATE_HOME", filepath.Join(home, "state"))
-	sshDir := filepath.Join(home, ".ssh")
-	if err := os.MkdirAll(sshDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	return home
-}
-
 func TestSSHKeyPushInProcess_RegistersManagedSSHEntry(t *testing.T) {
-	home := isolateSSHHome(t)
-	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
-
 	api := &sshKeyAPI{}
-	setupInProcessSSHKeyAPI(t, api)
+	home := setupInProcessSSHKeyAPI(t, api)
+	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
 
 	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
 		"--name", "laptop", "--from-file", keyPath+".pub")
@@ -834,7 +848,7 @@ func TestSSHKeyPushInProcess_RegistersManagedSSHEntry(t *testing.T) {
 // `IdentitiesOnly yes`. Re-pointing it here would offer OpenSSH only the newest
 // key and cut off every sandbox provisioned against the first.
 func TestSSHKeyPushInProcess_SecondPushDoesNotRepointTheIdentity(t *testing.T) {
-	home := isolateSSHHome(t)
+	home := setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
 	firstKey := writeTestKeypair(t, filepath.Join(home, ".ssh"))
 	// A second, complete keypair: adopting it is exactly what must not happen.
 	secondDir := filepath.Join(home, "other")
@@ -842,8 +856,6 @@ func TestSSHKeyPushInProcess_SecondPushDoesNotRepointTheIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	secondKey := writeTestKeypair(t, secondDir)
-
-	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
 
 	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
 		"--name", "laptop", "--from-file", firstKey+".pub"); err != nil {
@@ -867,7 +879,7 @@ func TestSSHKeyPushInProcess_SecondPushDoesNotRepointTheIdentity(t *testing.T) {
 	}
 	// The reader has just uploaded a key the entry does not name, so the line
 	// has to say which one it does name.
-	if !strings.Contains(out, "unchanged") || !strings.Contains(out, firstKey) {
+	if !strings.Contains(out, "still authenticates with "+firstKey) {
 		t.Errorf("output should name the identity still in effect: %s", out)
 	}
 }
@@ -875,10 +887,8 @@ func TestSSHKeyPushInProcess_SecondPushDoesNotRepointTheIdentity(t *testing.T) {
 // Idempotent in the strict sense: pushing the same key again reproduces the
 // same files, so a re-run cannot drift the config it wrote the first time.
 func TestSSHKeyPushInProcess_RepeatPushRewritesTheSameEntry(t *testing.T) {
-	home := isolateSSHHome(t)
+	home := setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
 	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
-
-	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
 
 	read := func() (string, string) {
 		t.Helper()
@@ -899,6 +909,19 @@ func TestSSHKeyPushInProcess_RepeatPushRewritesTheSameEntry(t *testing.T) {
 	}
 	firstConf, firstState := read()
 
+	// Deleting the generated files between the pushes is what makes this test
+	// mean something. Comparing two runs alone cannot tell "rewrote the same
+	// bytes" from "wrote nothing at all" — `Render` is deterministic and every
+	// input is held constant — so it stayed green with the whole non-adopting
+	// write deleted. Restoring them is also the behaviour the write is there
+	// for: a hand-deleted amika.conf or a stripped Include heals on the next
+	// push, rather than staying broken until a sandbox command is run.
+	for _, name := range []string{"amika.conf", "config"} {
+		if err := os.Remove(filepath.Join(home, ".ssh", name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
 		"--name", "laptop", "--from-file", keyPath+".pub"); err != nil {
 		t.Fatalf("second push failed: %v\n%s", err, out)
@@ -906,12 +929,19 @@ func TestSSHKeyPushInProcess_RepeatPushRewritesTheSameEntry(t *testing.T) {
 	secondConf, secondState := read()
 
 	if firstConf != secondConf {
-		t.Errorf("amika.conf changed on a repeat push:\n--- first ---\n%s\n--- second ---\n%s",
+		t.Errorf("amika.conf was not restored identically:\n--- first ---\n%s\n--- second ---\n%s",
 			firstConf, secondConf)
 	}
 	if firstState != secondState {
 		t.Errorf("ssh-hosts.json changed on a repeat push:\n--- first ---\n%s\n--- second ---\n%s",
 			firstState, secondState)
+	}
+	config, err := os.ReadFile(filepath.Join(home, ".ssh", "config"))
+	if err != nil {
+		t.Fatalf("~/.ssh/config was not restored: %v", err)
+	}
+	if !strings.Contains(string(config), "Include amika.conf") {
+		t.Errorf("the Include was not restored:\n%s", config)
 	}
 }
 
@@ -919,11 +949,9 @@ func TestSSHKeyPushInProcess_RepeatPushRewritesTheSameEntry(t *testing.T) {
 // that is not adopting one has no use for the private half at all. Before this
 // rule the resolution ran first and its failure suppressed the write.
 func TestSSHKeyPushInProcess_LaterPushNeedsNoPrivateKey(t *testing.T) {
-	home := isolateSSHHome(t)
+	home := setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
 	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
 	orphan, _ := writeTestPubKey(t, t.TempDir(), "elsewhere@host")
-
-	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
 
 	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
 		"--name", "laptop", "--from-file", keyPath+".pub"); err != nil {
@@ -935,22 +963,94 @@ func TestSSHKeyPushInProcess_LaterPushNeedsNoPrivateKey(t *testing.T) {
 		t.Fatalf("push of a key with no private half failed: %v\n%s", err, out)
 	}
 
-	// Reported as unchanged, not as skipped: nothing was missing, because
-	// nothing was needed.
-	if !strings.Contains(out, "unchanged") {
-		t.Errorf("output should report the entry unchanged: %s", out)
+	// Reported as still in effect, not as skipped: nothing was missing,
+	// because nothing was needed.
+	if !strings.Contains(out, "still authenticates with "+keyPath) {
+		t.Errorf("output should report the identity still in effect: %s", out)
+	}
+	if strings.Contains(out, "Left the managed SSH host entry alone") {
+		t.Errorf("no private key was needed, so nothing should have been skipped: %s", out)
+	}
+}
+
+// Refusing to re-point is the rule; saying nothing while re-rendering a config
+// that selects a deleted file is not part of it. The notice is the only place
+// the reader could learn their entry is dead, so it must not read as fine.
+func TestSSHKeyPushInProcess_ReportsARegisteredIdentityThatHasGone(t *testing.T) {
+	api := &sshKeyAPI{}
+	home := setupInProcessSSHKeyAPI(t, api)
+	firstKey := writeTestKeypair(t, filepath.Join(home, ".ssh"))
+
+	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", firstKey+".pub"); err != nil {
+		t.Fatalf("first push failed: %v\n%s", err, out)
+	}
+	// The adopted private key goes away behind the entry's back.
+	if err := os.Remove(firstKey); err != nil {
+		t.Fatal(err)
+	}
+
+	secondDir := filepath.Join(home, "other")
+	if err := os.MkdirAll(secondDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secondKey := writeTestKeypair(t, secondDir)
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "work", "--from-file", secondKey+".pub")
+	if err != nil {
+		t.Fatalf("second push failed: %v\n%s", err, out)
+	}
+
+	// Still not re-pointed — that is the rule, and a dead identity is not a
+	// licence to break it.
+	conf, err := os.ReadFile(filepath.Join(home, ".ssh", "amika.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(conf), "IdentityFile "+firstKey) {
+		t.Errorf("a dead identity was silently replaced:\n%s", conf)
+	}
+	if !strings.Contains(out, "missing or not owner-only") {
+		t.Errorf("output should say the entry names an unusable key: %s", out)
+	}
+	if !strings.Contains(out, "ssh-key create") {
+		t.Errorf("output should name the command that fixes it: %s", out)
+	}
+}
+
+// Same rule, the other way an identity stops being usable: OpenSSH refuses a
+// private key anyone but its owner can read, and so does `PrepareSessionTarget`
+// before it dials.
+func TestSSHKeyPushInProcess_ReportsARegisteredIdentityGoneWorldReadable(t *testing.T) {
+	api := &sshKeyAPI{}
+	home := setupInProcessSSHKeyAPI(t, api)
+	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
+
+	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", keyPath+".pub"); err != nil {
+		t.Fatalf("first push failed: %v\n%s", err, out)
+	}
+	if err := os.Chmod(keyPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", keyPath+".pub")
+	if err != nil {
+		t.Fatalf("second push failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "missing or not owner-only") {
+		t.Errorf("output should say the entry names an unusable key: %s", out)
 	}
 }
 
 func TestSSHKeyPushInProcess_UploadsWithoutRegisteringWhenPrivateKeyIsMissing(t *testing.T) {
-	home := isolateSSHHome(t)
+	api := &sshKeyAPI{}
+	home := setupInProcessSSHKeyAPI(t, api)
 	// A .pub with no private half beside it: a legitimate thing to push (the
 	// private key may live on another machine), and nothing a usable local
 	// config can be written from.
 	pubPath, canonical := writeTestPubKey(t, t.TempDir(), "me@host")
-
-	api := &sshKeyAPI{}
-	setupInProcessSSHKeyAPI(t, api)
 
 	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
 		"--name", "laptop", "--from-file", pubPath)
@@ -973,16 +1073,14 @@ func TestSSHKeyPushInProcess_UploadsWithoutRegisteringWhenPrivateKeyIsMissing(t 
 }
 
 func TestSSHKeyPushInProcess_DoesNotRegisterWhenUploadRefused(t *testing.T) {
-	home := isolateSSHHome(t)
-	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
-
 	// A different key already stored under this name, so the upload is
 	// refused without --force.
 	api := &sshKeyAPI{existing: []map[string]string{
 		{"id": "specsec_old", "name": "laptop",
 			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
 	}}
-	setupInProcessSSHKeyAPI(t, api)
+	home := setupInProcessSSHKeyAPI(t, api)
+	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
 
 	_, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
 		"--name", "laptop", "--from-file", keyPath+".pub")
@@ -1000,16 +1098,15 @@ func TestSSHKeyPushInProcess_DoesNotRegisterWhenUploadRefused(t *testing.T) {
 }
 
 func TestSSHKeygenInProcess_DoesNotPersistSessionWhenUploadRefused(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
 	// A key already stored under this name, with different material, so the
 	// upload is refused without --force.
 	api := &sshKeyAPI{existing: []map[string]string{
 		{"id": "specsec_old", "name": "default",
 			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
 	}}
-	setupInProcessSSHKeyAPI(t, api)
+	// The home the assertion below reads has to be the one the command wrote
+	// to, so it comes from the setup rather than being set alongside it.
+	home := setupInProcessSSHKeyAPI(t, api)
 
 	_, err := runRootCommandOutput(t, "secret", "ssh-keygen")
 	if err == nil {
@@ -1030,8 +1127,14 @@ func TestSSHKeygenInProcess_DoesNotPersistSessionWhenUploadRefused(t *testing.T)
 }
 
 func TestSSHKeygenInProcess_DoesNotUploadWhenSessionConfigIsInvalid(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	// A different key is already stored under this name, so --force would
+	// replace it. If validation ran after the upload, the remote key would be
+	// gone while the local config still selected the old identity.
+	api := &sshKeyAPI{existing: []map[string]string{
+		{"id": "specsec_old", "name": "default",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
+	}}
+	home := setupInProcessSSHKeyAPI(t, api)
 
 	// An --import path containing whitespace is a perfectly valid file but a
 	// config `ConfigureSession` refuses, because OpenSSH cannot express it.
@@ -1044,15 +1147,6 @@ func TestSSHKeygenInProcess_DoesNotUploadWhenSessionConfigIsInvalid(t *testing.T
 		"-f", keyPath).CombinedOutput(); err != nil {
 		t.Fatalf("ssh-keygen: %v\n%s", err, out)
 	}
-
-	// A different key is already stored under this name, so --force would
-	// replace it. If validation ran after the upload, the remote key would be
-	// gone while the local config still selected the old identity.
-	api := &sshKeyAPI{existing: []map[string]string{
-		{"id": "specsec_old", "name": "default",
-			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabcdefghijkl", "scope": "user"},
-	}}
-	setupInProcessSSHKeyAPI(t, api)
 
 	_, err := runRootCommandOutput(t, "secret", "ssh-keygen",
 		"--import", keyPath+".pub", "--force")

--- a/go/cmd/amika/ssh_key_test.go
+++ b/go/cmd/amika/ssh_key_test.go
@@ -828,6 +828,120 @@ func TestSSHKeyPushInProcess_RegistersManagedSSHEntry(t *testing.T) {
 	}
 }
 
+// The reason later pushes must not adopt: uploaded keys are a set, so a second
+// push authorizes another key rather than replacing one — while the entry names
+// the single identity every connection authenticates with, under
+// `IdentitiesOnly yes`. Re-pointing it here would offer OpenSSH only the newest
+// key and cut off every sandbox provisioned against the first.
+func TestSSHKeyPushInProcess_SecondPushDoesNotRepointTheIdentity(t *testing.T) {
+	home := isolateSSHHome(t)
+	firstKey := writeTestKeypair(t, filepath.Join(home, ".ssh"))
+	// A second, complete keypair: adopting it is exactly what must not happen.
+	secondDir := filepath.Join(home, "other")
+	if err := os.MkdirAll(secondDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secondKey := writeTestKeypair(t, secondDir)
+
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+
+	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", firstKey+".pub"); err != nil {
+		t.Fatalf("first push failed: %v\n%s", err, out)
+	}
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "work", "--from-file", secondKey+".pub")
+	if err != nil {
+		t.Fatalf("second push failed: %v\n%s", err, out)
+	}
+
+	conf, err := os.ReadFile(filepath.Join(home, ".ssh", "amika.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(conf), "IdentityFile "+firstKey) {
+		t.Errorf("the second push moved the entry off the adopted key:\n%s", conf)
+	}
+	if strings.Contains(string(conf), secondKey) {
+		t.Errorf("the second push adopted its own key:\n%s", conf)
+	}
+	// The reader has just uploaded a key the entry does not name, so the line
+	// has to say which one it does name.
+	if !strings.Contains(out, "unchanged") || !strings.Contains(out, firstKey) {
+		t.Errorf("output should name the identity still in effect: %s", out)
+	}
+}
+
+// Idempotent in the strict sense: pushing the same key again reproduces the
+// same files, so a re-run cannot drift the config it wrote the first time.
+func TestSSHKeyPushInProcess_RepeatPushRewritesTheSameEntry(t *testing.T) {
+	home := isolateSSHHome(t)
+	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
+
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+
+	read := func() (string, string) {
+		t.Helper()
+		conf, err := os.ReadFile(filepath.Join(home, ".ssh", "amika.conf"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		state, err := os.ReadFile(filepath.Join(home, "state", "amika", "ssh-hosts.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(conf), string(state)
+	}
+
+	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", keyPath+".pub"); err != nil {
+		t.Fatalf("first push failed: %v\n%s", err, out)
+	}
+	firstConf, firstState := read()
+
+	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", keyPath+".pub"); err != nil {
+		t.Fatalf("second push failed: %v\n%s", err, out)
+	}
+	secondConf, secondState := read()
+
+	if firstConf != secondConf {
+		t.Errorf("amika.conf changed on a repeat push:\n--- first ---\n%s\n--- second ---\n%s",
+			firstConf, secondConf)
+	}
+	if firstState != secondState {
+		t.Errorf("ssh-hosts.json changed on a repeat push:\n--- first ---\n%s\n--- second ---\n%s",
+			firstState, secondState)
+	}
+}
+
+// An adopted entry is the machine's answer to "which private key", so a push
+// that is not adopting one has no use for the private half at all. Before this
+// rule the resolution ran first and its failure suppressed the write.
+func TestSSHKeyPushInProcess_LaterPushNeedsNoPrivateKey(t *testing.T) {
+	home := isolateSSHHome(t)
+	keyPath := writeTestKeypair(t, filepath.Join(home, ".ssh"))
+	orphan, _ := writeTestPubKey(t, t.TempDir(), "elsewhere@host")
+
+	setupInProcessSSHKeyAPI(t, &sshKeyAPI{})
+
+	if out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "laptop", "--from-file", keyPath+".pub"); err != nil {
+		t.Fatalf("first push failed: %v\n%s", err, out)
+	}
+	out, err := runRootCommandOutput(t, "secret", "ssh-key", "push",
+		"--name", "remote", "--from-file", orphan)
+	if err != nil {
+		t.Fatalf("push of a key with no private half failed: %v\n%s", err, out)
+	}
+
+	// Reported as unchanged, not as skipped: nothing was missing, because
+	// nothing was needed.
+	if !strings.Contains(out, "unchanged") {
+		t.Errorf("output should report the entry unchanged: %s", out)
+	}
+}
+
 func TestSSHKeyPushInProcess_UploadsWithoutRegisteringWhenPrivateKeyIsMissing(t *testing.T) {
 	home := isolateSSHHome(t)
 	// A .pub with no private half beside it: a legitimate thing to push (the

--- a/go/cmd/amika/ssh_keygen.go
+++ b/go/cmd/amika/ssh_keygen.go
@@ -51,14 +51,6 @@ func newSSHKeygenCmdAs(use string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			knownHostsPath, err := paths.SSHKnownHostsFile()
-			if err != nil {
-				return err
-			}
-			session := ssh.SessionConfig{
-				IdentityFile:   identityPath,
-				KnownHostsFile: knownHostsPath,
-			}
 
 			// Order matters in both directions, because the upload and the
 			// local SSH config have to end up describing the same keypair.
@@ -73,7 +65,11 @@ func newSSHKeygenCmdAs(use string) *cobra.Command {
 			// upload (the name already holds different material and --force
 			// was not passed) must not leave the config pointing at a private
 			// key whose public half was never stored.
-			if err := ssh.ValidateSessionConfig(session); err != nil {
+			//
+			// `ssh-key push` builds and validates its session through the same
+			// helper, for the same reasons.
+			session, err := sshSessionFor(paths, identityPath)
+			if err != nil {
 				return err
 			}
 


### PR DESCRIPTION
## What

The first `amika secret ssh-key push` on a machine now writes the Amika-managed SSH entry for the key it uploads, the way `secret ssh-keygen` already does. Later pushes leave that entry alone.

## Why

A machine's managed SSH entry — the identity in `ssh-hosts.json`, the `~/.ssh/amika.conf` rendered from it, and the `Include` in `~/.ssh/config` — is written by `ssh-keygen` and by nothing else at key-upload time. A user whose only key arrived via `push` therefore had a key the sandbox authorizes and no local config naming it.

**What that does *not* break, contrary to the first draft of this PR:** `amika sandbox ssh` and `sandbox code` are fine either way. `PrepareSessionTarget` calls `ConfigureSession` itself and falls back to `~/.ssh/amika_id_ed25519`, so for the default `--from-file` the entry this writes is what the next sandbox command would have written anyway.

**What it does fix** is everything that hands an `amika` host alias straight to OpenSSH without the CLI in the loop — the `cmux://` and `cursor://` links the web app offers. Those resolve the alias through `~/.ssh/config`, so on a machine where no sandbox command has ever run they need the entry to exist already.

## Why later pushes must not adopt

This is the part worth reviewing. Uploaded keys are a **set**, keyed by name: `push --name work` authorizes a second key alongside the first. The session identity is a **single value**, shared by every environment and rendered under `IdentitiesOnly yes`.

So adopting each pushed key would silently re-point every sandbox connection at the newest one, and `IdentitiesOnly` means OpenSSH then offers nothing else — locking the user out of every sandbox provisioned against the previous key, with no message. `planSSHEntry` therefore adopts only when nothing is registered; `secret ssh-keygen` stays the command for deliberately changing which identity is in effect.

A repeat push re-renders the same entry from the same identity, so it is idempotent in the strict sense — a test compares the two files byte-for-byte. And a push that adopts nothing needs no private key at all, which is why the resolution sits behind the check.

## Also

- A `ConfigureSession` failure *after* a successful upload no longer exits non-zero. The key is stored; claiming the push failed sends a caller to a `--force` it does not need.
- The notice names the identity the entry holds even when unchanged — after a later push that is not the key just uploaded, and a `--force` replace can leave it naming material the server no longer stores.
- Resolve errors are wrapped with the path they concern. A key path containing a space used to surface as `invalid Amika SSH host alias`, which names an alias nobody asked for.
- Notices are text-mode only (`format.Progress`), per AGENTS.md "stdout carries only the JSON value". `-o json` is unchanged: exactly the API's `SshPublicKeySummary`.

## Tests

Six around push now: the entry is written on the first push; a second push does **not** re-point it (mutation-checked — flipping the guard fails it); a repeat push reproduces both files byte-for-byte; a later push of a `.pub` with no private half succeeds and reports unchanged; a first push of such a `.pub` uploads and reports the skip; a refused upload writes nothing.

`make lint`, `go vet`, `gofmt`, `go test ./cmd/amika/... ./internal/ssh/...` clean.

## Review note

An earlier revision of this branch registered on *every* push and claimed in the docs that it was what made `sandbox ssh` work. Both were wrong, and both are fixed in the second commit; the docs now describe the deep-link case instead.