### PR TITLE
Rename Coder Docker preset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ checked out as a sibling worktree rather than searching for those paths in this 
 
 ## Runtime Dependencies
 
-- **Docker** is required for `materialize`, `sandbox`, and `volume` commands. Preset images (`coder`, `coder-dind`) are auto-built on first use from the generated Dockerfiles in `sandbox-image/`.
+- **Docker** is required for `materialize`, `sandbox`, and `volume` commands. Preset images (`coder`, `coder-plus-docker`) are auto-built on first use from the generated Dockerfiles in `sandbox-image/`.
 - **rsync** is required by the `materialize` command to copy output files.
 
 ## Code Structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ docs/                    In-depth documentation
 
 ## Preset Images
 
-The `coder` and `coder-dind` preset Docker images are auto-built on first use
+The `coder` and `coder-plus-docker` preset Docker images are auto-built on first use
 from the shared bundle in `sandbox-image/`. See
 [docs/presets.md](docs/presets.md) for usage and
 [sandbox-image/README.md](sandbox-image/README.md) for the image change

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ clean:
 	rm -rf dist .gocache .gotmp .gomodcache
 
 clean-docker:
-	docker image rm amika/coder:latest amika/coder-dind:latest
+	docker image rm amika/coder:latest amika/coder-plus-docker:latest
 
 test: test-sandbox-image goenv
 	go -C $(GO_DIR) test ./...

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -8,7 +8,7 @@ set -euo pipefail
 #/ builds for linux/amd64 (Daytona's architecture) and publishes snapshots.
 #/
 #/ Arguments:
-#/   <image>...            One or more of: amika/coder, amika/coder-dind, all
+#/   <image>...            One or more of: amika/coder, amika/coder-plus-docker, all
 #/
 #/ Options:
 #/   --platform <plat>    Override build platform (linux/amd64 or linux/arm64)
@@ -174,7 +174,7 @@ done
 # canonical `<profile>:<revision>` id). The coder image is uploaded into Daytona's registry
 # with `snapshot push`, then turned into linux-vm snapshots with `snapshot create
 # --image … --sandbox-class linux-vm`. Built for `coder`
-# and used for both `coder` and `coder-dind` releases.
+# and used for both `coder` and `coder-plus-docker` releases.
 # VM snapshots must live in a region with linux-vm runners
 # (DAYTONA_VM_REGION, default "us-west-2"); Daytona's default region has only
 # container runners.
@@ -183,7 +183,7 @@ done
 # `linux-vm` sandbox is provisioned identically to its container equivalent —
 # the app advertises one size table for both. Keep these in sync with `SIZE_*`
 # above (and with `SANDBOX_SIZE_MAPPINGS` in amika-mono). Note that not every size
-# is published for every preset — see `vm_excluded_sizes` below (coder-dind has
+# is published for every preset — see `vm_excluded_sizes` below (coder-plus-docker has
 # no xs tier).
 VM_SIZES=("xs" "m" "l" "xl")
 VM_CPUS=("1" "2" "2" "4")
@@ -216,7 +216,7 @@ if [ -n "$VM_SIZES_FILTER" ]; then
   done
 fi
 
-VALID_IMAGES="amika/coder, amika/coder-dind, all"
+VALID_IMAGES="amika/coder, amika/coder-plus-docker, all"
 
 usage() {
   grep '^#/' "$0" | cut -c4-
@@ -226,8 +226,8 @@ usage() {
 image_presets() {
   case "$1" in
     amika/coder)      echo "coder" ;;
-    amika/coder-dind) echo "coder-dind" ;;
-    all)              echo "coder coder-dind" ;;
+    amika/coder-plus-docker) echo "coder-plus-docker" ;;
+    all)              echo "coder coder-plus-docker" ;;
     *) return 1 ;;
   esac
 }
@@ -422,7 +422,7 @@ for preset in "${PRESETS[@]}"; do
     done
   fi
 
-  # Publish the coder / coder-dind environment as linux-vm snapshots.
+  # Publish the coder / coder-plus-docker environment as linux-vm snapshots.
   #
   # A VM snapshot requires `--sandbox-class linux-vm`, which only `daytona
   # snapshot create` sets. But `create --image` PULLS its image from a registry
