### PR TITLE
Make state store writes atomic and serialize read-modify-write cycles

### DIFF
--- a/go/internal/sandbox/file_mount_store.go
+++ b/go/internal/sandbox/file_mount_store.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 )
 
@@ -71,51 +70,48 @@ func (s *fileFileMountStore) readAll() ([]FileMountInfo, error) {
 }
 
 func (s *fileFileMountStore) writeAll(mounts []FileMountInfo) error {
-	if err := os.MkdirAll(filepath.Dir(s.filePath), 0755); err != nil {
-		return fmt.Errorf("failed to create storage directory: %w", err)
-	}
-
-	f, err := os.Create(s.filePath)
+	lines, err := marshalJSONL(mounts, "file mount info")
 	if err != nil {
-		return fmt.Errorf("failed to create file mounts file: %w", err)
+		return err
 	}
-	defer f.Close()
-
-	for _, info := range mounts {
-		data, err := json.Marshal(info)
-		if err != nil {
-			return fmt.Errorf("failed to marshal file mount info: %w", err)
-		}
-		if _, err := f.Write(data); err != nil {
-			return fmt.Errorf("failed to write file mount info: %w", err)
-		}
-		if _, err := f.WriteString("\n"); err != nil {
-			return fmt.Errorf("failed to write newline: %w", err)
-		}
-	}
-
-	return nil
+	return writeJSONLAtomic(s.filePath, lines)
 }
 
