### PR TITLE
Rename sandbox CLI and API paths to rigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ Assuming you connected GitHub during web onboarding:
 amika secret ssh-keygen
 
 cd path/to/git/repo/you/want/to/work/on
-amika sandbox create --name my-first-sandbox
-amika sandbox ssh my-first-sandbox
+amika rig create --name my-first-sandbox
+amika rig ssh my-first-sandbox
 ```
 
 This spins up a sandbox, pre-loaded with your Git repo and agent credentials. List your sandboxes with:
 
 ```bash
-amika sandbox list
+amika rig list
 ```
 
 ### creating an agent chat session

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -25,7 +25,7 @@ For the vision and roadmap, see [roadmap.md](roadmap.md). For user-facing docs, 
 | Command                                       | Description                                                                         |
 | --------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `amika materialize`                           | Run a script/command in an ephemeral container and copy outputs to a host directory |
-| `amika sandbox create\|list\|connect\|delete` | Manage persistent Docker sandboxes                                                  |
+| `amika rig create\|list\|connect\|delete` | Manage persistent Docker sandboxes                                                  |
 | `amika volume list\|delete`                   | Manage tracked Docker volumes created by `rwcopy` mounts                            |
 | `amika auth extract`                          | Discover local credentials and print shell environment assignments                  |
 | `amika-server`                                | HTTP server exposing the same functionality as a REST API                           |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,7 +6,7 @@ Complete reference for all `amika` commands, flags, and environment variables.
 
 Most commands accept `--output` (short `-o`) to control how they print their result. This lets you read output at a terminal and pipe the same command into a script or `jq` without reformatting.
 
-Two commands do **not** produce JSON because they delegate to a system shell utility that streams its own output: `amika sandbox ssh` (runs `ssh`) rejects `--output` with an error, and `amika scp` (a thin wrapper around `scp`) rejects the unambiguous long form `--output`/`--output=VALUE` but forwards `scp`'s own short `-o` option (used for `ssh_config` overrides) to the system `scp`. For `sandbox ssh` the rejection applies to a flag written **before** the subcommand; anything after it is forwarded to `ssh`, where `-o` is ssh's own `ssh_config` option.
+Two commands do **not** produce JSON because they delegate to a system shell utility that streams its own output: `amika rig ssh` (runs `ssh`) rejects `--output` with an error, and `amika scp` (a thin wrapper around `scp`) rejects the unambiguous long form `--output`/`--output=VALUE` but forwards `scp`'s own short `-o` option (used for `ssh_config` overrides) to the system `scp`. For `sandbox ssh` the rejection applies to a flag written **before** the subcommand; anything after it is forwarded to `ssh`, where `-o` is ssh's own `ssh_config` option.
 
 | Value         | Description                                    |
 | ------------- | ---------------------------------------------- |
@@ -16,10 +16,10 @@ Two commands do **not** produce JSON because they delegate to a system shell uti
 
 ```bash
 # Default human-readable table
-amika sandbox list
+amika rig list
 
 # Compact JSON for a script or jq
-amika sandbox list --remote -o json | jq '.[].name'
+amika rig list --remote -o json | jq '.[].name'
 
 # Indented JSON for reading
 amika snapshot list -o json-pretty
@@ -29,15 +29,15 @@ Most list commands emit a JSON array (empty as `[]`, never `null`); `snapshot li
 
 ```bash
 # Create a sandbox and capture its name for a script
-name=$(amika sandbox create --remote --no-git -o json | jq -r .name)
+name=$(amika rig create --remote --no-git -o json | jq -r .name)
 
 # Delete several sandboxes and inspect per-item results
-amika sandbox delete a b c --remote --force -o json | jq '.[] | select(.status=="error")'
+amika rig delete a b c --remote --force -o json | jq '.[] | select(.status=="error")'
 ```
 
 Commands honoring `--output`: the read commands `sandbox list`, `snapshot list`, `volume list`, `service list`, `auth status`, and `secret <provider> list`, plus `sandbox create`, `sandbox start`, `sandbox stop`, `sandbox delete`, `sandbox agent-send`, `volume delete`, `snapshot create`, `snapshot delete`, `secret <provider> push`/`delete`, `secret ssh-keygen`, `secret ssh-key create`/`push`/`list`/`delete`, `auth login --api-key-file`, `auth logout`, and `materialize`. Commands that open a shell or editor (`sandbox connect`, `sandbox code`) or display a masked credential table and prompt for confirmation (`secret extract`, `secret push`) reject `-o json`/`json-pretty` since they produce no JSON result. `sandbox ssh` and `scp` do not accept `--output` at all (see above).
 
-## `amika sandbox`
+## `amika rig`
 
 Manage Docker-backed persistent sandboxes with bind mounts and named volumes.
 
@@ -54,75 +54,75 @@ When none of these flags are set, the default behavior depends on login state: i
 
 `--local` and `--remote` are mutually exclusive.
 
-### `amika sandbox create`
+### `amika rig create`
 
 Create a new sandbox.
 
 ```bash
 # Minimal — auto-generates a name, uses the coder preset image
-amika sandbox create --yes
+amika rig create --yes
 
 # Named sandbox with mounts
-amika sandbox create --name dev-sandbox \
+amika rig create --name dev-sandbox \
   --mount ./src:/workspace/src:ro \
   --mount ./out:/workspace/out
 
 # Auto-detect the git repo containing the current working directory
 # (this is the default behavior when no --git/--no-git flag is passed)
-amika sandbox create --name dev-sandbox
+amika rig create --name dev-sandbox
 
 # Mount git repo with untracked/uncommitted files included (local sandboxes only)
-amika sandbox create --name dev-sandbox --no-clean
+amika rig create --name dev-sandbox --no-clean
 
 # Mount git repo at a specific path
-amika sandbox create --name dev-sandbox --git ./src
+amika rig create --name dev-sandbox --git ./src
 
 # Mount a remote git repo by URL (HTTPS or SSH)
-amika sandbox create --name dev-sandbox --git https://github.com/octocat/Hello-World.git
+amika rig create --name dev-sandbox --git https://github.com/octocat/Hello-World.git
 
 # Skip git auto-detection and create a bare sandbox
-amika sandbox create --name dev-sandbox --no-git
+amika rig create --name dev-sandbox --no-git
 
 # Use the Docker-in-Docker preset image
-amika sandbox create --name docker-box --preset coder-dind
+amika rig create --name docker-box --preset coder-dind
 
 # Use a custom Docker image
-amika sandbox create --name custom-box --image myimage:latest
+amika rig create --name custom-box --image myimage:latest
 
 # Attach an existing tracked volume
-amika sandbox create --name dev-sandbox-2 \
+amika rig create --name dev-sandbox-2 \
   --volume amika-rwcopy-dev-sandbox-workspace-out-123:/workspace/out:rw
 
 # Set environment variables
-amika sandbox create --name dev-sandbox --env MY_KEY=my_value
+amika rig create --name dev-sandbox --env MY_KEY=my_value
 
 # Create and immediately connect
-amika sandbox create --name dev-sandbox --connect
+amika rig create --name dev-sandbox --connect
 
 # Run a setup script on container start
