### PR TITLE
Report the SSH config a login writes, and whether a key is behind it

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -284,7 +284,8 @@ amika sandbox ssh -N -D 1080 my-sandbox
 ```
 
 Local (`-L`) and dynamic (`-D`) forwarding are supported. Remote forwarding
-(`-R`), agent forwarding (`-A`), and X11 forwarding are not.
+(`-R`), agent forwarding (`-A`), and X11 forwarding are not: the sandbox's own
+SSH daemon refuses them, so no local config or `-o` override enables them.
 
 `-o` after the subcommand is ssh's ssh_config option, so amika's
 `-o`/`--output` is not available there; written before `ssh` it is rejected
@@ -419,7 +420,7 @@ A copy naming no sandbox at all is simply forwarded to the system `scp`.
 `sandbox ssh`, `sandbox code`, and `scp` all connect by handing system OpenSSH
 a hostname such as `my-sandbox.sb_123.app-amika-dev.amika`. Every setting that
 connection needs comes from a block Amika generates in `~/.ssh/amika.conf`,
-which `~/.ssh/config` pulls in through an `Include` line at the top. The file
+which `~/.ssh/config` pulls in through an `Include` line. The file
 is regenerated from Amika's own state whenever a command prepares an SSH
 target, so edits to it are lost. `amika auth login` and
 `amika secret ssh-keygen` both write it; `auth login` names the files it
@@ -428,14 +429,64 @@ touched.
 | Option                                        | Value                | Why                                                                          |
 | --------------------------------------------- | -------------------- | ---------------------------------------------------------------------------- |
 | `User`                                        | `amika`              | The sandbox account                                                          |
-| `IdentityFile` / `IdentitiesOnly`             | your Amika key, only | Offer exactly the key the control plane holds, not every key in your agent   |
+| `IdentityFile` / `IdentitiesOnly`             | your Amika key       | Offer the key the control plane holds, rather than every key in your agent   |
 | `StrictHostKeyChecking` / `UserKnownHostsFile`| `yes`, Amika's file  | Pin each sandbox host key in a dedicated file, so a change fails closed      |
 | `ProxyCommand`                                | `amika plumbing …`   | Carry the session over Amika's WebSocket transport instead of a TCP dial     |
 | `ServerAliveInterval` / `ServerAliveCountMax` | `15`, `3`            | Notice a dead transport instead of hanging                                   |
 
-Anything the block does not set is answered by whatever else in your
-`~/.ssh/config` matches the hostname, since OpenSSH merges every matching
-block and keeps the first value it finds for each option.
+These are defaults, not rules. OpenSSH resolves around 90 options per
+connection, merging across every block whose pattern matches the hostname and
+keeping the **first** value it finds for most of them. Amika appends its
+`Include` at the end of `~/.ssh/config`, so anything already in that file
+wins:
+
+```
+Host *
+  StrictHostKeyChecking no     # this wins for sandboxes too
+
+# Amika's defaults for sandbox hosts (*.amika). ssh uses the first value it
+# finds for each option, so settings ABOVE this line override them; settings
+# below it do not. "Host *" scopes the include so it is not swallowed by
+# whatever Host block happens to precede it.
+Host *
+Include amika.conf
+```
+
+That is deliberate: your own SSH config governs every connection your machine
+makes, and Amika does not overrule it. It does mean a wildcard stanza of your
+own can weaken a sandbox connection (turning off host-key checking, say) or
+break it outright (a `Host *` `ProxyCommand` replaces Amika's transport). If
+`sandbox ssh` misbehaves and you have wildcard blocks, check them first with
+`ssh -G <alias>`, which prints the settings OpenSSH actually resolved.
+
+To override an Amika default, put your setting **above** the `Include` line,
+or pass it on the command line, which outranks every config file:
+
+```bash
+amika sandbox ssh -o ServerAliveInterval=60 my-sandbox
+```
+
+Three exceptions to keep in mind.
+
+**A few options accumulate rather than resolving to one value**, `IdentityFile`
+among them. A wildcard `IdentityFile` of your own is therefore tried
+*alongside* Amika's key, not instead of it, so ssh may offer both. `ssh -G
+<alias>` lists every identity that will be tried.
+
+**Your override has to sit in a first-pass block.** OpenSSH re-parses the
+config in a second pass for the `final` and `canonical` match predicates, by
+which point the first pass has already assigned the scalar options. A
+`Match final` or `Match canonical` block therefore cannot override these
+defaults from either side of the `Include`. Use a plain `Host` or `Match`
+block above it, or `-o` on the command line.
+
+**Amika only chooses the position when it first adds the line.** If your config
+already contains `Include amika.conf` it is left exactly where it is, because
+moving a line in this file is a bigger liberty than adding one. Installations
+set up before this behavior changed have the include near the **top**, where
+Amika's defaults win instead of yielding. To switch to the current behavior,
+move the `Include` line (and the `Host *` above it, if present) to the end of
+the file yourself.
 
 Under WSL, `sandbox code` mirrors this file (and the key material it names) to
 the Windows side so a Windows editor's own OpenSSH can reach the sandbox. The

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -414,6 +414,33 @@ A copy naming no sandbox at all is simply forwarded to the system `scp`.
 
 ---
 
+## The managed SSH config
+
+`sandbox ssh`, `sandbox code`, and `scp` all connect by handing system OpenSSH
+a hostname such as `my-sandbox.sb_123.app-amika-dev.amika`. Every setting that
+connection needs comes from a block Amika generates in `~/.ssh/amika.conf`,
+which `~/.ssh/config` pulls in through an `Include` line at the top. The file
+is regenerated from Amika's own state whenever a command prepares an SSH
+target, so edits to it are lost. `amika auth login` and
+`amika secret ssh-keygen` both write it; `auth login` names the files it
+touched.
+
+| Option                                        | Value                | Why                                                                          |
+| --------------------------------------------- | -------------------- | ---------------------------------------------------------------------------- |
+| `User`                                        | `amika`              | The sandbox account                                                          |
+| `IdentityFile` / `IdentitiesOnly`             | your Amika key, only | Offer exactly the key the control plane holds, not every key in your agent   |
+| `StrictHostKeyChecking` / `UserKnownHostsFile`| `yes`, Amika's file  | Pin each sandbox host key in a dedicated file, so a change fails closed      |
+| `ProxyCommand`                                | `amika plumbing …`   | Carry the session over Amika's WebSocket transport instead of a TCP dial     |
+| `ServerAliveInterval` / `ServerAliveCountMax` | `15`, `3`            | Notice a dead transport instead of hanging                                   |
+
+Anything the block does not set is answered by whatever else in your
+`~/.ssh/config` matches the hostname, since OpenSSH merges every matching
+block and keeps the first value it finds for each option.
+
+Under WSL, `sandbox code` mirrors this file (and the key material it names) to
+the Windows side so a Windows editor's own OpenSSH can reach the sandbox. The
+mirrored block carries the same settings.
+
 ## `amika volume`
 
 Manage tracked Docker volumes used by sandboxes.
@@ -458,11 +485,22 @@ Log in to Amika via a device authorization flow. Opens a browser for you to auth
 amika auth login
 ```
 
