### PR TITLE
Reject reserved container ports on sandbox create and API paths

### DIFF
--- a/go/cmd/amika/sandbox/sandbox_create_mounts.go
+++ b/go/cmd/amika/sandbox/sandbox_create_mounts.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gofixpoint/amika/go/internal/gitrepo"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
+	"github.com/gofixpoint/amika/go/internal/services"
 	"github.com/gofixpoint/amika/go/pkg/amika"
 )
 
@@ -54,8 +55,10 @@ func parsePortFlags(flags []string, hostIP string) ([]sandbox.PortBinding, error
 		if hostPort < 1 || hostPort > 65535 {
 			return nil, fmt.Errorf("host port %d must be between 1 and 65535", hostPort)
 		}
-		if containerPort < 1 || containerPort > 65535 {
-			return nil, fmt.Errorf("container port %d must be between 1 and 65535", containerPort)
+		// Only the container side is reserved: publishing the host's 60998 is
+		// fine, binding a user service to container port 60998 is not.
+		if err := services.ValidatePort(containerPort); err != nil {
+			return nil, err
 		}
 
 		key := fmt.Sprintf("%s:%d/%s", hostIP, hostPort, protocol)

--- a/go/cmd/amika/sandbox/sandbox_flags_test.go
+++ b/go/cmd/amika/sandbox/sandbox_flags_test.go
@@ -214,6 +214,36 @@ func TestParsePortFlags(t *testing.T) {
 			hostIP:  " ",
 			wantErr: true,
 		},
+		{
+			name:    "reserved container port low boundary",
+			flags:   []string{"8080:60899"},
+			hostIP:  "127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "reserved container port opencode web",
+			flags:   []string{"8080:60998"},
+			hostIP:  "127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "reserved container port high boundary",
+			flags:   []string{"8080:60999"},
+			hostIP:  "127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "container port just above reserved",
+			flags:   []string{"8080:61000"},
+			hostIP:  "127.0.0.1",
+			wantLen: 1,
+		},
+		{
+			name:    "host port inside reserved range is allowed",
+			flags:   []string{"60998:8080"},
+			hostIP:  "127.0.0.1",
+			wantLen: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/internal/app/service_impl.go
+++ b/go/internal/app/service_impl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/auth"
 	"github.com/gofixpoint/amika/go/internal/materialize"
 	"github.com/gofixpoint/amika/go/internal/ports"
+	"github.com/gofixpoint/amika/go/internal/services"
 	"github.com/gofixpoint/amika/go/pkg/amika"
 )
 
@@ -368,8 +369,9 @@ func normalizePortBindings(in []amika.PortBinding) ([]amika.PortBinding, error) 
 		if p.HostPort < 1 || p.HostPort > 65535 {
 			return nil, fmt.Errorf("%w: HostPort %d must be between 1 and 65535", amika.ErrInvalidArgument, p.HostPort)
 		}
-		if p.ContainerPort < 1 || p.ContainerPort > 65535 {
-			return nil, fmt.Errorf("%w: ContainerPort %d must be between 1 and 65535", amika.ErrInvalidArgument, p.ContainerPort)
+		// Only the container side is reserved (see services.ValidatePort).
+		if err := services.ValidatePort(p.ContainerPort); err != nil {
+			return nil, fmt.Errorf("%w: %v", amika.ErrInvalidArgument, err)
 		}
 		protocol := strings.ToLower(strings.TrimSpace(p.Protocol))
 		if protocol == "" {

--- a/go/internal/services/services.go
+++ b/go/internal/services/services.go
@@ -2,17 +2,23 @@
 // consistent across the CLI and the HTTP API, such as port validation rules.
 package services
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/gofixpoint/amika/go/internal/constants"
+)
 
 const (
 	// ReservedPortMin is the inclusive lower bound of the container port range
-	// Amika reserves for its own internal sandbox services.
-	ReservedPortMin = 60899
+	// Amika reserves for its own internal sandbox services. It is an alias of
+	// constants.ReservedPortStart so the two cannot drift apart.
+	ReservedPortMin = constants.ReservedPortStart
 	// ReservedPortMax is the inclusive upper bound of the reserved range (e.g.
 	// the OpenCode web UI on 60998 and the amikad daemon on 60999). User
 	// services may not bind ports in this range. See
-	// docs/sandbox-configuration.md for the full allocation table.
-	ReservedPortMax = 60999
+	// docs/sandbox-configuration.md for the full allocation table. It is an
+	// alias of constants.ReservedPortEnd so the two cannot drift apart.
+	ReservedPortMax = constants.ReservedPortEnd
 )
 
 // ValidatePort reports whether port is a legal, user-assignable container port

--- a/go/pkg/amika/service.go
+++ b/go/pkg/amika/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gofixpoint/amika/go/internal/constants"
 	"github.com/gofixpoint/amika/go/internal/materialize"
 	"github.com/gofixpoint/amika/go/internal/sandbox"
+	"github.com/gofixpoint/amika/go/internal/services"
 )
 
 // Service defines the public API surface for running Amika operations from Go.
@@ -401,8 +402,11 @@ func normalizePortBindings(in []PortBinding) ([]PortBinding, error) {
 		if p.HostPort < 1 || p.HostPort > 65535 {
 			return nil, fmt.Errorf("%w: HostPort %d must be between 1 and 65535", ErrInvalidArgument, p.HostPort)
 		}
-		if p.ContainerPort < 1 || p.ContainerPort > 65535 {
-			return nil, fmt.Errorf("%w: ContainerPort %d must be between 1 and 65535", ErrInvalidArgument, p.ContainerPort)
+		// Only the container side is reserved: a host port inside the Amika
+		// reserved range is fine, a user service binding to a reserved
+		// container port (OpenCode web UI, amikad) is not.
+		if err := services.ValidatePort(p.ContainerPort); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
 		}
 		protocol := strings.ToLower(strings.TrimSpace(p.Protocol))
 		if protocol == "" {

--- a/go/pkg/amika/service_test.go
+++ b/go/pkg/amika/service_test.go
@@ -181,6 +181,24 @@ func TestCreateSandbox_InvalidPortBinding(t *testing.T) {
 	}
 }
 
+func TestCreateSandbox_ReservedContainerPort(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	svc := NewService(Options{})
+	for _, port := range []int{60899, 60998, 60999} {
+		_, err := svc.CreateSandbox(context.Background(), CreateSandboxRequest{
+			Provider: "docker",
+			Name:     "sb",
+			Image:    "img",
+			Ports: []PortBinding{
+				{HostIP: "127.0.0.1", HostPort: 8080, ContainerPort: port, Protocol: "tcp"},
+			},
+		})
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("container port %d: expected invalid argument, got %v", port, err)
+		}
+	}
+}
+
 func TestCreateSandbox_DuplicatePortBinding(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	svc := NewService(Options{})


### PR DESCRIPTION
## Problem

`sandbox create --port` and the API `CreateSandbox` request accepted container ports inside the Amika-reserved range 60899-60999 (see #420). A user could bind container port 60998 or 60999, colliding with the OpenCode web UI and the amikad daemon that the sandbox provisions on those ports.

Only `service create` validated the reserved range, via `services.ValidatePort` (go/cmd/amika/service.go). The two other paths that publish user port bindings only range-checked 1-65535:

1. CLI flag parsing: `parsePortFlags` in go/cmd/amika/sandbox/sandbox_create_mounts.go
2. Service/API path: `normalizePortBindings` in go/pkg/amika/service.go, reached via `POST /v1/sandboxes` (go/internal/httpapi/server.go)
3. The app service had the same gap in its own `normalizePortBindings` (go/internal/app/service_impl.go)

The repo-config service path already rejected reserved ports correctly (`internal/amikaconfig.validatePortNumber`), so the rule existed but was not applied to the flag and API port-binding inputs. AGENTS.md specifies that any command or API accepting a user container port must call `services.ValidatePort`, kept in sync client-side and server-side.

## Fix

All three paths now call `services.ValidatePort(containerPort)`. Errors surface as the existing validation messages: the CLI returns the "reserved for internal Amika services" error, and the service/API paths wrap it as `ErrInvalidArgument`.

Two deliberate details:

- Only the container port is validated against the reserved range. Host ports inside 60899-60999 remain allowed, since the reservation applies to container ports (docs/sandbox-configuration.md allocation table). Publishing a user service on the host's port 60998 is fine.
- `services.ReservedPortMin`/`ReservedPortMax` are now aliases of `constants.ReservedPortStart`/`ReservedPortEnd`, so the two independent definitions of the range cannot drift.

## Tests

- `TestParsePortFlags` gains cases rejecting container ports 60899, 60998, and 60999, accepting 61000, and accepting host port 60998.
- New `TestCreateSandbox_ReservedContainerPort` covers the service path end to end for 60899, 60998, and 60999.
- Existing `TestValidatePort` in internal/services already covers the range boundaries.

Verified with `go vet`, `make lint`, `make fmt`, `make build`, and fresh `go test` runs on the touched packages.

Fixes #420