-amika sandbox create --name dev-sandbox --setup-script ./install-deps.sh
+amika rig create --name dev-sandbox --setup-script ./install-deps.sh
 
 # Publish a container port to the host
-amika sandbox create --name dev-sandbox --port 8080:8080
+amika rig create --name dev-sandbox --port 8080:8080
 
 # Publish a port bound to all interfaces
-amika sandbox create --name dev-sandbox --port 3000:3000 --port-host-ip 0.0.0.0
+amika rig create --name dev-sandbox --port 3000:3000 --port-host-ip 0.0.0.0
 
 # Clone a specific git branch
-amika sandbox create --name dev-sandbox --branch develop
+amika rig create --name dev-sandbox --branch develop
 
 # Create a new branch from your current branch
-amika sandbox create --new-branch feature-x
+amika rig create --new-branch feature-x
 
 # Create a new branch starting from a specific existing branch
-amika sandbox create --branch main --new-branch bugfix-1
+amika rig create --branch main --new-branch bugfix-1
 
 # Inject remote secrets (remote sandboxes only)
-amika sandbox create --name dev-sandbox --remote \
+amika rig create --name dev-sandbox --remote \
   --secret env:ANTHROPIC_API_KEY=my-claude-key
 
 # Fork from a captured snapshot (remote sandboxes only)
-amika sandbox create --name dev-sandbox --remote --snapshot amika-mono-base
+amika rig create --name dev-sandbox --remote --snapshot amika-mono-base
 ```
 
 #### Flags
@@ -157,12 +157,12 @@ amika sandbox create --name dev-sandbox --remote --snapshot amika-mono-base
 | `rw`     | Read-write bind mount from host (writes sync back to host)                                                                               |
 | `rwcopy` | Read-write snapshot in a Docker volume (default for `--mount`). Host files are copied in; writes stay in the volume and do not sync back |
 
-### `amika sandbox list`
+### `amika rig list`
 
 List all tracked sandboxes.
 
 ```bash
-amika sandbox list
+amika rig list
 ```
 
 Output columns: `NAME`, `STATE`, `REPO`, `BRANCH`, `CREATOR`.
@@ -170,7 +170,7 @@ Output columns: `NAME`, `STATE`, `REPO`, `BRANCH`, `CREATOR`.
 Pass `-l`/`--long` for the full set, which adds `ID`, `LOCATION`, `BASE_SNAPSHOT`, `PORTS`, and `CREATED`:
 
 ```bash
-amika sandbox list --long
+amika rig list --long
 ```
 
 Column selection applies only to `--output text`. `-o json` and `-o json-pretty` always emit every field.
@@ -185,16 +185,16 @@ The `BASE_SNAPSHOT` column shows what the sandbox was built from: the snapshot o
 
 Either column shows `-` when the sandbox has no value for it.
 
-### `amika sandbox connect`
+### `amika rig connect`
 
 Connect to a running sandbox container with an interactive shell.
 
 ```bash
 # Connect with default shell (zsh)
-amika sandbox connect dev-sandbox
+amika rig connect dev-sandbox
 
 # Connect with a different shell
-amika sandbox connect dev-sandbox --shell bash
+amika rig connect dev-sandbox --shell bash
 ```
 
 | Flag              | Default | Description                           |
@@ -203,22 +203,22 @@ amika sandbox connect dev-sandbox --shell bash
 
 The shell starts in `/home/amika`.
 
-### `amika sandbox delete`
+### `amika rig delete`
 
 Delete one or more sandboxes and their backing containers. Aliases: `rm`, `remove`.
 
 ```bash
 # Delete a sandbox (prompts about exclusive volumes)
-amika sandbox delete dev-sandbox
+amika rig delete dev-sandbox
 
 # Delete multiple sandboxes
-amika sandbox delete sandbox-1 sandbox-2
+amika rig delete sandbox-1 sandbox-2
 
 # Also delete associated unreferenced volumes
-amika sandbox delete dev-sandbox --delete-volumes
+amika rig delete dev-sandbox --delete-volumes
 
 # Keep all volumes without prompting
-amika sandbox delete dev-sandbox --keep-volumes
+amika rig delete dev-sandbox --keep-volumes
 ```
 
 | Flag               | Default | Description                                                                           |
@@ -228,32 +228,32 @@ amika sandbox delete dev-sandbox --keep-volumes
 
 When neither flag is set and the sandbox is the sole reference for a volume, you will be prompted to decide.
 
-### `amika sandbox stop`
+### `amika rig stop`
 
 Stop one or more running sandboxes without removing them.
 
 ```bash
-amika sandbox stop dev-sandbox
-amika sandbox stop sandbox-1 sandbox-2
+amika rig stop dev-sandbox
+amika rig stop sandbox-1 sandbox-2
 ```
 
-### `amika sandbox start`
+### `amika rig start`
 
 Start (resume) one or more stopped sandboxes.
 
 ```bash
-amika sandbox start dev-sandbox
-amika sandbox start sandbox-1 sandbox-2
+amika rig start dev-sandbox
+amika rig start sandbox-1 sandbox-2
 ```
 
-### `amika sandbox ssh`
+### `amika rig ssh`
 
 Open an SSH session to a remote sandbox over Amika's direct WebSocket
 transport. Remote sandboxes only; requires an SSH identity from
 `amika secret ssh-keygen`.
 
 ```
-amika sandbox ssh [ssh-options] <name> [command...]
+amika rig ssh [ssh-options] <name> [command...]
 ```
 
 Use it like `ssh`: options go before the sandbox name, an optional command
@@ -263,24 +263,24 @@ defines no flags of its own.
 Amika's own flags go **before** `ssh`:
 
 ```bash
-amika sandbox --remote ssh -N -L 8080:localhost:80 my-sandbox
+amika rig --remote ssh -N -L 8080:localhost:80 my-sandbox
 ```
 
-`--help` is the one exception: `amika sandbox ssh --help` prints amika's
-help, as does `amika help sandbox ssh`.
+`--help` is the one exception: `amika rig ssh --help` prints amika's
+help, as does `amika help rig ssh`.
 
 ```bash
 # Interactive shell
-amika sandbox ssh my-sandbox
+amika rig ssh my-sandbox
 
 # Run a command instead of opening a shell
-amika sandbox ssh my-sandbox uptime
+amika rig ssh my-sandbox uptime
 
 # Forward local port 6789 to port 3010 inside the sandbox, without a shell
-amika sandbox ssh -N -L 6789:localhost:3010 my-sandbox
+amika rig ssh -N -L 6789:localhost:3010 my-sandbox
 
 # SOCKS proxy on local port 1080
-amika sandbox ssh -N -D 1080 my-sandbox
+amika rig ssh -N -D 1080 my-sandbox
 ```
 
 Local (`-L`) and dynamic (`-D`) forwarding are supported. Remote forwarding
@@ -291,7 +291,7 @@ SSH daemon refuses them, so no local config or `-o` override enables them.
 `-o`/`--output` is not available there; written before `ssh` it is rejected
 (see [Global flags](#global-flags) above).
 
-### `amika sandbox code`
+### `amika rig code`
 
 Open a remote sandbox in an editor or coding agent over Amika's direct
 WebSocket SSH transport. Remote sandboxes only; requires a signed-in Amika
@@ -329,11 +329,11 @@ with `--remote ssh-remote+<alias>`. This needs WSL interop (`cmd.exe`,
 `wslpath`) and `WSL_DISTRO_NAME` set (any interactive WSL shell sets it).
 
 ```bash