-A successful login also writes the managed SSH host block for the control plane
-you logged in to (`~/.ssh/amika.conf`, included from `~/.ssh/config`), so
-`amika sandbox ssh` and `amika scp` work even if your public key was uploaded
-through the web UI instead of by `amika secret ssh-keygen`. The block only
-describes where the key material lives; it does not create a keypair.
+A successful login also writes [the managed SSH config](#the-managed-ssh-config)
+for the control plane you logged in to, so a bare `ssh <alias>` works even if
+your public key was uploaded through the web UI instead of by
+`amika secret ssh-keygen`. Login prints the two files it touched, since
+`~/.ssh/config` governs every SSH connection your machine makes and is often a
+symlink into a dotfiles repo.
+
+The block records where your key material lives; it never creates a keypair.
+If no key is there yet, login says so and names both ways to fix it:
+
+```
+Updated ~/.ssh/amika.conf, included from ~/.ssh/config.
+No SSH identity at ~/.ssh/amika_id_ed25519 yet, so `amika sandbox ssh` will not connect until you add one:
+  amika secret ssh-keygen                                 # create a new key
+  amika secret ssh-keygen --import <path>.pub             # use a key you already have
+```
 
 See [auth.md](auth.md) for details on the login flow and session storage.
 
@@ -624,6 +662,8 @@ amika secret ssh-keygen --import ~/.ssh/id_ed25519.pub
 | `--force`         | `false`   | Replace an existing key of the same name                       |
 
 Re-running this command is safe: an existing keypair at `~/.ssh/amika_id_ed25519` is reused rather than regenerated, so the upload is a no-op. `--force` is only needed when the name already holds *different* key material (for example when switching `--import` targets).
+
+`--import` is also the fix when your public key is already registered (you uploaded it through the web UI, say) but your private key lives somewhere other than `~/.ssh/amika_id_ed25519`. Pointing it at that key's `.pub` re-uploads identical material as a no-op and updates [the managed SSH config](#the-managed-ssh-config) to name your key rather than the default path.
 
 `amika secret ssh-key create` is an alias for this command.
 

--- a/go/cmd/amika/auth.go
+++ b/go/cmd/amika/auth.go
@@ -20,14 +20,41 @@ import (
 // the web UI (and who therefore never runs `amika secret ssh-keygen`) still
 // ends up with the session block `amika sandbox ssh` needs.
 //
+// It names the files it touched. `~/.ssh/config` governs every SSH connection
+// the machine makes, not just Amika's, and it is commonly a symlink into a
+// dotfiles repo, so editing it as a side effect of logging in is not
+// something to do quietly.
+//
 // A failure only warns. The credential is already stored by this point, so
 // returning an error would report a login that actually succeeded as failed,
 // and every command that needs the block rewrites it on use anyway. The
-// warning goes to stderr to keep `-o json` stdout a single JSON value.
-func ensureSSHSessionConfig(cmd *cobra.Command) {
-	if err := ssh.EnsureSessionConfig(basedir.New("")); err != nil {
+// warning goes to stderr to keep `-o json` stdout a single JSON value, while
+// the routine disclosure goes through Progress, which discards it in JSON
+// mode.
+func ensureSSHSessionConfig(cmd *cobra.Command, format output.Format) {
+	paths := basedir.New("")
+	session, err := ssh.EnsureSessionConfig(paths)
+	if err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"Warning: could not update the managed SSH config (%v); run `amika secret ssh-keygen` to retry.\n", err)
+		return
+	}
+	out := format.Progress(cmd.OutOrStdout())
+	amikaConfig, configErr := paths.SSHAmikaConfigFile()
+	sshConfig, sshConfigErr := paths.SSHConfigFile()
+	if configErr == nil && sshConfigErr == nil {
+		fmt.Fprintf(out, "Updated %s, included from %s.\n", amikaConfig, sshConfig)
+	}
+
+	// The block names an identity whether or not one exists yet, so say so
+	// rather than letting the first `sandbox ssh` be where the user finds
+	// out. Both fixes are offered: a UI-uploaded key already has a private
+	// half somewhere, and only --import points the config at it.
+	if info, statErr := os.Stat(session.IdentityFile); statErr != nil || !info.Mode().IsRegular() {
+		fmt.Fprintf(out, "No SSH identity at %s yet, so `amika sandbox ssh` will not connect until you add one:\n",
+			session.IdentityFile)
+		fmt.Fprintln(out, "  amika secret ssh-keygen                                 # create a new key")
+		fmt.Fprintln(out, "  amika secret ssh-keygen --import <path>.pub             # use a key you already have")
 	}
 }
 
@@ -144,8 +171,8 @@ managers in CI (for example: "vault kv get -field=key … | amika auth login --a
 		if err != nil {
 			return err
 		}
-		ensureSSHSessionConfig(cmd)
 		fmt.Fprintf(cmd.OutOrStdout(), "Logged in as %s\n", session.Email)
+		ensureSSHSessionConfig(cmd, format)
 		return nil
 	},
 }
@@ -169,11 +196,12 @@ func loginWithAPIKeyFile(cmd *cobra.Command, path string, format output.Format) 
 	if err := auth.SaveAPIKey(auth.APIKeyAuth{Key: key, StoredAt: time.Now().UTC()}); err != nil {
 		return fmt.Errorf("saving api key: %w", err)
 	}
-	ensureSSHSessionConfig(cmd)
 	if format.IsJSON() {
+		ensureSSHSessionConfig(cmd, format)
 		return format.JSON(cmd.OutOrStdout(), authStatusJSON{Authenticated: true, Method: "stored_api_key", Warnings: []string{}})
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "Stored API key")
+	ensureSSHSessionConfig(cmd, format)
 	return nil
 }
 

