### PR TITLE
Add GitHub branch binding command

### DIFF
--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -34,6 +34,7 @@ func New() *cobra.Command {
 	sandboxCmd.AddCommand(sandboxCodeV2Cmd)
 	sandboxCmd.AddCommand(sandboxCodeV1Cmd)
 	sandboxCmd.AddCommand(sandboxAgentSendCmd)
+	sandboxCmd.AddCommand(sandboxBindGitHubBranchCmd)
 
 	sandboxCmd.PersistentFlags().Bool("local", false, "Only operate on local sandboxes")
 	sandboxCmd.PersistentFlags().Bool("remote", false, "Only operate on remote sandboxes")
@@ -86,6 +87,10 @@ func New() *cobra.Command {
 	sandboxAgentSendCmd.Flags().String("agent", "claude", "Agent CLI to use (default \"claude\")")
 	sandboxAgentSendCmd.Flags().String("session-id", "", "Resume an existing agent session by ID (remote sandboxes only)")
 	sandboxAgentSendCmd.Flags().Bool("new-session", false, "Start a new agent session (remote sandboxes only)")
+	sandboxBindGitHubBranchCmd.Flags().String("owner", "", "GitHub repository owner (defaults from the sandbox repository)")
+	sandboxBindGitHubBranchCmd.Flags().String("repo", "", "GitHub repository name (defaults from the sandbox repository)")
+	sandboxBindGitHubBranchCmd.Flags().String("branch", "", "GitHub branch (defaults from the sandbox branch)")
+	sandboxBindGitHubBranchCmd.Flags().Bool("rebind", false, "Move an existing branch binding from another sandbox")
 
 	return sandboxCmd
 }

--- a/go/cmd/amika/sandbox/sandbox_bind_github_branch.go
+++ b/go/cmd/amika/sandbox/sandbox_bind_github_branch.go
@@ -1,0 +1,113 @@
+package sandboxcmd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/gofixpoint/amika/go/internal/output"
+	"github.com/gofixpoint/amika/go/internal/runmode"
+	"github.com/spf13/cobra"
+)
+
+var sandboxBindGitHubBranchCmd = &cobra.Command{
+	Use:   "bind-github-branch <sandbox>",
+	Short: "Bind a remote sandbox to its GitHub branch",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if runmode.Resolve(cmd) != runmode.Remote {
+			return fmt.Errorf("bind-github-branch is only supported for remote sandboxes")
+		}
+		if err := runmode.RequireAuth(runmode.Remote, runmode.DefaultAuthChecker); err != nil {
+			return err
+		}
+		target, err := getRemoteTarget(cmd)
+		if err != nil {
+			return err
+		}
+		format, err := output.FormatFrom(cmd)
+		if err != nil {
+			return err
+		}
+		client, err := getRemoteClient(target)
+		if err != nil {
+			return err
+		}
+
+		sandboxRef := args[0]
+		sandbox, err := client.GetSandbox(sandboxRef)
+		if err != nil {
+			return err
+		}
+		owner, _ := cmd.Flags().GetString("owner")
+		repo, _ := cmd.Flags().GetString("repo")
+		branch, _ := cmd.Flags().GetString("branch")
+		rebind, _ := cmd.Flags().GetBool("rebind")
+
+		if owner == "" || repo == "" {
+			if sandbox.RepoURL == nil {
+				return fmt.Errorf("sandbox %q has no repository; pass --owner and --repo", sandboxRef)
+			}
+			resolvedOwner, resolvedRepo, parseErr := parseGitHubRepositoryURL(*sandbox.RepoURL)
+			if parseErr != nil {
+				return parseErr
+			}
+			if owner == "" {
+				owner = resolvedOwner
+			}
+			if repo == "" {
+				repo = resolvedRepo
+			}
+		}
+		if branch == "" && sandbox.Branch != nil {
+			branch = *sandbox.Branch
+		}
+		if branch == "" {
+			return fmt.Errorf("sandbox %q has no branch; pass --branch", sandboxRef)
+		}
+
+		binding, err := client.BindSandboxGitHubBranch(sandboxRef, owner, repo, branch, rebind)
+		if err != nil {
+			return err
+		}
+		if format.IsJSON() {
+			return format.JSON(cmd.OutOrStdout(), binding)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Bound sandbox %q to %s/%s branch %q (%s).\n", sandboxRef, owner, repo, branch, binding.ID)
+		return nil
+	},
+}
+
+func parseGitHubRepositoryURL(rawURL string) (string, string, error) {
+	value := strings.TrimSpace(rawURL)
+	if value == "" {
+		return "", "", fmt.Errorf("sandbox repository URL is empty")
+	}
+
+	var host, path string
+	if strings.HasPrefix(value, "git@github.com:") {
+		host = "github.com"
+		path = strings.TrimPrefix(value, "git@github.com:")
+	} else {
+		parsed, err := url.Parse(value)
+		if err != nil {
+			return "", "", fmt.Errorf("parse sandbox repository URL: %w", err)
+		}
+		host = parsed.Hostname()
+		path = parsed.Path
+	}
+	if !strings.EqualFold(host, "github.com") {
+		return "", "", fmt.Errorf("sandbox repository %q is not hosted on github.com", rawURL)
+	}
+
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("sandbox repository %q is not a GitHub owner/repository URL", rawURL)
+	}
+	owner := strings.TrimSpace(parts[0])
+	repo := strings.TrimSuffix(strings.TrimSpace(parts[1]), ".git")
+	if owner == "" || repo == "" || repo == "." || repo == ".." {
+		return "", "", fmt.Errorf("sandbox repository %q is not a GitHub owner/repository URL", rawURL)
+	}
+	return owner, repo, nil
+}