@@ -438,16 +438,16 @@ for preset in "${PRESETS[@]}"; do
   #      in the VM-capable region (VM_REGION).
   if [ "$PUSH_DAYTONA_VM" = true ]; then
     # Snapshot name base per preset: coder -> amika-daytona-vm,
-    # coder-dind -> amika-daytona-vm-dind. (dind runs dockerd natively in
+    # coder-plus-docker -> amika-daytona-vm-dind. (dind runs dockerd natively in
     # the VM — no privileged container nesting — so the same image works as a VM.)
     # `vm_excluded_sizes` (space-separated) drops tiers a preset can't support.
-    # coder-dind bundles the full Docker engine, whose image does not fit the xs
+    # coder-plus-docker bundles the full Docker engine, whose image does not fit the xs
     # tier's 3GB disk — the OCI→qcow2 build fails — and a 1 vCPU / 1GB RAM box
     # can't run docker-in-docker usefully anyway, so xs is not published for it.
     # Keep in sync with `EXCLUDED_SIZES_BY_PRESET` in amika-mono.
     case "$preset" in
       coder)      vm_name_base="amika-daytona-vm";      vm_excluded_sizes="" ;;
-      coder-dind) vm_name_base="amika-daytona-vm-dind"; vm_excluded_sizes="xs" ;;
+      coder-plus-docker) vm_name_base="amika-daytona-vm-dind"; vm_excluded_sizes="xs" ;;
     esac
     # Verifying an existing snapshot's state on conflict (below) parses
     # `daytona snapshot list --format json` with jq. Fail fast if jq is missing

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -84,7 +84,7 @@ amika sandbox create --name dev-sandbox --git https://github.com/octocat/Hello-W
 amika sandbox create --name dev-sandbox --no-git
 
 # Use the Docker-in-Docker preset image
-amika sandbox create --name docker-box --preset coder-dind
+amika sandbox create --name docker-box --preset coder-plus-docker
 
 # Use a custom Docker image
 amika sandbox create --name custom-box --image myimage:latest

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -26,11 +26,11 @@ The default preset, used when no `--image` or `--preset` flag is provided.
 - Pi (`@earendil-works/pi-coding-agent`)
 - amika, amikalog, and amikad CLIs
 
-### `coder-dind`
+### `coder-plus-docker`
 
 A variant of `coder` that also includes Docker-in-Docker support.
 
-**Image name:** `amika/coder-dind:latest`
+**Image name:** `amika/coder-plus-docker:latest`
 
 **Base:** Ubuntu 24.04
 