--- a/go/cmd/amika/auth_test.go
+++ b/go/cmd/amika/auth_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -384,10 +385,7 @@ func TestAuthLogin_WritesManagedSSHSessionBlock(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	// Pin the ProxyCommand: without an override it names the test binary.
-	binaryPath := filepath.Join(t.TempDir(), "amika")
-	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write stand-in binary: %v", err)
-	}
+	binaryPath := writeStandInBinary(t)
 	t.Setenv("AMIKA_BINARY_PATH", binaryPath)
 
 	keyPath := filepath.Join(t.TempDir(), "key")
@@ -455,4 +453,127 @@ func TestAuthLogin_WarnsButSucceedsWhenSSHConfigCannotBeWritten(t *testing.T) {
 	if loadErr != nil || loaded == nil || loaded.Key != "sk_abc" {
 		t.Fatalf("api key not stored: %+v (%v)", loaded, loadErr)
 	}
+}
+
+// `~/.ssh/config` governs every SSH connection the machine makes, and it is
+// often a symlink into a dotfiles repo, so a login that edits it has to say
+// which files it touched.
+func TestAuthLogin_NamesTheSSHFilesItTouched(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AMIKA_BINARY_PATH", writeStandInBinary(t))
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_abc\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	out, err := runRootCommandOutput(t, "auth", "login", "--api-key-file", keyPath)
+	if err != nil {
+		t.Fatalf("login: %v (out=%q)", err, out)
+	}
+	for _, want := range []string{
+		filepath.Join(home, ".ssh", "amika.conf"),
+		filepath.Join(home, ".ssh", "config"),
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("login did not disclose %q: %q", want, out)
+		}
+	}
+}
+
+// The block names an identity whether or not one exists. Saying so at login
+// beats letting the first `sandbox ssh` be where the user finds out, and the
+// --import route has to be offered because a UI-uploaded key already has a
+// private half that only --import points the config at.
+func TestAuthLogin_HintsBothFixesWhenNoIdentityExists(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AMIKA_BINARY_PATH", writeStandInBinary(t))
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_abc\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	out, err := runRootCommandOutput(t, "auth", "login", "--api-key-file", keyPath)
+	if err != nil {
+		t.Fatalf("login: %v (out=%q)", err, out)
+	}
+	for _, want := range []string{
+		"No SSH identity at",
+		"amika secret ssh-keygen",
+		"--import",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("login output missing %q: %q", want, out)
+		}
+	}
+}
+
+// With an identity in place there is nothing to fix, so the hint must not
+// fire — an unconditional warning trains users to ignore it.
+func TestAuthLogin_NoIdentityHintWhenOneExists(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AMIKA_BINARY_PATH", writeStandInBinary(t))
+
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+		t.Fatalf("mkdir .ssh: %v", err)
+	}
+	identity := filepath.Join(home, ".ssh", "amika_id_ed25519")
+	if err := os.WriteFile(identity, []byte("key material\n"), 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_abc\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	out, err := runRootCommandOutput(t, "auth", "login", "--api-key-file", keyPath)
+	if err != nil {
+		t.Fatalf("login: %v (out=%q)", err, out)
+	}
+	if strings.Contains(out, "No SSH identity at") {
+		t.Errorf("hint fired despite an identity being present: %q", out)
+	}
+}
+
+// In JSON mode stdout carries only the JSON value, so neither the disclosure
+// nor the hint may leak into it.
+func TestAuthLoginJSON_KeepsStdoutASingleJSONValue(t *testing.T) {
+	t.Setenv("AMIKA_STATE_DIRECTORY", t.TempDir())
+	t.Setenv("AMIKA_API_KEY", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AMIKA_BINARY_PATH", writeStandInBinary(t))
+
+	keyPath := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyPath, []byte("sk_abc\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	out, err := runRootCommandOutput(t, "auth", "login", "--api-key-file", keyPath, "-o", "json")
+	if err != nil {
+		t.Fatalf("login: %v (out=%q)", err, out)
+	}
+	var status authStatusJSON
+	if jsonErr := json.Unmarshal([]byte(out), &status); jsonErr != nil {
+		t.Fatalf("stdout is not a single JSON value (%v): %q", jsonErr, out)
+	}
+	if !status.Authenticated || status.Method != "stored_api_key" {
+		t.Errorf("unexpected status: %+v", status)
+	}
+}
+
+// writeStandInBinary creates a file that passes the ProxyCommand path checks,
+// so the rendered config does not name the test binary.
+func writeStandInBinary(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "amika")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write stand-in binary: %v", err)
+	}
+	return path
 }

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -476,10 +476,60 @@ func EnsureInclude(paths basedir.Paths) error {
 	return ensureIncludeIn(configPath)
 }
 
