### PR TITLE
Append the managed Include as overridable defaults

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -284,7 +284,8 @@ amika sandbox ssh -N -D 1080 my-sandbox
 ```
 
 Local (`-L`) and dynamic (`-D`) forwarding are supported. Remote forwarding
-(`-R`), agent forwarding (`-A`), and X11 forwarding are not.
+(`-R`), agent forwarding (`-A`), and X11 forwarding are not: the sandbox's own
+SSH daemon refuses them, so no local config or `-o` override enables them.
 
 `-o` after the subcommand is ssh's ssh_config option, so amika's
 `-o`/`--output` is not available there; written before `ssh` it is rejected
@@ -419,7 +420,7 @@ A copy naming no sandbox at all is simply forwarded to the system `scp`.
 `sandbox ssh`, `sandbox code`, and `scp` all connect by handing system OpenSSH
 a hostname such as `my-sandbox.sb_123.app-amika-dev.amika`. Every setting that
 connection needs comes from a block Amika generates in `~/.ssh/amika.conf`,
-which `~/.ssh/config` pulls in through an `Include` line at the top. The file
+which `~/.ssh/config` pulls in through an `Include` line. The file
 is regenerated from Amika's own state whenever a command prepares an SSH
 target, so edits to it are lost. `amika auth login` and
 `amika secret ssh-keygen` both write it; `auth login` names the files it
@@ -428,14 +429,64 @@ touched.
 | Option                                        | Value                | Why                                                                          |
 | --------------------------------------------- | -------------------- | ---------------------------------------------------------------------------- |
 | `User`                                        | `amika`              | The sandbox account                                                          |
-| `IdentityFile` / `IdentitiesOnly`             | your Amika key, only | Offer exactly the key the control plane holds, not every key in your agent   |
+| `IdentityFile` / `IdentitiesOnly`             | your Amika key       | Offer the key the control plane holds, rather than every key in your agent   |
 | `StrictHostKeyChecking` / `UserKnownHostsFile`| `yes`, Amika's file  | Pin each sandbox host key in a dedicated file, so a change fails closed      |
 | `ProxyCommand`                                | `amika plumbing …`   | Carry the session over Amika's WebSocket transport instead of a TCP dial     |
 | `ServerAliveInterval` / `ServerAliveCountMax` | `15`, `3`            | Notice a dead transport instead of hanging                                   |
 
-Anything the block does not set is answered by whatever else in your
-`~/.ssh/config` matches the hostname, since OpenSSH merges every matching
-block and keeps the first value it finds for each option.
+These are defaults, not rules. OpenSSH resolves around 90 options per
+connection, merging across every block whose pattern matches the hostname and
+keeping the **first** value it finds for most of them. Amika appends its
+`Include` at the end of `~/.ssh/config`, so anything already in that file
+wins:
+
+```
+Host *
+  StrictHostKeyChecking no     # this wins for sandboxes too
+
+# Amika's defaults for sandbox hosts (*.amika). ssh uses the first value it
+# finds for each option, so settings ABOVE this line override them; settings
+# below it do not. "Host *" scopes the include so it is not swallowed by
+# whatever Host block happens to precede it.
+Host *
+Include amika.conf
+```
+
+That is deliberate: your own SSH config governs every connection your machine
+makes, and Amika does not overrule it. It does mean a wildcard stanza of your
+own can weaken a sandbox connection (turning off host-key checking, say) or
+break it outright (a `Host *` `ProxyCommand` replaces Amika's transport). If
+`sandbox ssh` misbehaves and you have wildcard blocks, check them first with
+`ssh -G <alias>`, which prints the settings OpenSSH actually resolved.
+
+To override an Amika default, put your setting **above** the `Include` line,
+or pass it on the command line, which outranks every config file:
+
+```bash
+amika sandbox ssh -o ServerAliveInterval=60 my-sandbox
+```
+
+Three exceptions to keep in mind.
+
+**A few options accumulate rather than resolving to one value**, `IdentityFile`
+among them. A wildcard `IdentityFile` of your own is therefore tried
+*alongside* Amika's key, not instead of it, so ssh may offer both. `ssh -G
+<alias>` lists every identity that will be tried.
+
+**Your override has to sit in a first-pass block.** OpenSSH re-parses the
+config in a second pass for the `final` and `canonical` match predicates, by
+which point the first pass has already assigned the scalar options. A
+`Match final` or `Match canonical` block therefore cannot override these
+defaults from either side of the `Include`. Use a plain `Host` or `Match`
+block above it, or `-o` on the command line.
+
+**Amika only chooses the position when it first adds the line.** If your config
+already contains `Include amika.conf` it is left exactly where it is, because
+moving a line in this file is a bigger liberty than adding one. Installations
+set up before this behavior changed have the include near the **top**, where
+Amika's defaults win instead of yielding. To switch to the current behavior,
+move the `Include` line (and the `Host *` above it, if present) to the end of
+the file yourself.
 
 Under WSL, `sandbox code` mirrors this file (and the key material it names) to
 the Windows side so a Windows editor's own OpenSSH can reach the sandbox. The

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -476,10 +476,60 @@ func EnsureInclude(paths basedir.Paths) error {
 	return ensureIncludeIn(configPath)
 }
 
-// ensureIncludeIn prepends the Include line for the managed config to an ssh
+// includeStanza is the managed Include plus the comment explaining which side
+// of it wins, so the placement is self-describing in the user's own file.
+//
+// The wording follows OpenSSH's resolution order rather than intuition:
+// ssh_config(5) says the *first* obtained value for each option is used, so a
+// setting written above this stanza beats Amika's and one written below it is
+// the one ignored. That is the opposite of what "later wins" instincts
+// suggest, which is exactly why it is spelled out here.
+//
+// "Most" is doing real work in that sentence. A handful of options accumulate
+// rather than resolving to one value, IdentityFile among them, so a wildcard
+// IdentityFile above this stanza is tried *alongside* Amika's key rather than
+// replacing it. Verified with `ssh -G`, which lists both.
+//
+// The banner deliberately stops there rather than also covering OpenSSH's
+// second-pass match predicates, `final` and `canonical`. Neither can override
+// these defaults from either side, because the reparse happens after the
+// first pass has already assigned the scalar options. That belongs in the
+// docs, not in more lines inside the user's own file describing directives
+// almost nobody writes. Rendering the managed blocks with `Match final`
+// themselves would remove the inconsistency, but editors discover sandboxes
+// by enumerating `Host` entries, so the blocks have to stay `Host`.
+//
+// The `Host *` line is load-bearing, not decoration. An ssh config block has
+// no terminator: every directive belongs to the preceding Host or Match until
+// the next one. Appending a bare Include to a file that ends inside
+// `Host myserver` would make the include conditional on connecting to
+// myserver, so the managed block would silently never load. `Host *` reopens
+// an always-matching scope first. It cannot affect the user's other hosts,
+// because the file it pulls in contains nothing but Amika's own Host blocks.
+const includeStanza = `# Amika's defaults for sandbox hosts (*.amika). ssh takes the first value it
+# finds for most options, so settings ABOVE this line override them; settings
+# below it do not. A few options accumulate instead (IdentityFile among them),
+# where yours is tried alongside Amika's rather than replacing it. "Host *"
+# scopes the include so it is not swallowed by whatever Host block precedes it.
+Host *
+`
+
+// ensureIncludeIn appends the Include line for the managed config to an ssh
 // config file, creating the file when absent and preserving existing content.
 // It is target-agnostic so the Windows mirror can maintain its own config the
 // same way the Linux one is maintained.
+//
+// Appending rather than prepending makes the managed block a set of defaults
+// the user's own config outranks, which is the deliberate trade: Amika does
+// not get to quietly win an argument with a file that governs every SSH
+// connection the machine makes. The cost is that a `Host *` stanza setting
+// something the sandbox transport depends on (a ProxyCommand, say) takes
+// precedence, so anything Amika truly cannot yield on has to be passed on the
+// ssh command line, which outranks every config file.
+//
+// The line is left wherever it already is. Detecting it anywhere counts as
+// present, because moving a line in the user's config is a bigger liberty
+// than adding one.
 func ensureIncludeIn(configPath string) error {
 	writePath, err := resolveWriteTarget(configPath)
 	if err != nil {
@@ -497,14 +547,19 @@ func ensureIncludeIn(configPath string) error {
 
 	var content string
 	if len(existing) == 0 {
-		content = includeLine + "\n"
+		content = includeStanza + includeLine + "\n"
 	} else {
-		content = includeLine + "\n\n" + string(existing)
+		content = string(existing)
+		if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += "\n" + includeStanza + includeLine + "\n"
 	}
 	return writeFileAtomic(writePath, []byte(content), 0o600)
 }
 
-// hasIncludeLine reports whether the config already includes the managed file.
+// hasIncludeLine reports whether the config already includes the managed file,
+// wherever it sits.
 func hasIncludeLine(content, includeLine string) bool {
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	for scanner.Scan() {

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -246,10 +246,13 @@ func TestEnsureIncludePreservesExistingConfig(t *testing.T) {
 	if !strings.Contains(content, existing) {
 		t.Errorf("existing config not preserved:\n%s", content)
 	}
+	// The include goes last so the managed block reads as defaults the user's
+	// own config outranks: ssh keeps the first value it finds for an option,
+	// so everything already in the file wins.
 	includeIdx := strings.Index(content, "Include "+basedir.SSHAmikaConfigName())
 	hostIdx := strings.Index(content, "Host example")
-	if includeIdx < 0 || includeIdx > hostIdx {
-		t.Errorf("include should precede existing Host blocks:\n%s", content)
+	if includeIdx < 0 || includeIdx < hostIdx {
+		t.Errorf("include should follow the user's existing config:\n%s", content)
 	}
 }
 
@@ -624,5 +627,98 @@ func TestEnsureSessionConfigKeepsAnImportedIdentity(t *testing.T) {
 	defaultIdentity, _ := paths.SSHIdentityFile()
 	if strings.Contains(string(conf), defaultIdentity) {
 		t.Errorf("amika.conf reverted to the default identity:\n%s", conf)
+	}
+}
+
+// The banner is what makes the placement legible: a user who wants to change
+// a sandbox default has to write it above the include, which is the opposite
+// of what "later wins" instincts suggest.
+func TestEnsureIncludeExplainsAndScopesTheInclude(t *testing.T) {
+	paths := testPaths(t)
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude: %v", err)
+	}
+	configPath, _ := paths.SSHConfigFile()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"takes the first value it",
+		"ABOVE this line override them",
+		"accumulate instead (IdentityFile among them)",
+		"# Amika's defaults for sandbox hosts",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("include stanza missing %q:\n%s", want, content)
+		}
+	}
+	// An ssh config block has no terminator, so a bare Include appended after
+	// a Host block would be conditional on that block matching and would
+	// silently never load. The `Host *` guard has to sit immediately above it.
+	if !strings.Contains(content, "Host *\nInclude "+basedir.SSHAmikaConfigName()+"\n") {
+		t.Errorf("include is not scoped by a `Host *` guard:\n%s", content)
+	}
+}
+
+// A config whose include already sits early is left exactly as it is. Moving
+// a line in a file that governs every SSH connection the machine makes is a
+// bigger liberty than adding one, so placement is only chosen on first write.
+func TestEnsureIncludeLeavesAnExistingIncludeWhereItIs(t *testing.T) {
+	includeLine := "Include " + basedir.SSHAmikaConfigName()
+	paths := testPaths(t)
+	configPath, _ := paths.SSHConfigFile()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := includeLine + "\n\nHost *\n  ForwardAgent yes\n"
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != existing {
+		t.Errorf("config was rewritten:\ngot:\n%s\nwant:\n%s", data, existing)
+	}
+}
+
+// The guard has to survive the case it exists for: a config that ends inside
+// a Host block. Without it, the appended Include belongs to that block and
+// the managed settings never reach a sandbox alias.
+func TestEnsureIncludeStaysGlobalWhenTheConfigEndsInsideAHostBlock(t *testing.T) {
+	paths := testPaths(t)
+	configPath, _ := paths.SSHConfigFile()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := "Host myserver\n  HostName example.com\n  User me\n"
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, existing) {
+		t.Errorf("existing config not preserved verbatim at the front:\n%s", content)
+	}
+	guard := strings.Index(content, "Host *")
+	host := strings.Index(content, "Host myserver")
+	if guard < 0 || guard < host {
+		t.Errorf("guard must follow the user's block, not precede it:\n%s", content)
 	}
 }


### PR DESCRIPTION
Stacked on #429 (review that first; this PR's diff is the second commit only).

Replaces the earlier version of this PR, which fought the user's config to make Amika's settings win. This does the opposite, per review feedback: Amika's block becomes **overridable defaults**, and we never reorder anything.

## What changed

The `Include` line went at the *top* of `~/.ssh/config`, which made the managed block win every option it named — ssh_config(5) resolves each option to the [first value it finds](https://man.openbsd.org/ssh_config). Wrong default for a file that governs every SSH connection the machine makes, not just Amika's. It now goes at the **end**, with a comment saying which side wins:

```
# Amika's defaults for sandbox hosts (*.amika). ssh uses the first value it
# finds for each option, so settings ABOVE this line override them; settings
# below it do not. "Host *" scopes the include so it is not swallowed by
# whatever Host block happens to precede it.
Host *
Include amika.conf
```

An Include that already exists is left exactly where it is. No reordering.

## The `Host *` guard is not decoration

This bit me while building it, so it's worth flagging. An ssh config block has no terminator — every directive belongs to the preceding `Host`/`Match` until the next one. So appending a bare `Include` to a config that ends inside `Host myserver` makes the include **conditional on connecting to myserver**, and the managed block silently never loads.

Measured with `ssh -G` on a sandbox alias, config ending in a `Host myserver` block:

| | bare `Include` appended | with `Host *` guard |
|---|---|---|
| `proxycommand` | *(absent)* | `amika plumbing ssh-stdio-proxy %h` |
| `identitiesonly` | `no` (default) | `yes` |
| `userknownhostsfile` | `~/.ssh/known_hosts` (default) | Amika's file |

The guard can't affect the user's other hosts, since the included file contains nothing but Amika's own `Host` blocks — verified that `myserver` still resolves to its own `user me` / `hostname example.com`.

## The trade-off, stated plainly

A wildcard stanza of the user's own now outranks Amika for sandboxes. Measured with `Host *` / `ForwardAgent yes` / `StrictHostKeyChecking no` above the include:

- `stricthostkeychecking false` — **their setting wins, so host-key pinning is off for sandbox connections**
- `proxycommand`, `user`, `identitiesonly`, `userknownhostsfile` — Amika's, since their stanza didn't set those

That's the deliberate cost of not overruling the user's config. Two notes on it:

- A `Host *` `ProxyCommand` in someone's config will now **break** `sandbox ssh` outright. Rare, but it will look like an Amika bug. The docs point at `ssh -G <alias>` as the diagnostic.
- The robust fix for anything we truly can't yield on is to pass it via `-o` on the ssh command line, which outranks every config file. Not done here; worth its own PR if we decide host-key pinning qualifies.

## What this PR no longer contains

The four client-side forwarding denials (`ForwardAgent no` etc.) are dropped, for two reasons:

1. **Already enforced server-side.** `amikad`'s loopback sshd — the daemon every `*.amika` connection terminates at — already sets `AllowAgentForwarding no`, `X11Forwarding no`, `PermitTunnel no`, `AllowTcpForwarding local` (`go/internal/amikad/sshd/manager.go`). The server refusing is authoritative; the client asking is irrelevant.
2. **Inert here anyway.** With the include last, either nothing else matches the alias (and OpenSSH's own defaults for those options are already `no`) or the user's stanza wins. Either way the lines do nothing.

So Codex's P1 on the previous version is moot: it was about the denials needing to outrank the user's config, and we're no longer trying to.

## Review follow-ups

Both live Codex findings were correct and are fixed:

- **`IdentityFile` accumulates, so "first value wins" was too broad.** Confirmed: with a wildcard `IdentityFile /user-key` above the include, `ssh -G` lists *both* it and Amika's key, while a scalar option (`ServerAliveInterval`) resolves to the user's value alone. The banner in the user's config, the code comment, and the docs now distinguish scalar from accumulating options, and the table no longer promises exactly one key.
- **A second-pass match block cannot override these defaults from either side.** Confirmed for both predicates: `Match final` and `Match canonical` (the latter whether or not `CanonicalizeHostname` is on) resolve to Amika's value above *or* below the include, since the reparse happens after the first pass assigned the scalars. Rather than enumerate predicates, the docs now state the rule: your override has to sit in a first-pass block, i.e. a plain `Host`/`Match` above the include, or `-o`. Left out of the in-file banner on purpose: more lines in the user's own config about directives almost nobody writes. Rendering the managed blocks with `Match final` would remove the inconsistency, but editors discover sandboxes by enumerating `Host` entries, so they have to stay `Host`.
- **An existing include is not repositioned, so the "appends, and your config wins" claim was unconditional and wrong for upgraded installs.** Anyone set up before this change has the include near the top, where Amika still wins. Documented as an explicit exception, with how to relocate it by hand.

Also removed a paragraph of mine that contradicted this page's existing forwarding contract (it said `-o ForwardAgent=yes` re-enables agent forwarding; the sandbox's sshd refuses it regardless). That contract is now stated once, with where it is enforced.

The two P1s on earlier revisions are moot: both were about the client-side denials needing to outrank the user's config, and this revision no longer tries to.

## Tests

`fmtcheck`/`vet`/`lint` clean; `go test ./...` passes except `internal/materialize`, which needs `rsync` (fails the same way on `main`).

New coverage: the include lands after existing content with its guard and banner; the guard survives a config ending inside a `Host` block; an existing include is left byte-for-byte where it is; the stanza states which side overrides.