-amika sandbox code my-sandbox
-amika sandbox code my-sandbox --editor=cursor
-amika sandbox code my-sandbox --editor=vscode
-amika sandbox code my-sandbox --editor=claude
-amika sandbox code my-sandbox --editor=codex
+amika rig code my-sandbox
+amika rig code my-sandbox --editor=cursor
+amika rig code my-sandbox --editor=vscode
+amika rig code my-sandbox --editor=claude
+amika rig code my-sandbox --editor=codex
 ```
 
 | Flag              | Default  | Description                                              |
@@ -341,22 +341,22 @@ amika sandbox code my-sandbox --editor=codex
 | `--editor <name>` | `cursor` | Editor or agent to open: `cursor`, `vscode`, `claude`, or `codex`  |
 | `--path <path>`   | —        | Override the remote path to open (absolute, or relative to the sandbox workspace root) |
 
-### `amika sandbox agent-send`
+### `amika rig agent-send`
 
 Send a prompt to an AI agent CLI running inside a sandbox container. The message can be provided as a positional argument or piped via stdin. By default the command waits for the agent to finish and streams the response.
 
 ```bash
 # Send a message to Claude in a sandbox
-amika sandbox agent-send my-sandbox "Add unit tests for the auth module"
+amika rig agent-send my-sandbox "Add unit tests for the auth module"
 
 # Pipe a message via stdin
-echo "Fix the failing tests" | amika sandbox agent-send my-sandbox
+echo "Fix the failing tests" | amika rig agent-send my-sandbox
 
 # Send without waiting for a response
-amika sandbox agent-send my-sandbox "Refactor the API layer" --no-wait
+amika rig agent-send my-sandbox "Refactor the API layer" --no-wait
 
 # Use a different agent CLI
-amika sandbox agent-send my-sandbox "Review this code" --agent codex
+amika rig agent-send my-sandbox "Review this code" --agent codex
 ```
 
 | Flag                  | Default            | Description                                                  |
@@ -458,7 +458,7 @@ options Amika already supplied. To override one of those options, pass it on
 the command line, which outranks every config file:
 
 ```bash
-amika sandbox ssh -o ServerAliveInterval=60 my-sandbox
+amika rig ssh -o ServerAliveInterval=60 my-sandbox
 ```
 
 Three exceptions to keep in mind.
@@ -533,7 +533,7 @@ If no key is there yet, login says so and names both ways to fix it:
 
 ```
 Updated ~/.ssh/amika.conf, included from ~/.ssh/config.
-No SSH identity at ~/.ssh/amika_id_ed25519 yet, so `amika sandbox ssh` will not connect until you add one:
+No SSH identity at ~/.ssh/amika_id_ed25519 yet, so `amika rig ssh` will not connect until you add one:
   amika secret ssh-keygen                                 # create a new key
   amika secret ssh-keygen --import <path>.pub             # use a key you already have
 ```

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -43,11 +43,11 @@ A variant of `coder` that also includes Docker-in-Docker support.
 
 ```bash
 # Explicit preset selection
-amika sandbox create --preset coder
-amika sandbox create --preset coder-dind
+amika rig create --preset coder
+amika rig create --preset coder-dind
 
 # Default behavior (uses coder preset automatically)
-amika sandbox create
+amika rig create
 
 # Materialize with a preset
 amika materialize --preset coder --cmd "claude --help" --destdir /tmp/out
@@ -76,7 +76,7 @@ sandbox command. By default this is a no-op script. When creating a sandbox,
 use `--setup-script` to inject your own setup logic:
 
 ```bash
-amika sandbox create --setup-script ./install-deps.sh
+amika rig create --setup-script ./install-deps.sh
 ```
 
 See [sandbox-configuration.md](sandbox-configuration.md) for details.

--- a/docs/sandbox-configuration.md
+++ b/docs/sandbox-configuration.md
@@ -8,7 +8,7 @@ The `--setup-script` flag lets you mount a local script into the container at `/
 
 ```bash
 # sandbox create
-amika sandbox create --setup-script ./my-setup.sh
+amika rig create --setup-script ./my-setup.sh
 
 # materialize
 amika materialize --setup-script ./my-setup.sh --cmd "echo done" --destdir /tmp/out
@@ -55,23 +55,23 @@ The `--git` CLI flag and the `GitRepo` HTTP API field clone a remote or local gi
 
 ### CLI (`--git`)
 
-By default, `amika sandbox create` walks up from the current working directory and uses the first git repo it finds. Pass `--git <path|url>` to override the source, or `--no-git` to skip git entirely.
+By default, `amika rig create` walks up from the current working directory and uses the first git repo it finds. Pass `--git <path|url>` to override the source, or `--no-git` to skip git entirely.
 
 ```bash
 # Auto-detect the repo containing the current working directory (clean clone)
-amika sandbox create
+amika rig create
 
 # Auto-detect and include untracked/uncommitted files (local sandboxes only)
-amika sandbox create --no-clean
+amika rig create --no-clean
 
 # Use the repo at a specific path
-amika sandbox create --git ./src
+amika rig create --git ./src
 
 # Clone a remote git URL (HTTPS or SSH)
-amika sandbox create --git https://github.com/octocat/Hello-World.git
+amika rig create --git https://github.com/octocat/Hello-World.git
 
 # Skip auto-detection and create a sandbox without any repo
-amika sandbox create --no-git
+amika rig create --no-git
 ```
 
 ### HTTP API (`GitRepo`)
@@ -157,7 +157,7 @@ my-project/
     setup.sh          # must be executable (chmod +x)
 ```
 
-Running `amika sandbox create` from anywhere inside `my-project` (the repo is auto-detected) will automatically mount `scripts/setup.sh` to `/usr/local/etc/amikad/setup/setup.sh` in the container.
+Running `amika rig create` from anywhere inside `my-project` (the repo is auto-detected) will automatically mount `scripts/setup.sh` to `/usr/local/etc/amikad/setup/setup.sh` in the container.
 
 ### `[env]` — Environment variables
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -100,7 +100,7 @@ amika secret claude push --type api_key --value sk-ant-xxx
 amika secret claude list
 ```
 
-3. **Inject when creating a sandbox** — credentials can be selected via the web UI or referenced via the `--secret` flag on `amika sandbox create`.
+3. **Inject when creating a sandbox** — credentials can be selected via the web UI or referenced via the `--secret` flag on `amika rig create`.
 
 4. **Delete a credential:**
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -24,10 +24,10 @@ Self-hosting currently supports a "local-only" mode that spins up Docker contain
 To run local Rigs, include the `--local` flag whenever you run an `amika` command.
 
 ```
-amika sandbox create --local --name local-rig
-amika sandbox ls --local
-amika sandbox connect --local local-rig
-amika sandbox rm --local local-rig
+amika rig create --local --name local-rig
+amika rig ls --local
+amika rig connect --local local-rig
+amika rig rm --local local-rig
 ```
 
 