-// ensureIncludeIn prepends the Include line for the managed config to an ssh
+// includeStanza is the managed Include plus the comment explaining which side
+// of it wins, so the placement is self-describing in the user's own file.
+//
+// The wording follows OpenSSH's resolution order rather than intuition:
+// ssh_config(5) says the *first* obtained value for each option is used, so a
+// setting written above this stanza beats Amika's and one written below it is
+// the one ignored. That is the opposite of what "later wins" instincts
+// suggest, which is exactly why it is spelled out here.
+//
+// "Most" is doing real work in that sentence. A handful of options accumulate
+// rather than resolving to one value, IdentityFile among them, so a wildcard
+// IdentityFile above this stanza is tried *alongside* Amika's key rather than
+// replacing it. Verified with `ssh -G`, which lists both.
+//
+// The banner deliberately stops there rather than also covering OpenSSH's
+// second-pass match predicates, `final` and `canonical`. Neither can override
+// these defaults from either side, because the reparse happens after the
+// first pass has already assigned the scalar options. That belongs in the
+// docs, not in more lines inside the user's own file describing directives
+// almost nobody writes. Rendering the managed blocks with `Match final`
+// themselves would remove the inconsistency, but editors discover sandboxes
+// by enumerating `Host` entries, so the blocks have to stay `Host`.
+//
+// The `Host *` line is load-bearing, not decoration. An ssh config block has
+// no terminator: every directive belongs to the preceding Host or Match until
+// the next one. Appending a bare Include to a file that ends inside
+// `Host myserver` would make the include conditional on connecting to
+// myserver, so the managed block would silently never load. `Host *` reopens
+// an always-matching scope first. It cannot affect the user's other hosts,
+// because the file it pulls in contains nothing but Amika's own Host blocks.
+const includeStanza = `# Amika's defaults for sandbox hosts (*.amika). ssh takes the first value it
+# finds for most options, so settings ABOVE this line override them; settings
+# below it do not. A few options accumulate instead (IdentityFile among them),
+# where yours is tried alongside Amika's rather than replacing it. "Host *"
+# scopes the include so it is not swallowed by whatever Host block precedes it.
+Host *
+`
+
+// ensureIncludeIn appends the Include line for the managed config to an ssh
 // config file, creating the file when absent and preserving existing content.
 // It is target-agnostic so the Windows mirror can maintain its own config the
 // same way the Linux one is maintained.