-func (s *fileFileMountStore) Save(info FileMountInfo) error {
+// update runs fn over the current entries while holding the store's advisory
+// lock and atomically writes the result back, so concurrent processes cannot
+// drop each other's changes through last-writer-wins. A false changed skips
+// the write.
+func (s *fileFileMountStore) update(fn func(mounts []FileMountInfo) ([]FileMountInfo, bool, error)) error {
+	lock, err := lockStore(s.filePath)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+
 	mounts, err := s.readAll()
 	if err != nil {
 		return err
 	}
+	updated, changed, err := fn(mounts)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	return s.writeAll(updated)
+}
 
-	found := false
-	for i := range mounts {
-		if mounts[i].Name == info.Name {
-			mounts[i] = info
-			found = true
-			break
+func (s *fileFileMountStore) Save(info FileMountInfo) error {
+	return s.update(func(mounts []FileMountInfo) ([]FileMountInfo, bool, error) {
+		for i, m := range mounts {
+			if m.Name == info.Name {
+				mounts[i] = info
+				return mounts, true, nil
+			}
 		}
-	}
-	if !found {
-		mounts = append(mounts, info)
-	}
-
-	return s.writeAll(mounts)
+		return append(mounts, info), true, nil
+	})
 }
 
 func (s *fileFileMountStore) Get(name string) (FileMountInfo, error) {
@@ -133,23 +129,19 @@ func (s *fileFileMountStore) Get(name string) (FileMountInfo, error) {
 }
 
 func (s *fileFileMountStore) Remove(name string) error {
-	mounts, err := s.readAll()
-	if err != nil {
-		return err
-	}
-
-	var filtered []FileMountInfo
-	for _, m := range mounts {
-		if m.Name != name {
-			filtered = append(filtered, m)
+	return s.update(func(mounts []FileMountInfo) ([]FileMountInfo, bool, error) {
+		var filtered []FileMountInfo
+		for _, m := range mounts {
+			if m.Name != name {
+				filtered = append(filtered, m)
+			}
 		}
-	}
 
-	if len(filtered) == len(mounts) {
-		return nil
-	}
-
-	return s.writeAll(filtered)
+		if len(filtered) == len(mounts) {
+			return mounts, false, nil
+		}
+		return filtered, true, nil
+	})
 }
 
 func (s *fileFileMountStore) List() ([]FileMountInfo, error) {
@@ -157,31 +149,39 @@ func (s *fileFileMountStore) List() ([]FileMountInfo, error) {
 }
 
 func (s *fileFileMountStore) AddSandboxRef(name, sandbox string) error {
-	info, err := s.Get(name)
-	if err != nil {
-		return err
-	}
-
-	if !slices.Contains(info.SandboxRefs, sandbox) {
-		info.SandboxRefs = append(info.SandboxRefs, sandbox)
-	}
-	return s.Save(info)
+	return s.update(func(mounts []FileMountInfo) ([]FileMountInfo, bool, error) {
+		for i, m := range mounts {
+			if m.Name != name {
+				continue
+			}
+			if !slices.Contains(m.SandboxRefs, sandbox) {
+				m.SandboxRefs = append(m.SandboxRefs, sandbox)
+				mounts[i] = m
+			}
+			return mounts, true, nil
+		}
+		return nil, false, fmt.Errorf("no file mount found with name: %s", name)
+	})
 }
 
 func (s *fileFileMountStore) RemoveSandboxRef(name, sandbox string) error {
-	info, err := s.Get(name)
-	if err != nil {
-		return err
-	}
-
-	refs := info.SandboxRefs[:0]
-	for _, ref := range info.SandboxRefs {
-		if ref != sandbox {
-			refs = append(refs, ref)
+	return s.update(func(mounts []FileMountInfo) ([]FileMountInfo, bool, error) {
+		for i, m := range mounts {
+			if m.Name != name {
+				continue
+			}
+			refs := m.SandboxRefs[:0]
+			for _, ref := range m.SandboxRefs {
+				if ref != sandbox {
+					refs = append(refs, ref)
+				}
+			}
+			m.SandboxRefs = refs
+			mounts[i] = m
+			return mounts, true, nil
 		}
-	}
-	info.SandboxRefs = refs
-	return s.Save(info)
+		return nil, false, fmt.Errorf("no file mount found with name: %s", name)
+	})
 }
 
 func (s *fileFileMountStore) FileMountsForSandbox(sandbox string) ([]FileMountInfo, error) {

--- a/go/internal/sandbox/store.go
+++ b/go/internal/sandbox/store.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 )
 
 // MountBinding represents a host directory mounted into a sandbox.
@@ -113,51 +112,51 @@ func (s *fileStore) readAll() ([]Info, error) {
 }
 
 func (s *fileStore) writeAll(sandboxes []Info) error {
-	if err := os.MkdirAll(filepath.Dir(s.filePath), 0755); err != nil {
-		return fmt.Errorf("failed to create storage directory: %w", err)
-	}
-
-	f, err := os.Create(s.filePath)
+	lines, err := marshalJSONL(sandboxes, "sandbox info")
 	if err != nil {
-		return fmt.Errorf("failed to create sandboxes file: %w", err)
+		return err
 	}
-	defer f.Close()
-
-	for _, info := range sandboxes {
-		data, err := json.Marshal(info)
-		if err != nil {
-			return fmt.Errorf("failed to marshal sandbox info: %w", err)
-		}
-		if _, err := f.Write(data); err != nil {
-			return fmt.Errorf("failed to write sandbox info: %w", err)
-		}
-		if _, err := f.WriteString("\n"); err != nil {
-			return fmt.Errorf("failed to write newline: %w", err)
-		}
-	}
-	return nil
+	return writeJSONLAtomic(s.filePath, lines)
 }
 
-func (s *fileStore) Save(info Info) error {
+// update runs fn over the current entries while holding the store's advisory
+// lock and atomically writes the result back. Holding the lock across the
+// whole read-modify-write cycle prevents concurrent processes (separate CLI
+// runs, amika-server) from silently dropping each other's changes through
+// last-writer-wins. A false changed skips the write, leaving the file (and
+// its mtime) untouched.
+func (s *fileStore) update(fn func(sandboxes []Info) ([]Info, bool, error)) error {
+	lock, err := lockStore(s.filePath)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+
 	sandboxes, err := s.readAll()
 	if err != nil {
 		return err
 	}
+	updated, changed, err := fn(sandboxes)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	return s.writeAll(updated)
+}
 
-	// Replace existing sandbox with same name, or append
-	found := false
-	for i, sb := range sandboxes {
-		if sb.Name == info.Name {
-			sandboxes[i] = info
-			found = true
-			break
+func (s *fileStore) Save(info Info) error {
+	return s.update(func(sandboxes []Info) ([]Info, bool, error) {
+		// Replace existing sandbox with same name, or append
+		for i, sb := range sandboxes {
+			if sb.Name == info.Name {
+				sandboxes[i] = info
+				return sandboxes, true, nil
+			}
 		}
-	}
-	if !found {
-		sandboxes = append(sandboxes, info)
-	}
-
-	return s.writeAll(sandboxes)
+		return append(sandboxes, info), true, nil
+	})
 }
 
 func (s *fileStore) Get(name string) (Info, error) {
@@ -175,23 +174,19 @@ func (s *fileStore) Get(name string) (Info, error) {
 }
 
 func (s *fileStore) Remove(name string) error {
-	sandboxes, err := s.readAll()
-	if err != nil {
-		return err
-	}
-
-	var filtered []Info
-	for _, sb := range sandboxes {
-		if sb.Name != name {
-			filtered = append(filtered, sb)
+	return s.update(func(sandboxes []Info) ([]Info, bool, error) {
+		var filtered []Info
+		for _, sb := range sandboxes {
+			if sb.Name != name {
+				filtered = append(filtered, sb)
+			}
 		}
-	}
 
-	if len(filtered) == len(sandboxes) {
-		return nil
-	}
-
-	return s.writeAll(filtered)
+		if len(filtered) == len(sandboxes) {
+			return sandboxes, false, nil
+		}
+		return filtered, true, nil
+	})
 }
 
 func (s *fileStore) List() ([]Info, error) {

--- a/go/internal/sandbox/store_atomic_test.go
+++ b/go/internal/sandbox/store_atomic_test.go
@@ -1,0 +1,209 @@
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestStore_ConcurrentSavesKeepAllEntries drives concurrent Save calls for
+// distinct names through one store. Each Save is a read-modify-write cycle, so
+// without the advisory lock the goroutines overwrite each other's changes and
+// the final file silently loses entries.
+func TestStore_ConcurrentSavesKeepAllEntries(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "sandboxes.jsonl"))
+
+	const n = 32
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			info := Info{Name: fmt.Sprintf("sb-%02d", i), Provider: "docker"}
+			if err := store.Save(info); err != nil {
+				t.Errorf("Save sb-%02d: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	sandboxes, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sandboxes) != n {
+		t.Fatalf("List returned %d sandboxes, want %d", len(sandboxes), n)
+	}
+}
+
+// TestStore_ConcurrentSavesAndRemoves mixes adds and removes so the final
+// state must reflect both sides of the interleaving, not whichever writer
+// happened to flush last.
+func TestStore_ConcurrentSavesAndRemoves(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "sandboxes.jsonl"))
+
+	const n = 16
+	for i := range n {
+		if err := store.Save(Info{Name: fmt.Sprintf("gone-%02d", i)}); err != nil {
+			t.Fatalf("seed Save: %v", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := store.Save(Info{Name: fmt.Sprintf("kept-%02d", i)}); err != nil {
+				t.Errorf("Save kept-%02d: %v", i, err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if err := store.Remove(fmt.Sprintf("gone-%02d", i)); err != nil {
+				t.Errorf("Remove gone-%02d: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	sandboxes, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sandboxes) != n {
+		t.Fatalf("List returned %d sandboxes, want %d", len(sandboxes), n)
+	}
+	for _, sb := range sandboxes {
+		if len(sb.Name) > 4 && sb.Name[:4] == "gone" {
+			t.Errorf("sandbox %q should have been removed", sb.Name)
+		}
+	}
+}
+
+// TestStore_WriteLeavesNoTempFiles verifies the atomic write cleans up its
+// temp file after success.
+func TestStore_WriteLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "sandboxes.jsonl"))
+	if err := store.Save(Info{Name: "sb"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "sandboxes.jsonl.tmp-*"))
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("leftover temp files after Save: %v", matches)
+	}
+}
+
+// TestWriteJSONLAtomic_ErrorKeepsOriginalFile verifies a failed write leaves
+// the previous file content intact rather than truncating it.
+func TestWriteJSONLAtomic_ErrorKeepsOriginalFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.jsonl")
+	if err := writeJSONLAtomic(path, [][]byte{[]byte(`{"name":"original"}`)}); err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+
+	// Make the directory unwritable so creating the temp file fails.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	if err := writeJSONLAtomic(path, [][]byte{[]byte(`{"name":"replacement"}`)}); err == nil {
+		t.Fatal("expected write error on read-only directory")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != `{"name":"original"}`+"\n" {
+		t.Fatalf("original file content changed after failed write: %q", data)
+	}
+}
+
+// TestVolumeStore_ConcurrentRefUpdates drives concurrent AddSandboxRef calls
+// for distinct sandboxes against one volume. Each call is a read-modify-write
+// cycle, so without the lock earlier updates are lost and final SandboxRefs
+// ends up shorter than the number of writers.
+func TestVolumeStore_ConcurrentRefUpdates(t *testing.T) {
+	dir := t.TempDir()
+	store := NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	if err := store.Save(VolumeInfo{Name: "vol"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	const n = 16
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := store.AddSandboxRef("vol", fmt.Sprintf("sb-%02d", i)); err != nil {
+				t.Errorf("AddSandboxRef sb-%02d: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	vol, err := store.Get("vol")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(vol.SandboxRefs) != n {
+		t.Fatalf("SandboxRefs has %d entries, want %d: %v", len(vol.SandboxRefs), n, vol.SandboxRefs)
+	}
+}
+
+// TestFileMountStore_ConcurrentRefUpdates is the file-mount counterpart of
+// TestVolumeStore_ConcurrentRefUpdates.
+func TestFileMountStore_ConcurrentRefUpdates(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileMountStore(filepath.Join(dir, "file-mounts.jsonl"))
+	if err := store.Save(FileMountInfo{Name: "fm", Type: "bind", CopyPath: "/copy"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	const n = 16
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := store.AddSandboxRef("fm", fmt.Sprintf("sb-%02d", i)); err != nil {
+				t.Errorf("AddSandboxRef sb-%02d: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	fm, err := store.Get("fm")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(fm.SandboxRefs) != n {
+		t.Fatalf("SandboxRefs has %d entries, want %d: %v", len(fm.SandboxRefs), n, fm.SandboxRefs)
+	}
+}
+
+// TestStore_RefUpdateOnMissingEntry pins the not-found error message that
+// AddSandboxRef previously surfaced through Get.
+func TestRefUpdateOnMissingEntry(t *testing.T) {
+	dir := t.TempDir()
+	volumes := NewVolumeStore(filepath.Join(dir, "volumes.jsonl"))
+	if err := volumes.AddSandboxRef("missing", "sb"); err == nil {
+		t.Fatal("expected error adding ref to missing volume")
+	}
+	mounts := NewFileMountStore(filepath.Join(dir, "file-mounts.jsonl"))
+	if err := mounts.AddSandboxRef("missing", "sb"); err == nil {
+		t.Fatal("expected error adding ref to missing file mount")
+	}
+}

--- a/go/internal/sandbox/store_write.go
+++ b/go/internal/sandbox/store_write.go
@@ -1,0 +1,90 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofixpoint/amika/go/internal/filelock"
+)
+
+// storeLockTimeout bounds how long a store mutation waits for its advisory
+// file lock. Mutations are short (read, rewrite a small JSONL file), so a
+// wedged holder should fail the operation rather than hang the caller.
+const storeLockTimeout = 10 * time.Second
+
+// lockStore takes the advisory lock that serializes read-modify-write cycles
+// on the store file at path. The lock file is path + ".lock", created next to
+// the store file.
+func lockStore(path string) (*filelock.Lock, error) {
+	// The lock file lives next to the store file, which may not exist yet on
+	// the very first Save.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create storage directory: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), storeLockTimeout)
+	defer cancel()
+	lock, err := filelock.Acquire(ctx, path+".lock")
+	if err != nil {
+		return nil, fmt.Errorf("locking store file %s: %w", path, err)
+	}
+	return lock, nil
+}
+
+// writeJSONLAtomic atomically replaces the JSONL file at path with the
+// marshaled lines: it writes a temp file in the same directory and renames it
+// over path, so a crash mid-write leaves the previous file intact instead of
+// truncating it to zero bytes. Lines must not carry trailing newlines.
+func writeJSONLAtomic(path string, lines [][]byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+
+	for _, line := range lines {
+		if _, err := tmp.Write(line); err != nil {
+			tmp.Close()
+			return fmt.Errorf("failed to write store file: %w", err)
+		}
+		if _, err := tmp.WriteString("\n"); err != nil {
+			tmp.Close()
+			return fmt.Errorf("failed to write newline: %w", err)
+		}
+	}
+	// Match the permissions os.Create produced before the store switched to
+	// atomic writes (0666 & umask, typically 0644).
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to set permissions on %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("failed to replace store file %s: %w", path, err)
+	}
+	return nil
+}
+
+// marshalJSONL marshals each entry as one JSON line.
+func marshalJSONL[T any](items []T, label string) ([][]byte, error) {
+	lines := make([][]byte, 0, len(items))
+	for _, item := range items {
+		data, err := json.Marshal(item)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal %s: %w", label, err)
+		}
+		lines = append(lines, data)
+	}
+	return lines, nil
+}

--- a/go/internal/sandbox/volume_store.go
+++ b/go/internal/sandbox/volume_store.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 )
 
@@ -69,51 +68,48 @@ func (s *fileVolumeStore) readAll() ([]VolumeInfo, error) {
 }
 
 func (s *fileVolumeStore) writeAll(volumes []VolumeInfo) error {
-	if err := os.MkdirAll(filepath.Dir(s.filePath), 0755); err != nil {
-		return fmt.Errorf("failed to create storage directory: %w", err)
-	}
-
-	f, err := os.Create(s.filePath)
+	lines, err := marshalJSONL(volumes, "volume info")
 	if err != nil {
-		return fmt.Errorf("failed to create volumes file: %w", err)
+		return err
 	}
-	defer f.Close()
-
-	for _, info := range volumes {
-		data, err := json.Marshal(info)
-		if err != nil {
-			return fmt.Errorf("failed to marshal volume info: %w", err)
-		}
-		if _, err := f.Write(data); err != nil {
-			return fmt.Errorf("failed to write volume info: %w", err)
-		}
-		if _, err := f.WriteString("\n"); err != nil {
-			return fmt.Errorf("failed to write newline: %w", err)
-		}
-	}
-
-	return nil
+	return writeJSONLAtomic(s.filePath, lines)
 }
 
-func (s *fileVolumeStore) Save(info VolumeInfo) error {
+// update runs fn over the current entries while holding the store's advisory
+// lock and atomically writes the result back, so concurrent processes cannot
+// drop each other's changes through last-writer-wins. A false changed skips
+// the write.
+func (s *fileVolumeStore) update(fn func(volumes []VolumeInfo) ([]VolumeInfo, bool, error)) error {
+	lock, err := lockStore(s.filePath)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+
 	volumes, err := s.readAll()
 	if err != nil {
 		return err
 	}
+	updated, changed, err := fn(volumes)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	return s.writeAll(updated)
+}
 
-	found := false
-	for i := range volumes {
-		if volumes[i].Name == info.Name {
-			volumes[i] = info
-			found = true
-			break
+func (s *fileVolumeStore) Save(info VolumeInfo) error {
+	return s.update(func(volumes []VolumeInfo) ([]VolumeInfo, bool, error) {
+		for i, v := range volumes {
+			if v.Name == info.Name {
+				volumes[i] = info
+				return volumes, true, nil
+			}
 		}
-	}
-	if !found {
-		volumes = append(volumes, info)
-	}
-
-	return s.writeAll(volumes)
+		return append(volumes, info), true, nil
+	})
 }
 
 func (s *fileVolumeStore) Get(name string) (VolumeInfo, error) {
@@ -131,23 +127,19 @@ func (s *fileVolumeStore) Get(name string) (VolumeInfo, error) {
 }
 
 func (s *fileVolumeStore) Remove(name string) error {
-	volumes, err := s.readAll()
-	if err != nil {
-		return err
-	}
-
-	var filtered []VolumeInfo
-	for _, v := range volumes {
-		if v.Name != name {
-			filtered = append(filtered, v)
+	return s.update(func(volumes []VolumeInfo) ([]VolumeInfo, bool, error) {
+		var filtered []VolumeInfo
+		for _, v := range volumes {
+			if v.Name != name {
+				filtered = append(filtered, v)
+			}
 		}
-	}
 
-	if len(filtered) == len(volumes) {
-		return nil
-	}
-
-	return s.writeAll(filtered)
+		if len(filtered) == len(volumes) {
+			return volumes, false, nil
+		}
+		return filtered, true, nil
+	})
 }
 
 func (s *fileVolumeStore) List() ([]VolumeInfo, error) {
@@ -155,31 +147,39 @@ func (s *fileVolumeStore) List() ([]VolumeInfo, error) {
 }
 
 func (s *fileVolumeStore) AddSandboxRef(name, sandbox string) error {
-	info, err := s.Get(name)
-	if err != nil {
-		return err
-	}
-
-	if !slices.Contains(info.SandboxRefs, sandbox) {
-		info.SandboxRefs = append(info.SandboxRefs, sandbox)
-	}
-	return s.Save(info)
+	return s.update(func(volumes []VolumeInfo) ([]VolumeInfo, bool, error) {
+		for i, v := range volumes {
+			if v.Name != name {
+				continue
+			}
+			if !slices.Contains(v.SandboxRefs, sandbox) {
+				v.SandboxRefs = append(v.SandboxRefs, sandbox)
+				volumes[i] = v
+			}
+			return volumes, true, nil
+		}
+		return nil, false, fmt.Errorf("no volume found with name: %s", name)
+	})
 }
 
 func (s *fileVolumeStore) RemoveSandboxRef(name, sandbox string) error {
-	info, err := s.Get(name)
-	if err != nil {
-		return err
-	}
-
-	refs := info.SandboxRefs[:0]
-	for _, ref := range info.SandboxRefs {
-		if ref != sandbox {
-			refs = append(refs, ref)
+	return s.update(func(volumes []VolumeInfo) ([]VolumeInfo, bool, error) {
+		for i, v := range volumes {
+			if v.Name != name {
+				continue
+			}
+			refs := v.SandboxRefs[:0]
+			for _, ref := range v.SandboxRefs {
+				if ref != sandbox {
+					refs = append(refs, ref)
+				}
+			}
+			v.SandboxRefs = refs
+			volumes[i] = v
+			return volumes, true, nil
 		}
-	}
-	info.SandboxRefs = refs
-	return s.Save(info)
+		return nil, false, fmt.Errorf("no volume found with name: %s", name)
+	})
 }
 
 func (s *fileVolumeStore) VolumesForSandbox(sandbox string) ([]VolumeInfo, error) {


### PR DESCRIPTION
## Problem

The three JSONL state stores truncate their file in place on every write and race on concurrent writes (see #422). They matter for the local Docker sandbox mode; the cloud path does not use them, but they are the state of record for `sandbox`, `volume`, and file-mount operations in local mode.

Two failure modes:

- **Truncation on crash.** Each store's `writeAll` used `os.Create`, which truncates the file before writing. A crash or kill mid-write leaves a zero-length file, silently discarding all tracked sandboxes (or volumes / file mounts) while their Docker containers still exist.
- **Lost updates under concurrency.** `Save`, `Remove`, `AddSandboxRef`, and `RemoveSandboxRef` each read the whole file, modify it, and rewrite it with no locking. Two concurrent `amika` processes (or the server plus a CLI run) can overwrite each other: two concurrent `sandbox create` runs can end with only one sandbox recorded, and dropped volume refs can later cause `volume delete --delete-volumes` to free a volume that is still referenced.

## Fix

The change applies the patterns the codebase already uses elsewhere (`writeFileAtomic` in internal/ssh, `internal/filelock` used by known_hosts pinning):

- New `store_write.go` in internal/sandbox provides `writeJSONLAtomic` (temp file in the same directory, then rename over the target, so the file is never observed truncated) and `lockStore`, an advisory flock on `<file>.lock` next to the state file with a 10 second timeout so a wedged holder fails the operation instead of hanging the CLI.
- Each store gained an `update` helper that holds the lock across the entire read-modify-write cycle: read, apply the mutation, atomic write. `Save`, `Remove`, `AddSandboxRef`, and `RemoveSandboxRef` run under it. `AddSandboxRef`/`RemoveSandboxRef` previously did an unlocked `Get` then `Save`, which was itself racy; they now complete under one lock acquisition.
- Read-only paths (`Get`, `List`, `VolumesForSandbox`, `IsInUse`) stay lock-free, since rename is atomic and readers always see either the old or the new complete file.

Behavior is preserved: removing an absent name still skips the write entirely (it does not create the file), not-found error messages are unchanged, and file permissions stay 0644.

## Tests

New `store_atomic_test.go`:

- Concurrent saves of 32 distinct names through one store must all survive in the final `List` (this fails without the lock).
- Concurrent adds and removes interleave into the correct final state.
- Concurrent `AddSandboxRef` calls for 16 distinct sandboxes must all be recorded, for both the volume and file-mount stores.
- A failed write leaves the original file content intact.
- No temp files remain after a successful write.

Existing store tests pass unchanged, which pins the preserved behavior. Verified with `go test -race ./internal/sandbox/`, plus `go vet`, `make lint`, `make fmt`, and `make build`.

Fixes #422
