### PR TITLE
Re-apply auto-stop interval on Daytona start

### DIFF
--- a/js/sandbox/src/providers/daytona/internal/operations.ts
+++ b/js/sandbox/src/providers/daytona/internal/operations.ts
@@ -170,9 +170,17 @@ export async function listDaytonaSandboxes(
 export async function startDaytonaSandbox(
   config: DaytonaConfig,
   providerSandboxId: string,
+  autoStopInterval?: number | null,
 ): Promise<void> {
   const daytona = getDaytonaClient(config);
   const sandbox = await daytona.get(providerSandboxId);
+  // Re-apply the caller's interval before resuming, so a sandbox whose stored
+  // interval changed since create (an unapproved org's clamp) comes back on the
+  // current value rather than the one baked in server-side. Negatives are
+  // skipped: the SDK rejects anything but a non-negative integer.
+  if (autoStopInterval != null && autoStopInterval >= 0) {
+    await sandbox.setAutostopInterval(autoStopInterval);
+  }
   await sandbox.start();
 }
 

--- a/js/sandbox/src/providers/daytona/internal/sandbox-ops.test.ts
+++ b/js/sandbox/src/providers/daytona/internal/sandbox-ops.test.ts
@@ -4,7 +4,11 @@ import {
   SANDBOX_ENV_SECRETS_EXCLUDED_LABEL,
   SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
 } from "../../../constants";
-import { createDaytonaSandbox, deleteDaytonaSandbox } from "./operations";
+import {
+  createDaytonaSandbox,
+  deleteDaytonaSandbox,
+  startDaytonaSandbox,
+} from "./operations";
 
 vi.mock("@daytonaio/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@daytonaio/sdk")>();
@@ -293,5 +297,53 @@ describe("createDaytonaSandbox", () => {
     expect(body.labels[SANDBOX_ENV_SECRETS_EXCLUDED_LABEL]).toBe(
       SANDBOX_ENV_SECRETS_EXCLUDED_VALUE,
     );
+  });
+});
+
+describe("startDaytonaSandbox", () => {
+  function setupMockSandbox(): {
+    setAutostopInterval: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+  } {
+    const sandbox = {
+      setAutostopInterval: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(Daytona).mockImplementation(function () {
+      return {
+        get: vi.fn().mockResolvedValue(sandbox),
+      } as unknown as InstanceType<typeof Daytona>;
+    });
+    return sandbox;
+  }
+
+  it("re-applies the given interval before resuming", async () => {
+    const sandbox = setupMockSandbox();
+
+    await startDaytonaSandbox(testConfig(), "sandbox-1", 30);
+
+    expect(sandbox.setAutostopInterval).toHaveBeenCalledWith(30);
+    expect(sandbox.start).toHaveBeenCalledTimes(1);
+    expect(
+      sandbox.setAutostopInterval.mock.invocationCallOrder[0],
+    ).toBeLessThan(sandbox.start.mock.invocationCallOrder[0]);
+  });
+
+  it("leaves the server-side interval alone when none is given", async () => {
+    const sandbox = setupMockSandbox();
+
+    await startDaytonaSandbox(testConfig(), "sandbox-1");
+    await startDaytonaSandbox(testConfig(), "sandbox-1", null);
+
+    expect(sandbox.setAutostopInterval).not.toHaveBeenCalled();
+    expect(sandbox.start).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a never-auto-stop interval of 0", async () => {
+    const sandbox = setupMockSandbox();
+
+    await startDaytonaSandbox(testConfig(), "sandbox-1", 0);
+
+    expect(sandbox.setAutostopInterval).toHaveBeenCalledWith(0);
   });
 });

--- a/js/sandbox/src/providers/daytona/provider.ts
+++ b/js/sandbox/src/providers/daytona/provider.ts
@@ -57,9 +57,8 @@ export default defineProvider(daytonaCapabilities, (config: DaytonaConfig) => ({
     create: (ctx, input) => createDaytonaSandbox(ctx, config, input),
     delete: (id) => deleteDaytonaSandbox(config, id),
 
-    // Daytona persists the auto-stop interval server-side (set at create), so
-    // it does not need to be re-applied on start.
-    start: (id) => startDaytonaSandbox(config, id),
+    start: (id, autoStopInterval) =>
+      startDaytonaSandbox(config, id, autoStopInterval),
     stop: (id) => stopDaytonaSandbox(config, id),
     getState: (id) => getDaytonaSandboxState(config, id),
     mapState: mapDaytonaSandboxState,


### PR DESCRIPTION
`startDaytonaSandbox` dropped the `autoStopInterval` that the shared `Sandbox.start()` interface passes, so a Daytona sandbox always resumed with the interval baked in at create time. Thread the argument through and call `setAutostopInterval` before `start()` so callers can change the interval on resume (amika-mono clamps unapproved orgs' stored `0` = never-stop values on start). Negative values are skipped since the SDK rejects them.