### PR TITLE
Prepend Amika SSH include for Codex discovery

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -434,33 +434,28 @@ touched.
 | `ProxyCommand`                                | `amika plumbing …`   | Carry the session over Amika's WebSocket transport instead of a TCP dial     |
 | `ServerAliveInterval` / `ServerAliveCountMax` | `15`, `3`            | Notice a dead transport instead of hanging                                   |
 
-These are defaults, not rules. OpenSSH resolves around 90 options per
-connection, merging across every block whose pattern matches the hostname and
-keeping the **first** value it finds for most of them. Amika appends its
-`Include` at the end of `~/.ssh/config`, so anything already in that file
-wins:
+OpenSSH resolves around 90 options per connection, merging across every block
+whose pattern matches the hostname and keeping the **first** value it finds for
+most of them. Amika puts its `Include` first because Codex only discovers the
+managed hosts when the directive precedes every `Host` block:
 
 ```
-Host *
-  StrictHostKeyChecking no     # this wins for sandboxes too
-
-# Amika's defaults for sandbox hosts (*.amika). ssh uses the first value it
-# finds for each option, so settings ABOVE this line override them; settings
-# below it do not. "Host *" scopes the include so it is not swallowed by
-# whatever Host block happens to precede it.
-Host *
+# This `Include` directive must be the first line, or Codex cannot find your Amika SSH
+# hosts.
+#
+# To modify amika SSH target settings, add another host config block below this, like:
+#
+# ```
+# Host *.amika
+#   ForwardAgent yes
+# ```
 Include amika.conf
 ```
 
-That is deliberate: your own SSH config governs every connection your machine
-makes, and Amika does not overrule it. It does mean a wildcard stanza of your
-own can weaken a sandbox connection (turning off host-key checking, say) or
-break it outright (a `Host *` `ProxyCommand` replaces Amika's transport). If
-`sandbox ssh` misbehaves and you have wildcard blocks, check them first with
-`ssh -G <alias>`, which prints the settings OpenSSH actually resolved.
-
-To override an Amika default, put your setting **above** the `Include` line,
-or pass it on the command line, which outranks every config file:
+Because the include comes first, blocks below it can add options that
+`amika.conf` does not set, such as `ForwardAgent`, but cannot replace scalar
+options Amika already supplied. To override one of those options, pass it on
+the command line, which outranks every config file:
 
 ```bash
 amika sandbox ssh -o ServerAliveInterval=60 my-sandbox
