### PR TITLE
Use kebab-case agent credential defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ To get started with Amika's cloud product:
 
    ```bash
    amika auth login
-   amika secret codex push --type oauth --name "Codex Subscription"
-   amika secret claude push --type oauth --name "Claude Subscription"
+   amika secret codex push --type oauth --name codex-oauth
+   amika secret claude push --type oauth --name claude-oauth
    ```
 
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -640,7 +640,7 @@ Push Claude Code credentials (API key or OAuth token) to the remote Amika secret
 amika secret claude push
 
 # Push with a custom label
-amika secret claude push --name "Claude OAuth (Work Laptop)"
+amika secret claude push --name claude-oauth-work-laptop
 
 # Push from a credentials file
 amika secret claude push --from-file ~/.claude/.credentials.json
@@ -660,6 +660,7 @@ amika secret claude push --type api_key
 | `--type <type>`      | `oauth` | Credential type: `oauth` or `api_key`                           |
 
 `--value` and `--from-file` are mutually exclusive.
+When `--name` is omitted, the prompt defaults to `claude-oauth` for OAuth credentials and `claude-api-key` for API keys.
 
 #### `amika secret claude list`
 

--- a/go/cmd/amika/secrets.go
+++ b/go/cmd/amika/secrets.go
@@ -418,8 +418,7 @@ type providerConfig struct {
 	// DisplayName is the user-facing provider name shown in help text
 	// ("Claude Code", "Codex").
 	DisplayName string
-	// ShortName is the prefix used for default credential labels and
-	// terse messages ("Claude", "Codex").
+	// ShortName is used for terse messages ("Claude", "Codex").
 	ShortName string
 	// APIPath is the provider segment of the API endpoint used to build
 	// /api/v0beta1/secrets/<APIPath>.
@@ -459,7 +458,7 @@ When run interactively (no flags), scans all known credential sources:
 
 Examples:
   amika secret claude push
-  amika secret claude push --name "Claude OAuth (Work Laptop)"
+  amika secret claude push --name claude-oauth-work-laptop
   amika secret claude push --from-file ~/.claude/.credentials.json
   amika secret claude push --value '{"claudeAiOauth":{...}}'`,
 	Discover:    discoverClaudeCredentials,
@@ -485,8 +484,8 @@ When using --type to auto-resolve credentials:
 
 Examples:
   amika secret codex push
-  amika secret codex push --type oauth --name "Codex OAuth"
-  amika secret codex push --type api_key --name "Codex API Key"
+  amika secret codex push --type oauth --name codex-oauth
+  amika secret codex push --type api_key --name codex-api-key
   amika secret codex push --from-file ~/.codex/auth.json
   amika secret codex push --value '{"tokens":{"access_token":"..."}}'`,
 	Discover:    discoverCodexCredentials,
@@ -754,9 +753,9 @@ func parseProviderName(cmd *cobra.Command, p providerConfig, credType string) (s
 	}
 
 	reader := bufio.NewReader(cmd.InOrStdin())
-	defaultName := p.ShortName + " OAuth"
+	defaultName := p.Use + "-oauth"
 	if credType == "api_key" {
-		defaultName = p.ShortName + " API Key"
+		defaultName = p.Use + "-api-key"
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Name for this credential [%s]: ", defaultName)
 	input, err := reader.ReadString('\n')


### PR DESCRIPTION
## Summary

- default Claude and Codex OAuth/API-key credential names to kebab-case
- update CLI examples and reference documentation to use the same names
- preserve explicitly supplied custom names

## Verification

- `~/tests/task1-cli-credential-names.sh`
- all four Claude/Codex OAuth/API-key cases passed against a built CLI