+//
+// Appending rather than prepending makes the managed block a set of defaults
+// the user's own config outranks, which is the deliberate trade: Amika does
+// not get to quietly win an argument with a file that governs every SSH
+// connection the machine makes. The cost is that a `Host *` stanza setting
+// something the sandbox transport depends on (a ProxyCommand, say) takes
+// precedence, so anything Amika truly cannot yield on has to be passed on the
+// ssh command line, which outranks every config file.
+//
+// The line is left wherever it already is. Detecting it anywhere counts as
+// present, because moving a line in the user's config is a bigger liberty
+// than adding one.
 func ensureIncludeIn(configPath string) error {
 	writePath, err := resolveWriteTarget(configPath)
 	if err != nil {
@@ -497,14 +547,19 @@ func ensureIncludeIn(configPath string) error {
 
 	var content string
 	if len(existing) == 0 {
-		content = includeLine + "\n"
+		content = includeStanza + includeLine + "\n"
 	} else {
-		content = includeLine + "\n\n" + string(existing)
+		content = string(existing)
+		if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += "\n" + includeStanza + includeLine + "\n"
 	}
 	return writeFileAtomic(writePath, []byte(content), 0o600)
 }
 
-// hasIncludeLine reports whether the config already includes the managed file.
+// hasIncludeLine reports whether the config already includes the managed file,
+// wherever it sits.
 func hasIncludeLine(content, includeLine string) bool {
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	for scanner.Scan() {

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -555,7 +555,7 @@ func TestEnsureSessionConfigWritesTheBlockWithoutAnyKeyMaterial(t *testing.T) {
 	t.Setenv(config.EnvAPIURL, "https://app.amika.dev")
 	binary := testBinary(t, "amika")
 
-	if err := EnsureSessionConfig(paths); err != nil {
+	if _, err := EnsureSessionConfig(paths); err != nil {
 		t.Fatalf("EnsureSessionConfig: %v", err)
 	}
 
@@ -609,7 +609,7 @@ func TestEnsureSessionConfigKeepsAnImportedIdentity(t *testing.T) {
 	if err := ConfigureSession(paths, imported); err != nil {
 		t.Fatalf("ConfigureSession: %v", err)
 	}
-	if err := EnsureSessionConfig(paths); err != nil {
+	if _, err := EnsureSessionConfig(paths); err != nil {
 		t.Fatalf("EnsureSessionConfig: %v", err)
 	}
 

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -246,10 +246,13 @@ func TestEnsureIncludePreservesExistingConfig(t *testing.T) {
 	if !strings.Contains(content, existing) {
 		t.Errorf("existing config not preserved:\n%s", content)
 	}
+	// The include goes last so the managed block reads as defaults the user's
+	// own config outranks: ssh keeps the first value it finds for an option,
+	// so everything already in the file wins.
 	includeIdx := strings.Index(content, "Include "+basedir.SSHAmikaConfigName())
 	hostIdx := strings.Index(content, "Host example")
-	if includeIdx < 0 || includeIdx > hostIdx {
-		t.Errorf("include should precede existing Host blocks:\n%s", content)
+	if includeIdx < 0 || includeIdx < hostIdx {
+		t.Errorf("include should follow the user's existing config:\n%s", content)
 	}
 }
 
@@ -624,5 +627,98 @@ func TestEnsureSessionConfigKeepsAnImportedIdentity(t *testing.T) {
 	defaultIdentity, _ := paths.SSHIdentityFile()
 	if strings.Contains(string(conf), defaultIdentity) {
 		t.Errorf("amika.conf reverted to the default identity:\n%s", conf)
+	}
+}
+
+// The banner is what makes the placement legible: a user who wants to change
+// a sandbox default has to write it above the include, which is the opposite
+// of what "later wins" instincts suggest.
+func TestEnsureIncludeExplainsAndScopesTheInclude(t *testing.T) {
+	paths := testPaths(t)
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude: %v", err)
+	}
+	configPath, _ := paths.SSHConfigFile()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"takes the first value it",
+		"ABOVE this line override them",
+		"accumulate instead (IdentityFile among them)",
+		"# Amika's defaults for sandbox hosts",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("include stanza missing %q:\n%s", want, content)
+		}
+	}
+	// An ssh config block has no terminator, so a bare Include appended after
+	// a Host block would be conditional on that block matching and would
+	// silently never load. The `Host *` guard has to sit immediately above it.
+	if !strings.Contains(content, "Host *\nInclude "+basedir.SSHAmikaConfigName()+"\n") {
+		t.Errorf("include is not scoped by a `Host *` guard:\n%s", content)
+	}
+}
+
+// A config whose include already sits early is left exactly as it is. Moving
+// a line in a file that governs every SSH connection the machine makes is a
+// bigger liberty than adding one, so placement is only chosen on first write.
+func TestEnsureIncludeLeavesAnExistingIncludeWhereItIs(t *testing.T) {
+	includeLine := "Include " + basedir.SSHAmikaConfigName()
+	paths := testPaths(t)
+	configPath, _ := paths.SSHConfigFile()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := includeLine + "\n\nHost *\n  ForwardAgent yes\n"
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != existing {
+		t.Errorf("config was rewritten:\ngot:\n%s\nwant:\n%s", data, existing)
+	}
+}
+
+// The guard has to survive the case it exists for: a config that ends inside
+// a Host block. Without it, the appended Include belongs to that block and
+// the managed settings never reach a sandbox alias.
+func TestEnsureIncludeStaysGlobalWhenTheConfigEndsInsideAHostBlock(t *testing.T) {
+	paths := testPaths(t)
+	configPath, _ := paths.SSHConfigFile()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := "Host myserver\n  HostName example.com\n  User me\n"
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInclude(paths); err != nil {
+		t.Fatalf("EnsureInclude: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, existing) {
+		t.Errorf("existing config not preserved verbatim at the front:\n%s", content)
+	}
+	guard := strings.Index(content, "Host *")
+	host := strings.Index(content, "Host myserver")
+	if guard < 0 || guard < host {
+		t.Errorf("guard must follow the user's block, not precede it:\n%s", content)
 	}
 }

--- a/go/internal/ssh/session.go
+++ b/go/internal/ssh/session.go
@@ -399,9 +399,17 @@ func PrepareSessionTarget(
 	}
 	// A world- or group-readable private key is refused rather than used:
 	// OpenSSH would reject it anyway, and the clearer error names the fix.
+	//
+	// Both fixes are named because the likelier one is not the obvious one: a
+	// user whose public key was uploaded through the web UI already has a
+	// keypair, and "run ssh-keygen" reads as an instruction to throw it away.
 	identityInfo, statErr := os.Stat(sessionConfig.IdentityFile)
 	if statErr != nil || !identityInfo.Mode().IsRegular() || identityInfo.Mode().Perm()&0o077 != 0 {
-		return "", fmt.Errorf("SSH identity is missing or unsafe; run %q", "amika secret ssh-keygen")
+		return "", fmt.Errorf(
+			"SSH identity %s is missing or unsafe; run %q to create one, or %q to use a key you already have",
+			sessionConfig.IdentityFile,
+			"amika secret ssh-keygen",
+			"amika secret ssh-keygen --import <path>.pub")
 	}
 	if err := ConfigureSession(paths, sessionConfig); err != nil {
 		return "", err
@@ -419,19 +427,24 @@ func PrepareSessionTarget(
 
 // EnsureSessionConfig writes the wildcard session block for the environment
 // this process points at, using whichever identity is already configured
-// without generating, importing, or requiring any key material.
+// without generating, importing, or requiring any key material. It returns
+// the session it recorded, so a caller can tell the user which identity the
+// block now names and whether that file is actually there yet.
 //
 // It exists so logging in also repairs the managed SSH config. A user who
 // uploads their public key through the web UI never runs
 // `amika secret ssh-keygen`, so nothing would have written the block, and the
 // aliases `amika sandbox ssh` hands to system OpenSSH would resolve against
 // whatever the user's own `~/.ssh/config` happens to say.
-func EnsureSessionConfig(paths basedir.Paths) error {
+func EnsureSessionConfig(paths basedir.Paths) (SessionConfig, error) {
 	session, err := resolveSessionConfig(paths)
 	if err != nil {
-		return err
+		return SessionConfig{}, err
 	}
-	return ConfigureSession(paths, session)
+	if err := ConfigureSession(paths, session); err != nil {
+		return SessionConfig{}, err
+	}
+	return session, nil
 }
 
 // resolveSessionConfig returns the persisted session identity, or the default


### PR DESCRIPTION
Split out of #428, which bundled this with a behavior change. This half is the uncontroversial part; #428 now holds the security hardening and stacks on top.

## 1. Login says which files it touched

#427 made `auth login` write `~/.ssh/amika.conf` and add an `Include` line to `~/.ssh/config`. That second file governs every SSH connection the machine makes, not just Amika's, and is often a symlink into a dotfiles repo that the write follows through to. Doing that as a silent side effect of logging in was the wrong call:

```
Updated ~/.ssh/amika.conf, included from ~/.ssh/config.
```

## 2. Login reports a block with no key behind it

Codex's P2 on #427. Login writes local config only and never uploads a key, so after uploading a public key through the web UI you could end up with a block naming a `~/.ssh/amika_id_ed25519` that was never created. The first `sandbox ssh` was where that surfaced.

The fix already existed and nothing pointed at it, so login now does:

```
No SSH identity at ~/.ssh/amika_id_ed25519 yet, so `amika sandbox ssh` will not connect until you add one:
  amika secret ssh-keygen                                 # create a new key
  amika secret ssh-keygen --import <path>.pub             # use a key you already have
```

`--import` is the one that matters for that user: it re-uploads identical material as a no-op and repoints the config at the key they already have. `PrepareSessionTarget`'s error names both routes too, and now includes the path it checked.

Both messages go through `format.Progress`, so `-o json` stdout stays a single JSON value.

## 3. Docs

New "The managed SSH config" section, since `auth login`, `sandbox ssh`, `sandbox code`, `scp` and `secret ssh-keygen` all now refer to it. Also fixes Codex's other P2 on #428: I had claimed `secret ssh-keygen` names the files it touched. It doesn't — only `auth login` does, and the text now says so.

## Tests

`fmtcheck`/`vet`/`lint` clean; `go test ./...` passes except `internal/materialize`, which needs `rsync` (fails the same way on `main`).

New coverage: login discloses both paths; the hint fires with no identity, stays quiet when one exists, and never leaks into `-o json` stdout.