@@ -473,20 +468,10 @@ among them. A wildcard `IdentityFile` of your own is therefore tried
 *alongside* Amika's key, not instead of it, so ssh may offer both. `ssh -G
 <alias>` lists every identity that will be tried.
 
-**Your override has to sit in a first-pass block.** OpenSSH re-parses the
-config in a second pass for the `final` and `canonical` match predicates, by
-which point the first pass has already assigned the scalar options. A
-`Match final` or `Match canonical` block therefore cannot override these
-defaults from either side of the `Include`. Use a plain `Host` or `Match`
-block above it, or `-o` on the command line.
-
 **Amika only chooses the position when it first adds the line.** If your config
-already contains `Include amika.conf` it is left exactly where it is, because
-moving a line in this file is a bigger liberty than adding one. Installations
-set up before this behavior changed have the include near the **top**, where
-Amika's defaults win instead of yielding. To switch to the current behavior,
-move the `Include` line (and the `Host *` above it, if present) to the end of
-the file yourself.
+already contains `Include amika.conf`, Amika leaves the file byte-for-byte
+unchanged. Move an existing directive to the beginning yourself if Codex does
+not discover the managed hosts.
 
 Under WSL, `sandbox code` mirrors this file (and the key material it names) to
 the Windows side so a Windows editor's own OpenSSH can reach the sandbox. The

--- a/go/internal/ssh/config.go
+++ b/go/internal/ssh/config.go
@@ -465,9 +465,8 @@ func resolveSessionRendering(session SessionConfig) (string, string, error) {
 }
 
 // EnsureInclude makes sure ~/.ssh/config pulls in the managed amika.conf via an
-// Include directive near the top (Include must precede Host blocks to take
-// effect, since ssh resolves options first-match-wins). It is idempotent and
-// creates ~/.ssh/config if absent.
+// Include directive before every Host block so Codex discovers the managed
+// hosts. It is idempotent and creates ~/.ssh/config if absent.
 func EnsureInclude(paths basedir.Paths) error {
 	configPath, err := paths.SSHConfigFile()
 	if err != nil {
@@ -476,56 +475,24 @@ func EnsureInclude(paths basedir.Paths) error {
 	return ensureIncludeIn(configPath)
 }
 
-// includeStanza is the managed Include plus the comment explaining which side
-// of it wins, so the placement is self-describing in the user's own file.
-//
-// The wording follows OpenSSH's resolution order rather than intuition:
-// ssh_config(5) says the *first* obtained value for each option is used, so a
-// setting written above this stanza beats Amika's and one written below it is
-// the one ignored. That is the opposite of what "later wins" instincts
-// suggest, which is exactly why it is spelled out here.
-//
-// "Most" is doing real work in that sentence. A handful of options accumulate
-// rather than resolving to one value, IdentityFile among them, so a wildcard
-// IdentityFile above this stanza is tried *alongside* Amika's key rather than
-// replacing it. Verified with `ssh -G`, which lists both.
-//
-// The banner deliberately stops there rather than also covering OpenSSH's
-// second-pass match predicates, `final` and `canonical`. Neither can override
-// these defaults from either side, because the reparse happens after the
-// first pass has already assigned the scalar options. That belongs in the
-// docs, not in more lines inside the user's own file describing directives
-// almost nobody writes. Rendering the managed blocks with `Match final`
-// themselves would remove the inconsistency, but editors discover sandboxes
-// by enumerating `Host` entries, so the blocks have to stay `Host`.
-//
-// The `Host *` line is load-bearing, not decoration. An ssh config block has
-// no terminator: every directive belongs to the preceding Host or Match until
-// the next one. Appending a bare Include to a file that ends inside
-// `Host myserver` would make the include conditional on connecting to
-// myserver, so the managed block would silently never load. `Host *` reopens
-// an always-matching scope first. It cannot affect the user's other hosts,
-// because the file it pulls in contains nothing but Amika's own Host blocks.
-const includeStanza = `# Amika's defaults for sandbox hosts (*.amika). ssh takes the first value it
-# finds for most options, so settings ABOVE this line override them; settings
-# below it do not. A few options accumulate instead (IdentityFile among them),
-# where yours is tried alongside Amika's rather than replacing it. "Host *"
-# scopes the include so it is not swallowed by whatever Host block precedes it.
-Host *
-`
+// includeStanza explains why the managed Include is prepended and shows how to
+// add an SSH option that amika.conf does not already set. OpenSSH keeps the
+// first value it finds for most options, so a block below the Include cannot
+// replace scalar values already supplied by amika.conf.
+const includeStanza = "# This `Include` directive must be the first line, or Codex cannot find your Amika SSH\n" +
+	"# hosts.\n" +
+	"#\n" +
+	"# To modify amika SSH target settings, add another host config block below this, like:\n" +
+	"#\n" +
+	"# ```\n" +
+	"# Host *.amika\n" +
+	"#   ForwardAgent yes\n" +
+	"# ```\n"
 
-// ensureIncludeIn appends the Include line for the managed config to an ssh
+// ensureIncludeIn prepends the Include line for the managed config to an ssh
 // config file, creating the file when absent and preserving existing content.
 // It is target-agnostic so the Windows mirror can maintain its own config the
 // same way the Linux one is maintained.
-//
-// Appending rather than prepending makes the managed block a set of defaults
-// the user's own config outranks, which is the deliberate trade: Amika does
-// not get to quietly win an argument with a file that governs every SSH
-// connection the machine makes. The cost is that a `Host *` stanza setting
-// something the sandbox transport depends on (a ProxyCommand, say) takes
-// precedence, so anything Amika truly cannot yield on has to be passed on the
-// ssh command line, which outranks every config file.
 //
 // The line is left wherever it already is. Detecting it anywhere counts as
 // present, because moving a line in the user's config is a bigger liberty
@@ -545,15 +512,9 @@ func ensureIncludeIn(configPath string) error {
 		return nil
 	}
 
