### PR TITLE
Ensure the managed SSH host block on auth login

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -458,6 +458,12 @@ Log in to Amika via a device authorization flow. Opens a browser for you to auth
 amika auth login
 ```
 
+A successful login also writes the managed SSH host block for the control plane
+you logged in to (`~/.ssh/amika.conf`, included from `~/.ssh/config`), so
+`amika sandbox ssh` and `amika scp` work even if your public key was uploaded
+through the web UI instead of by `amika secret ssh-keygen`. The block only
+describes where the key material lives; it does not create a keypair.
+
 See [auth.md](auth.md) for details on the login flow and session storage.
 
 ### `amika auth status`

--- a/go/cmd/amika/auth.go
+++ b/go/cmd/amika/auth.go
@@ -8,10 +8,28 @@ import (
 	"time"
 
 	"github.com/gofixpoint/amika/go/internal/auth"
+	"github.com/gofixpoint/amika/go/internal/basedir"
 	"github.com/gofixpoint/amika/go/internal/config"
 	"github.com/gofixpoint/amika/go/internal/output"
+	"github.com/gofixpoint/amika/go/internal/ssh"
 	"github.com/spf13/cobra"
 )
+
+// ensureSSHSessionConfig refreshes the managed SSH config for the control
+// plane just logged in to, so a user whose public key was uploaded through
+// the web UI (and who therefore never runs `amika secret ssh-keygen`) still
+// ends up with the session block `amika sandbox ssh` needs.
+//
+// A failure only warns. The credential is already stored by this point, so
+// returning an error would report a login that actually succeeded as failed,
+// and every command that needs the block rewrites it on use anyway. The
+// warning goes to stderr to keep `-o json` stdout a single JSON value.
+func ensureSSHSessionConfig(cmd *cobra.Command) {
+	if err := ssh.EnsureSessionConfig(basedir.New("")); err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"Warning: could not update the managed SSH config (%v); run `amika secret ssh-keygen` to retry.\n", err)
+	}
+}
 
 // logoutJSON is the JSON representation of `auth logout`, reporting which
 // stored credentials were cleared.
@@ -126,6 +144,7 @@ managers in CI (for example: "vault kv get -field=key … | amika auth login --a
 		if err != nil {
 			return err
 		}
+		ensureSSHSessionConfig(cmd)
 		fmt.Fprintf(cmd.OutOrStdout(), "Logged in as %s\n", session.Email)
 		return nil
 	},
@@ -150,6 +169,7 @@ func loginWithAPIKeyFile(cmd *cobra.Command, path string, format output.Format) 
 	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: key, StoredAt: time.Now().UTC()}); err != nil {
 		return fmt.Errorf("saving api key: %w", err)
 	}
+	ensureSSHSessionConfig(cmd)
 	if format.IsJSON() {
 		return format.JSON(cmd.OutOrStdout(), authStatusJSON{Authenticated: true, Method: "stored_api_key", Warnings: []string{}})
 	}

--- a/go/cmd/amika/auth_test.go
+++ b/go/cmd/amika/auth_test.go
@@ -13,6 +13,9 @@ import (
 func TestAuthLogin_APIKeyFile(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	t.Setenv("AMIKA_API_KEY", "")
+	// A successful login writes the managed SSH config, so HOME has to be
+	// redirected or the test would edit the developer's own ~/.ssh.
+	t.Setenv("HOME", t.TempDir())
 
 	keyPath := filepath.Join(t.TempDir(), "key")
 	if err := os.WriteFile(keyPath, []byte("sk_abc\n"), 0600); err != nil {
@@ -66,6 +69,7 @@ func TestAuthLogin_RefusesWhenAlreadyLoggedIn(t *testing.T) {
 func TestAuthLogin_APIKeyFileIgnoresStoredSession(t *testing.T) {
 	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
 	t.Setenv("AMIKA_API_KEY", "")
+	t.Setenv("HOME", t.TempDir())
 
 	// A stored session — valid or not — must not block API-key login.
 	// runmode.DefaultAuthChecker resolves API keys ahead of sessions, so they
@@ -106,6 +110,8 @@ func TestAuthLogout_RecoversFromCorruptFiles(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("AMIKA_STATE_DIRECTORY", stateDir)
 	t.Setenv("AMIKA_API_KEY", "")
+	// The recovery login at the end writes the managed SSH config.
+	t.Setenv("HOME", t.TempDir())
 
 	// Write garbage where each credential file is expected. Logout must
 	// still succeed so the user can recover and log back in.
@@ -364,5 +370,89 @@ func TestAuthStatus_NotLoggedIn(t *testing.T) {
 	}
 	if !strings.Contains(out, "Not logged in") {
 		t.Fatalf("unexpected status: %q", out)
+	}
+}
+
+// A login has to leave a usable SSH host block behind, so a user whose public
+// key was uploaded through the web UI — and who therefore never runs
+// `secret ssh-keygen` — can still reach a sandbox.
+func TestAuthLogin_WritesManagedSSHSessionBlock(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+	t.Setenv("AMIKA_API_URL", "https://app.amika.dev")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Pin the ProxyCommand: without an override it names the test binary.
+	binaryPath := filepath.Join(t.TempDir(), "amika")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write stand-in binary: %v", err)
+	}
+	t.Setenv("AMIKA_BINARY_PATH", binaryPath)
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_abc\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	if out, err := runRootCommandOutput(t, "auth", "login", "--api-key-file", keyPath); err != nil {
+		t.Fatalf("login: %v (out=%q)", err, out)
+	}
+
+	conf, err := os.ReadFile(filepath.Join(home, ".ssh", "amika.conf"))
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	want := "Host *.app-amika-dev.amika\n" +
+		"  User amika\n" +
+		"  IdentityFile " + filepath.Join(home, ".ssh", "amika_id_ed25519") + "\n" +
+		"  IdentitiesOnly yes\n" +
+		"  StrictHostKeyChecking yes\n" +
+		"  UserKnownHostsFile " + filepath.Join(home, ".ssh", "amika_known_hosts") + "\n" +
+		"  ProxyCommand " + binaryPath + " plumbing ssh-stdio-proxy %h\n" +
+		"  ServerAliveInterval 15\n" +
+		"  ServerAliveCountMax 3\n"
+	if !strings.Contains(string(conf), want) {
+		t.Fatalf("amika.conf missing the session block:\nwant:\n%s\ngot:\n%s", want, conf)
+	}
+
+	sshConfig, err := os.ReadFile(filepath.Join(home, ".ssh", "config"))
+	if err != nil {
+		t.Fatalf("read ssh config: %v", err)
+	}
+	if !strings.Contains(string(sshConfig), "Include amika.conf") {
+		t.Fatalf("~/.ssh/config missing the Include line:\n%s", sshConfig)
+	}
+}
+
+// The credential is already stored by the time the SSH config is written, so a
+// config that cannot be written must warn rather than report the login as
+// failed. Every command that needs the block rewrites it on use anyway.
+func TestAuthLogin_WarnsButSucceedsWhenSSHConfigCannotBeWritten(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// A relative override cannot be embedded in a ProxyCommand, so resolving
+	// the session config fails before anything is written.
+	t.Setenv("AMIKA_BINARY_PATH", "relative/amika")
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_abc\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	out, err := runRootCommandOutput(t, "auth", "login", "--api-key-file", keyPath)
+	if err != nil {
+		t.Fatalf("login must still succeed: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "could not update the managed SSH config") {
+		t.Errorf("no warning about the unwritable SSH config: %q", out)
+	}
+	if !strings.Contains(out, "Stored API key") {
+		t.Errorf("login did not report success: %q", out)
+	}
+
+	loaded, loadErr := auth.LoadAPIKey()
+	if loadErr != nil || loaded == nil || loaded.Key != "sk_abc" {
+		t.Fatalf("api key not stored: %+v (%v)", loaded, loadErr)
 	}
 }

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -546,3 +546,83 @@ func TestLegacySessionStateLosesItsEnvironmentAgnosticWildcard(t *testing.T) {
 		t.Errorf("amika.conf missing the resolved ProxyCommand:\n%s", conf)
 	}
 }
+
+// A user who uploads their public key through the web UI never runs
+// `secret ssh-keygen`, so nothing has created key material locally. The block
+// still has to be written, naming the default paths the key will land in.
+func TestEnsureSessionConfigWritesTheBlockWithoutAnyKeyMaterial(t *testing.T) {
+	paths := testPaths(t)
+	t.Setenv(config.EnvAPIURL, "https://app.amika.dev")
+	binary := testBinary(t, "amika")
+
+	if err := EnsureSessionConfig(paths); err != nil {
+		t.Fatalf("EnsureSessionConfig: %v", err)
+	}
+
+	identityPath, _ := paths.SSHIdentityFile()
+	knownHostsPath, _ := paths.SSHKnownHostsFile()
+	if _, err := os.Stat(identityPath); !os.IsNotExist(err) {
+		t.Fatalf("EnsureSessionConfig must not create key material: %v", err)
+	}
+
+	confPath, _ := paths.SSHAmikaConfigFile()
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	want := "Host *.app-amika-dev.amika\n" +
+		"  User amika\n" +
+		"  IdentityFile " + identityPath + "\n" +
+		"  IdentitiesOnly yes\n" +
+		"  StrictHostKeyChecking yes\n" +
+		"  UserKnownHostsFile " + knownHostsPath + "\n" +
+		"  ProxyCommand " + binary + " plumbing ssh-stdio-proxy %h\n" +
+		"  ServerAliveInterval 15\n" +
+		"  ServerAliveCountMax 3\n"
+	if !strings.Contains(string(conf), want) {
+		t.Errorf("amika.conf missing the session block:\nwant:\n%s\ngot:\n%s", want, conf)
+	}
+
+	// The block only takes effect once ~/.ssh/config pulls the file in.
+	sshConfigPath, _ := paths.SSHConfigFile()
+	sshConfig, err := os.ReadFile(sshConfigPath)
+	if err != nil {
+		t.Fatalf("read ssh config: %v", err)
+	}
+	if !strings.Contains(string(sshConfig), "Include "+basedir.SSHAmikaConfigName()) {
+		t.Errorf("ssh config missing the Include line:\n%s", sshConfig)
+	}
+}
+
+// Ensuring the block must not silently retarget an identity imported by
+// `secret ssh-keygen --import`, whose private key lives outside the default
+// path and is the only one the control plane holds the public half of.
+func TestEnsureSessionConfigKeepsAnImportedIdentity(t *testing.T) {
+	paths := testPaths(t)
+	t.Setenv(config.EnvAPIURL, "https://app.amika.dev")
+	testBinary(t, "amika")
+
+	imported := SessionConfig{
+		IdentityFile:   "/home/user/keys/work_ed25519",
+		KnownHostsFile: "/home/user/keys/amika_known_hosts",
+	}
+	if err := ConfigureSession(paths, imported); err != nil {
+		t.Fatalf("ConfigureSession: %v", err)
+	}
+	if err := EnsureSessionConfig(paths); err != nil {
+		t.Fatalf("EnsureSessionConfig: %v", err)
+	}
+
+	confPath, _ := paths.SSHAmikaConfigFile()
+	conf, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read amika.conf: %v", err)
+	}
+	if !strings.Contains(string(conf), "  IdentityFile "+imported.IdentityFile+"\n") {
+		t.Errorf("imported identity was replaced:\n%s", conf)
+	}
+	defaultIdentity, _ := paths.SSHIdentityFile()
+	if strings.Contains(string(conf), defaultIdentity) {
+		t.Errorf("amika.conf reverted to the default identity:\n%s", conf)
+	}
+}

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -417,6 +417,23 @@ func PrepareSessionTarget(
 	return alias, nil
 }
 
+// EnsureSessionConfig writes the wildcard session block for the environment
+// this process points at, using whichever identity is already configured
+// without generating, importing, or requiring any key material.
+//
+// It exists so logging in also repairs the managed SSH config. A user who
+// uploads their public key through the web UI never runs
+// `amika secret ssh-keygen`, so nothing would have written the block, and the
+// aliases `amika sandbox ssh` hands to system OpenSSH would resolve against
+// whatever the user's own `~/.ssh/config` happens to say.
+func EnsureSessionConfig(paths basedir.Paths) error {
+	session, err := resolveSessionConfig(paths)
+	if err != nil {
+		return err
+	}
+	return ConfigureSession(paths, session)
+}
+
 // resolveSessionConfig returns the persisted session identity, or the default
 // one built from the standard identity and known-hosts paths. The persisted
 // value is honored so an identity imported by `amika ssh-keygen --import` keeps


### PR DESCRIPTION
Closes [KAPRO-919](https://linear.app/fixpoint/issue/KAPRO-919/amika-cli-ensure-proper-ssh-hosts-block).

## Problem

`amika secret ssh-keygen` already writes the wildcard session block for the control plane it uploads to. A user who uploads their public key through the web UI never runs it, so nothing writes the block, and the `*.amika` aliases `sandbox ssh` and `scp` hand to system OpenSSH resolve against whatever the user's own `~/.ssh/config` happens to say.

## Change

`auth login` (both the device flow and `--api-key-file`) now writes the block too, via a new `ssh.EnsureSessionConfig`. It configures the session from the already-persisted identity, or the default `~/.ssh/amika_id_ed25519` / `~/.ssh/amika_known_hosts` paths when none is persisted, without generating, importing, or requiring any key material — so an identity imported with `ssh-keygen --import` is not silently retargeted, and no keypair is created behind the user's back.

The credential is stored before this runs, so a failure only warns rather than reporting a login that succeeded as failed. The warning goes to stderr to keep `-o json` stdout a single JSON value.

Verified against a real login (`AMIKA_API_URL=https://app.amika.dev`, scratch `HOME`):

```
# No-relay WebSocket SSH aliases, one block per control plane.
Host *.app-amika-dev.amika
  User amika
  IdentityFile /tmp/…/.ssh/amika_id_ed25519
  IdentitiesOnly yes
  StrictHostKeyChecking yes
  UserKnownHostsFile /tmp/…/.ssh/amika_known_hosts
  ProxyCommand /home/…/dist/amika plumbing ssh-stdio-proxy %h
  ServerAliveInterval 15
  ServerAliveCountMax 3
```

with `Include amika.conf` in `~/.ssh/config` and no key material created.

## Tests

- `ssh`: `EnsureSessionConfig` writes the exact block with no key material present; it does not replace an imported identity.
- `cmd/amika`: `auth login` writes the block and the `Include` line; an unwritable config warns but still succeeds and still stores the credential.
- Existing `auth login` tests now redirect `HOME`, since a successful login writes to `~/.ssh`.

`make fmtcheck vet lint` and `go test ./cmd/amika/... ./internal/ssh/...` pass. (`make ci` also runs `test-sandbox-image`, which needs `shellcheck`, and `internal/gitrepo` / `internal/materialize` fail on `main` in this environment for unrelated reasons — no `rsync`.)