--- a/go/cmd/amika/sandbox/sandbox_bind_github_branch_test.go
+++ b/go/cmd/amika/sandbox/sandbox_bind_github_branch_test.go
@@ -1,0 +1,37 @@
+package sandboxcmd
+
+import "testing"
+
+func TestParseGitHubRepositoryURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantOwner string
+		wantRepo  string
+		wantError bool
+	}{
+		{name: "https", raw: "https://github.com/gofixpoint/amika.git", wantOwner: "gofixpoint", wantRepo: "amika"},
+		{name: "ssh URL", raw: "ssh://git@github.com/gofixpoint/amika.git", wantOwner: "gofixpoint", wantRepo: "amika"},
+		{name: "scp syntax", raw: "git@github.com:gofixpoint/amika.git", wantOwner: "gofixpoint", wantRepo: "amika"},
+		{name: "other host", raw: "https://example.com/gofixpoint/amika.git", wantError: true},
+		{name: "extra path", raw: "https://github.com/gofixpoint/amika/tree/main", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, err := parseGitHubRepositoryURL(tt.raw)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected an error, got %s/%s", owner, repo)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("got %s/%s, want %s/%s", owner, repo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -217,6 +217,55 @@ func (c *Client) GetSandbox(name string) (*RemoteSandbox, error) {
 	return &result, nil
 }
 
+// GitHubBranchBindingRequest is the request body for binding a sandbox to a
+// GitHub repository branch. Rebind must be explicitly true to move an
+// existing branch binding from another sandbox.
+type GitHubBranchBindingRequest struct {
+	Target GitHubBranchBindingTarget `json:"target"`
+	Rebind bool                      `json:"rebind,omitempty"`
+}
+
+// GitHubBranchBindingTarget identifies a GitHub repository branch.
+type GitHubBranchBindingTarget struct {
+	Kind       string                        `json:"kind"`
+	Repository GitHubBranchBindingRepository `json:"repository"`
+	Branch     string                        `json:"branch"`
+}
+
+// GitHubBranchBindingRepository identifies a GitHub repository by owner and
+// name.
+type GitHubBranchBindingRepository struct {
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
+}
+
+// SandboxBindingReference is the stable reference returned after creating or
+// reusing a sandbox binding.
+type SandboxBindingReference struct {
+	ID string `json:"id"`
+}
+
+// BindSandboxGitHubBranch creates or reuses a sandbox's GitHub branch binding.
+func (c *Client) BindSandboxGitHubBranch(sandboxRef, owner, repo, branch string, rebind bool) (*SandboxBindingReference, error) {
+	req := GitHubBranchBindingRequest{
+		Target: GitHubBranchBindingTarget{
+			Kind: "github_branch",
+			Repository: GitHubBranchBindingRepository{
+				Owner: owner,
+				Name:  repo,
+			},
+			Branch: branch,
+		},
+		Rebind: rebind,
+	}
+	var result SandboxBindingReference
+	path := apiBasePath + "/sandboxes/" + url.PathEscape(sandboxRef) + "/bindings?sandbox_by=ref"
+	if err := c.doJSON("POST", path, req, &result); err != nil {
+		return nil, fmt.Errorf("remote bind sandbox GitHub branch: %w", err)
+	}
+	return &result, nil
+}
+
 // pollInterval is the delay between polls in the WaitForSandbox* loops.
 // It is a package var (not a constant) so tests can shrink it to keep the
 // suite fast; production always uses the 3 second default.

--- a/go/internal/apiclient/client_bindings_test.go
+++ b/go/internal/apiclient/client_bindings_test.go
@@ -1,0 +1,39 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBindSandboxGitHubBranch(t *testing.T) {
+	var got GitHubBranchBindingRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.RequestURI != "/api/v0beta1/sandboxes/org%2Fbox/bindings?sandbox_by=ref" {
+			t.Errorf("request URI = %q", r.RequestURI)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(SandboxBindingReference{ID: "sbind_1"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	binding, err := client.BindSandboxGitHubBranch("org/box", "gofixpoint", "amika", "feature/one", true)
+	if err != nil {
+		t.Fatalf("BindSandboxGitHubBranch: %v", err)
+	}
+	if binding.ID != "sbind_1" {
+		t.Errorf("binding ID = %q, want sbind_1", binding.ID)
+	}
+	if got.Target.Kind != "github_branch" || got.Target.Repository.Owner != "gofixpoint" || got.Target.Repository.Name != "amika" || got.Target.Branch != "feature/one" || !got.Rebind {
+		t.Errorf("request = %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add `amika sandbox bind-github-branch <sandbox>` for remote sandboxes
- infer the GitHub owner, repository, and branch from sandbox metadata while allowing explicit overrides
- require `--rebind` before moving a branch binding owned by another sandbox
- add typed API client support and JSON output for the binding resource
- cover GitHub URL parsing and binding requests with unit tests

## Why

GitHub Actions sandbox delegation selects reusable environments by repository and branch. This command gives users an explicit, scriptable way to bind a prepared sandbox before pushing a branch or opening a pull request, avoiding a race with the first workflow run.

## Validation

- focused CLI and API-client unit tests
- `go vet ./...`
- CLI build