-	var content string
-	if len(existing) == 0 {
-		content = includeStanza + includeLine + "\n"
-	} else {
-		content = string(existing)
-		if !strings.HasSuffix(content, "\n") {
-			content += "\n"
-		}
-		content += "\n" + includeStanza + includeLine + "\n"
+	content := includeStanza + includeLine + "\n"
+	if len(existing) > 0 {
+		content += "\n" + string(existing)
 	}
 	return writeFileAtomic(writePath, []byte(content), 0o600)
 }

--- a/go/internal/ssh/config_test.go
+++ b/go/internal/ssh/config_test.go
@@ -201,16 +201,13 @@ func TestUpsertSessionHostRendersConcreteAliasBeforeWildcardSettings(t *testing.
 	}
 }
 
-func TestEnsureIncludeCreatesAndIsIdempotent(t *testing.T) {
+func TestEnsureIncludeCreatesMissingConfig(t *testing.T) {
 	paths := testPaths(t)
 	configPath, _ := paths.SSHConfigFile()
 	includeLine := "Include " + basedir.SSHAmikaConfigName()
 
 	if err := EnsureInclude(paths); err != nil {
-		t.Fatalf("EnsureInclude (create): %v", err)
-	}
-	if err := EnsureInclude(paths); err != nil {
-		t.Fatalf("EnsureInclude (idempotent): %v", err)
+		t.Fatalf("EnsureInclude: %v", err)
 	}
 
 	data, err := os.ReadFile(configPath)
@@ -220,10 +217,13 @@ func TestEnsureIncludeCreatesAndIsIdempotent(t *testing.T) {
 	if n := strings.Count(string(data), includeLine); n != 1 {
 		t.Fatalf("expected exactly 1 include line, got %d:\n%s", n, data)
 	}
+	if !strings.HasPrefix(string(data), includeStanza+includeLine+"\n") {
+		t.Fatalf("include stanza is not first:\n%s", data)
+	}
 	assertPerm(t, configPath, 0o600)
 }
 
-func TestEnsureIncludePreservesExistingConfig(t *testing.T) {
+func TestEnsureIncludePrependsToConfigWithoutInclude(t *testing.T) {
 	paths := testPaths(t)
 	configPath, _ := paths.SSHConfigFile()
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
@@ -243,16 +243,9 @@ func TestEnsureIncludePreservesExistingConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	content := string(data)
-	if !strings.Contains(content, existing) {
-		t.Errorf("existing config not preserved:\n%s", content)
-	}
-	// The include goes last so the managed block reads as defaults the user's
-	// own config outranks: ssh keeps the first value it finds for an option,
-	// so everything already in the file wins.
-	includeIdx := strings.Index(content, "Include "+basedir.SSHAmikaConfigName())
-	hostIdx := strings.Index(content, "Host example")
-	if includeIdx < 0 || includeIdx < hostIdx {
-		t.Errorf("include should follow the user's existing config:\n%s", content)
+	want := includeStanza + "Include " + basedir.SSHAmikaConfigName() + "\n\n" + existing
+	if content != want {
+		t.Errorf("config rewrite mismatch:\ngot:\n%s\nwant:\n%s", content, want)
 	}
 }
 
@@ -298,11 +291,9 @@ func TestEnsureIncludePreservesSymlinkedConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	content := string(data)
-	if !strings.Contains(content, "Include "+basedir.SSHAmikaConfigName()) {
-		t.Errorf("target config missing include:\n%s", content)
-	}
-	if !strings.Contains(content, existing) {
-		t.Errorf("target config did not preserve existing content:\n%s", content)
+	want := includeStanza + "Include " + basedir.SSHAmikaConfigName() + "\n\n" + existing
+	if content != want {
+		t.Errorf("target config rewrite mismatch:\ngot:\n%s\nwant:\n%s", content, want)
 	}
 	assertPerm(t, targetPath, 0o600)
 }
@@ -630,10 +621,7 @@ func TestEnsureSessionConfigKeepsAnImportedIdentity(t *testing.T) {
 	}
 }
 
-// The banner is what makes the placement legible: a user who wants to change
-// a sandbox default has to write it above the include, which is the opposite
-// of what "later wins" instincts suggest.
-func TestEnsureIncludeExplainsAndScopesTheInclude(t *testing.T) {
+func TestEnsureIncludeWritesCodexDiscoveryComment(t *testing.T) {
 	paths := testPaths(t)
 	if err := EnsureInclude(paths); err != nil {
 		t.Fatalf("EnsureInclude: %v", err)
@@ -644,35 +632,20 @@ func TestEnsureIncludeExplainsAndScopesTheInclude(t *testing.T) {
 		t.Fatal(err)
 	}
 	content := string(data)
-	for _, want := range []string{
-		"takes the first value it",
-		"ABOVE this line override them",
-		"accumulate instead (IdentityFile among them)",
-		"# Amika's defaults for sandbox hosts",
-	} {
-		if !strings.Contains(content, want) {
-			t.Errorf("include stanza missing %q:\n%s", want, content)
-		}
-	}
-	// An ssh config block has no terminator, so a bare Include appended after
-	// a Host block would be conditional on that block matching and would
-	// silently never load. The `Host *` guard has to sit immediately above it.
-	if !strings.Contains(content, "Host *\nInclude "+basedir.SSHAmikaConfigName()+"\n") {
-		t.Errorf("include is not scoped by a `Host *` guard:\n%s", content)
+	want := includeStanza + "Include " + basedir.SSHAmikaConfigName() + "\n"
+	if content != want {
+		t.Errorf("config mismatch:\ngot:\n%s\nwant:\n%s", content, want)
 	}
 }
 
-// A config whose include already sits early is left exactly as it is. Moving
-// a line in a file that governs every SSH connection the machine makes is a
-// bigger liberty than adding one, so placement is only chosen on first write.
-func TestEnsureIncludeLeavesAnExistingIncludeWhereItIs(t *testing.T) {
+func TestEnsureIncludeDoesNotModifyConfigWithExistingInclude(t *testing.T) {
 	includeLine := "Include " + basedir.SSHAmikaConfigName()
 	paths := testPaths(t)
 	configPath, _ := paths.SSHConfigFile()
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	existing := includeLine + "\n\nHost *\n  ForwardAgent yes\n"
+	existing := "Host example\n  HostName example.com\n\n" + includeLine + "\n"
 	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -687,38 +660,5 @@ func TestEnsureIncludeLeavesAnExistingIncludeWhereItIs(t *testing.T) {
 	}
 	if string(data) != existing {
 		t.Errorf("config was rewritten:\ngot:\n%s\nwant:\n%s", data, existing)
-	}
-}
-
-// The guard has to survive the case it exists for: a config that ends inside
-// a Host block. Without it, the appended Include belongs to that block and
-// the managed settings never reach a sandbox alias.
-func TestEnsureIncludeStaysGlobalWhenTheConfigEndsInsideAHostBlock(t *testing.T) {
-	paths := testPaths(t)
-	configPath, _ := paths.SSHConfigFile()
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	existing := "Host myserver\n  HostName example.com\n  User me\n"
-	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := EnsureInclude(paths); err != nil {
-		t.Fatalf("EnsureInclude: %v", err)
-	}
-
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	content := string(data)
-	if !strings.HasPrefix(content, existing) {
-		t.Errorf("existing config not preserved verbatim at the front:\n%s", content)
-	}
-	guard := strings.Index(content, "Host *")
-	host := strings.Index(content, "Host myserver")
-	if guard < 0 || guard < host {
-		t.Errorf("guard must follow the user's block, not precede it:\n%s", content)
 	}
 }


### PR DESCRIPTION
## Summary

- prepend the managed Amika SSH include so Codex can discover generated hosts
- leave an existing Include amika.conf directive and the surrounding SSH config byte-for-byte unchanged
- document the new ordering and cover missing, absent-include, and existing-include cases

## Validation

- make fmt vet lint
- go -C go test ./internal/ssh -count=1
- pre-commit checks (vet and revive)

The broader make ci run completed formatting, shell checks, vet, lint, all builds, and the internal/ssh tests. Its unit-test phase also reported existing platform/environment failures in untouched amikad and amikalyze packages on macOS (Linux-only sensitive writes and frozen-path hook behavior).