--- a/go/cmd/amika/sandbox/command.go
+++ b/go/cmd/amika/sandbox/command.go
@@ -10,12 +10,14 @@ import (
 
 const sandboxConnectWorkdir = "/home/amika"
 
-// New builds the sandbox command tree.
+// New builds the rig command tree. `sandbox` remains an alias for scripts
+// written before the terminology change.
 func New() *cobra.Command {
 	sandboxCmd := &cobra.Command{
-		Use:   "sandbox",
-		Short: "Manage sandboxes",
-		Long:  `Create and delete sandboxed environments backed by container providers.`,
+		Use:     "rig",
+		Aliases: []string{"sandbox"},
+		Short:   "Manage rigs",
+		Long:    `Create and delete rig environments backed by container providers.`,
 	}
 
 	sandboxCmd.AddCommand(sandboxCreateCmd)

--- a/go/cmd/amika/sandbox_commands_test.go
+++ b/go/cmd/amika/sandbox_commands_test.go
@@ -23,14 +23,17 @@ func findSubcommand(t *testing.T, parent *cobra.Command, name string) *cobra.Com
 }
 
 func TestSandboxCommandRegistered(t *testing.T) {
-	sandboxCmd := findSubcommand(t, rootCmd, "sandbox")
-	if sandboxCmd.Name() != "sandbox" {
-		t.Fatalf("command name = %q, want sandbox", sandboxCmd.Name())
+	sandboxCmd := findSubcommand(t, rootCmd, "rig")
+	if sandboxCmd.Name() != "rig" {
+		t.Fatalf("command name = %q, want rig", sandboxCmd.Name())
+	}
+	if !slices.Contains(sandboxCmd.Aliases, "sandbox") {
+		t.Fatal("rig command must retain the sandbox alias")
 	}
 }
 
 func TestSandboxDeleteAliases(t *testing.T) {
-	sandboxCmd := findSubcommand(t, rootCmd, "sandbox")
+	sandboxCmd := findSubcommand(t, rootCmd, "rig")
 	deleteCmd := findSubcommand(t, sandboxCmd, "delete")
 	if !slices.Contains(deleteCmd.Aliases, "rm") {
 		t.Fatal("sandbox delete command must include alias \"rm\"")
@@ -41,7 +44,7 @@ func TestSandboxDeleteAliases(t *testing.T) {
 }
 
 func TestSandboxCreateHasConnectFlag(t *testing.T) {
-	sandboxCmd := findSubcommand(t, rootCmd, "sandbox")
+	sandboxCmd := findSubcommand(t, rootCmd, "rig")
 	createCmd := findSubcommand(t, sandboxCmd, "create")
 	flag := createCmd.Flags().Lookup("connect")
 	if flag == nil {
@@ -53,7 +56,7 @@ func TestSandboxCreateHasConnectFlag(t *testing.T) {
 }
 
 func TestSandboxCreateHasSnapshotFlag(t *testing.T) {
-	sandboxCmd := findSubcommand(t, rootCmd, "sandbox")
+	sandboxCmd := findSubcommand(t, rootCmd, "rig")
 	createCmd := findSubcommand(t, sandboxCmd, "create")
 	flag := createCmd.Flags().Lookup("snapshot")
 	if flag == nil {
@@ -68,7 +71,7 @@ func TestSandboxCreateSnapshotRequiresRemote(t *testing.T) {
 	// runRootCommand shares the package-global rootCmd, and cobra carries flag
 	// values and their Changed state across Execute calls. Reset what this test
 	// sets so it can't leak --local/--snapshot onto later sandbox tests.
-	sandboxCmd := findSubcommand(t, rootCmd, "sandbox")
+	sandboxCmd := findSubcommand(t, rootCmd, "rig")
 	createCmd := findSubcommand(t, sandboxCmd, "create")
 	t.Cleanup(func() {
 		resetFlag(t, sandboxCmd.PersistentFlags().Lookup("local"))

--- a/go/internal/apiclient/client.go
+++ b/go/internal/apiclient/client.go
@@ -41,7 +41,7 @@ func NewClientWithTokenSource(baseURL string, ts TokenSource) *Client {
 	}
 }
 
-// CreateSandboxRequest is the request body for POST /api/v0beta1/sandboxes.
+// CreateSandboxRequest is the request body for POST /api/v0beta1/rigs.
 type CreateSandboxRequest struct {
 	Name               string               `json:"name,omitempty"`
 	Provider           string               `json:"provider,omitempty"`
@@ -102,7 +102,7 @@ type RemoteSandboxService struct {
 }
 
 // RemoteSandbox mirrors the API's Sandbox schema (see
-// /api/v0beta1/sandboxes and the "Sandbox" component schema in the API's
+// /api/v0beta1/rigs and the "Sandbox" component schema in the API's
 // OpenAPI document, served at /api/openapi.json).
 // It is the single decode/encode type: the CLI decodes API responses into it
 // and re-encodes the same value for `-o json`, so the two stay byte-for-byte
@@ -191,7 +191,7 @@ type MountedSecret struct {
 // ListSandboxes fetches sandboxes from the remote API.
 func (c *Client) ListSandboxes() ([]RemoteSandbox, error) {
 	var result []RemoteSandbox
-	if err := c.doJSON("GET", apiBasePath+"/sandboxes", nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/rigs", nil, &result); err != nil {
 		return nil, fmt.Errorf("remote list sandboxes: %w", err)
 	}
 	return result, nil
@@ -202,7 +202,7 @@ func (c *Client) ListSandboxes() ([]RemoteSandbox, error) {
 // Use GetSandbox or WaitForSandbox to poll until provisioning completes.
 func (c *Client) CreateSandbox(req CreateSandboxRequest) (*RemoteSandbox, error) {
 	var result RemoteSandbox
-	if err := c.doJSON("POST", apiBasePath+"/sandboxes", req, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/rigs", req, &result); err != nil {
 		return nil, fmt.Errorf("remote create sandbox: %w", err)
 	}
 	return &result, nil
@@ -211,7 +211,7 @@ func (c *Client) CreateSandbox(req CreateSandboxRequest) (*RemoteSandbox, error)
 // GetSandbox fetches a single sandbox by name from the remote API.
 func (c *Client) GetSandbox(name string) (*RemoteSandbox, error) {
 	var result RemoteSandbox
-	if err := c.doJSON("GET", apiBasePath+"/sandboxes/"+url.PathEscape(name), nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/rigs/"+url.PathEscape(name), nil, &result); err != nil {
 		return nil, fmt.Errorf("remote get sandbox: %w", err)
 	}
 	return &result, nil
@@ -222,7 +222,7 @@ func (c *Client) GetSandbox(name string) (*RemoteSandbox, error) {
 // suite fast; production always uses the 3 second default.
 var pollInterval = 3 * time.Second
 
-// waitForSandboxState polls GET /api/v0beta1/sandboxes/{name} every pollInterval
+// waitForSandboxState polls GET /api/v0beta1/rigs/{name} every pollInterval
 // until the sandbox state matches one of readyStates or "failed".
 func (c *Client) waitForSandboxState(name string, readyStates []string, failMsg string) (*RemoteSandbox, error) {
 	for {
@@ -245,7 +245,7 @@ func (c *Client) waitForSandboxState(name string, readyStates []string, failMsg 
 	}
 }
 
-// WaitForSandbox polls GET /api/v0beta1/sandboxes/{name} until the sandbox reaches
+// WaitForSandbox polls GET /api/v0beta1/rigs/{name} until the sandbox reaches
 // a ready or terminal state. It polls every 3 seconds.
 func (c *Client) WaitForSandbox(name string) (*RemoteSandbox, error) {
 	return c.waitForSandboxState(name, []string{"active", "running", "started"}, "sandbox provisioning failed")
@@ -268,13 +268,13 @@ type SSHInfo struct {
 // GetSSH retrieves SSH connection details for a remote sandbox.
 func (c *Client) GetSSH(name string) (*SSHInfo, error) {
 	var result SSHInfo
-	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/ssh", nil, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/rigs/"+url.PathEscape(name)+"/ssh", nil, &result); err != nil {
 		return nil, fmt.Errorf("remote ssh: %w", err)
 	}
 	return &result, nil
 }
 
-// RevokeSSHRequest is the request body for DELETE /api/v0beta1/sandboxes/{id}/ssh.
+// RevokeSSHRequest is the request body for DELETE /api/v0beta1/rigs/{id}/ssh.
 type RevokeSSHRequest struct {
 	Token string `json:"token"`
 }
@@ -282,7 +282,7 @@ type RevokeSSHRequest struct {
 // RevokeSSH revokes an SSH token for a remote sandbox.
 func (c *Client) RevokeSSH(name, token string) error {
 	req := RevokeSSHRequest{Token: token}
-	if err := c.doJSON("DELETE", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/ssh", req, nil); err != nil {
+	if err := c.doJSON("DELETE", apiBasePath+"/rigs/"+url.PathEscape(name)+"/ssh", req, nil); err != nil {
 		return fmt.Errorf("remote revoke ssh: %w", err)
 	}
 	return nil
@@ -292,13 +292,13 @@ func (c *Client) RevokeSSH(name, token string) error {
 // The endpoint returns 202 Accepted with the sandbox in "initializing" state.
 // Use WaitForSandboxStart to poll until the sandbox is active.
 func (c *Client) StartSandbox(name string) error {
-	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/start", nil, nil); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/rigs/"+url.PathEscape(name)+"/start", nil, nil); err != nil {
 		return fmt.Errorf("remote start sandbox: %w", err)
 	}
 	return nil
 }
 
-// WaitForSandboxStart polls GET /api/v0beta1/sandboxes/{name} until the sandbox
+// WaitForSandboxStart polls GET /api/v0beta1/rigs/{name} until the sandbox
 // transitions out of "initializing" state. It polls every 3 seconds.
 func (c *Client) WaitForSandboxStart(name string) (*RemoteSandbox, error) {
 	return c.waitForSandboxState(name, []string{"active", "running", "started"}, "sandbox start failed")
@@ -308,13 +308,13 @@ func (c *Client) WaitForSandboxStart(name string) (*RemoteSandbox, error) {
 // The endpoint returns 202 Accepted with the sandbox in "stopping" state.
 // Use WaitForSandboxStop to poll until the sandbox is stopped.
 func (c *Client) StopSandbox(name string) error {
-	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(name)+"/stop", nil, nil); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/rigs/"+url.PathEscape(name)+"/stop", nil, nil); err != nil {
 		return fmt.Errorf("remote stop sandbox: %w", err)
 	}
 	return nil
 }
 
-// WaitForSandboxStop polls GET /api/v0beta1/sandboxes/{name} until the sandbox
+// WaitForSandboxStop polls GET /api/v0beta1/rigs/{name} until the sandbox
 // transitions out of "stopping" state. It polls every 3 seconds.
 func (c *Client) WaitForSandboxStop(name string) (*RemoteSandbox, error) {
 	return c.waitForSandboxState(name, []string{"stopped"}, "sandbox stop failed")
@@ -322,7 +322,7 @@ func (c *Client) WaitForSandboxStop(name string) (*RemoteSandbox, error) {
 
 // DeleteSandbox deletes a sandbox on the remote API.
 func (c *Client) DeleteSandbox(name string) error {
-	if err := c.doJSON("DELETE", apiBasePath+"/sandboxes/"+url.PathEscape(name), nil, nil); err != nil {
+	if err := c.doJSON("DELETE", apiBasePath+"/rigs/"+url.PathEscape(name), nil, nil); err != nil {
 		return fmt.Errorf("remote delete sandbox: %w", err)
 	}
 	return nil
@@ -562,7 +562,7 @@ func (c *Client) ListSandboxServices(sandboxRef string) ([]SandboxServiceResourc
 // id. The server resolves sandboxRef (id first, then name) and returns the
 // created SandboxServiceResource.
 func (c *Client) CreateSandboxService(sandboxRef string, req SandboxServiceRequest) (*SandboxServiceResource, error) {
-	path := apiBasePath + "/sandboxes/" + url.PathEscape(sandboxRef) + "/services"
+	path := apiBasePath + "/rigs/" + url.PathEscape(sandboxRef) + "/services"
 	var result SandboxServiceResource
 	if err := c.doJSON("POST", path, req, &result); err != nil {
 		return nil, fmt.Errorf("remote create sandbox service: %w", err)
@@ -579,7 +579,7 @@ func (c *Client) PutSandboxService(sandboxRef, serviceRef, by string, req Sandbo
 	}
 	q := url.Values{}
 	q.Set("by", by)
-	path := apiBasePath + "/sandboxes/" + url.PathEscape(sandboxRef) + "/services/" + url.PathEscape(serviceRef) + "?" + q.Encode()
+	path := apiBasePath + "/rigs/" + url.PathEscape(sandboxRef) + "/services/" + url.PathEscape(serviceRef) + "?" + q.Encode()
 	var result SandboxServiceResource
 	if err := c.doJSON("PUT", path, req, &result); err != nil {
 		return nil, fmt.Errorf("remote put sandbox service: %w", err)
@@ -590,7 +590,7 @@ func (c *Client) PutSandboxService(sandboxRef, serviceRef, by string, req Sandbo
 // DeleteSandboxService deletes the service identified by serviceRef (resolved
 // by name) within the given sandbox.
 func (c *Client) DeleteSandboxService(sandboxRef, serviceRef string) error {
-	path := apiBasePath + "/sandboxes/" + url.PathEscape(sandboxRef) + "/services/" + url.PathEscape(serviceRef) + "?by=name"
+	path := apiBasePath + "/rigs/" + url.PathEscape(sandboxRef) + "/services/" + url.PathEscape(serviceRef) + "?by=name"
 	if err := c.doJSON("DELETE", path, nil, nil); err != nil {
 		return fmt.Errorf("remote delete sandbox service: %w", err)
 	}
@@ -704,7 +704,7 @@ func (c *Client) DeleteProviderSecret(provider, id string) error {
 	return nil
 }
 
-// AgentSendRequest is the request body for POST /api/v0beta1/sandboxes/{id}/agent-send.
+// AgentSendRequest is the request body for POST /api/v0beta1/rigs/{id}/agent-send.
 type AgentSendRequest struct {
 	Message    string `json:"message"`
 	NewSession bool   `json:"new_session,omitempty"`
@@ -713,7 +713,7 @@ type AgentSendRequest struct {
 }
 
 // AgentSendResponse mirrors the API's AgentSendResponse schema, returned by
-// POST /api/v0beta1/sandboxes/{id}/agent-send. SessionID, Response, IsError,
+// POST /api/v0beta1/rigs/{id}/agent-send. SessionID, Response, IsError,
 // and IsNewSession are required by the schema (no omitempty); AgentSessionID
 // and CostUSD are optional.
 type AgentSendResponse struct {
@@ -727,7 +727,7 @@ type AgentSendResponse struct {
 
 // AgentSendJobResponse mirrors the API's AgentSendJobResponse schema,
 // returned by the asynchronous agent-send-jobs endpoints
-// (POST /api/v0beta1/sandboxes/{id}/agent-send-jobs and
+// (POST /api/v0beta1/rigs/{id}/agent-send-jobs and
 // GET .../agent-send-jobs/{job_id}). AgentSessionID and ResultText are
 // nullable (pointers); CostUSD is the only non-required field.
 type AgentSendJobResponse struct {
@@ -751,7 +751,7 @@ func (c *Client) AgentSend(sandboxName string, req AgentSendRequest) (*AgentSend
 	defer func() { c.HTTP.Timeout = saved }()
 
 	var result AgentSendResponse
-	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/agent-send", req, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/rigs/"+url.PathEscape(sandboxName)+"/agent-send", req, &result); err != nil {
 		if authErr := extractAgentAuthError(err); authErr != "" {
 			return nil, fmt.Errorf("remote agent-send: agent failed to authenticate with its AI provider: %s\n\nthe sandbox agent's API credentials may have expired or been revoked; recreate the sandbox or update its API keys to restore access", authErr)
 		}
@@ -777,13 +777,13 @@ type Session struct {
 	UpdatedAt string  `json:"updated_at"`
 }
 
-// CreateSessionRequest is the request body for POST /api/v0beta1/sandboxes/{id}/sessions.
+// CreateSessionRequest is the request body for POST /api/v0beta1/rigs/{id}/sessions.
 type CreateSessionRequest struct {
 	AgentName string                 `json:"agent_name"`
 	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
 
-// UpdateSessionRequest is the request body for PATCH /api/v0beta1/sandboxes/{id}/sessions/{sessionId}.
+// UpdateSessionRequest is the request body for PATCH /api/v0beta1/rigs/{id}/sessions/{sessionId}.
 type UpdateSessionRequest struct {
 	Status   string                 `json:"status,omitempty"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
@@ -792,7 +792,7 @@ type UpdateSessionRequest struct {
 // CreateSession creates a new agent session on a remote sandbox.
 func (c *Client) CreateSession(sandboxName string, req CreateSessionRequest) (*Session, error) {
 	var result Session
-	if err := c.doJSON("POST", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions", req, &result); err != nil {
+	if err := c.doJSON("POST", apiBasePath+"/rigs/"+url.PathEscape(sandboxName)+"/sessions", req, &result); err != nil {
 		return nil, fmt.Errorf("remote create session: %w", err)
 	}
 	return &result, nil
@@ -804,7 +804,7 @@ func (c *Client) ListSessions(sandboxName string) ([]Session, error) {
 		Sessions []Session `json:"sessions"`
 		Total    int       `json:"total"`
 	}
-	if err := c.doJSON("GET", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions", nil, &envelope); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/rigs/"+url.PathEscape(sandboxName)+"/sessions", nil, &envelope); err != nil {
 		return nil, fmt.Errorf("remote list sessions: %w", err)
 	}
 	return envelope.Sessions, nil
@@ -814,7 +814,7 @@ func (c *Client) ListSessions(sandboxName string) ([]Session, error) {
 // Returns nil, nil if no session exists (HTTP 404).
 func (c *Client) GetLatestSession(sandboxName string) (*Session, error) {
 	var result Session
-	if err := c.doJSON("GET", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/latest", nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/rigs/"+url.PathEscape(sandboxName)+"/sessions/latest", nil, &result); err != nil {
 		if strings.Contains(err.Error(), "HTTP 404") {
 			return nil, nil
 		}
@@ -826,7 +826,7 @@ func (c *Client) GetLatestSession(sandboxName string) (*Session, error) {
 // GetSession returns a specific session by ID.
 func (c *Client) GetSession(sandboxName, sessionID string) (*Session, error) {
 	var result Session
-	if err := c.doJSON("GET", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), nil, &result); err != nil {
+	if err := c.doJSON("GET", apiBasePath+"/rigs/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), nil, &result); err != nil {
 		return nil, fmt.Errorf("remote get session: %w", err)
 	}
 	return &result, nil
@@ -835,7 +835,7 @@ func (c *Client) GetSession(sandboxName, sessionID string) (*Session, error) {
 // UpdateSession updates a session on a remote sandbox.
 func (c *Client) UpdateSession(sandboxName, sessionID string, req UpdateSessionRequest) (*Session, error) {
 	var result Session
-	if err := c.doJSON("PATCH", apiBasePath+"/sandboxes/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), req, &result); err != nil {
+	if err := c.doJSON("PATCH", apiBasePath+"/rigs/"+url.PathEscape(sandboxName)+"/sessions/"+url.PathEscape(sessionID), req, &result); err != nil {
 		return nil, fmt.Errorf("remote update session: %w", err)
 	}
 	return &result, nil
@@ -938,7 +938,7 @@ func (c *Client) SendAgentSession(req AgentSessionSendRequest) (*AgentSessionSen
 
 	var result AgentSessionSendResponse
 	// Note: no extractAgentAuthError branch here, unlike the older
-	// /sandboxes/{}/agent/send route. This endpoint reports a provider auth
+	// /rigs/{}/agent/send route. This endpoint reports a provider auth
 	// failure as a 200 with is_error set and the agent CLI's own message in
 	// `response` — not as an HTTP error — so there is no error body to inspect.
 	if err := c.doJSON("POST", apiBasePath+"/agent-sessions", req, &result); err != nil {

--- a/go/internal/apiclient/client_services_test.go
+++ b/go/internal/apiclient/client_services_test.go
@@ -40,7 +40,7 @@ func TestSandboxServiceRequestPaths(t *testing.T) {
 				return err
 			},
 			wantMethod: "POST",
-			wantPath:   "/api/v0beta1/sandboxes/org%2Fbox/services",
+			wantPath:   "/api/v0beta1/rigs/org%2Fbox/services",
 		},
 		{
 			name: "PutSandboxService defaults by=name and escapes refs",
@@ -49,7 +49,7 @@ func TestSandboxServiceRequestPaths(t *testing.T) {
 				return err
 			},
 			wantMethod: "PUT",
-			wantPath:   "/api/v0beta1/sandboxes/my-box/services/web?by=name",
+			wantPath:   "/api/v0beta1/rigs/my-box/services/web?by=name",
 		},
 		{
 			name: "PutSandboxService honors an explicit by param",
@@ -58,7 +58,7 @@ func TestSandboxServiceRequestPaths(t *testing.T) {
 				return err
 			},
 			wantMethod: "PUT",
-			wantPath:   "/api/v0beta1/sandboxes/my-box/services/sbsvc_1?by=id",
+			wantPath:   "/api/v0beta1/rigs/my-box/services/sbsvc_1?by=id",
 		},
 		{
 			name: "DeleteSandboxService resolves by name",
@@ -66,7 +66,7 @@ func TestSandboxServiceRequestPaths(t *testing.T) {
 				return c.DeleteSandboxService("my-box", "web")
 			},
 			wantMethod: "DELETE",
-			wantPath:   "/api/v0beta1/sandboxes/my-box/services/web?by=name",
+			wantPath:   "/api/v0beta1/rigs/my-box/services/web?by=name",
 		},
 	}
 

--- a/go/internal/apiclient/client_test.go
+++ b/go/internal/apiclient/client_test.go
@@ -23,43 +23,43 @@ func TestPathEscapesSandboxName(t *testing.T) {
 			name:       "GetSandbox with slash",
 			call:       func(c *Client) error { _, err := c.GetSandbox("org/proj"); return err },
 			wantMethod: "GET",
-			wantPath:   "/api/v0beta1/sandboxes/org%2Fproj",
+			wantPath:   "/api/v0beta1/rigs/org%2Fproj",
 		},
 		{
 			name:       "DeleteSandbox with slash",
 			call:       func(c *Client) error { return c.DeleteSandbox("org/proj") },
 			wantMethod: "DELETE",
-			wantPath:   "/api/v0beta1/sandboxes/org%2Fproj",
+			wantPath:   "/api/v0beta1/rigs/org%2Fproj",
 		},
 		{
 			name:       "StartSandbox with slash",
 			call:       func(c *Client) error { return c.StartSandbox("a/b") },
 			wantMethod: "POST",
-			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/start",
+			wantPath:   "/api/v0beta1/rigs/a%2Fb/start",
 		},
 		{
 			name:       "StopSandbox with slash",
 			call:       func(c *Client) error { return c.StopSandbox("a/b") },
 			wantMethod: "POST",
-			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/stop",
+			wantPath:   "/api/v0beta1/rigs/a%2Fb/stop",
 		},
 		{
 			name:       "GetSSH with slash",
 			call:       func(c *Client) error { _, err := c.GetSSH("a/b"); return err },
 			wantMethod: "POST",
-			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/ssh",
+			wantPath:   "/api/v0beta1/rigs/a%2Fb/ssh",
 		},
 		{
 			name:       "RevokeSSH with slash",
 			call:       func(c *Client) error { return c.RevokeSSH("a/b", "tok") },
 			wantMethod: "DELETE",
-			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/ssh",
+			wantPath:   "/api/v0beta1/rigs/a%2Fb/ssh",
 		},
 		{
 			name:       "ListSessions with slash",
 			call:       func(c *Client) error { _, err := c.ListSessions("a/b"); return err },
 			wantMethod: "GET",
-			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/sessions",
+			wantPath:   "/api/v0beta1/rigs/a%2Fb/sessions",
 		},
 		{
 			name: "AgentSend with slash",
@@ -68,13 +68,13 @@ func TestPathEscapesSandboxName(t *testing.T) {
 				return err
 			},
 			wantMethod: "POST",
-			wantPath:   "/api/v0beta1/sandboxes/a%2Fb/agent-send",
+			wantPath:   "/api/v0beta1/rigs/a%2Fb/agent-send",
 		},
 		{
 			name:       "GetSandbox without slash",
 			call:       func(c *Client) error { _, err := c.GetSandbox("simple-name"); return err },
 			wantMethod: "GET",
-			wantPath:   "/api/v0beta1/sandboxes/simple-name",
+			wantPath:   "/api/v0beta1/rigs/simple-name",
 		},
 	}
 

--- a/go/internal/apiclient/ssh_session.go
+++ b/go/internal/apiclient/ssh_session.go
@@ -68,7 +68,7 @@ func (s *SSHSession) Validate(expectedSandboxID string) error {
 // CreateSSHSession creates and validates a fresh descriptor for one dial.
 func (c *Client) CreateSSHSession(sandboxID string) (*SSHSession, error) {
 	var result SSHSession
-	path := apiBasePath + "/sandboxes/" + url.PathEscape(sandboxID) + "/ssh-sessions"
+	path := apiBasePath + "/rigs/" + url.PathEscape(sandboxID) + "/ssh-sessions"
 	if err := c.doJSON("POST", path, nil, &result); err != nil {
 		return nil, fmt.Errorf("remote create SSH session: %w", err)
 	}

--- a/go/internal/apiclient/ssh_session_test.go
+++ b/go/internal/apiclient/ssh_session_test.go
@@ -30,7 +30,7 @@ func TestCreateSSHSessionPostsForEveryDial(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		if r.URL.Path != "/api/v0beta1/sandboxes/sbx_123/ssh-sessions" {
+		if r.URL.Path != "/api/v0beta1/rigs/sbx_123/ssh-sessions" {
 			t.Errorf("path = %s", r.URL.Path)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer api-token" {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -89,7 +89,7 @@ export class AmikaClient {
   async listSandboxes(): Promise<RemoteSandbox[]> {
     const data = await this.http.doJSON<unknown[]>(
       "GET",
-      `${API_BASE_PATH}/sandboxes`,
+      `${API_BASE_PATH}/rigs`,
     );
     return mapArray(data, remoteSandboxFromWire);
   }
@@ -97,7 +97,7 @@ export class AmikaClient {
   async createSandbox(req: CreateSandboxRequest): Promise<RemoteSandbox> {
     const data = await this.http.doJSON<Record<string, unknown>>(
       "POST",
-      `${API_BASE_PATH}/sandboxes`,
+      `${API_BASE_PATH}/rigs`,
       createSandboxRequestToWire(req),
     );
     return remoteSandboxFromWire(data ?? {});
@@ -106,7 +106,7 @@ export class AmikaClient {
   async getSandbox(name: string): Promise<RemoteSandbox> {
     const data = await this.http.doJSON<Record<string, unknown>>(
       "GET",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(name)}`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(name)}`,
     );
     return remoteSandboxFromWire(data ?? {});
   }
@@ -128,7 +128,7 @@ export class AmikaClient {
   async startSandbox(name: string): Promise<void> {
     await this.http.doJSON(
       "POST",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(name)}/start`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(name)}/start`,
     );
   }
 
@@ -144,7 +144,7 @@ export class AmikaClient {
   async stopSandbox(name: string): Promise<void> {
     await this.http.doJSON(
       "POST",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(name)}/stop`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(name)}/stop`,
     );
   }
 
@@ -160,7 +160,7 @@ export class AmikaClient {
   async deleteSandbox(name: string): Promise<void> {
     await this.http.doJSON(
       "DELETE",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(name)}`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(name)}`,
     );
   }
 
@@ -204,7 +204,7 @@ export class AmikaClient {
   ): Promise<SandboxServiceResource> {
     const data = await this.http.doJSON<Record<string, unknown>>(
       "POST",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxRef)}/services`,
       sandboxServiceRequestToWire(req),
     );
     return sandboxServiceResourceFromWire(data ?? {});
@@ -223,7 +223,7 @@ export class AmikaClient {
     const params = new URLSearchParams({ by });
     const data = await this.http.doJSON<Record<string, unknown>>(
       "PUT",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?${params.toString()}`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?${params.toString()}`,
       sandboxServiceRequestToWire(req),
     );
     return sandboxServiceResourceFromWire(data ?? {});
@@ -236,7 +236,7 @@ export class AmikaClient {
   ): Promise<void> {
     await this.http.doJSON(
       "DELETE",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?by=name`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxRef)}/services/${encodeURIComponent(serviceRef)}?by=name`,
     );
   }
 
@@ -304,7 +304,7 @@ export class AmikaClient {
     try {
       const data = await this.http.doJSON<Record<string, unknown>>(
         "POST",
-        `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxName)}/agent-send`,
+        `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxName)}/agent-send`,
         agentSendRequestToWire(req),
         { timeoutMs: AGENT_SEND_TIMEOUT_MS },
       );
@@ -328,7 +328,7 @@ export class AmikaClient {
   ): Promise<Session> {
     const data = await this.http.doJSON<Record<string, unknown>>(
       "POST",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxName)}/sessions`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxName)}/sessions`,
       createSessionRequestToWire(req),
     );
     return sessionFromWire(data ?? {});
@@ -339,7 +339,7 @@ export class AmikaClient {
       sessions?: Record<string, unknown>[];
     }>(
       "GET",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxName)}/sessions`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxName)}/sessions`,
     );
     const sessions = envelope?.sessions ?? [];
     return sessions.map((s) => sessionFromWire(s));
@@ -350,7 +350,7 @@ export class AmikaClient {
     try {
       const data = await this.http.doJSON<Record<string, unknown>>(
         "GET",
-        `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxName)}/sessions/latest`,
+        `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxName)}/sessions/latest`,
       );
       return sessionFromWire(data ?? {});
     } catch (err) {
@@ -362,7 +362,7 @@ export class AmikaClient {
   async getSession(sandboxName: string, sessionId: string): Promise<Session> {
     const data = await this.http.doJSON<Record<string, unknown>>(
       "GET",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxName)}/sessions/${encodeURIComponent(sessionId)}`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxName)}/sessions/${encodeURIComponent(sessionId)}`,
     );
     return sessionFromWire(data ?? {});
   }
@@ -374,7 +374,7 @@ export class AmikaClient {
   ): Promise<Session> {
     const data = await this.http.doJSON<Record<string, unknown>>(
       "PATCH",
-      `${API_BASE_PATH}/sandboxes/${encodeURIComponent(sandboxName)}/sessions/${encodeURIComponent(sessionId)}`,
+      `${API_BASE_PATH}/rigs/${encodeURIComponent(sandboxName)}/sessions/${encodeURIComponent(sessionId)}`,
       updateSessionRequestToWire(req),
     );
     return sessionFromWire(data ?? {});

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -81,7 +81,7 @@ export interface AgentCredentialRef {
   none?: boolean;
 }
 
-/** Request body for POST /api/v0beta1/sandboxes. */
+/** Request body for POST /api/v0beta1/rigs. */
 export interface CreateSandboxRequest {
   name?: string;
   provider?: string;

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -51,7 +51,7 @@ describe("AmikaClient.listSandboxes", () => {
     const client = makeClient(fetch);
     const sandboxes = await client.listSandboxes();
     expect(calls[0]?.method).toBe("GET");
-    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/sandboxes`);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/rigs`);
     expect(sandboxes).toHaveLength(1);
     expect(sandboxes[0]?.repoUrl).toBe("git@github.com:org/a.git");
   });
@@ -128,7 +128,7 @@ describe("AmikaClient sandbox lifecycle", () => {
     ]);
     const client = makeClient(fetch);
     await client.getSandbox("org/proj");
-    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/sandboxes/org%2Fproj`);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/rigs/org%2Fproj`);
   });
 
   it("startSandbox POSTs to /start", async () => {
@@ -136,14 +136,14 @@ describe("AmikaClient sandbox lifecycle", () => {
     const client = makeClient(fetch);
     await client.startSandbox("dev");
     expect(calls[0]?.method).toBe("POST");
-    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/sandboxes/dev/start`);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/rigs/dev/start`);
   });
 
   it("stopSandbox POSTs to /stop", async () => {
     const { fetch, calls } = mockFetch([{ status: 202, body: "" }]);
     const client = makeClient(fetch);
     await client.stopSandbox("dev");
-    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/sandboxes/dev/stop`);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/rigs/dev/stop`);
   });
 
   it("deleteSandbox DELETEs the sandbox", async () => {
@@ -151,7 +151,7 @@ describe("AmikaClient sandbox lifecycle", () => {
     const client = makeClient(fetch);
     await client.deleteSandbox("dev");
     expect(calls[0]?.method).toBe("DELETE");
-    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/sandboxes/dev`);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/rigs/dev`);
   });
 });
 
@@ -460,7 +460,7 @@ describe("AmikaClient sessions", () => {
     const client = makeClient(fetch);
     await client.updateSession("dev", "s1", { status: "completed" });
     expect(calls[0]?.method).toBe("PATCH");
-    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/sandboxes/dev/sessions/s1`);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v0beta1/rigs/dev/sessions/s1`);
   });
 });
 
@@ -895,7 +895,7 @@ describe("AmikaClient sandbox services", () => {
     });
     expect(calls[0]?.method).toBe("POST");
     expect(calls[0]?.url).toBe(
-      `${BASE}/api/v0beta1/sandboxes/org%2Fdev/services`,
+      `${BASE}/api/v0beta1/rigs/org%2Fdev/services`,
     );
     expect(JSON.parse(calls[0]?.body ?? "")).toEqual({
       name: "web",
@@ -916,10 +916,10 @@ describe("AmikaClient sandbox services", () => {
     await client.putSandboxService("dev", "svc_1", req, "id");
     expect(calls[0]?.method).toBe("PUT");
     expect(calls[0]?.url).toBe(
-      `${BASE}/api/v0beta1/sandboxes/dev/services/web?by=name`,
+      `${BASE}/api/v0beta1/rigs/dev/services/web?by=name`,
     );
     expect(calls[1]?.url).toBe(
-      `${BASE}/api/v0beta1/sandboxes/dev/services/svc_1?by=id`,
+      `${BASE}/api/v0beta1/rigs/dev/services/svc_1?by=id`,
     );
   });
 
@@ -928,7 +928,7 @@ describe("AmikaClient sandbox services", () => {
     await makeClient(fetch).deleteSandboxService("dev", "web");
     expect(calls[0]?.method).toBe("DELETE");
     expect(calls[0]?.url).toBe(
-      `${BASE}/api/v0beta1/sandboxes/dev/services/web?by=name`,
+      `${BASE}/api/v0beta1/rigs/dev/services/web?by=name`,
     );
   });
 });


### PR DESCRIPTION
Makes `amika rig` and `/api/v0beta1/rigs` canonical while retaining `amika sandbox` as a CLI alias and keeping client behavior compatible.