@@ -44,7 +44,7 @@ A variant of `coder` that also includes Docker-in-Docker support.
 ```bash
 # Explicit preset selection
 amika sandbox create --preset coder
-amika sandbox create --preset coder-dind
+amika sandbox create --preset coder-plus-docker
 
 # Default behavior (uses coder preset automatically)
 amika sandbox create

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -31,7 +31,7 @@ The script is mounted read-only, so it cannot be modified from inside the contai
 
 ### How it works
 
-Preset images (`coder` and `coder-dind`) bake a no-op
+Preset images (`coder` and `coder-plus-docker`) bake a no-op
 `/usr/local/etc/amikad/setup/setup.sh` into the image. At container creation,
 the local runtime wraps the requested command with the shared lifecycle hooks:
 

--- a/go/cmd/amika/materialize.go
+++ b/go/cmd/amika/materialize.go
@@ -336,7 +336,7 @@ func init() {
 	topMaterializeCmd.Flags().String("outdir", "", "Container directory to copy from (default: workdir)")
 	topMaterializeCmd.Flags().String("destdir", "", "Host directory where output files are copied")
 	topMaterializeCmd.Flags().String("image", sandbox.DefaultCoderImage, "Docker image to use")
-	topMaterializeCmd.Flags().String("preset", "", `Use a preset environment ("coder" or "coder-dind")`)
+	topMaterializeCmd.Flags().String("preset", "", `Use a preset environment ("coder" or "coder-plus-docker")`)
 	topMaterializeCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rw)")
 	topMaterializeCmd.Flags().StringArray("env", nil, "Set environment variable (KEY=VALUE)")
 	topMaterializeCmd.Flags().BoolP("interactive", "i", false, "Run interactively with TTY (for programs like claude)")

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -43,7 +43,7 @@ func New() *cobra.Command {
 	addProviderFlag(sandboxCreateCmd)
 	sandboxCreateCmd.Flags().String("name", "", "Name for the sandbox (auto-generated if not set)")
 	sandboxCreateCmd.Flags().String("image", sandbox.DefaultCoderImage, "Docker image to use")
-	sandboxCreateCmd.Flags().String("preset", "", `Use a preset environment ("coder" or "coder-dind")`)
+	sandboxCreateCmd.Flags().String("preset", "", `Use a preset environment ("coder" or "coder-plus-docker")`)
 	sandboxCreateCmd.Flags().StringArray("mount", nil, "Mount a host directory (source:target[:mode], mode defaults to rwcopy)")
 	sandboxCreateCmd.Flags().StringArray("volume", nil, "Mount an existing named volume (name:target[:mode], mode defaults to rw)")
 	sandboxCreateCmd.Flags().StringArray("port", nil, "Publish a container port (hostPort:containerPort[/protocol], protocol defaults to tcp)")

--- a/go/internal/sandbox/image_resolution.go
+++ b/go/internal/sandbox/image_resolution.go
@@ -13,7 +13,7 @@ const presetImagePrefixEnv = "AMIKA_PRESET_IMAGE_PREFIX"
 const DefaultCoderImage = "amika/coder:latest"
 
 // AllowedPresets lists the preset names available for user selection via --preset.
-var AllowedPresets = []string{"coder", "coder-dind"}
+var AllowedPresets = []string{"coder", "coder-plus-docker"}
 
 // ValidatePreset returns an error if preset is non-empty and not in AllowedPresets.
 func ValidatePreset(preset string) error {

--- a/go/internal/sandbox/image_resolution_test.go
+++ b/go/internal/sandbox/image_resolution_test.go
@@ -19,7 +19,7 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherImageWins(t *testing.T) {
 
 	res, err := ResolveAndEnsureImage(PresetImageOptions{
 		Image:            "ubuntu:latest",
-		Preset:           "coder-dind",
+		Preset:           "coder-plus-docker",
 		ImageFlagChanged: true,
 	})
 	if err != nil {
@@ -28,8 +28,8 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherImageWins(t *testing.T) {
 	if res.Image != "ubuntu:latest" {
 		t.Fatalf("image = %q, want %q", res.Image, "ubuntu:latest")
 	}
-	if res.EffectivePreset != "coder-dind" {
-		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder-dind")
+	if res.EffectivePreset != "coder-plus-docker" {
+		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder-plus-docker")
 	}
 	if res.BuildPreset != "" {
 		t.Fatalf("build preset = %q, want empty", res.BuildPreset)
@@ -71,7 +71,7 @@ func TestResolveAndEnsureImage_PresetAndImageTogetherNoAutoBuild(t *testing.T) {
 	}
 }
 
-func TestResolveAndEnsureImage_ExplicitCoderDindPresetBuildsWhenMissing(t *testing.T) {
+func TestResolveAndEnsureImage_ExplicitCoderPlusDockerPresetBuildsWhenMissing(t *testing.T) {
 	resetImageResolutionStubs(t)
 
 	var builtPreset string
@@ -87,24 +87,24 @@ func TestResolveAndEnsureImage_ExplicitCoderDindPresetBuildsWhenMissing(t *testi
 	}
 
 	res, err := ResolveAndEnsureImage(PresetImageOptions{
-		Image:              "amika/coder-dind:latest",
-		Preset:             "coder-dind",
+		Image:              "amika/coder-plus-docker:latest",
+		Preset:             "coder-plus-docker",
 		DefaultBuildPreset: "coder",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Image != "amika/coder-dind:latest" {
-		t.Fatalf("image = %q, want %q", res.Image, "amika/coder-dind:latest")
+	if res.Image != "amika/coder-plus-docker:latest" {
+		t.Fatalf("image = %q, want %q", res.Image, "amika/coder-plus-docker:latest")
 	}
-	if res.EffectivePreset != "coder-dind" {
-		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder-dind")
+	if res.EffectivePreset != "coder-plus-docker" {
+		t.Fatalf("effective preset = %q, want %q", res.EffectivePreset, "coder-plus-docker")
 	}
-	if res.BuildPreset != "coder-dind" {
-		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder-dind")
+	if res.BuildPreset != "coder-plus-docker" {
+		t.Fatalf("build preset = %q, want %q", res.BuildPreset, "coder-plus-docker")
 	}
-	if builtPreset != "coder-dind" {
-		t.Fatalf("built preset = %q, want %q", builtPreset, "coder-dind")
+	if builtPreset != "coder-plus-docker" {
+		t.Fatalf("built preset = %q, want %q", builtPreset, "coder-plus-docker")
 	}
 	if builtContextDir != "/fake/context" {
 		t.Fatalf("context dir = %q, want %q", builtContextDir, "/fake/context")

--- a/go/internal/sandbox/preset_build_test.go
+++ b/go/internal/sandbox/preset_build_test.go
@@ -15,11 +15,11 @@ func TestBuildPresetImage_BuildsGeneratedDockerfile(t *testing.T) {
 		return nil
 	}
 
-	if err := BuildPresetImage("coder-dind", "/tmp/context", io.Discard); err != nil {
+	if err := BuildPresetImage("coder-plus-docker", "/tmp/context", io.Discard); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := "amika/coder-dind:latest|/tmp/context|sandbox-image/generated/coder-dind.Dockerfile|map[]"
+	want := "amika/coder-plus-docker:latest|/tmp/context|sandbox-image/generated/coder-plus-docker.Dockerfile|map[]"
 	if built != want {
 		t.Fatalf("built = %q, want %q", built, want)
 	}

--- a/go/internal/sandbox/presets_test.go
+++ b/go/internal/sandbox/presets_test.go
@@ -45,7 +45,7 @@ func TestWritePresetBuildContext_ExtractsBundle(t *testing.T) {
 		filepath.Join("sandbox-image", "versions.env"),
 		filepath.Join("sandbox-image", "assets", "stable", ".zshrc"),
 		filepath.Join("sandbox-image", "generated", "coder.Dockerfile"),
-		filepath.Join("sandbox-image", "generated", "coder-dind.Dockerfile"),
+		filepath.Join("sandbox-image", "generated", "coder-plus-docker.Dockerfile"),
 		filepath.Join("sandbox-image", "steps", "10-os-packages.sh"),
 		filepath.Join("sandbox-image", "verify", "run.sh"),
 	} {

--- a/go/internal/sandbox/sandbox-image/generated/bundle.json
+++ b/go/internal/sandbox/sandbox-image/generated/bundle.json
@@ -212,7 +212,7 @@
         }
       ]
     },
-    "coder-dind": {
+    "coder-plus-docker": {
       "binaries": [
         "node",
         "npm",

--- a/go/internal/sandbox/sandbox-image/generated/coder-plus-docker.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/coder-plus-docker.Dockerfile
@@ -68,7 +68,7 @@ COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
 COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
-RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-dind /opt/amika-build/step.sh \
+RUN AMIKA_PRESET=coder-plus-docker /opt/amika-build/step.sh \
     && rm -rf /opt/amika-build
 
 USER amika

--- a/go/internal/sandbox/sandbox-image/generated/daytona/coder-plus-docker.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/daytona/coder-plus-docker.Dockerfile
@@ -29,6 +29,11 @@ RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
 RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
+COPY sandbox-image/assets/providers/daytona /opt/amika-build/step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
+
 COPY sandbox-image/assets/stable /opt/amika-build/step-assets
 COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
 RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
@@ -68,7 +73,8 @@ COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
 COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
-RUN AMIKA_PRESET=coder-dind /opt/amika-build/step.sh && rm -rf /opt/amika-build
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-plus-docker /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/go/internal/sandbox/sandbox-image/generated/e2b/coder-plus-docker.Dockerfile
+++ b/go/internal/sandbox/sandbox-image/generated/e2b/coder-plus-docker.Dockerfile
@@ -29,11 +29,6 @@ RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
 RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/providers/daytona /opt/amika-build/step-assets
-COPY sandbox-image/steps/55-daytona-vm-user.sh /opt/amika-build/step.sh
-RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
-    && rm -rf /opt/amika-build
-
 COPY sandbox-image/assets/stable /opt/amika-build/step-assets
 COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
 RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
@@ -73,7 +68,7 @@ COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
 COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
-RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-dind /opt/amika-build/step.sh \
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-plus-docker /opt/amika-build/step.sh \
     && rm -rf /opt/amika-build
 
 USER amika

--- a/go/internal/sandbox/sandbox-image/manifest.toml
+++ b/go/internal/sandbox/sandbox-image/manifest.toml
@@ -205,7 +205,7 @@ binaries = [
   "amikad",
 ]
 
-[presets.coder-dind]
+[presets.coder-plus-docker]
 steps = [
   "os-packages",
   "static-config",
@@ -317,10 +317,10 @@ command = ["amikad", "--version"]
 id = "docker"
 env = "DOCKER_VERSION"
 command = ["docker", "--version"]
-presets = ["coder-dind"]
+presets = ["coder-plus-docker"]
 
 [[version_checks]]
 id = "buildx"
 env = "BUILDX_VERSION"
 command = ["docker", "buildx", "version"]
-presets = ["coder-dind"]
+presets = ["coder-plus-docker"]

--- a/go/internal/sandbox/sandbox-image/verify/checks/65-dind-smoke.sh
+++ b/go/internal/sandbox/sandbox-image/verify/checks/65-dind-smoke.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Verifies Docker can run a container in the coder-dind image.
+# Verifies Docker can run a container in the coder-plus-docker image.
 # shellcheck disable=SC1091,SC2034
 CHECK_ID="dind-smoke"
 CHECK_CONTEXTS="boot"
 source "$(dirname "$0")/../lib/check.sh" "$@"
 
-if [[ "$PRESET" != "coder-dind" ]]; then
+if [[ "$PRESET" != "coder-plus-docker" ]]; then
   skip "docker run --rm hello-world succeeds for dind preset" "not applicable to preset $PRESET"
 fi
 actual="$(run_as_runtime_user docker run --rm hello-world 2>&1)"

--- a/go/test/e2e/cases/api-base-snapshot-coder-plus-docker.yaml
+++ b/go/test/e2e/cases/api-base-snapshot-coder-plus-docker.yaml
@@ -1,9 +1,9 @@
-name: selected provider coder-dind base snapshot contract
+name: selected provider coder-plus-docker base snapshot contract
 # This real-API case verifies the selected provider's medium DinD
 # base snapshot, including a Docker container smoke test in the boot verifier.
 vars:
   # See api-base-snapshot-coder.yaml for why the request and the expectation
-  # are both provider-conditional. coder-dind excludes the xs tier, so a1.tiny
+  # are both provider-conditional. coder-plus-docker excludes the xs tier, so a1.tiny
   # has no dind image; a1.medium does.
   request_size:
     default: m
@@ -26,8 +26,8 @@ steps:
       name: "{{ssh_key_id}}"
       cleanup: [secret, ssh-key, delete, "{{ssh_key_id}}", --force, -o, json]
 
-  - name: create a medium coder-dind sandbox from the selected provider base snapshot
-    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder-dind, --size, "{{request_size}}", --yes, -o, json]
+  - name: create a medium coder-plus-docker sandbox from the selected provider base snapshot
+    cmd: [sandbox, create, --remote, --provider, "{{sandbox_provider}}", --no-git, --preset, coder-plus-docker, --size, "{{request_size}}", --yes, -o, json]
     expect:
       exit: 0
       schema: Sandbox
@@ -35,7 +35,7 @@ steps:
         name: "@string"
         provider: "{{sandbox_provider}}"
         snapshot: "@string"
-        sandbox_preset: coder-dind
+        sandbox_preset: coder-plus-docker
         sandbox_size: "{{expected_size}}"
     capture:
       sandbox_name: $.name
@@ -69,7 +69,7 @@ steps:
       sudo rm -f /tmp/verify/checks/11-no-root-build-cache.sh \
         /tmp/verify/checks/12-no-package-cache.sh
 
-      sudo env AMIKA_PRESET=coder-dind AMIKA_VERIFY_CHECKS_DIR=/tmp/verify/checks \
+      sudo env AMIKA_PRESET=coder-plus-docker AMIKA_VERIFY_CHECKS_DIR=/tmp/verify/checks \
         /usr/lib/amika-image/verify/run.sh boot
     expect:
       exit: 0

--- a/js/sandbox/src/providers/daytona/internal/configure.ts
+++ b/js/sandbox/src/providers/daytona/internal/configure.ts
@@ -89,7 +89,7 @@ exit 0
  * Stop the Docker daemon and leave `/var/lib/docker` at rest before a
  * snapshot is captured.
  *
- * Dind sandboxes (`coder-dind` preset) start `dockerd` from the image's
+ * Dind sandboxes (`coder-plus-docker` preset) start `dockerd` from the image's
  * `pre-setup.sh` hook on every boot. A snapshot taken while the daemon is
  * live bakes in the source sandbox's mid-flight Docker state — active
  * overlay mounts and network namespaces that no longer exist on a fresh

--- a/sandbox-image/AGENTS.md
+++ b/sandbox-image/AGENTS.md
@@ -1,6 +1,6 @@
 # Sandbox image — agent guidance
 
-Source of truth for the `coder` and `coder-dind` images. Most of this
+Source of truth for the `coder` and `coder-plus-docker` images. Most of this
 directory is generated, so an edit here is only half the change.
 
 - **Never hand-edit generated files.** `generated/*.Dockerfile`,

--- a/sandbox-image/README.md
+++ b/sandbox-image/README.md
@@ -1,6 +1,6 @@
 # Sandbox image bundle
 
-This directory is the source of truth for the `coder` and `coder-dind`
+This directory is the source of truth for the `coder` and `coder-plus-docker`
 sandbox images. The manifest declares the image contract, ordered steps,
 assets, version pins, and preset membership. Provider publishers and the local
 CLI consume generated artifacts rather than implementing provisioning logic of
@@ -37,9 +37,9 @@ generator instead.
 The generator writes these provider-facing artifacts:
 
 - `generated/coder.Dockerfile`
-- `generated/coder-dind.Dockerfile`
-- `generated/daytona/{coder,coder-dind}.Dockerfile`
-- `generated/e2b/{coder,coder-dind}.Dockerfile`
+- `generated/coder-plus-docker.Dockerfile`
+- `generated/daytona/{coder,coder-plus-docker}.Dockerfile`
+- `generated/e2b/{coder,coder-plus-docker}.Dockerfile`
 - `generated/bundle.json`
 
 The top-level Dockerfiles contain the shared preset steps and remain the OCI
@@ -83,7 +83,7 @@ Build a generated image directly from this repository:
 
 ```bash
 ./sandbox-image/build.sh coder
-./sandbox-image/build.sh coder-dind amika/coder-dind:dev
+./sandbox-image/build.sh coder-plus-docker amika/coder-plus-docker:dev
 ```
 
 The build context must be the repository root because generated Dockerfiles

--- a/sandbox-image/build.sh
+++ b/sandbox-image/build.sh
@@ -3,13 +3,13 @@
 set -euo pipefail
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then
-  echo "usage: $0 <coder|coder-dind> [image-tag]" >&2
+  echo "usage: $0 <coder|coder-plus-docker> [image-tag]" >&2
   exit 64
 fi
 
 preset="$1"
 case "$preset" in
-  coder|coder-dind) ;;
+  coder|coder-plus-docker) ;;
   *) echo "unknown sandbox image preset: $preset" >&2; exit 64 ;;
 esac
 

--- a/sandbox-image/generated/bundle.json
+++ b/sandbox-image/generated/bundle.json
@@ -212,7 +212,7 @@
         }
       ]
     },
-    "coder-dind": {
+    "coder-plus-docker": {
       "binaries": [
         "node",
         "npm",

--- a/sandbox-image/generated/coder-plus-docker.Dockerfile
+++ b/sandbox-image/generated/coder-plus-docker.Dockerfile
@@ -68,7 +68,7 @@ COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
 COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
-RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-dind /opt/amika-build/step.sh \
+RUN AMIKA_PRESET=coder-plus-docker /opt/amika-build/step.sh \
     && rm -rf /opt/amika-build
 
 USER amika

--- a/sandbox-image/generated/daytona/coder-plus-docker.Dockerfile
+++ b/sandbox-image/generated/daytona/coder-plus-docker.Dockerfile
@@ -29,6 +29,11 @@ RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
 RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
+COPY sandbox-image/assets/providers/daytona /opt/amika-build/step-assets
+COPY sandbox-image/steps/55-daytona-vm-user.sh /opt/amika-build/step.sh
+RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
+    && rm -rf /opt/amika-build
+
 COPY sandbox-image/assets/stable /opt/amika-build/step-assets
 COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
 RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
@@ -68,7 +73,8 @@ COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
 COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
-RUN AMIKA_PRESET=coder-dind /opt/amika-build/step.sh && rm -rf /opt/amika-build
+RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-plus-docker /opt/amika-build/step.sh \
+    && rm -rf /opt/amika-build
 
 USER amika
 ENV HOME=/home/amika

--- a/sandbox-image/generated/e2b/coder-plus-docker.Dockerfile
+++ b/sandbox-image/generated/e2b/coder-plus-docker.Dockerfile
@@ -29,11 +29,6 @@ RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 COPY sandbox-image/steps/50-runtime-user.sh /opt/amika-build/step.sh
 RUN /opt/amika-build/step.sh && rm -rf /opt/amika-build
 
-COPY sandbox-image/assets/providers/daytona /opt/amika-build/step-assets
-COPY sandbox-image/steps/55-daytona-vm-user.sh /opt/amika-build/step.sh
-RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
-    && rm -rf /opt/amika-build
-
 COPY sandbox-image/assets/stable /opt/amika-build/step-assets
 COPY sandbox-image/steps/60-dotfiles.sh /opt/amika-build/step.sh
 RUN /opt/amika-build/step.sh /opt/amika-build/step-assets \
@@ -73,7 +68,7 @@ COPY sandbox-image/manifest.toml /usr/lib/amika-image/manifest.toml
 COPY sandbox-image/versions.env /usr/lib/amika-image/versions.env
 COPY sandbox-image/verify /usr/lib/amika-image/verify
 COPY sandbox-image/steps/95-verify.sh /opt/amika-build/step.sh
-RUN AMIKA_IMAGE_PROVIDER=daytona AMIKA_PRESET=coder-dind /opt/amika-build/step.sh \
+RUN AMIKA_IMAGE_PROVIDER=e2b AMIKA_PRESET=coder-plus-docker /opt/amika-build/step.sh \
     && rm -rf /opt/amika-build
 
 USER amika

--- a/sandbox-image/manifest.toml
+++ b/sandbox-image/manifest.toml
@@ -205,7 +205,7 @@ binaries = [
   "amikad",
 ]
 
-[presets.coder-dind]
+[presets.coder-plus-docker]
 steps = [
   "os-packages",
   "static-config",
@@ -317,10 +317,10 @@ command = ["amikad", "--version"]
 id = "docker"
 env = "DOCKER_VERSION"
 command = ["docker", "--version"]
-presets = ["coder-dind"]
+presets = ["coder-plus-docker"]
 
 [[version_checks]]
 id = "buildx"
 env = "BUILDX_VERSION"
 command = ["docker", "buildx", "version"]
-presets = ["coder-dind"]
+presets = ["coder-plus-docker"]

--- a/sandbox-image/verify/checks/65-dind-smoke.sh
+++ b/sandbox-image/verify/checks/65-dind-smoke.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Verifies Docker can run a container in the coder-dind image.
+# Verifies Docker can run a container in the coder-plus-docker image.
 # shellcheck disable=SC1091,SC2034
 CHECK_ID="dind-smoke"
 CHECK_CONTEXTS="boot"
 source "$(dirname "$0")/../lib/check.sh" "$@"
 
-if [[ "$PRESET" != "coder-dind" ]]; then
+if [[ "$PRESET" != "coder-plus-docker" ]]; then
   skip "docker run --rm hello-world succeeds for dind preset" "not applicable to preset $PRESET"
 fi
 actual="$(run_as_runtime_user docker run --rm hello-world 2>&1)"


### PR DESCRIPTION
## Summary

- Rename the CLI and sandbox image preset from `coder-dind` to `coder-plus-docker`.
- Rename generated Dockerfiles, embedded bundle assets, and the base-snapshot E2E case.
- Keep Docker-in-Docker internals named `dind`, while exposing the new preset name.

## Validation

- `pnpm --dir js/sandbox run formatcheck`
- `pnpm --dir js/sandbox run typecheck`
- `pnpm --dir js/sandbox test` (383 tests)
- `python3 sandbox-image/generate.py --check`

The image test suite could not run its final shell lint because `shellcheck` is unavailable; Go tooling is also unavailable in this environment.